### PR TITLE
Updated code to use fb_alloc.

### DIFF
--- a/src/omv/ff_wrapper.c
+++ b/src/omv/ff_wrapper.c
@@ -7,7 +7,10 @@
  *
  */
 #include <mp.h>
+#include "mdefs.h"
+#include "fb_alloc.h"
 #include "ff_wrapper.h"
+#define FF_MIN(x,y) (((x)<(y))?(x):(y))
 
 extern const char *ffs_strerror(FRESULT res);
 
@@ -83,6 +86,56 @@ void file_seek(FIL *fp, UINT offset)
     if (res != FR_OK) ff_fail(fp, res);
 }
 
+// When a sector boundary is encountered while writing a file and there are
+// more than 512 bytes left to write FatFs will detect that it can bypass
+// its internal write buffer and pass the data buffer passed to it directly
+// to the disk write function. However, the disk write function needs the
+// buffer to be aligned to a 4-byte boundary. FatFs doesn't know this and
+// will pass an unaligned buffer if we don't fix the issue. To fix this problem
+// we use a temporary buffer to fix the alignment and to speed everything up.
+
+static uint32_t file_buffer_offset = 0;
+static uint8_t *file_buffer_pointer = 0;
+static uint32_t file_buffer_size = 0;
+static uint32_t file_buffer_index = 0;
+
+ALWAYS_INLINE static void file_flush(FIL *fp)
+{
+    if (file_buffer_index == file_buffer_size) {
+        UINT bytes;
+        FRESULT res = f_write(fp, file_buffer_pointer, file_buffer_index, &bytes);
+        if (res != FR_OK) ff_fail(fp, res);
+        if (bytes != file_buffer_index) ff_write_fail(fp);
+        file_buffer_pointer -= file_buffer_offset;
+        file_buffer_size += file_buffer_offset;
+        file_buffer_offset = 0;
+        file_buffer_index = 0;
+    }
+}
+
+void file_buffer_on(FIL *fp)
+{
+    file_buffer_offset = f_tell(fp) % 4;
+    file_buffer_pointer = fb_alloc_all(&file_buffer_size) + file_buffer_offset;
+    if (!file_buffer_size) {
+        nlr_raise(mp_obj_new_exception_msg(&mp_type_MemoryError, "No memory!"));
+    }
+    file_buffer_size -= file_buffer_offset;
+    file_buffer_index = 0;
+}
+
+void file_buffer_off(FIL *fp)
+{
+    if ((fp->flag & FA_WRITE) && file_buffer_index) {
+        UINT bytes;
+        FRESULT res = f_write(fp, file_buffer_pointer, file_buffer_index, &bytes);
+        if (res != FR_OK) ff_fail(fp, res);
+        if (bytes != file_buffer_index) ff_write_fail(fp);
+    }
+    file_buffer_pointer = 0;
+    fb_free();
+}
+
 void read_byte(FIL *fp, uint8_t *value)
 {
     UINT bytes;
@@ -156,32 +209,75 @@ void read_data(FIL *fp, void *data, UINT size)
 
 void write_byte(FIL *fp, uint8_t value)
 {
-    UINT bytes;
-    FRESULT res = f_write(fp, &value, sizeof(value), &bytes);
-    if (res != FR_OK) ff_fail(fp, res);
-    if (bytes != sizeof(value)) ff_write_fail(fp);
+    if (file_buffer_pointer) {
+        // We get a massive speed boost by buffering up as much data as possible
+        // before a write to the SD card. So much so that the time wasted by
+        // all these operations does not cost us.
+        for (int i = 0; i < sizeof(value); i++) {
+            file_buffer_pointer[file_buffer_index++] = ((uint8_t *) &value)[i];
+            file_flush(fp);
+        }
+    } else {
+        UINT bytes;
+        FRESULT res = f_write(fp, &value, sizeof(value), &bytes);
+        if (res != FR_OK) ff_fail(fp, res);
+        if (bytes != sizeof(value)) ff_write_fail(fp);
+    }
 }
 
 void write_word(FIL *fp, uint16_t value)
 {
-    UINT bytes;
-    FRESULT res = f_write(fp, &value, sizeof(value), &bytes);
-    if (res != FR_OK) ff_fail(fp, res);
-    if (bytes != sizeof(value)) ff_write_fail(fp);
+    if (file_buffer_pointer) {
+        // We get a massive speed boost by buffering up as much data as possible
+        // before a write to the SD card. So much so that the time wasted by
+        // all these operations does not cost us.
+        for (int i = 0; i < sizeof(value); i++) {
+            file_buffer_pointer[file_buffer_index++] = ((uint8_t *) &value)[i];
+            file_flush(fp);
+        }
+    } else {
+        UINT bytes;
+        FRESULT res = f_write(fp, &value, sizeof(value), &bytes);
+        if (res != FR_OK) ff_fail(fp, res);
+        if (bytes != sizeof(value)) ff_write_fail(fp);
+    }
 }
 
 void write_long(FIL *fp, uint32_t value)
 {
-    UINT bytes;
-    FRESULT res = f_write(fp, &value, sizeof(value), &bytes);
-    if (res != FR_OK) ff_fail(fp, res);
-    if (bytes != sizeof(value)) ff_write_fail(fp);
+    if (file_buffer_pointer) {
+        // We get a massive speed boost by buffering up as much data as possible
+        // before a write to the SD card. So much so that the time wasted by
+        // all these operations does not cost us.
+        for (int i = 0; i < sizeof(value); i++) {
+            file_buffer_pointer[file_buffer_index++] = ((uint8_t *) &value)[i];
+            file_flush(fp);
+        }
+    } else {
+        UINT bytes;
+        FRESULT res = f_write(fp, &value, sizeof(value), &bytes);
+        if (res != FR_OK) ff_fail(fp, res);
+        if (bytes != sizeof(value)) ff_write_fail(fp);
+    }
 }
 
 void write_data(FIL *fp, const void *data, UINT size)
 {
-    UINT bytes;
-    FRESULT res = f_write(fp, data, size, &bytes);
-    if (res != FR_OK) ff_fail(fp, res);
-    if (bytes != size) ff_write_fail(fp);
+    if (file_buffer_pointer) {
+        // We get a massive speed boost by buffering up as much data as possible
+        // before a write to the SD card. So much so that the time wasted by
+        // all these operations does not cost us.
+        for (int i = 0; i < size;) {
+            int can_do = FF_MIN(size, file_buffer_size - file_buffer_index);
+            memcpy(file_buffer_pointer+file_buffer_index, ((uint8_t *) data)+i, can_do);
+            file_buffer_index += can_do;
+            file_flush(fp);
+            i += can_do;
+        }
+    } else {
+        UINT bytes;
+        FRESULT res = f_write(fp, data, size, &bytes);
+        if (res != FR_OK) ff_fail(fp, res);
+        if (bytes != size) ff_write_fail(fp);
+    }
 }

--- a/src/omv/ff_wrapper.h
+++ b/src/omv/ff_wrapper.h
@@ -18,6 +18,8 @@ void file_read_open(FIL *fp, const char *path);
 void file_write_open(FIL *fp, const char *path);
 void file_close(FIL *fp);
 void file_seek(FIL *fp, UINT offset);
+void file_buffer_on(FIL *fp); // does fb_alloc_all
+void file_buffer_off(FIL *fp); // does fb_free
 void read_byte(FIL *fp, uint8_t *value);
 void read_byte_expect(FIL *fp, uint8_t value);
 void read_byte_ignore(FIL *fp);

--- a/src/omv/img/bmp.c
+++ b/src/omv/img/bmp.c
@@ -181,6 +181,7 @@ void bmp_write_subimg(image_t *img, const char *path, rectangle_t *r)
     FIL fp;
     file_write_open(&fp, path);
 
+    file_buffer_on(&fp);
     if (IM_IS_GS(img)) {
         const int row_bytes = (((rect.w * 8) + 31) / 32) * 4;
         const int data_size = (row_bytes * rect.h);
@@ -256,6 +257,7 @@ void bmp_write_subimg(image_t *img, const char *path, rectangle_t *r)
             }
         }
     }
+    file_buffer_off(&fp);
 
     file_close(&fp);
 }

--- a/src/omv/img/imlib.h
+++ b/src/omv/img/imlib.h
@@ -175,36 +175,6 @@ extern const int8_t lab_table[196608];
 
 #define IM_JPEG_QUALITY (50)
 
-// Main Ram = 196,608 bytes
-// -
-// struct framebuffer = 20 bytes
-// FB_JPEG_OFFS_SIZE = 1,024 bytes
-// GRAYSCALE 320x240x1 image = 76,800 bytes
-// fb_alloc = 4 bytes
-// flash cache = 16,384 bytes
-// =
-// 102,376 bytes
-// /
-// GRAYSCALE 320x1 lines
-// =
-// 319 GRAYSCALE 320x1 lines
-#define GS_LINE_BUFFER_SIZE (64) // double rgb565
-
-// Main Ram = 196,608 bytes
-// -
-// struct framebuffer = 20 bytes
-// FB_JPEG_OFFS_SIZE = 1,024 bytes
-// RGB565 320x240x2 image = 153,600 bytes
-// fb_alloc = 4 bytes
-// flash cache = 16,384 bytes
-// =
-// 25,576 bytes
-// /
-// RGB565 320x2 lines
-// =
-// 39 RGB565 320x2 lines
-#define RGB565_LINE_BUFFER_SIZE (32)
-
 typedef struct size {
     int w;
     int h;

--- a/src/omv/img/mjpeg.c
+++ b/src/omv/img/mjpeg.c
@@ -6,9 +6,9 @@
  * A super simple MJPEG encoder.
  *
  */
+#include "fb_alloc.h"
 #include "ff_wrapper.h"
 #include "imlib.h"
-#include "fb_alloc.h"
 
 #define SIZE_OFFSET             (1*4)
 #define MICROS_OFFSET           (8*4)

--- a/src/omv/img/ppm.c
+++ b/src/omv/img/ppm.c
@@ -126,6 +126,7 @@ void ppm_write_subimg(image_t *img, const char *path, rectangle_t *r)
     FIL fp;
     file_write_open(&fp, path);
 
+    file_buffer_on(&fp);
     if (IM_IS_GS(img)) {
         char buffer[20]; // exactly big enough for 5-digit w/h
         int len = snprintf(buffer, 20, "P5\n%d %d\n255\n", rect.w, rect.h);
@@ -154,6 +155,7 @@ void ppm_write_subimg(image_t *img, const char *path, rectangle_t *r)
             }
         }
     }
+    file_buffer_off(&fp);
 
     file_close(&fp);
 }


### PR DESCRIPTION
All file write functions now use fb_alloc to go much faster. Writes are
re-directed to the extra frame buffer RAM and are grouped until they can
be written in a massive multi-block write to the SD card. We get the
best SD card write speed by doing things this way.

Ideally we'd want to buffer the whole file... but, this is about as good
as we're going to get for now.

Going to fix reading functions to use the same buffer next.