### PR TITLE
Dilate and errode working.

### DIFF
--- a/src/omv/img/imlib.h
+++ b/src/omv/img/imlib.h
@@ -146,6 +146,36 @@ extern const uint8_t g826_table[256];
        __typeof__ (img1) _img1 = (img1); \
        (_img0->w==_img1->w)&&(_img0->h==_img1->h)&&(_img0->bpp==_img1->bpp); })
 
+// Main Ram = 196,608 bytes
+// -
+// struct framebuffer = 20 bytes
+// FB_JPEG_OFFS_SIZE = 1,024 bytes
+// GRAYSCALE 320x240x1 image = 76,800 bytes
+// fb_alloc = 4 bytes
+// flash cache = 16,384 bytes
+// =
+// 102,376 bytes
+// /
+// GRAYSCALE 320x1 lines
+// =
+// 319 GRAYSCALE 320x1 lines
+#define GS_LINE_BUFFER_SIZE (64) // double rgb565
+
+// Main Ram = 196,608 bytes
+// -
+// struct framebuffer = 20 bytes
+// FB_JPEG_OFFS_SIZE = 1,024 bytes
+// RGB565 320x240x2 image = 153,600 bytes
+// fb_alloc = 4 bytes
+// flash cache = 16,384 bytes
+// =
+// 25,576 bytes
+// /
+// RGB565 320x2 lines
+// =
+// 39 RGB565 320x2 lines
+#define RGB565_LINE_BUFFER_SIZE (32)
+
 typedef struct size {
     int w;
     int h;
@@ -370,6 +400,8 @@ int imlib_pixels(image_t *img, rectangle_t *r);
 int imlib_centroid(image_t *img, int *x_center, int *y_center, rectangle_t *r);
 float imlib_orientation_radians(image_t *img, int *sum, int *x_center, int *y_center, rectangle_t *r);
 float imlib_orientation_degrees(image_t *img, int *sum, int *x_center, int *y_center, rectangle_t *r);
+void imlib_erode(image_t *img, int ksize, int threshold);
+void imlib_dilate(image_t *img, int ksize, int threshold);
 
 /* Background Subtraction (Frame Differencing) functions */
 void imlib_negate(image_t *img);
@@ -391,8 +423,6 @@ void imlib_rgb_to_hsv(struct color *rgb, struct color *hsv);
 int  imlib_image_mean(struct image *src);
 void imlib_histeq(struct image *src);
 void imlib_median_filter(image_t *src, int r);
-void imlib_erode(image_t *src, int ksize);
-void imlib_dilate(image_t *src, int ksize);
 void imlib_threshold(image_t *src, image_t *dst, color_t *color, int color_size, int threshold);
 void imlib_rainbow(image_t *src, struct image *dst);
 array_t *imlib_count_blobs(struct image *image);

--- a/usr/tests/test_erode_and_dilate.py
+++ b/usr/tests/test_erode_and_dilate.py
@@ -1,0 +1,24 @@
+import pyb, sensor, image, math
+sensor.reset()
+sensor.set_framesize(sensor.QVGA)
+grayscale_thres = (170, 255)
+rgb565_thres = (70, 100, -128, 127, -128, 127)
+while(True):
+    sensor.set_pixformat(sensor.GRAYSCALE)
+    for i in range(100):
+        img = sensor.snapshot()
+        img.binary([grayscale_thres])
+        img.erode(2)
+    for i in range(100):
+        img = sensor.snapshot()
+        img.binary([grayscale_thres])
+        img.dilate(2)
+    sensor.set_pixformat(sensor.RGB565)
+    for i in range(100):
+        img = sensor.snapshot()
+        img.binary([rgb565_thres])
+        img.erode(2)
+    for i in range(100):
+        img = sensor.snapshot()
+        img.binary([rgb565_thres])
+        img.dilate(2)


### PR DESCRIPTION
The old code did not actually implement the erode and dilate kernels
correctly. However, it might have been a little faster because it avoided
the boundary problem.

In the future we can optimize all the kernel code to have different loops
for doing the edges of image versus the center. But, for now, this is
good enough. QVGA color tracking with kernels will be slow, but, the
speed can be improved with QQVGA resolution. Using a 3x3 kernel is
plenty fast. Larger ones are slower.

I also added the ability for you to set the threshold for erode and
dilate. This lets you make the kernel a little bit smarter so that it
won't erode or dilate a pixel unless the threshold is met. Meaning,
you'll be able to use erode to erode an image down to 1 pixel wide
lines.