### PR TITLE
Speed up lens_corr.

### DIFF
--- a/src/omv/img/imlib.h
+++ b/src/omv/img/imlib.h
@@ -447,7 +447,7 @@ float IMAGE_Y_RATIO = ((float) _source_rect->s.h) / ((float) _target_rect->s.h);
     __typeof__ (row_ptr) _row_ptr = (row_ptr); \
     __typeof__ (x) _x = (x); \
     __typeof__ (v) _v = (v); \
-    size_t _i = _x >> UINT32_T_SHIFT \
+    size_t _i = _x >> UINT32_T_SHIFT; \
     size_t _j = _x & UINT32_T_MASK; \
     _row_ptr[_i] = (_row_ptr[_i] & (~(1 << _j))) | ((_v & 1) << _j); \
 })
@@ -1057,8 +1057,7 @@ void imlib_edge_canny(image_t *src, rectangle_t *roi, int low_thresh, int high_t
 void imlib_find_hog(image_t *src, rectangle_t *roi, int cell_size);
 
 // Lens correction
-void imlib_lens_corr(image_t *src, float strength);
-
+void imlib_lens_corr(image_t *img, float strength, float zoom);
 // Statistics
 void imlib_get_histogram(histogram_t *out, image_t *ptr, rectangle_t *roi);
 void imlib_get_percentile(percentile_t *out, image_bpp_t bpp, histogram_t *ptr, float percentile);

--- a/src/omv/py/py_image.c
+++ b/src/omv/py/py_image.c
@@ -850,15 +850,22 @@ static mp_obj_t py_image_histeq(mp_obj_t img_obj)
     return img_obj;
 }
 
-static mp_obj_t py_image_lens_corr(mp_obj_t img_obj, mp_obj_t s_obj)
+static mp_obj_t py_image_lens_corr(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
 {
-    image_t *arg_img = py_image_cobj(img_obj);
-    PY_ASSERT_FALSE_MSG(IM_IS_JPEG(arg_img), "Operation not supported on JPEG");
+    image_t *arg_img = py_image_cobj(args[0]);
+    PY_ASSERT_FALSE_MSG(IM_IS_JPEG(arg_img),
+            "Operation not supported on JPEG");
 
-    imlib_lens_corr(arg_img, mp_obj_get_float(s_obj));
-    return img_obj;
+    float strength = py_helper_lookup_float(kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_strength),
+                                            (n_args > 1) ? mp_obj_get_float(args[1]) : 1.8);
+    PY_ASSERT_TRUE_MSG(strength >= 0.0, "strength must be > 0");
+    float zoom = py_helper_lookup_float(kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_zoom),
+                                        (n_args > 2) ? mp_obj_get_float(args[2]) : 1.0);
+    PY_ASSERT_TRUE_MSG(zoom >= 1.0, "zoom must be > 1");
+
+    imlib_lens_corr(arg_img, strength, zoom);
+    return args[0];
 }
-
 
 static mp_obj_t py_image_mask_ellipse(mp_obj_t img_obj)
 {
@@ -2329,7 +2336,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(py_image_mode_obj, py_image_mode);
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_image_median_obj, 2, py_image_median);
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_image_gaussian_obj, 1, py_image_gaussian);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_image_histeq_obj, py_image_histeq);
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(py_image_lens_corr_obj, py_image_lens_corr);
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_image_lens_corr_obj, 1, py_image_lens_corr);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_image_mask_ellipse_obj, py_image_mask_ellipse);
 /* Image Statistics */
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_image_get_histogram_obj, 1, py_image_get_histogram);

--- a/src/omv/py/qstrdefsomv.h
+++ b/src/omv/py/qstrdefsomv.h
@@ -93,7 +93,6 @@ Q(add)
 Q(bias)
 Q(percentile)
 Q(normalized)
-Q(lens_corr)
 Q(filter_outliers)
 Q(scale_factor)
 Q(max_keypoints)
@@ -308,6 +307,11 @@ Q(CPUFREQ_192MHZ)
 Q(CPUFREQ_216MHZ)
 Q(get_frequency)
 Q(set_frequency)
+
+// Lens Correction
+Q(lens_corr)
+Q(strength)
+Q(zoom)
 
 // Get Histogram
 Q(get_hist)

--- a/usr/examples/09-Feature-Detection/qrcodes_with_lens_corr.py
+++ b/usr/examples/09-Feature-Detection/qrcodes_with_lens_corr.py
@@ -1,29 +1,21 @@
 # QRCode Example
 #
-# This example shows the power of the OpenMV Cam to detect QR Codes.
-#
-# On the new M7 OpenMV Cam you can detect QR codes at up to 320x240 in Grayscale or RGB565.
-# We may be able to enable 640x480 operation in the future if we re-write the QR code library's front end code.
-#
-# On the M4 OpenMV Cam QR code detection should be done strictly at a maximum of 160x120 for Grayscale or RGB565.
-#
-# Lastly, reading QRCodes requires lens correction to improve the detection rate.
-# Additionally, histogram equalization could be used to increase the contrast but is not required.
+# This example shows the power of the OpenMV Cam to detect QR Codes
+# using lens correction (see the qrcodes_with_lens_corr.py script for higher performance).
 
 import sensor, image, time
 
-# For the new M7 OpenMV Cam...
 sensor.reset()
-sensor.set_pixformat(sensor.GRAYSCALE)
-sensor.set_framesize(sensor.QVGA)
-sensor.skip_frames(10)
-sensor.set_auto_gain(False)
+sensor.set_pixformat(sensor.RGB565)
+sensor.set_framesize(sensor.QQVGA) # can be QQVGA on M7...
+sensor.skip_frames(30)
+sensor.set_auto_gain(False) # must turn this off to prevent image washout...
 clock = time.clock()
 
 while(True):
     clock.tick()
     img = sensor.snapshot()
-    img.lens_corr(1.6) # Lens correction does not work on RGB565 images right now. This will be fixed ASAP.
+    img.lens_corr(1.8) # strength of 1.8 is good for the 2.8mm lens.
     for code in img.find_qrcodes():
         print(code)
     print(clock.fps())


### PR DESCRIPTION
Speed up the algorithm by fixing the abs() issue. Do not use that
function in any of your code. It by itself cut the speed of the code
in half. I don't know what's in that function but I'm guessing it does
ABS of a float using ints or something.

I made the zoom parameter functional now too so you can use lens_corr to
zoom in on the image. Argument parsing is handled too. Finally, I
updated the only script where this is used.

Note that I'm able to get more than 10 FPS at 160x120 on the M4 and 15
FPS at 160x120 on the M7. Previous this was at about 5 FPS and 7.5 FPS
respectively.

Note: I noticed how you only allocated half the image in your old code. That was a good idea. However, after doing the RAM calculations the effort doesn't make it so that the M4 can operate on images as large as 240x240 in RGB565. On the M7 the effort is moot since it has enough RAM. So, I just took it out and alloced a whole image at once.