### PR TITLE
Fix compress and compressed.

### DIFF
--- a/src/omv/sensor.c
+++ b/src/omv/sensor.c
@@ -664,6 +664,20 @@ int sensor_snapshot(image_t *image, line_filter_t line_filter_func, void *line_f
             // Unlock the framebuffer mutex
             mutex_unlock(&JPEG_FB()->lock, MUTEX_TID_OMV);
         }
+    } else if ((fb->bpp >= 3) && JPEG_FB()->enabled && sensor.pixformat != PIXFORMAT_JPEG) {
+        // Lock FB
+        if (mutex_try_lock(&JPEG_FB()->lock, MUTEX_TID_OMV)) {
+            if(OMV_JPEG_BUF_SIZE < fb->bpp) {
+                // image won't fit. so don't copy.
+                JPEG_FB()->w = 0; JPEG_FB()->h = 0; JPEG_FB()->size = 0;
+            } else {
+                memcpy(JPEG_FB()->pixels, fb->pixels, fb->bpp);
+                JPEG_FB()->w = fb->w; JPEG_FB()->h = fb->h; JPEG_FB()->size = fb->bpp;
+            }
+
+            // Unlock the framebuffer mutex
+            mutex_unlock(&JPEG_FB()->lock, MUTEX_TID_OMV);
+        }
     }
 
     // Setup the size and address of the transfer


### PR DESCRIPTION
Note that I removed the compressing overlapped code for the main frame buffer. So, on the M4 you can't compress large images in place using the frame buffer anymore. That said, the code was bugged from other things being changed so who cares. On the M7 fb_alloc will have plenty of RAM to compress anything.