### PR TITLE
Add frame differencing functions.

### DIFF
--- a/src/omv/img/imlib.c
+++ b/src/omv/img/imlib.c
@@ -432,6 +432,54 @@ float imlib_orientation_degrees(image_t *img, int *sum, int *x_center, int *y_ce
     return (imlib_orientation_radians(img, sum, x_center, y_center, r) * 180.0) / M_PI;
 }
 
+void imlib_negate(image_t *img)
+{
+    if (IM_IS_GS(img)) {
+        uint8_t *pixels = img->pixels;
+        for (int i=0, j=img->w*img->h; i<j; i++) {
+            pixels[i] = IM_MAX_GS - pixels[i];
+        }
+    } else {
+        uint16_t *pixels = (uint16_t *) img->pixels;
+        for (int i=0, j=img->w*img->h; i<j; i++) {
+            const int pixel = pixels[i];
+            const int r = IM_MAX_R5 - IM_R565(pixel);
+            const int g = IM_MAX_G6 - IM_G565(pixel);
+            const int b = IM_MAX_B5 - IM_B565(pixel);
+            pixels[i] = IM_RGB565(r, g, b);
+        }
+    }
+}
+
+void imlib_difference(image_t *img, const char *file, image_t *other)
+{
+    if (IM_IS_GS(img)) {
+        uint8_t *pixels = img->pixels;
+        if (file) {
+
+        } else {
+            uint8_t *other_pixels = other->pixels;
+            for (int i=0, j=img->w*img->h; i<j; i++) {
+                pixels[i] = abs(pixels[i] - other_pixels[i]);
+            }
+        }
+    } else {
+        uint16_t *pixels = (uint16_t *) img->pixels;
+        if (file) {
+
+        } else {
+            uint16_t *other_pixels = (uint16_t *) img->pixels;
+            for (int i=0, j=img->w*img->h; i<j; i++) {
+                const int pixel = pixels[i], other_pixel = other_pixels[i];
+                const int r = abs(IM_R565(pixel) - IM_R565(other_pixel));
+                const int g = abs(IM_G565(pixel) - IM_G565(other_pixel));
+                const int b = abs(IM_B565(pixel) - IM_B565(other_pixel));
+                pixels[i] = IM_RGB565(r, g, b);
+            }
+        }
+    }
+}
+
 uint32_t imlib_lab_distance(struct color *c0, struct color *c1)
 {
     uint32_t sum=0;

--- a/src/omv/img/imlib.h
+++ b/src/omv/img/imlib.h
@@ -315,6 +315,10 @@ int imlib_centroid(image_t *img, int *x_center, int *y_center, rectangle_t *r);
 float imlib_orientation_radians(image_t *img, int *sum, int *x_center, int *y_center, rectangle_t *r);
 float imlib_orientation_degrees(image_t *img, int *sum, int *x_center, int *y_center, rectangle_t *r);
 
+/* Background Subtraction (Frame Differencing) functions */
+void imlib_negate(image_t *img);
+void imlib_difference(image_t *img, const char *file, image_t *other);
+
 /* Clustering functions */
 array_t *cluster_kmeans(array_t *points, int k);
 

--- a/src/omv/py/py_image.c
+++ b/src/omv/py/py_image.c
@@ -636,6 +636,33 @@ static mp_obj_t py_image_orientation_degrees(uint n_args, const mp_obj_t *args, 
     return mp_obj_new_tuple(4, result);
 }
 
+static mp_obj_t py_image_negate(mp_obj_t img_obj)
+{
+    image_t *arg_img = py_image_cobj(img_obj);
+    PY_ASSERT_FALSE_MSG(IM_IS_JPEG(arg_img),
+            "Operation not supported on JPEG");
+
+    imlib_negate(arg_img);
+    return mp_const_none;
+}
+
+static mp_obj_t py_image_difference(mp_obj_t img_obj, mp_obj_t other_obj)
+{
+    image_t *arg_img = py_image_cobj(img_obj);
+    PY_ASSERT_FALSE_MSG(IM_IS_JPEG(arg_img),
+            "Operation not supported on JPEG");
+
+    if (MP_OBJ_IS_STR(other_obj)) {
+        imlib_difference(arg_img, mp_obj_str_get_str(other_obj), NULL);
+    } else {
+        image_t *arg_other = py_image_cobj(other_obj);
+        PY_ASSERT_TRUE_MSG(IM_EQUAL(arg_img, arg_other),
+                "Invalid Argument: img_0_geometry != img_1_geometry");
+        imlib_difference(arg_img, NULL, arg_other);
+    }
+    return mp_const_none;
+}
+
 static mp_obj_t py_image_save(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
 {
     int res;
@@ -1292,6 +1319,9 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_image_pixels_obj, 1, py_image_pixels);
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_image_centroid_obj, 1, py_image_centroid);
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_image_orientation_radians_obj, 1, py_image_orientation_radians);
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_image_orientation_degrees_obj, 1, py_image_orientation_degrees);
+/* Background Subtraction (Frame Differencing) functions */
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_image_negate_obj, py_image_negate);
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(py_image_difference_obj, py_image_difference);
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_image_save_obj, 2, py_image_save);
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(py_image_scale_obj, py_image_scale);
@@ -1343,6 +1373,9 @@ static const mp_map_elem_t locals_dict_table[] = {
     {MP_OBJ_NEW_QSTR(MP_QSTR_centroid),            (mp_obj_t)&py_image_centroid_obj},
     {MP_OBJ_NEW_QSTR(MP_QSTR_orientation_radians), (mp_obj_t)&py_image_orientation_radians_obj},
     {MP_OBJ_NEW_QSTR(MP_QSTR_orientation_degrees), (mp_obj_t)&py_image_orientation_degrees_obj},
+    /* Background Subtraction (Frame Differencing) functions */
+    {MP_OBJ_NEW_QSTR(MP_QSTR_negate),              (mp_obj_t)&py_image_negate_obj},
+    {MP_OBJ_NEW_QSTR(MP_QSTR_difference),          (mp_obj_t)&py_image_difference_obj},
 
     /* basic image functions */
     {MP_OBJ_NEW_QSTR(MP_QSTR_save),                (mp_obj_t)&py_image_save_obj},


### PR DESCRIPTION
The negate function gives you the ability to negate an image before
running difference on it. The difference function will subtract two images
from each other and return the abs() of the result.

I believe it would have been optimal to work on the RGB565 image in the
LAB color space. However, since we don't have an inverse LAB lut this is
not possible. If we could replace LAB with YUV then that would free up
space to have an inverse YUV table (YUV->RGB).