### PR TITLE
Fixed save image.

### DIFF
--- a/src/omv/img/imlib.h
+++ b/src/omv/img/imlib.h
@@ -296,8 +296,10 @@ typedef struct ppm_read_settings {
 } ppm_read_settings_t;
 
 typedef enum save_image_format {
+    FORMAT_DONT_CARE,
     FORMAT_BMP,
-    FORMAT_PNM
+    FORMAT_PNM,
+    FORMAT_JPG
 } save_image_format_t;
 
 typedef struct img_read_settings {
@@ -322,10 +324,8 @@ void jpeg_read_geometry(FIL *fp, image_t *img, const char *path);
 void jpeg_read_pixels(FIL *fp, image_t *img);
 void jpeg_read(image_t *img, const char *path);
 void jpeg_write(image_t *img, const char *path);
-bool imlib_read_geometry(FIL *fp, image_t *img, const char *path, img_read_settings_t *rs);
-void imlib_read_pixels(FIL *fp, image_t *img, int line_start, int line_end, img_read_settings_t *rs);
 void imlib_load_image(image_t *img, const char *path);
-void imlib_save_image(image_t *img, const char *path, rectangle_t *roi, save_image_format_t format);
+void imlib_save_image(image_t *img, const char *path, rectangle_t *roi);
 
 /* Basic image functions */
 int imlib_get_pixel(image_t *img, int x, int y);

--- a/src/omv/mdefs.h
+++ b/src/omv/mdefs.h
@@ -17,3 +17,7 @@
 #ifndef DISABLE_OPT
 #define DISABLE_OPT __attribute__((optimize("O0")))
 #endif
+
+#ifndef PRINT_LINE
+#define PRINT_LINE printf("%s:%d\n", __FILE__, __LINE__)
+#endif

--- a/src/omv/py/py_image.c
+++ b/src/omv/py/py_image.c
@@ -164,9 +164,7 @@ static mp_obj_t py_image_save(uint n_args, const mp_obj_t *args, mp_map_t *kw_ar
     rectangle_t roi;
     py_helper_lookup_rectangle(kw_args, arg_img, &roi);
 
-    imlib_save_image(arg_img, path, &roi,
-            py_helper_lookup_int(kw_args,
-            MP_OBJ_NEW_QSTR(MP_QSTR_format), FORMAT_BMP));
+    imlib_save_image(arg_img, path, &roi);
     return mp_const_true;
 }
 
@@ -1202,8 +1200,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(py_image_match_keypoints_obj, 4, 4, p
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_image_match_lbp_obj, 2, py_image_match_lbp);
 
 static const mp_map_elem_t locals_dict_table[] = {
-    {MP_OBJ_NEW_QSTR(MP_QSTR_FORMAT_BMP),          MP_OBJ_NEW_SMALL_INT(FORMAT_BMP)},
-    {MP_OBJ_NEW_QSTR(MP_QSTR_FORMAT_PNM),          MP_OBJ_NEW_SMALL_INT(FORMAT_PNM)},
     /* Image file functions */
     {MP_OBJ_NEW_QSTR(MP_QSTR_save),                (mp_obj_t)&py_image_save_obj},
     /* Basic image functions */

--- a/src/omv/usbdbg.c
+++ b/src/omv/usbdbg.c
@@ -168,7 +168,7 @@ void usbdbg_data_out(void *buffer, int length)
             rectangle_t *roi = (rectangle_t*)buffer;
             char *path = (char*)buffer+sizeof(rectangle_t);
 
-            imlib_save_image(&image, path, roi, FORMAT_PNM);
+            imlib_save_image(&image, path, roi);
             // raise a flash IRQ to flush image
             //NVIC->STIR = FLASH_IRQn;
             break;

--- a/usr/tests/test_save.py
+++ b/usr/tests/test_save.py
@@ -1,0 +1,111 @@
+import pyb, sensor, image, os, time
+sensor.reset()
+sensor.set_framesize(sensor.QVGA)
+if not "test" in os.listdir(): os.mkdir("test")
+while(True):
+    sensor.set_pixformat(sensor.GRAYSCALE)
+    for i in range(2):
+        img = sensor.snapshot()
+        num = pyb.rng()
+        print("Saving %d" % num)
+        img.save("test/image-%d" % num)
+        #
+        img = sensor.snapshot()
+        num = pyb.rng()
+        print("Saving %d" % num)
+        img.save("test/image-%d.bmp" % num)
+        #
+        img = sensor.snapshot()
+        num = pyb.rng()
+        print("Saving %d" % num)
+        img.save("test/image-%d.pgm" % num)
+        #
+        img = sensor.snapshot()
+        num = pyb.rng()
+        print("Saving %d" % num)
+        img.save("/test/image-%d" % num)
+        #
+        img = sensor.snapshot()
+        num = pyb.rng()
+        print("Saving %d" % num)
+        img.save("/test/image-%d.bmp" % num)
+        #
+        img = sensor.snapshot()
+        num = pyb.rng()
+        print("Saving %d" % num)
+        img.save("/test/image-%d.pgm" % num)
+        #
+    sensor.set_pixformat(sensor.RGB565)
+    for i in range(2):
+        img = sensor.snapshot()
+        num = pyb.rng()
+        print("Saving %d" % num)
+        img.save("test/image-%d" % num)
+        #
+        img = sensor.snapshot()
+        num = pyb.rng()
+        print("Saving %d" % num)
+        img.save("test/image-%d.bmp" % num)
+        #
+        img = sensor.snapshot()
+        num = pyb.rng()
+        print("Saving %d" % num)
+        img.save("test/image-%d.ppm" % num)
+        #
+        img = sensor.snapshot()
+        num = pyb.rng()
+        print("Saving %d" % num)
+        img.save("/test/image-%d" % num)
+        #
+        img = sensor.snapshot()
+        num = pyb.rng()
+        print("Saving %d" % num)
+        img.save("/test/image-%d.bmp" % num)
+        #
+        img = sensor.snapshot()
+        num = pyb.rng()
+        print("Saving %d" % num)
+        img.save("/test/image-%d.ppm" % num)
+        #
+    sensor.set_pixformat(sensor.JPEG)
+    for i in range(2):
+        img = sensor.snapshot()
+        num = pyb.rng()
+        print("Saving %d" % num)
+        img.save("test/image-%d" % num)
+        #
+        img = sensor.snapshot()
+        num = pyb.rng()
+        print("Saving %d" % num)
+        img.save("test/image-%d.jpg" % num)
+        #
+        img = sensor.snapshot()
+        num = pyb.rng()
+        print("Saving %d" % num)
+        img.save("test/image-%d.jpeg" % num)
+        #
+        img = sensor.snapshot()
+        num = pyb.rng()
+        print("Saving %d" % num)
+        img.save("/test/image-%d" % num)
+        #
+        img = sensor.snapshot()
+        num = pyb.rng()
+        print("Saving %d" % num)
+        img.save("/test/image-%d.jpg" % num)
+        #
+        img = sensor.snapshot()
+        num = pyb.rng()
+        print("Saving %d" % num)
+        img.save("/test/image-%d.jpeg" % num)
+        #
+    print("Sleeping 5...")
+    time.sleep(1000)
+    print("Sleeping 4...")
+    time.sleep(1000)
+    print("Sleeping 3...")
+    time.sleep(1000)
+    print("Sleeping 2...")
+    time.sleep(1000)
+    print("Sleeping 1...")
+    time.sleep(1000)


### PR DESCRIPTION
It now figures out the file type from the file extension. If no file
extension is given it just saves the file as BMP if its not a JPEG image
or JPEG if it's a JPEG image. If you specify an extension and the file is
not of that type then it will give you an error.

The new test_save.py should run until you reach the JPEG image part
where it quits due to lack of JPEG support natively on OV7725 boards.
Maybe JPEG mode should be supported by just compressing pictures?