### PR TITLE
Fix UMM_Refactor Issues.

### DIFF
--- a/src/omv/img/apriltag.c
+++ b/src/omv/img/apriltag.c
@@ -11802,15 +11802,13 @@ void apriltag_detections_destroy(zarray_t *detections)
 void imlib_find_apriltags(list_t *out, image_t *ptr, rectangle_t *roi, apriltag_families_t families,
                           float fx, float fy, float cx, float cy)
 {
-    // Frame Buffer Memory Usage for M7:
-    // -> RGB565 (160x120) FB Image = 38400 Bytes
-    // -> Heap (160x120) * 9 = 172800 Bytes
-    // -> GRAYSCALE (160x120) Input Image = 38400 Bytes
-    // -> GRAYSCALE (160x120) Threhsolded Image = 38400 Bytes
-    // -> UnionFind (160x120) * 4 = 76800 Bytes
-    // == 364800 Bytes out of 393216 Bytes
-    // 28416 left -> used for hash table
-    umm_init_x(roi->w * roi->h * 9);
+    // Frame Buffer Memory Usage...
+    // -> GRAYSCALE Input Image = w*h*1
+    // -> GRAYSCALE Threhsolded Image = w*h*1
+    // -> UnionFind = w*h*4 (+w*h*2 for hash table)
+    size_t resolution = roi->w * roi->h;
+    size_t fb_alloc_need = resolution * (1 + 1 + 4 + 2); // read above...
+    umm_init_x(((fb_avail() - fb_alloc_need) / resolution) * resolution);
     apriltag_detector_t *td = apriltag_detector_create();
 
     if (families & TAG16H5) {


### PR DESCRIPTION
Memory allocation will grow organically now when more RAM is available.

... Note for the H7 we'll have to revisit the constant I'm using here to reserve space. It can be as low as 6 on the F7 and the algorithm will still work.  However, this means the hash table has less space. Raising the constant gives the hash table more space but takes away from the memory pool. On the F7 a value of 8 for the constant works great... but, if you scale the resolution up to 320x240 on the H7 you run into RAM issues  which favor using a constant value of 6. We'll need to wait and see how much RAM is on the high end H7 devices. 