### PR TITLE
Modified udev rules, openmv-ide.py to use /dev/openmvcam.

### DIFF
--- a/udev/50-openmv.rules
+++ b/udev/50-openmv.rules
@@ -2,6 +2,7 @@
 #SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", MODE:="0666"
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", MODE:="0666"
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="f055", ATTRS{idProduct}=="9800", MODE:="0666"
+KERNEL=="ttyACM*", ATTRS{idVendor}=="f055", ATTRS{idProduct}=="9800", MODE:="0666", SYMLINK+="openmvcam"
 # If you share your linux system with other users, or just don't like the
 # idea of write permission for everybody, you can replace MODE:="0666" with
 # OWNER:="yourusername" to create the device owned by you, or with

--- a/usr/openmv-ide.py
+++ b/usr/openmv-ide.py
@@ -128,7 +128,7 @@ class OMVGtk:
         self.terminal = self.builder.get_object('terminal')
         try:
             # open VCP and configure the terminal
-            self.fd = os.open("/dev/ttyACM0", os.O_RDWR)
+            self.fd = os.open("/dev/openmvcam", os.O_RDWR)
             self.terminal.reset(True, True)
             self.terminal.set_size(80,24)
             self.terminal.set_pty(self.fd)


### PR DESCRIPTION
Ok, let's try this one. I deleted the udevfix branch and re-created it.
