### PR TITLE
Refactor framebuffer

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -123,6 +123,7 @@ FIRM_OBJ += $(addprefix $(BUILD)/$(OMV_DIR)/, \
 	fb_alloc.o                              \
 	umm_malloc.o                            \
 	ff_wrapper.o                            \
+	framebuffer.o                           \
 	array.o                                 \
 	usbdbg.o                                \
 	sccb.o                                  \

--- a/src/omv/Makefile
+++ b/src/omv/Makefile
@@ -5,6 +5,7 @@ SRCS += $(addprefix ,   \
 	fb_alloc.c          \
 	umm_malloc.c        \
 	ff_wrapper.c        \
+	framebuffer.c       \
 	array.c             \
 	usbdbg.c            \
 	sccb.c              \

--- a/src/omv/boards/OPENMV2/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV2/omv_boardconfig.h
@@ -36,6 +36,10 @@
 // JPEG buffer size (header + data)
 #define OMV_JPEG_BUF_SIZE       (8000)
 
+// If buffer size is bigger than this threshold, the quality is reduced.
+// This is only used for JPEG images sent to the IDE not normal compression.
+#define JPEG_QUALITY_THRESH     (160*120*2)
+
 /* SCCB/I2C */
 #define SCCB_I2C                (I2C1)
 #define SCCB_AF                 (GPIO_AF4_I2C1)

--- a/src/omv/boards/OPENMV3/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV3/omv_boardconfig.h
@@ -45,6 +45,10 @@
 // JPEG buffer size (header + data)
 #define OMV_JPEG_BUF_SIZE       (23000)
 
+// If buffer size is bigger than this threshold, the quality is reduced.
+// This is only used for JPEG images sent to the IDE not normal compression.
+#define JPEG_QUALITY_THRESH     (160*120*2)
+
 /* SCCB/I2C */
 #define SCCB_I2C                (I2C1)
 #define SCCB_AF                 (GPIO_AF4_I2C1)

--- a/src/omv/framebuffer.c
+++ b/src/omv/framebuffer.c
@@ -1,0 +1,75 @@
+/*
+ * This file is part of the OpenMV project.
+ * Copyright (c) 2013/2014 Ibrahim Abdelkader <i.abdalkader@gmail.com>
+ * This work is licensed under the MIT license, see the file LICENSE for details.
+ *
+ * Framebuffer stuff.
+ *
+ */
+#include "imlib.h"
+#include "omv_boardconfig.h"
+#include "framebuffer.h"
+// If buffer size is bigger than this threshold, the quality is reduced.
+// This is only used for JPEG images sent to the IDE not normal compression.
+#define JPEG_QUALITY_THRESH     (160*120*2)
+
+extern char _fb_base;
+framebuffer_t *fb = (framebuffer_t *) &_fb_base;
+
+extern char _jpeg_buf;
+jpegbuffer_t *jpeg_fb = (jpegbuffer_t *) &_jpeg_buf;
+
+void copy_fb_to_jpeg_fb()
+{
+    static int overflow_count = 0;
+
+    if ((fb->bpp > 3) && JPEG_FB()->enabled) {
+        // Lock FB
+        if (mutex_try_lock(&JPEG_FB()->lock, MUTEX_TID_OMV)) {
+            if(OMV_JPEG_BUF_SIZE < fb->bpp) {
+                // image won't fit. so don't copy.
+                JPEG_FB()->w = 0; JPEG_FB()->h = 0; JPEG_FB()->size = 0;
+            } else {
+                memcpy(JPEG_FB()->pixels, fb->pixels, fb->bpp);
+                JPEG_FB()->w = fb->w; JPEG_FB()->h = fb->h; JPEG_FB()->size = fb->bpp;
+            }
+
+            // Unlock the framebuffer mutex
+            mutex_unlock(&JPEG_FB()->lock, MUTEX_TID_OMV);
+        }
+    } else if ((fb->bpp > 0) && JPEG_FB()->enabled) {
+        // Lock FB
+        if (mutex_try_lock(&JPEG_FB()->lock, MUTEX_TID_OMV)) {
+            // Set JPEG src and dst images.
+            image_t src = {.w=fb->w, .h=fb->h, .bpp=fb->bpp,            .pixels=fb->pixels};
+            image_t dst = {.w=fb->w, .h=fb->h, .bpp=OMV_JPEG_BUF_SIZE,  .pixels=JPEG_FB()->pixels};
+
+            // Note: lower quality saves USB bandwidth and results in a faster IDE FPS.
+            bool overflow = jpeg_compress(&src, &dst, JPEG_FB()->quality, false);
+            if (overflow == true) {
+                // JPEG buffer overflowed, reduce JPEG quality for the next frame
+                // and skip the current frame. The IDE doesn't receive this frame.
+                if (JPEG_FB()->quality > 1) {
+                    // Keep this quality for the next n frames
+                    overflow_count = 60;
+                    JPEG_FB()->quality = IM_MAX(1, (JPEG_FB()->quality/2));
+                }
+                JPEG_FB()->w = 0; JPEG_FB()->h = 0; JPEG_FB()->size = 0;
+            } else {
+                if (overflow_count) {
+                    overflow_count--;
+                }
+                // No buffer overflow, increase quality up to max quality based on frame size
+                if (overflow_count == 0 &&
+                        JPEG_FB()->quality < ((MAIN_FB_SIZE() > JPEG_QUALITY_THRESH) ? 35:60)) {
+                    JPEG_FB()->quality++;
+                }
+                // Set FB from JPEG image
+                JPEG_FB()->w = dst.w; JPEG_FB()->h = dst.h; JPEG_FB()->size = dst.bpp;
+            }
+
+            // Unlock the framebuffer mutex
+            mutex_unlock(&JPEG_FB()->lock, MUTEX_TID_OMV);
+        }
+    }
+}

--- a/src/omv/framebuffer.c
+++ b/src/omv/framebuffer.c
@@ -9,40 +9,37 @@
 #include "imlib.h"
 #include "omv_boardconfig.h"
 #include "framebuffer.h"
-// If buffer size is bigger than this threshold, the quality is reduced.
-// This is only used for JPEG images sent to the IDE not normal compression.
-#define JPEG_QUALITY_THRESH     (160*120*2)
 
 extern char _fb_base;
-framebuffer_t *fb = (framebuffer_t *) &_fb_base;
+framebuffer_t *fb_framebuffer = (framebuffer_t *) &_fb_base;
 
 extern char _jpeg_buf;
-jpegbuffer_t *jpeg_fb = (jpegbuffer_t *) &_jpeg_buf;
+jpegbuffer_t *jpeg_fb_framebuffer = (jpegbuffer_t *) &_jpeg_buf;
 
-void copy_fb_to_jpeg_fb()
+void fb_update_jpeg_buffer()
 {
     static int overflow_count = 0;
 
-    if ((fb->bpp > 3) && JPEG_FB()->enabled) {
+    if ((MAIN_FB()->bpp > 3) && JPEG_FB()->enabled) {
         // Lock FB
         if (mutex_try_lock(&JPEG_FB()->lock, MUTEX_TID_OMV)) {
-            if(OMV_JPEG_BUF_SIZE < fb->bpp) {
+            if(OMV_JPEG_BUF_SIZE < MAIN_FB()->bpp) {
                 // image won't fit. so don't copy.
                 JPEG_FB()->w = 0; JPEG_FB()->h = 0; JPEG_FB()->size = 0;
             } else {
-                memcpy(JPEG_FB()->pixels, fb->pixels, fb->bpp);
-                JPEG_FB()->w = fb->w; JPEG_FB()->h = fb->h; JPEG_FB()->size = fb->bpp;
+                memcpy(JPEG_FB()->pixels, MAIN_FB()->pixels, MAIN_FB()->bpp);
+                JPEG_FB()->w = MAIN_FB()->w; JPEG_FB()->h = MAIN_FB()->h; JPEG_FB()->size = MAIN_FB()->bpp;
             }
 
             // Unlock the framebuffer mutex
             mutex_unlock(&JPEG_FB()->lock, MUTEX_TID_OMV);
         }
-    } else if ((fb->bpp > 0) && JPEG_FB()->enabled) {
+    } else if ((MAIN_FB()->bpp > 0) && JPEG_FB()->enabled) {
         // Lock FB
         if (mutex_try_lock(&JPEG_FB()->lock, MUTEX_TID_OMV)) {
             // Set JPEG src and dst images.
-            image_t src = {.w=fb->w, .h=fb->h, .bpp=fb->bpp,            .pixels=fb->pixels};
-            image_t dst = {.w=fb->w, .h=fb->h, .bpp=OMV_JPEG_BUF_SIZE,  .pixels=JPEG_FB()->pixels};
+            image_t src = {.w=MAIN_FB()->w, .h=MAIN_FB()->h, .bpp=MAIN_FB()->bpp,     .pixels=MAIN_FB()->pixels};
+            image_t dst = {.w=MAIN_FB()->w, .h=MAIN_FB()->h, .bpp=OMV_JPEG_BUF_SIZE,  .pixels=JPEG_FB()->pixels};
 
             // Note: lower quality saves USB bandwidth and results in a faster IDE FPS.
             bool overflow = jpeg_compress(&src, &dst, JPEG_FB()->quality, false);

--- a/src/omv/framebuffer.h
+++ b/src/omv/framebuffer.h
@@ -3,30 +3,32 @@
  * Copyright (c) 2013/2014 Ibrahim Abdelkader <i.abdalkader@gmail.com>
  * This work is licensed under the MIT license, see the file LICENSE for details.
  *
- * Framebuffer pointer.
+ * Framebuffer stuff.
  *
  */
 #ifndef __FRAMEBUFFER_H__
 #define __FRAMEBUFFER_H__
+#include <stdint.h>
 #include "mutex.h"
-extern char _fb_base;
-static struct framebuffer {
+
+typedef struct framebuffer {
     int w,h;
     int bpp;
     uint8_t pixels[];
-// Note all instances of fb point to the same memory address.
-}*__attribute__ ((__unused__)) fb = (struct framebuffer *) &_fb_base;
+} framebuffer_t;
 
-extern char _jpeg_buf;
-static struct jpegbuffer {
+extern framebuffer_t *fb;
+
+typedef struct jpegbuffer {
     int w,h;
     int size;
     int enabled;
     int quality;
     mutex_t lock;
     uint8_t pixels[];
-// Note all instances of jepg_fb point to the same memory address.
-}*__attribute__ ((__unused__)) jpeg_fb = (struct jpegbuffer *) &_jpeg_buf;
+} jpegbuffer_t;
+
+extern jpegbuffer_t *jpeg_fb;
 
 // Use these macros to get a pointer to main or JPEG framebuffer.
 #define MAIN_FB()       (fb)
@@ -36,4 +38,8 @@ static struct jpegbuffer {
 
 // Use this macro to get a pointer to the free SRAM area located after the framebuffer.
 #define FB_PIXELS() (MAIN_FB()->pixels+MAIN_FB_SIZE())
+
+// Transfers the frame buffer to the jpeg frame buffer if not locked.
+void copy_fb_to_jpeg_fb();
+
 #endif /* __FRAMEBUFFER_H__ */

--- a/src/omv/framebuffer.h
+++ b/src/omv/framebuffer.h
@@ -17,7 +17,7 @@ typedef struct framebuffer {
     uint8_t pixels[];
 } framebuffer_t;
 
-extern framebuffer_t *fb;
+extern framebuffer_t *fb_framebuffer;
 
 typedef struct jpegbuffer {
     int w,h;
@@ -28,11 +28,12 @@ typedef struct jpegbuffer {
     uint8_t pixels[];
 } jpegbuffer_t;
 
-extern jpegbuffer_t *jpeg_fb;
+extern jpegbuffer_t *jpeg_fb_framebuffer;
 
 // Use these macros to get a pointer to main or JPEG framebuffer.
-#define MAIN_FB()       (fb)
-#define JPEG_FB()       (jpeg_fb)
+#define MAIN_FB()       (fb_framebuffer)
+#define JPEG_FB()       (jpeg_fb_framebuffer)
+
 // Returns MAIN FB size
 #define MAIN_FB_SIZE()  (MAIN_FB()->w*MAIN_FB()->h*MAIN_FB()->bpp)
 
@@ -40,6 +41,6 @@ extern jpegbuffer_t *jpeg_fb;
 #define FB_PIXELS() (MAIN_FB()->pixels+MAIN_FB_SIZE())
 
 // Transfers the frame buffer to the jpeg frame buffer if not locked.
-void copy_fb_to_jpeg_fb();
+void fb_update_jpeg_buffer();
 
 #endif /* __FRAMEBUFFER_H__ */

--- a/src/omv/py/py_gif.c
+++ b/src/omv/py/py_gif.c
@@ -28,9 +28,9 @@ typedef struct py_gif_obj {
 static mp_obj_t py_gif_open(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
 {
     py_gif_obj_t *gif = m_new_obj(py_gif_obj_t);
-    gif->width  = py_helper_lookup_int(kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_width), fb->w);
-    gif->height = py_helper_lookup_int(kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_height), fb->h);
-    gif->color  = py_helper_lookup_int(kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_color), fb->bpp>=2);
+    gif->width  = py_helper_lookup_int(kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_width), MAIN_FB()->w);
+    gif->height = py_helper_lookup_int(kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_height), MAIN_FB()->h);
+    gif->color  = py_helper_lookup_int(kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_color), MAIN_FB()->bpp>=2);
     gif->loop   = py_helper_lookup_int(kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_loop), true);
     gif->base.type = &py_gif_type;
 

--- a/src/omv/py/py_image.c
+++ b/src/omv/py/py_image.c
@@ -486,9 +486,9 @@ static mp_obj_t py_image_copy_to_fb(uint n_args, const mp_obj_t *args, mp_map_t 
     image_t *arg_img = py_image_cobj(args[0]);
     py_helper_lookup_offset(kw_args, arg_img, &arg_offs);
 
-    fb->w = arg_img->w;
-    fb->h = arg_img->h;
-    fb->bpp = arg_img->bpp;
+    MAIN_FB()->w = arg_img->w;
+    MAIN_FB()->h = arg_img->h;
+    MAIN_FB()->bpp = arg_img->bpp;
 
     int yoffs = arg_offs.y;
     int xoffs = arg_offs.x * arg_img->bpp;
@@ -496,7 +496,7 @@ static mp_obj_t py_image_copy_to_fb(uint n_args, const mp_obj_t *args, mp_map_t 
 
     for (int y=yoffs; y<arg_img->h; y++) {
         for (int x=xoffs; x<stride; x++) {
-            fb->pixels[y*stride+x] = arg_img->pixels[y*stride+x];
+            MAIN_FB()->pixels[y*stride+x] = arg_img->pixels[y*stride+x];
         }
     }
     return mp_const_true;
@@ -553,8 +553,8 @@ static mp_obj_t py_image_compress(uint n_args, const mp_obj_t *args, mp_map_t *k
     fb_free();
     fb_alloc_free_till_mark();
 
-    if (fb->pixels == arg_img->data) {
-        fb->bpp = arg_img->bpp;
+    if (MAIN_FB()->pixels == arg_img->data) {
+        MAIN_FB()->bpp = arg_img->bpp;
     }
 
     return args[0];
@@ -635,8 +635,8 @@ static mp_obj_t py_image_compress_for_ide(uint n_args, const mp_obj_t *args, mp_
     fb_free();
     fb_alloc_free_till_mark();
 
-    if (fb->pixels == arg_img->data) {
-        fb->bpp = arg_img->bpp;
+    if (MAIN_FB()->pixels == arg_img->data) {
+        MAIN_FB()->bpp = arg_img->bpp;
     }
 
     return args[0];
@@ -3131,9 +3131,9 @@ static mp_obj_t py_image_mean_pool(mp_obj_t img_obj, mp_obj_t x_div_obj, mp_obj_
     arg_img->w = out_img.w;
     arg_img->h = out_img.h;
     // Check if this image is the one in the frame buffer...
-    if ((fb->pixels == arg_img->pixels) || (fb->pixels == arg_img->pixels)) {
-        fb->w = out_img.w;
-        fb->h = out_img.h;
+    if ((MAIN_FB()->pixels == arg_img->pixels) || (MAIN_FB()->pixels == arg_img->pixels)) {
+        MAIN_FB()->w = out_img.w;
+        MAIN_FB()->h = out_img.h;
     }
 
     return img_obj;
@@ -3672,18 +3672,18 @@ mp_obj_t py_image_load_image(uint n_args, const mp_obj_t *args, mp_map_t *kw_arg
     int copy_to_fb = py_helper_lookup_int(kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_copy_to_fb), false);
 
     if (copy_to_fb) {
-       fb->w   = 4; // non-zero init value
-       fb->h   = 4; // non-zero init value
-       fb->bpp = 1; // non-zero init value
+       MAIN_FB()->w   = 4; // non-zero init value
+       MAIN_FB()->h   = 4; // non-zero init value
+       MAIN_FB()->bpp = 1; // non-zero init value
        image.pixels = MAIN_FB()->pixels;
        FIL fp;
        img_read_settings_t rs;
        imlib_read_geometry(&fp, &image, path, &rs);
        file_buffer_off(&fp);
        file_close(&fp);
-       fb->w   = image.w;
-       fb->h   = image.h;
-       fb->bpp = image.bpp;
+       MAIN_FB()->w   = image.w;
+       MAIN_FB()->h   = image.h;
+       MAIN_FB()->bpp = image.bpp;
     }
 
     imlib_load_image(&image, path);

--- a/src/omv/py/py_mjpeg.c
+++ b/src/omv/py/py_mjpeg.c
@@ -28,8 +28,8 @@ typedef struct py_mjpeg_obj {
 static mp_obj_t py_mjpeg_open(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
 {
     py_mjpeg_obj_t *mjpeg = m_new_obj(py_mjpeg_obj_t);
-    mjpeg->width  = py_helper_lookup_int(kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_width), fb->w);
-    mjpeg->height = py_helper_lookup_int(kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_height), fb->h);
+    mjpeg->width  = py_helper_lookup_int(kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_width), MAIN_FB()->w);
+    mjpeg->height = py_helper_lookup_int(kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_height), MAIN_FB()->h);
     mjpeg->frames = 0; // private
     mjpeg->bytes = 0; // private
     mjpeg->base.type = &py_mjpeg_type;

--- a/src/omv/sensor.c
+++ b/src/omv/sensor.c
@@ -26,9 +26,6 @@
 #define REG_MIDL       0x1D
 
 #define MAX_XFER_SIZE (0xFFFC)
-// If buffer size is bigger than this threshold, the quality is reduced.
-// This is only used for JPEG images sent to the IDE not normal compression.
-#define JPEG_QUALITY_THRESH     (160*120*2)
 
 sensor_t sensor;
 TIM_HandleTypeDef  TIMHandle;
@@ -699,7 +696,6 @@ static void sensor_check_bufsize()
 // overwrite image pixels before they are compressed.
 int sensor_snapshot(image_t *image, line_filter_t line_filter_func, void *line_filter_args)
 {
-    static int overflow_count = 0;
     uint32_t addr, length, tick_start;
 
     // Set line filter
@@ -712,55 +708,7 @@ int sensor_snapshot(image_t *image, line_filter_t line_filter_func, void *line_f
     // Compress the framebuffer for the IDE preview, only if it's not the first frame,
     // the framebuffer is enabled and the image sensor does not support JPEG encoding.
     // Note: This doesn't run unless the IDE is connected and the framebuffer is enabled.
-    if ((fb->bpp > 3) && JPEG_FB()->enabled && sensor.pixformat != PIXFORMAT_JPEG) {
-        // Lock FB
-        if (mutex_try_lock(&JPEG_FB()->lock, MUTEX_TID_OMV)) {
-            if(OMV_JPEG_BUF_SIZE < fb->bpp) {
-                // image won't fit. so don't copy.
-                JPEG_FB()->w = 0; JPEG_FB()->h = 0; JPEG_FB()->size = 0;
-            } else {
-                memcpy(JPEG_FB()->pixels, fb->pixels, fb->bpp);
-                JPEG_FB()->w = fb->w; JPEG_FB()->h = fb->h; JPEG_FB()->size = fb->bpp;
-            }
-
-            // Unlock the framebuffer mutex
-            mutex_unlock(&JPEG_FB()->lock, MUTEX_TID_OMV);
-        }
-    } else if ((fb->bpp > 0) && JPEG_FB()->enabled && sensor.pixformat != PIXFORMAT_JPEG) {
-        // Lock FB
-        if (mutex_try_lock(&JPEG_FB()->lock, MUTEX_TID_OMV)) {
-            // Set JPEG src and dst images.
-            image_t src = {.w=fb->w, .h=fb->h, .bpp=fb->bpp,            .pixels=fb->pixels};
-            image_t dst = {.w=fb->w, .h=fb->h, .bpp=OMV_JPEG_BUF_SIZE,  .pixels=JPEG_FB()->pixels};
-
-            // Note: lower quality saves USB bandwidth and results in a faster IDE FPS.
-            bool overflow = jpeg_compress(&src, &dst, JPEG_FB()->quality, false);
-            if (overflow == true) {
-                // JPEG buffer overflowed, reduce JPEG quality for the next frame
-                // and skip the current frame. The IDE doesn't receive this frame.
-                if (JPEG_FB()->quality > 1) {
-                    // Keep this quality for the next n frames
-                    overflow_count = 60;
-                    JPEG_FB()->quality = IM_MAX(1, (JPEG_FB()->quality/2));
-                }
-                JPEG_FB()->w = 0; JPEG_FB()->h = 0; JPEG_FB()->size = 0;
-            } else {
-                if (overflow_count) {
-                    overflow_count--;
-                }
-                // No buffer overflow, increase quality up to max quality based on frame size
-                if (overflow_count == 0 &&
-                        JPEG_FB()->quality < ((MAIN_FB_SIZE() > JPEG_QUALITY_THRESH) ? 35:60)) {
-                    JPEG_FB()->quality++;
-                }
-                // Set FB from JPEG image
-                JPEG_FB()->w = dst.w; JPEG_FB()->h = dst.h; JPEG_FB()->size = dst.bpp;
-            }
-
-            // Unlock the framebuffer mutex
-            mutex_unlock(&JPEG_FB()->lock, MUTEX_TID_OMV);
-        }
-    }
+    if (sensor.pixformat != PIXFORMAT_JPEG) copy_fb_to_jpeg_fb();
 
     // Setup the size and address of the transfer
     switch (sensor.pixformat) {

--- a/src/omv/usbdbg.c
+++ b/src/omv/usbdbg.c
@@ -180,10 +180,10 @@ void usbdbg_data_out(void *buffer, int length)
 
         case USBDBG_TEMPLATE_SAVE: {
             image_t image ={
-                .w = fb->w,
-                .h = fb->h,
-                .bpp = fb->bpp,
-                .pixels = fb->pixels
+                .w = MAIN_FB()->w,
+                .h = MAIN_FB()->h,
+                .bpp = MAIN_FB()->bpp,
+                .pixels = MAIN_FB()->pixels
             };
 
             // null terminate the path
@@ -201,10 +201,10 @@ void usbdbg_data_out(void *buffer, int length)
 
         case USBDBG_DESCRIPTOR_SAVE: {
             image_t image ={
-                .w = fb->w,
-                .h = fb->h,
-                .bpp = fb->bpp,
-                .pixels = fb->pixels
+                .w = MAIN_FB()->w,
+                .h = MAIN_FB()->h,
+                .bpp = MAIN_FB()->bpp,
+                .pixels = MAIN_FB()->pixels
             };
 
             // null terminate the path


### PR DESCRIPTION
Moved structs along with image copying code from sensor into
framebuffer.c so that we can use the new copy_fb_to_jpeg_fb() function
in the image library for methods with "copy_to_fb" so that they update
the IDE preview when called. In particular, I need for for my new ImageWriter/Reader classes.
Will send them once this PR is accepted.

Also, I noticed that the MAIN_FB_SIZE() value is not calculated
correctly in all cases. Will fix later. Trying to keep this commit clean
for just the refactoring.

All changes have been tested. Too.