### PR TITLE
Add BLE Driver

### DIFF
--- a/usr/examples/ble.py
+++ b/usr/examples/ble.py
@@ -1,49 +1,83 @@
-# Copy this module to storage and import it if you want
-# to use it in your own scripts. See example usage below.
+# ble.py - ASM001/ASM002 BLE Driver
+#
+# Note: You should copy this module to your OpenMV Cam's SD card or internal
+# file system.
+#
+# This is a driver for the ASM001/ASM002 BLE modules. It takes care of parsing
+# commands for you. Please see the http://truconnect.ack.me/2.0/general_overview
+# reference guide for how to use the ASM001/ASM002 BLE modules.
+
 from time import sleep
 from pyb import Pin, UART
 
 class BLE:
-    def reset(self):
-        self.rst.low()
-        sleep(100)
-        self.rst.high()
-        sleep(100)
-        
-    def _write_cmd(self, cmd):
-        self.uart.write(cmd)
-        if (self.uart.any()):
-            print(self.uart.readline())
-        		
-    def set_discoverable(self, discoverable):
-        if (discoverable):
-            self._write_cmd('adv high\r\n')
-        else:
-            self._write_cmd('adv off\r\n')
-            
-    def scan(self):
-        devices = []
-        #Scan all
-        self._write_cmd('scan high all dup\r\n')
-        
-        # Read scanning results
-        sleep(100)
-        for i in range(100):
-            if (self.uart.any()):
-                devices.append(self.uart.readline())
-                sleep(10)
-                                
-        self._write_cmd('scan off\r\n') #Scan off
-        return devices
-        
-    def __init__(self):
-        self.rst = Pin('P7', Pin.OUT_PP, Pin.PULL_UP)
-        self.uart = UART(3, 115200, bits=8, parity=None, stop=1, flow=UART.RTS|UART.CTS)
+    BLE_NONE=0
+    BLE_SHIELD=1
 
-if __name__ == "__main__":
-    ble = BLE()
-    ble.reset()
-    ble.set_discoverable(True)
-    devices = ble.scan()
-    for d in devices:
-        print(d)
+    def command(self, cmd):
+        if self.type==self.BLE_SHIELD:
+            self.uart.write(cmd)
+            self.uart.write("\r\n")
+            r=self.uart.read(9)
+            if r[0]!=82: raise OSError("Response corrupted!")
+            if r[1]==49: raise OSError("Command failed!")
+            if r[1]==50: raise OSError("Parse error!")
+            if r[1]==51: raise OSError("Unknown command!")
+            if r[1]==52: raise OSError("Too few args!")
+            if r[1]==53: raise OSError("Too many args!")
+            if r[1]==54: raise OSError("Unknown variable or option!")
+            if r[1]==55: raise OSError("Invalid argument!")
+            if r[1]==56: raise OSError("Timeout!")
+            if r[1]==57: raise OSError("Security mismatch!")
+            if r[1]!=48: raise OSError("Response corrupted!")
+            for i in range(2,6):
+                if r[i]<48 or 57<r[i]: raise OSError("Response corrupted!")
+            if r[7]!=13 or r[8]!=10: raise OSError("Response corrupted!")
+            l=((r[2]-48)*10000)+\
+              ((r[3]-48)*1000)+\
+              ((r[4]-48)*100)+\
+              ((r[5]-48)*10)+\
+              ((r[6]-48)*1)
+            if not l: return ""
+            if l==1 or l==2: raise OSError("Response corrupted!")
+            response=self.uart.read(l-2)
+            if self.uart.readchar()!=13: raise OSError("Response corrupted!")
+            if self.uart.readchar()!=10: raise OSError("Response corrupted!")
+            return response
+
+    def deinit(self):
+        if self.type==self.BLE_SHIELD:
+            self.uart.deinit()
+            self.rst=None
+            self.uart=None
+            self.type=self.BLE_NONE
+
+    def init(self, type=BLE_SHIELD):
+        self.deinit()
+        if type==self.BLE_SHIELD:
+            self.rst=Pin("P7",Pin.OUT_OD,Pin.PULL_NONE)
+            self.uart=UART(3,115200,timeout_char=1000)
+            self.type=self.BLE_SHIELD
+            self.rst.low()
+            sleep(100)
+            self.rst.high()
+            sleep(100)
+            self.uart.write("set sy c m machine\r\nsave\r\nreboot\r\n")
+            sleep(1000)
+            self.uart.readall() # clear
+
+    def uart(self):
+        if self.type==self.BLE_SHIELD: return self.uart
+
+    def type(self):
+        if self.type==self.BLE_SHIELD: return self.BLE_SHIELD
+
+    def __init__(self):
+        self.rst=None
+        self.uart=None
+        self.type=self.BLE_NONE
+
+if __name__=="__main__":
+    ble=BLE()
+    ble.init()
+    print(ble.command("ver"))


### PR DESCRIPTION
This a python module driver for the BLE module. It puts the module into
a mode that's good for machine interfacing and handles parsing commands
for you. Additionally, it lets you get access to the low level serial
port.

Users who want to use this driver will need to read and understand the
TruConnect API for what commands they can execute. This driver simply
makes executing commands easy. The user simply needs to call the
"command()" function with the strings listed on the TruConnect API and
they will get the response from the command back as a byte object.

Once the user has executed the necessary commands to setup the BLE
connection they can then do:

ble.command("str")

To put the BLE module into streaming mode and then they can just
directly access the serial port via:

ble.uart().write(<data>)

And etc.