### PR TITLE
Fix udev rules

### DIFF
--- a/udev/50-openmv.rules
+++ b/udev/50-openmv.rules
@@ -3,5 +3,7 @@
 # idea of write permission for everybody, you can replace MODE:="0666" with
 # OWNER:="yourusername" to create the device owned by you, or with
 # GROUP:="somegroupname" and mange access using standard unix groups.
+ATTRS{idVendor}=="1209", ATTRS{idProduct}=="abd1", ENV{ID_MM_DEVICE_IGNORE}="1"
+ATTRS{idVendor}=="1209", ATTRS{idProduct}=="abd1", ENV{MTP_NO_PROBE}="1"
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", MODE:="0666"
 KERNEL=="ttyACM*", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="abd1", MODE:="0666", SYMLINK+="openmvcam"


### PR DESCRIPTION
These changes cause modemmanager to ignore the serial port
created when plugging in the OpenMV board.

Without these changes, the modemmanager open /dev/ttyACM0 and
sends AT commnads. This delays being able to access the REPL
using a temrinal emulator and also cause a syntax error
since the AT commands aren't valid python.