### PR TITLE
Fix volatile issue.

### DIFF
--- a/src/omv/main.c
+++ b/src/omv/main.c
@@ -462,7 +462,7 @@ soft_reset:
         f_unlink("selftest.py");
         storage_flush();
         // Set flag for SWD debugger (main.py does not use the frame buffer).
-        MAIN_FB()->bpp = 0xDEADBEEF;
+        *((volatile int *) &(MAIN_FB()->bpp)) = 0xDEADBEEF;
     }
 
     // Run the main script from the current directory.


### PR DESCRIPTION
This flag has to be set for the SWD debugger to pass. This worked for
the M4 without volatile but failed for the M7 without the keyword.

As for how this worked before. I don't know. Anyway, good this was caught now.