### PR TITLE
Add file read speed.

### DIFF
--- a/src/omv/fb_alloc.c
+++ b/src/omv/fb_alloc.c
@@ -23,6 +23,13 @@ void fb_alloc_init0()
     pointer = &_fballoc;
 }
 
+uint32_t fb_avail()
+{
+    int32_t temp = pointer - ((char *) FB_PIXELS()) - sizeof(uint32_t);
+
+    return (temp < sizeof(uint32_t)) ? 0 : temp;
+}
+
 // returns null pointer without error if size==0
 void *fb_alloc(uint32_t size)
 {

--- a/src/omv/fb_alloc.h
+++ b/src/omv/fb_alloc.h
@@ -10,6 +10,7 @@
 #define __FB_ALLOC_H__
 #include <stdint.h>
 void fb_alloc_init0();
+uint32_t fb_avail();
 void *fb_alloc(uint32_t size);
 void *fb_alloc0(uint32_t size);
 void *fb_alloc_all(uint32_t *size); // returns pointer and sets size

--- a/src/omv/ff_wrapper.h
+++ b/src/omv/ff_wrapper.h
@@ -19,6 +19,8 @@ void file_write_open(FIL *fp, const char *path);
 void file_close(FIL *fp);
 void file_seek(FIL *fp, UINT offset);
 void file_buffer_on(FIL *fp); // does fb_alloc_all
+uint32_t file_tell_w_buf(FIL *fp); // valid between on and off
+uint32_t file_size_w_buf(FIL *fp); // valid between on and off
 void file_buffer_off(FIL *fp); // does fb_free
 void read_byte(FIL *fp, uint8_t *value);
 void read_byte_expect(FIL *fp, uint8_t value);

--- a/src/omv/img/bmp.c
+++ b/src/omv/img/bmp.c
@@ -16,7 +16,6 @@
 // This function inits the geometry values of an image (opens file).
 bool bmp_read_geometry(FIL *fp, image_t *img, const char *path, bmp_read_settings_t *rs)
 {
-    file_read_open(fp, path);
     read_byte_expect(fp, 'B');
     read_byte_expect(fp, 'M');
 
@@ -115,7 +114,7 @@ void bmp_read_pixels(FIL *fp, image_t *img, int line_start, int line_end, bmp_re
             for (int j = 0, jj = rs->bmp_row_bytes / 2; j < jj; j++) {
                 uint16_t pixel;
                 read_word(fp, &pixel);
-                IM_SWAP16(pixel);
+                pixel = IM_SWAP16(pixel);
                 if (j < img->w) {
                     if (rs->bmp_h < 0) { // vertical flip (BMP file perspective)
                         if (rs->bmp_w < 0) { // horizontal flip (BMP file perspective)
@@ -168,9 +167,12 @@ void bmp_read(image_t *img, const char *path)
 {
     FIL fp;
     bmp_read_settings_t rs;
+    file_read_open(&fp, path);
+    file_buffer_on(&fp);
     bmp_read_geometry(&fp, img, path, &rs);
     if (!img->pixels) img->pixels = xalloc(img->w * img->h * img->bpp);
     bmp_read_pixels(&fp, img, 0, img->h, &rs);
+    file_buffer_off(&fp);
     file_close(&fp);
 }
 

--- a/src/omv/img/jpeg.c
+++ b/src/omv/img/jpeg.c
@@ -636,11 +636,10 @@ void jpeg_compress(image_t *src, image_t *dst, int quality)
 // This function inits the geometry values of an image.
 void jpeg_read_geometry(FIL *fp, image_t *img, const char *path)
 {
-    file_read_open(fp, path);
     for (;;) {
         uint16_t header;
         read_word(fp, &header);
-        IM_SWAP16(header);
+        header = IM_SWAP16(header);
         if ((0xFFD0 <= header) && (header <= 0xFFD9)) {
             continue;
         } else if (((0xFFC0 <= header) && (header <= 0xFFCF))
@@ -650,7 +649,7 @@ void jpeg_read_geometry(FIL *fp, image_t *img, const char *path)
         {
             uint16_t size;
             read_word(fp, &size);
-            IM_SWAP16(size);
+            size = IM_SWAP16(size);
             if (((0xFFC0 <= header) && (header <= 0xFFC3))
              || ((0xFFC5 <= header) && (header <= 0xFFC7))
              || ((0xFFC9 <= header) && (header <= 0xFFCB))
@@ -659,10 +658,10 @@ void jpeg_read_geometry(FIL *fp, image_t *img, const char *path)
                 read_byte_ignore(fp);
                 uint16_t width;
                 read_word(fp, &width);
-                IM_SWAP16(width);
+                width = IM_SWAP16(width);
                 uint16_t height;
                 read_word(fp, &height);
-                IM_SWAP16(height);
+                height = IM_SWAP16(height);
                 img->w = width;
                 img->h = height;
                 img->bpp = f_size(fp);
@@ -686,9 +685,12 @@ void jpeg_read_pixels(FIL *fp, image_t *img)
 void jpeg_read(image_t *img, const char *path)
 {
     FIL fp;
+    file_read_open(&fp, path);
+    // Do not use file_buffer_on() here.
     jpeg_read_geometry(&fp, img, path);
     if (!img->pixels) img->pixels = xalloc(img->bpp);
     jpeg_read_pixels(&fp, img);
+    // Do not use file_buffer_off() here.
     file_close(&fp);
 }
 

--- a/src/omv/py/py_gif.c
+++ b/src/omv/py/py_gif.c
@@ -60,7 +60,7 @@ static mp_obj_t py_gif_format(mp_obj_t gif_obj)
 static mp_obj_t py_gif_size(mp_obj_t gif_obj)
 {
     py_gif_obj_t *arg_gif = gif_obj;
-    return mp_obj_new_int(f_size(&arg_gif->fp));
+    return mp_obj_new_int(file_size_w_buf(&arg_gif->fp));
 }
 
 static mp_obj_t py_gif_loop(mp_obj_t gif_obj)


### PR DESCRIPTION
File reading is runing ultra fast now. We're getting that SD card speed
the STM32 promised now. The file buffer commands have been updated to
alloc as much available memory to read as much of a file in as possible
now to speed up things. This works really great.

Note however, while the file buffer is active you have to use the file
buffer versions of tell and size. Spent a few hours on tracking down an
error related to not using the buffered versions.