### PR TITLE
Update blob_detection example for the case there are no blobs

### DIFF
--- a/usr/examples/blob_detection.py
+++ b/usr/examples/blob_detection.py
@@ -25,7 +25,7 @@ while (True):
     binary.erode(3)
 
     # Detect blobs in image
-    blobs = binary.find_blobs()
+    blobs = binary.find_blobs() or ()
 
     led_r.off()
     led_g.off()


### PR DESCRIPTION
The image.find_blobs function now returns None when there are no blobs,
instead of an empty list. Since we can't iterate over a None, we need to
replace it with an empty tuple in that case.