### PR TITLE
April Tag Release Fixes

### DIFF
--- a/usr/examples/16-Codes/find_apriltags_w_lens_zoom.py
+++ b/usr/examples/16-Codes/find_apriltags_w_lens_zoom.py
@@ -3,13 +3,12 @@
 # This example shows the power of the OpenMV Cam to detect April Tags
 # on the OpenMV Cam M7. The M4 versions cannot detect April Tags.
 
-import sensor, image, time
+import sensor, image, time, math
 
 sensor.reset()
 sensor.set_pixformat(sensor.RGB565)
 sensor.set_framesize(sensor.VGA) # we run out of memory if the resolution is much bigger...
-# Look at center 160x120 pixels of the VGA resolution.
-sensor.set_windowing((160, 120))
+sensor.set_windowing((160, 120)) # Look at center 160x120 pixels of the VGA resolution.
 sensor.skip_frames(30)
 sensor.set_auto_gain(False)  # must turn this off to prevent image washout...
 sensor.set_auto_whitebal(False)  # must turn this off to prevent image washout...
@@ -29,5 +28,6 @@ while(True):
     for tag in img.find_apriltags(): # defaults to TAG36H11
         img.draw_rectangle(tag.rect(), color = (255, 0, 0))
         img.draw_cross(tag.cx(), tag.cy(), color = (0, 255, 0))
-        print("Tag Family TAG36H11, Tag ID %d" % tag.id())
+        print_args = (tag.id(), (180 * tag.rotation()) / math.pi)
+        print("Tag Family TAG36H11, Tag ID %d - rotation %f (degrees)" % print_args)
     print(clock.fps())


### PR DESCRIPTION
Everything works. Running out of memory is fixed and the rotation value
is valid now. For 320x240 operation on the STM32H7 we're going to need
on the order of 1 MB in the entire frame buffer. The code is designed to
handle us getting this amount of memory without any new changes for
320x240 support.