### PR TITLE
Add BMP/PNM/JPEG image file loading and saving.

### DIFF
--- a/src/omv/ff_wrapper.c
+++ b/src/omv/ff_wrapper.c
@@ -6,52 +6,180 @@
  * File System Helper Functions
  *
  */
+#include <mp.h>
 #include "ff_wrapper.h"
 
-int read_byte(FIL *fp, uint8_t *value)
+extern const char *ffs_strerror(FRESULT res);
+
+NORETURN static void ff_fail(FIL *fp, FRESULT res)
 {
-    UINT bytes; FRESULT res = f_read(fp, value, sizeof(*value), &bytes);
-    return (bytes==sizeof(*value)) ? res : -1;
+    if (fp) f_close(fp);
+    nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, ffs_strerror(res)));
 }
 
-int read_word(FIL *fp, uint16_t *value)
+NORETURN static void ff_read_fail(FIL *fp)
 {
-    UINT bytes; FRESULT res = f_read(fp, value, sizeof(*value), &bytes);
-    return (bytes==sizeof(*value)) ? res : -1;
+    if (fp) f_close(fp);
+    nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "Failed to read requested bytes!"));
 }
 
-int read_long(FIL *fp, uint32_t *value)
+NORETURN static void ff_write_fail(FIL *fp)
 {
-    UINT bytes; FRESULT res = f_read(fp, value, sizeof(*value), &bytes);
-    return (bytes==sizeof(*value)) ? res : -1;
+    if (fp) f_close(fp);
+    nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "Failed to write requested bytes!"));
 }
 
-int read_data(FIL *fp, void *data, UINT size)
+NORETURN static void ff_expect_fail(FIL *fp)
 {
-    UINT bytes; FRESULT res = f_read(fp, data, size, &bytes);
-    return (bytes==size) ? res : -1;
+    if (fp) f_close(fp);
+    nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "Unexpected value read!"));
 }
 
-int write_byte(FIL *fp, uint8_t value)
+NORETURN void ff_unsupported_format(FIL *fp)
 {
-    UINT bytes; FRESULT res = f_write(fp, &value, sizeof(value), &bytes);
-    return (bytes==sizeof(value)) ? res : -1;
+    if (fp) f_close(fp);
+    nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "Unsupported format!"));
 }
 
-int write_word(FIL *fp, uint16_t value)
+NORETURN void ff_file_corrupted(FIL *fp)
 {
-    UINT bytes; FRESULT res = f_write(fp, &value, sizeof(value), &bytes);
-    return (bytes==sizeof(value)) ? res : -1;
+    if (fp) f_close(fp);
+    nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "File corrupted!"));
 }
 
-int write_long(FIL *fp, uint32_t value)
+NORETURN void ff_not_equal()
 {
-    UINT bytes; FRESULT res = f_write(fp, &value, sizeof(value), &bytes);
-    return (bytes==sizeof(value)) ? res : -1;
+    nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "Images not equal!"));
 }
 
-int write_data(FIL *fp, const void *data, UINT size)
+NORETURN void ff_no_intersection()
 {
-    UINT bytes; FRESULT res = f_write(fp, data, size, &bytes);
-    return (bytes==size) ? res : -1;
+    nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "No intersection!"));
+}
+
+void file_read_open(FIL *fp, const char *path)
+{
+    FRESULT res = f_open(fp, path, FA_READ|FA_OPEN_EXISTING);
+    if (res != FR_OK) ff_fail(fp, res);
+}
+
+void file_write_open(FIL *fp, const char *path)
+{
+    FRESULT res = f_open(fp, path, FA_WRITE|FA_CREATE_ALWAYS);
+    if (res != FR_OK) ff_fail(fp, res);
+}
+
+void file_close(FIL *fp)
+{
+    FRESULT res = f_close(fp);
+    if (res != FR_OK) ff_fail(fp, res);
+}
+
+void file_seek(FIL *fp, UINT offset)
+{
+    FRESULT res = f_lseek(fp, offset);
+    if (res != FR_OK) ff_fail(fp, res);
+}
+
+void read_byte(FIL *fp, uint8_t *value)
+{
+    UINT bytes;
+    FRESULT res = f_read(fp, value, sizeof(*value), &bytes);
+    if (res != FR_OK) ff_fail(fp, res);
+    if (bytes != sizeof(*value)) ff_read_fail(fp);
+}
+
+void read_byte_expect(FIL *fp, uint8_t value)
+{
+    uint8_t compare;
+    read_byte(fp, &compare);
+    if (value != compare) ff_expect_fail(fp);
+}
+
+void read_byte_ignore(FIL *fp)
+{
+    uint8_t trash;
+    read_byte(fp, &trash);
+}
+
+void read_word(FIL *fp, uint16_t *value)
+{
+    UINT bytes;
+    FRESULT res = f_read(fp, value, sizeof(*value), &bytes);
+    if (res != FR_OK) ff_fail(fp, res);
+    if (bytes != sizeof(*value)) ff_read_fail(fp);
+}
+
+void read_word_expect(FIL *fp, uint16_t value)
+{
+    uint16_t compare;
+    read_word(fp, &compare);
+    if (value != compare) ff_expect_fail(fp);
+}
+
+void read_word_ignore(FIL *fp)
+{
+    uint16_t trash;
+    read_word(fp, &trash);
+}
+
+void read_long(FIL *fp, uint32_t *value)
+{
+    UINT bytes;
+    FRESULT res = f_read(fp, value, sizeof(*value), &bytes);
+    if (res != FR_OK) ff_fail(fp, res);
+    if (bytes != sizeof(*value)) ff_read_fail(fp);
+}
+
+void read_long_expect(FIL *fp, uint32_t value)
+{
+    uint32_t compare;
+    read_long(fp, &compare);
+    if (value != compare) ff_expect_fail(fp);
+}
+
+void read_long_ignore(FIL *fp)
+{
+    uint32_t trash;
+    read_long(fp, &trash);
+}
+
+void read_data(FIL *fp, void *data, UINT size)
+{
+    UINT bytes;
+    FRESULT res = f_read(fp, data, size, &bytes);
+    if (res != FR_OK) ff_fail(fp, res);
+    if (bytes != size) ff_read_fail(fp);
+}
+
+void write_byte(FIL *fp, uint8_t value)
+{
+    UINT bytes;
+    FRESULT res = f_write(fp, &value, sizeof(value), &bytes);
+    if (res != FR_OK) ff_fail(fp, res);
+    if (bytes != sizeof(value)) ff_write_fail(fp);
+}
+
+void write_word(FIL *fp, uint16_t value)
+{
+    UINT bytes;
+    FRESULT res = f_write(fp, &value, sizeof(value), &bytes);
+    if (res != FR_OK) ff_fail(fp, res);
+    if (bytes != sizeof(value)) ff_write_fail(fp);
+}
+
+void write_long(FIL *fp, uint32_t value)
+{
+    UINT bytes;
+    FRESULT res = f_write(fp, &value, sizeof(value), &bytes);
+    if (res != FR_OK) ff_fail(fp, res);
+    if (bytes != sizeof(value)) ff_write_fail(fp);
+}
+
+void write_data(FIL *fp, const void *data, UINT size)
+{
+    UINT bytes;
+    FRESULT res = f_write(fp, data, size, &bytes);
+    if (res != FR_OK) ff_fail(fp, res);
+    if (bytes != size) ff_write_fail(fp);
 }

--- a/src/omv/ff_wrapper.h
+++ b/src/omv/ff_wrapper.h
@@ -10,72 +10,26 @@
 #define __FF_WRAPPER_H__
 #include <stdint.h>
 #include <ff.h>
-
-#define READ_BYTE(fp, value) \
-    ({ FRESULT _res = read_byte((fp), (value)); \
-       if (_res != FR_OK) { f_close((fp)); return _res; } })
-
-#define READ_BYTE_EXPECT(fp, value) \
-    ({ uint8_t comp; FRESULT _res = read_byte((fp), &comp); \
-       if (_res != FR_OK) { f_close((fp)); return _res; } \
-       if (comp != (value)) { f_close((fp)); return -1; } })
-
-#define READ_BYTE_IGNORE(fp) \
-    ({ uint8_t value; FRESULT _res = read_byte((fp), &value); \
-       if (_res != FR_OK) { f_close((fp)); return _res; } })
-
-#define READ_WORD(fp, value) \
-    ({ FRESULT _res = read_word((fp), (value)); \
-       if (_res != FR_OK) { f_close((fp)); return _res; } })
-
-#define READ_WORD_EXPECT(fp, value) \
-    ({ uint16_t comp; FRESULT _res = read_word((fp), &comp); \
-       if (_res != FR_OK) { f_close((fp)); return _res; } \
-       if (comp != (value)) { f_close((fp)); return -1; } })
-
-#define READ_WORD_IGNORE(fp) \
-    ({ uint16_t value; FRESULT _res = read_word((fp), &value); \
-       if (_res != FR_OK) { f_close((fp)); return _res; } })
-
-#define READ_LONG(fp, value) \
-    ({ FRESULT _res = read_long((fp), (value)); \
-       if (_res != FR_OK) { f_close((fp)); return _res; } })
-
-#define READ_LONG_EXPECT(fp, value) \
-    ({ uint32_t comp; FRESULT _res = read_long((fp), &comp); \
-       if (_res != FR_OK) { f_close((fp)); return _res; } \
-       if (comp != (value)) { f_close((fp)); return -1; } })
-
-#define READ_LONG_IGNORE(fp) \
-    ({ uint32_t value; FRESULT _res = read_long((fp), &value); \
-       if (_res != FR_OK) { f_close((fp)); return _res; } })
-
-#define READ_DATA(fp, data, size) \
-    ({ FRESULT _res = read_data((fp), (data), (size)); \
-       if (_res != FR_OK) { f_close((fp)); return _res; } })
-
-#define WRITE_BYTE(fp, value) \
-    ({ FRESULT _res = write_byte((fp), (value)); \
-       if (_res != FR_OK) { f_close((fp)); return _res; } })
-
-#define WRITE_WORD(fp, value) \
-    ({ FRESULT _res = write_word((fp), (value)); \
-       if (_res != FR_OK) { f_close((fp)); return _res; } })
-
-#define WRITE_LONG(fp, value) \
-    ({ FRESULT _res = write_long((fp), (value)); \
-       if (_res != FR_OK) { f_close((fp)); return _res; } })
-
-#define WRITE_DATA(fp, data, size) \
-    ({ FRESULT _res = write_data((fp), (data), (size)); \
-       if (_res != FR_OK) { f_close((fp)); return _res; } })
-
-int read_byte(FIL *fp, uint8_t *value);
-int read_word(FIL *fp, uint16_t *value);
-int read_long(FIL *fp, uint32_t *value);
-int read_data(FIL *fp, void *data, UINT size);
-int write_byte(FIL *fp, uint8_t value);
-int write_word(FIL *fp, uint16_t value);
-int write_long(FIL *fp, uint32_t value);
-int write_data(FIL *fp, const void *data, UINT size);
+void ff_unsupported_format(FIL *fp);
+void ff_file_corrupted(FIL *fp);
+void ff_not_equal();
+void ff_no_intersection();
+void file_read_open(FIL *fp, const char *path);
+void file_write_open(FIL *fp, const char *path);
+void file_close(FIL *fp);
+void file_seek(FIL *fp, UINT offset);
+void read_byte(FIL *fp, uint8_t *value);
+void read_byte_expect(FIL *fp, uint8_t value);
+void read_byte_ignore(FIL *fp);
+void read_word(FIL *fp, uint16_t *value);
+void read_word_expect(FIL *fp, uint16_t value);
+void read_word_ignore(FIL *fp);
+void read_long(FIL *fp, uint32_t *value);
+void read_long_expect(FIL *fp, uint32_t value);
+void read_long_ignore(FIL *fp);
+void read_data(FIL *fp, void *data, UINT size);
+void write_byte(FIL *fp, uint8_t value);
+void write_word(FIL *fp, uint16_t value);
+void write_long(FIL *fp, uint32_t value);
+void write_data(FIL *fp, const void *data, UINT size);
 #endif /* __FF_WRAPPER_H__ */

--- a/src/omv/img/bmp.c
+++ b/src/omv/img/bmp.c
@@ -13,138 +13,94 @@
 #include "xalloc.h"
 #include "imlib.h"
 
-// Store mode settings internally, no need for callers to store this info.
-static int32_t bmp_w;
-static int32_t bmp_h;
-static uint16_t bmp_bpp;
-static uint32_t bmp_fmt;
-static uint32_t bmp_row_bytes;
-
-// This function inits the geometry values of an image.
-int bmp_read_geometry(FIL *fp, image_t *img, const char *path,
-                      bool *w_flipped, bool *h_flipped)
+// This function inits the geometry values of an image (opens file).
+bool bmp_read_geometry(FIL *fp, image_t *img, const char *path, bmp_read_settings_t *rs)
 {
-    FRESULT res = f_open(fp, path, FA_READ|FA_OPEN_EXISTING);
-    if (res != FR_OK) {
-        return res;
-    }
+    file_read_open(fp, path);
+    read_byte_expect(fp, 'B');
+    read_byte_expect(fp, 'M');
 
-    READ_BYTE_EXPECT(fp, 'B');
-    READ_BYTE_EXPECT(fp, 'M');
     uint32_t file_size;
-    READ_LONG(fp, &file_size);
-    READ_LONG_IGNORE(fp);
-    READ_LONG_IGNORE(fp);
+    read_long(fp, &file_size);
+    read_long_ignore(fp);
+    read_long_ignore(fp);
 
     uint32_t header_size;
-    READ_LONG(fp, &header_size);
-    if (file_size <= header_size) {
-        f_close(fp);
-        return -1;
-    }
+    read_long(fp, &header_size);
+    if (file_size <= header_size) ff_file_corrupted(fp);
 
     uint32_t data_size = file_size - header_size;
-    if (data_size % 4) { // must be some number of dwords
-        f_close(fp);
-        return -1;
-    }
+    if (data_size % 4) ff_file_corrupted(fp);
 
-    READ_LONG_EXPECT(fp, 40);
-    READ_LONG(fp, (uint32_t*) &bmp_w);
-    READ_LONG(fp, (uint32_t*) &bmp_h);
-    if ((bmp_w == 0) || (bmp_h == 0)) {
-        f_close(fp);
-        return -1;
-    }
-    img->w = abs(bmp_w);
-    img->h = abs(bmp_h);
+    read_long_expect(fp, 40);
+    read_long(fp, (uint32_t*) &rs->bmp_w);
+    read_long(fp, (uint32_t*) &rs->bmp_h);
+    if ((rs->bmp_w == 0) || (rs->bmp_h == 0)) ff_file_corrupted(fp);
+    img->w = abs(rs->bmp_w);
+    img->h = abs(rs->bmp_h);
 
-    READ_WORD_EXPECT(fp, 1);
-    READ_WORD(fp, &bmp_bpp);
-    if ((bmp_bpp != 8) && (bmp_bpp != 16) && (bmp_bpp != 24)) {
-        f_close(fp);
-        return -1;
-    }
-    img->bpp = (bmp_bpp == 8) ? 1 : 2;
+    read_word_expect(fp, 1);
+    read_word(fp, &rs->bmp_bpp);
+    if ((rs->bmp_bpp != 8) && (rs->bmp_bpp != 16) && (rs->bmp_bpp != 24)) ff_unsupported_format(fp);
+    img->bpp = (rs->bmp_bpp == 8) ? 1 : 2;
 
-    READ_LONG(fp, &bmp_fmt);
-    if ((bmp_fmt != 0) && (bmp_fmt != 3)) {
-        f_close(fp);
-        return -1;
-    }
+    read_long(fp, &rs->bmp_fmt);
+    if ((rs->bmp_fmt != 0) && (rs->bmp_fmt != 3)) ff_unsupported_format(fp);
 
-    READ_LONG_EXPECT(fp, data_size);
-    READ_LONG_IGNORE(fp);
-    READ_LONG_IGNORE(fp);
-    READ_LONG_IGNORE(fp);
-    READ_LONG_IGNORE(fp);
+    read_long_expect(fp, data_size);
+    read_long_ignore(fp);
+    read_long_ignore(fp);
+    read_long_ignore(fp);
+    read_long_ignore(fp);
 
-    if (bmp_bpp == 8) {
-        if (bmp_fmt != 0) {
-            f_close(fp);
-            return -1;
-        }
+    if (rs->bmp_bpp == 8) {
+        if (rs->bmp_fmt != 0) ff_unsupported_format(fp);
         // Color Table (1024 bytes)
         for (int i = 0; i < 256; i++) {
-            READ_LONG_EXPECT(fp, ((i) << 16) | ((i) << 8) | i);
+            read_long_expect(fp, ((i) << 16) | ((i) << 8) | i);
         }
-    } else if (bmp_bpp == 16) {
-        if (bmp_fmt != 3) {
-            f_close(fp);
-            return -1;
-        }
+    } else if (rs->bmp_bpp == 16) {
+        if (rs->bmp_fmt != 3) ff_unsupported_format(fp);
         // Bit Masks (12 bytes)
-        READ_LONG_EXPECT(fp, 0x1F << 11);
-        READ_LONG_EXPECT(fp, 0x3F << 5);
-        READ_LONG_EXPECT(fp, 0x1F);
-    } else if (bmp_bpp == 24) {
-        if (bmp_fmt == 3) {
+        read_long_expect(fp, 0x1F << 11);
+        read_long_expect(fp, 0x3F << 5);
+        read_long_expect(fp, 0x1F);
+    } else if (rs->bmp_bpp == 24) {
+        if (rs->bmp_fmt == 3) {
             // Bit Masks (12 bytes)
-            READ_LONG_EXPECT(fp, 0xFF << 16);
-            READ_LONG_EXPECT(fp, 0xFF << 8);
-            READ_LONG_EXPECT(fp, 0xFF);
+            read_long_expect(fp, 0xFF << 16);
+            read_long_expect(fp, 0xFF << 8);
+            read_long_expect(fp, 0xFF);
         }
-
     }
 
-    bmp_row_bytes = (((img->w * bmp_bpp) + 31) / 32) * 4;
-    if (data_size != (bmp_row_bytes * img->h)) {
-        f_close(fp);
-        return -1;
-    }
-
-    if (w_flipped) {
-        *w_flipped = (bmp_w < 0); // Raster scan perspective
-    }
-    if (h_flipped) {
-        *h_flipped = (bmp_h >= 0); // Raster scan perspective
-    }
-
-    return FR_OK;
+    rs->bmp_row_bytes = (((img->w * rs->bmp_bpp) + 31) / 32) * 4;
+    if (data_size != (rs->bmp_row_bytes * img->h)) ff_file_corrupted(fp);
+    return (rs->bmp_h >= 0);
 }
 
 // This function reads the pixel values of an image.
-int bmp_read_pixels(FIL *fp, image_t *img, int line_start, int line_end)
+void bmp_read_pixels(FIL *fp, image_t *img, int line_start, int line_end, bmp_read_settings_t *rs)
 {
-    if (bmp_bpp == 8) {
-        if ((bmp_h < 0) && (bmp_w >= 0) && (img->w == bmp_row_bytes)) {
-            READ_DATA(fp, // Super Fast - Zoom, Zoom!
+    if (rs->bmp_bpp == 8) {
+        if ((rs->bmp_h < 0) && (rs->bmp_w >= 0) && (img->w == rs->bmp_row_bytes)) {
+            read_data(fp, // Super Fast - Zoom, Zoom!
                       img->pixels + (line_start * img->w),
                       (line_end - line_start + 1) * img->w);
         } else {
             for (int i = line_start; i < line_end; i++) {
-                for (int j = 0; j < bmp_row_bytes; j++) {
+                for (int j = 0; j < rs->bmp_row_bytes; j++) {
                     uint8_t pixel;
-                    READ_BYTE(fp, &pixel);
+                    read_byte(fp, &pixel);
                     if (j < img->w) {
-                        if (bmp_h < 0) { // vertical flip (BMP file perspective)
-                            if (bmp_w < 0) { // horizontal flip (BMP file perspective)
+                        if (rs->bmp_h < 0) { // vertical flip (BMP file perspective)
+                            if (rs->bmp_w < 0) { // horizontal flip (BMP file perspective)
                                 IM_SET_GS_PIXEL(img, (img->w-j-1), i, pixel);
                             } else {
                                 IM_SET_GS_PIXEL(img, j, i, pixel);
                             }
                         } else {
-                            if (bmp_w < 0) {
+                            if (rs->bmp_w < 0) {
                                 IM_SET_GS_PIXEL(img, (img->w-j-1), (img->h-i-1), pixel);
                             } else {
                                 IM_SET_GS_PIXEL(img, j, (img->h-i-1), pixel);
@@ -154,21 +110,21 @@ int bmp_read_pixels(FIL *fp, image_t *img, int line_start, int line_end)
                 }
             }
         }
-    } else if (bmp_bpp == 16) {
+    } else if (rs->bmp_bpp == 16) {
         for (int i = line_start; i < line_end; i++) {
-            for (int j = 0, jj = bmp_row_bytes / 2; j < jj; j++) {
+            for (int j = 0, jj = rs->bmp_row_bytes / 2; j < jj; j++) {
                 uint16_t pixel;
-                READ_WORD(fp, &pixel);
+                read_word(fp, &pixel);
                 IM_SWAP16(pixel);
                 if (j < img->w) {
-                    if (bmp_h < 0) { // vertical flip (BMP file perspective)
-                        if (bmp_w < 0) { // horizontal flip (BMP file perspective)
+                    if (rs->bmp_h < 0) { // vertical flip (BMP file perspective)
+                        if (rs->bmp_w < 0) { // horizontal flip (BMP file perspective)
                             IM_SET_RGB565_PIXEL(img, (img->w-j-1), i, pixel);
                         } else {
                             IM_SET_RGB565_PIXEL(img, j, i, pixel);
                         }
                     } else {
-                        if (bmp_w < 0) {
+                        if (rs->bmp_w < 0) {
                             IM_SET_RGB565_PIXEL(img, (img->w-j-1), (img->h-i-1), pixel);
                         } else {
                             IM_SET_RGB565_PIXEL(img, j, (img->h-i-1), pixel);
@@ -177,23 +133,23 @@ int bmp_read_pixels(FIL *fp, image_t *img, int line_start, int line_end)
                 }
             }
         }
-    } else if (bmp_bpp == 24) {
+    } else if (rs->bmp_bpp == 24) {
         for (int i = line_start; i < line_end; i++) {
-            for (int j = 0, jj = bmp_row_bytes / 3; j < jj; j++) {
+            for (int j = 0, jj = rs->bmp_row_bytes / 3; j < jj; j++) {
                 uint8_t r, g, b;
-                READ_BYTE(fp, &r);
-                READ_BYTE(fp, &g);
-                READ_BYTE(fp, &b);
+                read_byte(fp, &r);
+                read_byte(fp, &g);
+                read_byte(fp, &b);
                 uint16_t pixel = IM_RGB565(IM_R825(r), IM_G826(g), IM_B825(b));
                 if (j < img->w) {
-                    if (bmp_h < 0) { // vertical flip
-                        if (bmp_w < 0) { // horizontal flip
+                    if (rs->bmp_h < 0) { // vertical flip
+                        if (rs->bmp_w < 0) { // horizontal flip
                             IM_SET_RGB565_PIXEL(img, (img->w-j-1), i, pixel);
                         } else {
                             IM_SET_RGB565_PIXEL(img, j, i, pixel);
                         }
                     } else {
-                        if (bmp_w < 0) {
+                        if (rs->bmp_w < 0) {
                             IM_SET_RGB565_PIXEL(img, (img->w-j-1), (img->h-i-1), pixel);
                         } else {
                             IM_SET_RGB565_PIXEL(img, j, (img->h-i-1), pixel);
@@ -201,96 +157,66 @@ int bmp_read_pixels(FIL *fp, image_t *img, int line_start, int line_end)
                     }
                 }
             }
-            for (int j = 0, jj = bmp_row_bytes % 3; j < jj; j++) {
-                READ_BYTE_IGNORE(fp);
+            for (int j = 0, jj = rs->bmp_row_bytes % 3; j < jj; j++) {
+                read_byte_ignore(fp);
             }
         }
     }
-
-    return FR_OK;
 }
 
-static int bmp_read_int(image_t *img, const char *path)
+void bmp_read(image_t *img, const char *path)
 {
     FIL fp;
-
-    int res = bmp_read_geometry(&fp, img, path, NULL, NULL);
-    if (res != FR_OK) {
-        return res;
-    }
-
-    if (!img->pixels) { // don't allocate if already allocated...
-        img->pixels = xalloc(img->w * img->h * img->bpp);
-    }
-
-    res = bmp_read_pixels(&fp, img, 0, img->h);
-    if (res != FR_OK) {
-        return res;
-    }
-
-    return f_close(&fp);
+    bmp_read_settings_t rs;
+    bmp_read_geometry(&fp, img, path, &rs);
+    if (!img->pixels) img->pixels = xalloc(img->w * img->h * img->bpp);
+    bmp_read_pixels(&fp, img, 0, img->h, &rs);
+    file_close(&fp);
 }
 
-int bmp_read(image_t *img, const char *path)
-{
-    const uint8_t *backup = img->pixels;
-    const int res = bmp_read_int(img, path);
-    // free image if I didn't start with one...
-    if ((res != FR_OK) && (!backup) && (img->pixels)) {
-        xfree(img->pixels);
-    }
-    return res;
-}
-
-int bmp_write_subimg(image_t *img, const char *path, rectangle_t *r)
+void bmp_write_subimg(image_t *img, const char *path, rectangle_t *r)
 {
     rectangle_t rect;
-    if (!rectangle_subimg(img, r, &rect)) {
-        return -1; // no image intersection
-    }
-
+    if (!rectangle_subimg(img, r, &rect)) ff_no_intersection();
     FIL fp;
-    FRESULT res = f_open(&fp, path, FA_WRITE|FA_CREATE_ALWAYS);
-    if (res != FR_OK) {
-        return res;
-    }
+    file_write_open(&fp, path);
 
     if (IM_IS_GS(img)) {
         const int row_bytes = (((rect.w * 8) + 31) / 32) * 4;
         const int data_size = (row_bytes * rect.h);
         const int waste = (row_bytes / sizeof(uint8_t)) - rect.w;
         // File Header (14 bytes)
-        WRITE_BYTE(&fp, 'B');
-        WRITE_BYTE(&fp, 'M');
-        WRITE_LONG(&fp, 14 + 40 + 1024 + data_size);
-        WRITE_WORD(&fp, 0);
-        WRITE_WORD(&fp, 0);
-        WRITE_LONG(&fp, 14 + 40 + 1024);
+        write_byte(&fp, 'B');
+        write_byte(&fp, 'M');
+        write_long(&fp, 14 + 40 + 1024 + data_size);
+        write_word(&fp, 0);
+        write_word(&fp, 0);
+        write_long(&fp, 14 + 40 + 1024);
         // Info Header (40 bytes)
-        WRITE_LONG(&fp, 40);
-        WRITE_LONG(&fp, rect.w);
-        WRITE_LONG(&fp, -rect.h); // store the image flipped (correctly)
-        WRITE_WORD(&fp, 1);
-        WRITE_WORD(&fp, 8);
-        WRITE_LONG(&fp, 0);
-        WRITE_LONG(&fp, data_size);
-        WRITE_LONG(&fp, 0);
-        WRITE_LONG(&fp, 0);
-        WRITE_LONG(&fp, 0);
-        WRITE_LONG(&fp, 0);
+        write_long(&fp, 40);
+        write_long(&fp, rect.w);
+        write_long(&fp, -rect.h); // store the image flipped (correctly)
+        write_word(&fp, 1);
+        write_word(&fp, 8);
+        write_long(&fp, 0);
+        write_long(&fp, data_size);
+        write_long(&fp, 0);
+        write_long(&fp, 0);
+        write_long(&fp, 0);
+        write_long(&fp, 0);
         // Color Table (1024 bytes)
         for (int i = 0; i < 256; i++) {
-            WRITE_LONG(&fp, ((i) << 16) | ((i) << 8) | i);
+            write_long(&fp, ((i) << 16) | ((i) << 8) | i);
         }
         if ((rect.x == 0) && (rect.w == img->w) && (img->w == row_bytes)) {
-            WRITE_DATA(&fp, // Super Fast - Zoom, Zoom!
+            write_data(&fp, // Super Fast - Zoom, Zoom!
                        img->pixels + (rect.y * img->w),
                        rect.w * rect.h);
         } else {
             for (int i = 0; i < rect.h; i++) {
-                WRITE_DATA(&fp, img->pixels+((rect.y+i)*img->w)+rect.x, rect.w);
+                write_data(&fp, img->pixels+((rect.y+i)*img->w)+rect.x, rect.w);
                 for (int j = 0; j < waste; j++) {
-                    WRITE_BYTE(&fp, 0);
+                    write_byte(&fp, 0);
                 }
             }
         }
@@ -299,37 +225,37 @@ int bmp_write_subimg(image_t *img, const char *path, rectangle_t *r)
         const int data_size = (row_bytes * rect.h);
         const int waste = (row_bytes / sizeof(uint16_t)) - rect.w;
         // File Header (14 bytes)
-        WRITE_BYTE(&fp, 'B');
-        WRITE_BYTE(&fp, 'M');
-        WRITE_LONG(&fp, 14 + 40 + 12 + data_size);
-        WRITE_WORD(&fp, 0);
-        WRITE_WORD(&fp, 0);
-        WRITE_LONG(&fp, 14 + 40 + 12);
+        write_byte(&fp, 'B');
+        write_byte(&fp, 'M');
+        write_long(&fp, 14 + 40 + 12 + data_size);
+        write_word(&fp, 0);
+        write_word(&fp, 0);
+        write_long(&fp, 14 + 40 + 12);
         // Info Header (40 bytes)
-        WRITE_LONG(&fp, 40);
-        WRITE_LONG(&fp, rect.w);
-        WRITE_LONG(&fp, -rect.h); // store the image flipped (correctly)
-        WRITE_WORD(&fp, 1);
-        WRITE_WORD(&fp, 16);
-        WRITE_LONG(&fp, 3);
-        WRITE_LONG(&fp, data_size);
-        WRITE_LONG(&fp, 0);
-        WRITE_LONG(&fp, 0);
-        WRITE_LONG(&fp, 0);
-        WRITE_LONG(&fp, 0);
+        write_long(&fp, 40);
+        write_long(&fp, rect.w);
+        write_long(&fp, -rect.h); // store the image flipped (correctly)
+        write_word(&fp, 1);
+        write_word(&fp, 16);
+        write_long(&fp, 3);
+        write_long(&fp, data_size);
+        write_long(&fp, 0);
+        write_long(&fp, 0);
+        write_long(&fp, 0);
+        write_long(&fp, 0);
         // Bit Masks (12 bytes)
-        WRITE_LONG(&fp, 0x1F << 11);
-        WRITE_LONG(&fp, 0x3F << 5);
-        WRITE_LONG(&fp, 0x1F);
+        write_long(&fp, 0x1F << 11);
+        write_long(&fp, 0x3F << 5);
+        write_long(&fp, 0x1F);
         for (int i = 0; i < rect.h; i++) {
             for (int j = 0; j < rect.w; j++) {
-                WRITE_WORD(&fp, IM_SWAP16(IM_GET_RGB565_PIXEL(img, (rect.x + j), (rect.y + i))));
+                write_word(&fp, IM_SWAP16(IM_GET_RGB565_PIXEL(img, (rect.x + j), (rect.y + i))));
             }
             for (int j = 0; j < waste; j++) {
-                WRITE_WORD(&fp, 0);
+                write_word(&fp, 0);
             }
         }
     }
 
-    return f_close(&fp);
+    file_close(&fp);
 }

--- a/src/omv/img/imlib.h
+++ b/src/omv/img/imlib.h
@@ -281,25 +281,51 @@ typedef enum interp {
     INTERP_BICUBIC
 } interp_t;
 
+typedef struct bmp_read_settings {
+    int32_t bmp_w;
+    int32_t bmp_h;
+    uint16_t bmp_bpp;
+    uint32_t bmp_fmt;
+    uint32_t bmp_row_bytes;
+} bmp_read_settings_t;
+
+typedef struct ppm_read_settings {
+    uint8_t read_int_c;
+    bool read_int_c_valid;
+    uint8_t ppm_fmt;
+} ppm_read_settings_t;
+
+typedef enum save_image_format {
+    FORMAT_BMP,
+    FORMAT_PNM
+} save_image_format_t;
+
+typedef struct img_read_settings {
+    union
+    {
+        bmp_read_settings_t bmp_rs;
+        ppm_read_settings_t ppm_rs;
+    };
+    save_image_format_t format;
+} img_read_settings_t;
+
 /* Image file functions */
-int ppm_read_geometry(FIL *fp, image_t *img, const char *path);
-int ppm_read_pixels(FIL *fp, image_t *img, int line_start, int line_end);
-int ppm_read(image_t *img, const char *path);
-int ppm_write_subimg(image_t *img, const char *path, rectangle_t *r);
-int bmp_read_geometry(FIL *fp, image_t *img, const char *path,
-                      bool *w_flipped, bool *h_flipped);
-int bmp_read_pixels(FIL *fp, image_t *img, int line_start, int line_end);
-int bmp_read(image_t *img, const char *path);
-int bmp_write_subimg(image_t *img, const char *path, rectangle_t *r);
-int jpeg_read_geometry(FIL *fp, image_t *img, const char *path);
-int jpeg_read_pixels(FIL *fp, image_t *img);
-int jpeg_read(image_t *img, const char *path);
-int jpeg_write(image_t *img, const char *path);
-int imlib_read_geometry(FIL *fp, image_t *img, const char *path,
-                        bool *w_flipped, bool *h_flipped, bool disable_jpeg);
-int imlib_read_pixels(FIL *fp, image_t *img, int line_start, int line_end);
-int imlib_load_image(image_t *image, const char *path);
-int imlib_save_image(image_t *image, const char *path, rectangle_t *roi);
+void ppm_read_geometry(FIL *fp, image_t *img, const char *path, ppm_read_settings_t *rs);
+void ppm_read_pixels(FIL *fp, image_t *img, int line_start, int line_end, ppm_read_settings_t *rs);
+void ppm_read(image_t *img, const char *path);
+void ppm_write_subimg(image_t *img, const char *path, rectangle_t *r);
+bool bmp_read_geometry(FIL *fp, image_t *img, const char *path, bmp_read_settings_t *rs);
+void bmp_read_pixels(FIL *fp, image_t *img, int line_start, int line_end, bmp_read_settings_t *rs);
+void bmp_read(image_t *img, const char *path);
+void bmp_write_subimg(image_t *img, const char *path, rectangle_t *r);
+void jpeg_read_geometry(FIL *fp, image_t *img, const char *path);
+void jpeg_read_pixels(FIL *fp, image_t *img);
+void jpeg_read(image_t *img, const char *path);
+void jpeg_write(image_t *img, const char *path);
+bool imlib_read_geometry(FIL *fp, image_t *img, const char *path, img_read_settings_t *rs);
+void imlib_read_pixels(FIL *fp, image_t *img, int line_start, int line_end, img_read_settings_t *rs);
+void imlib_load_image(image_t *img, const char *path);
+void imlib_save_image(image_t *img, const char *path, rectangle_t *roi, save_image_format_t format);
 
 /* Basic image functions */
 int imlib_get_pixel(image_t *img, int x, int y);

--- a/src/omv/usbdbg.c
+++ b/src/omv/usbdbg.c
@@ -162,16 +162,13 @@ void usbdbg_data_out(void *buffer, int length)
             };
 
             // null terminate the path
-            length = (length == 64) ? 63:length; 
+            length = (length == 64) ? 63:length;
             ((char*)buffer)[length] = 0;
 
             rectangle_t *roi = (rectangle_t*)buffer;
             char *path = (char*)buffer+sizeof(rectangle_t);
 
-            int res=imlib_save_image(&image, path, roi);
-            if (res != FR_OK) {
-                nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, ffs_strerror(res)));
-            }
+            imlib_save_image(&image, path, roi, FORMAT_PNM);
             // raise a flash IRQ to flush image
             //NVIC->STIR = FLASH_IRQn;
             break;
@@ -186,7 +183,7 @@ void usbdbg_data_out(void *buffer, int length)
             };
 
             // null terminate the path
-            length = (length == 64) ? 63:length; 
+            length = (length == 64) ? 63:length;
             ((char*)buffer)[length] = 0;
 
             rectangle_t *roi = (rectangle_t*)buffer;


### PR DESCRIPTION
There's not a lot of actual functionality changes from the last commit.
However, switching the basic wrapper library to just long_jump on
failure and moving all the state info to structs required changes to all
the base functions in the last commit. The rest of the changes are to
link in the new functionality and to get the code to compile (usbdbg.c
edits). GitHub's diff makes the changes look 2X longer.

Next I'll work on a function which abstracts the problem of opening an
image up and executing a line by line function op on it. I already
worked the code out for that. But, it's not in this commit to keep
things streamlined.