### PR TITLE
Fixed fb_alloc() with mark for recently re-worked code.

### DIFF
--- a/src/omv/fb_alloc.c
+++ b/src/omv/fb_alloc.c
@@ -36,7 +36,7 @@ void fb_alloc_mark()
 
     // Check if allocation overwrites the framebuffer pixels
     if (new_pointer < (char *) FB_PIXELS()) {
-        fb_alloc_fail();
+        nlr_raise_for_fb_alloc_mark(mp_obj_new_exception_msg(&mp_type_MemoryError, "FB Alloc Collision!!!"));
     }
 
     // fb_alloc does not allow regions which are a size of 0 to be alloced,

--- a/src/omv/fb_alloc.h
+++ b/src/omv/fb_alloc.h
@@ -11,6 +11,8 @@
 #include <stdint.h>
 void fb_alloc_init0();
 uint32_t fb_avail();
+void fb_alloc_mark();
+void fb_alloc_free_till_mark();
 void *fb_alloc(uint32_t size);
 void *fb_alloc0(uint32_t size);
 void *fb_alloc_all(uint32_t *size); // returns pointer and sets size

--- a/src/omv/py/py_sensor.c
+++ b/src/omv/py/py_sensor.c
@@ -66,7 +66,7 @@ static mp_obj_t py_sensor_snapshot(uint n_args, const mp_obj_t *args, mp_map_t *
     }
 
     if (sensor_snapshot((struct image*) py_image_cobj(image), line_filter_func, line_filter_args)==-1) {
-        nlr_jump(mp_obj_new_exception_msg(&mp_type_RuntimeError, "Sensor Timeout!!"));
+        nlr_raise(mp_obj_new_exception_msg(&mp_type_RuntimeError, "Sensor Timeout!!"));
         return mp_const_false;
     }
 
@@ -77,7 +77,7 @@ static mp_obj_t py_sensor_skip_frames(uint n_args, const mp_obj_t *args) {
     int frames = (n_args == 1) ? mp_obj_get_int(args[0]) : 10; // OV Recommended.
     for (int i = 0; i < frames; i++) {
         if (sensor_snapshot(NULL, NULL, NULL) == -1) {
-            nlr_jump(mp_obj_new_exception_msg(&mp_type_RuntimeError, "Sensor Timeout!!"));
+            nlr_raise(mp_obj_new_exception_msg(&mp_type_RuntimeError, "Sensor Timeout!!"));
         }
     }
     return mp_const_none;
@@ -129,7 +129,7 @@ static mp_obj_t py_sensor_set_framerate(mp_obj_t framerate) {
             fr = FRAMERATE_60FPS;
             break;
         default:
-            nlr_jump(mp_obj_new_exception_msg(&mp_type_ValueError, "Invalid framerate"));
+            nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Invalid framerate"));
             break;
     }
 
@@ -199,7 +199,7 @@ static mp_obj_t py_sensor_set_gainceiling(mp_obj_t gainceiling) {
             gain = GAINCEILING_128X;
             break;
         default:
-            nlr_jump(mp_obj_new_exception_msg(&mp_type_ValueError, "Invalid gainceiling"));
+            nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Invalid gainceiling"));
             break;
     }
 


### PR DESCRIPTION
I also tested the firmware for about an hour to make sure there was no
stack leak.

Note that I prefer for fb_free() to still be called versus
fb_free_till_mark() doing that for you in the code.

For functions without this fix they will just free the entire fb_alloc
stack when an exception happens. For functions with this fix they will
only free up to and including the mark. Since there are no places in the
firmware where you could start building a second fb_alloc stack when one
is already in place this point is moot currently. But, if we do
something like that in the future the problem will have already been
solved.

Any new code or re-worked code should use the mark function.