### PR TITLE
Made Soft I2C Pretty

### DIFF
--- a/src/omv/soft_i2c.h
+++ b/src/omv/soft_i2c.h
@@ -9,7 +9,7 @@
 #ifndef __SOFT_I2C_H__
 #define __SOFT_I2C_H__
 #include <stdint.h>
-void soft_i2c_init();
 int soft_i2c_read_bytes(uint8_t slv_addr, uint8_t *buf, int len, bool stop);
 int soft_i2c_write_bytes(uint8_t slv_addr, uint8_t *buf, int len, bool stop);
+void soft_i2c_init();
 #endif // __SOFT_I2C_H__


### PR DESCRIPTION
The soft_i2c code now does not glitch on startup, scans the bus to get all devices unstuck if they are, and generates a very pretty and precise waveform. The data line does not change unless between clocks now. Also, I fixed a bug in the previous code where the data line was not released to receive an ACK back from the I2C device. The software would read the value of the data line instead if the last data bit transmitted was a 1.

All this work was put in because I couldn't get the MLX sensor working on a bad board. Might as well not have the effort go to waste.