### PR TITLE
Add Image Writer/Reader

### DIFF
--- a/src/omv/ff_wrapper.c
+++ b/src/omv/ff_wrapper.c
@@ -86,6 +86,18 @@ void file_seek(FIL *fp, UINT offset)
     if (res != FR_OK) ff_fail(fp, res);
 }
 
+void file_truncate(FIL *fp)
+{
+    FRESULT res = f_truncate(fp);
+    if (res != FR_OK) ff_fail(fp, res);
+}
+
+void file_sync(FIL *fp)
+{
+    FRESULT res = f_sync(fp);
+    if (res != FR_OK) ff_fail(fp, res);
+}
+
 // When a sector boundary is encountered while writing a file and there are
 // more than 512 bytes left to write FatFs will detect that it can bypass
 // its internal write buffer and pass the data buffer passed to it directly

--- a/src/omv/ff_wrapper.h
+++ b/src/omv/ff_wrapper.h
@@ -18,6 +18,8 @@ void file_read_open(FIL *fp, const char *path);
 void file_write_open(FIL *fp, const char *path);
 void file_close(FIL *fp);
 void file_seek(FIL *fp, UINT offset);
+void file_truncate(FIL *fp);
+void file_sync(FIL *fp);
 // File buffer functions.
 void file_buffer_init0();
 void file_buffer_on(FIL *fp); // does fb_alloc_all

--- a/src/omv/py/qstrdefsomv.h
+++ b/src/omv/py/qstrdefsomv.h
@@ -568,3 +568,21 @@ Q(CODE39)
 Q(PDF417)
 Q(CODE93)
 Q(CODE128)
+
+// Image Writer
+Q(ImageWriter)
+// Image Writer Object
+Q(imagewriter)
+// duplicate Q(size)
+// duplicate Q(add_frame)
+// duplicate Q(close)
+
+// Image Reader
+Q(ImageReader)
+// Image Reader Object
+Q(imagereader)
+// duplicate Q(size)
+Q(next_frame)
+// duplicate Q(copy_to_fb)
+// duplicate Q(loop)
+// duplicate Q(close)

--- a/usr/examples/06-Video-Recording/image_reader.py
+++ b/usr/examples/06-Video-Recording/image_reader.py
@@ -1,0 +1,25 @@
+# Image Reader Example
+#
+# USE THIS EXAMPLE WITH A USD CARD!
+#
+# This example shows how to use the Image Reader object to replay snapshots of what your
+# OpenMV Cam saw saved by the Image Writer object for testing machine vision algorithms.
+
+import sensor, image, time
+
+snapshot_source = False # Set to true once finished to pull data from sensor.
+
+sensor.reset()
+sensor.set_pixformat(sensor.RGB565)
+sensor.set_framesize(sensor.QQVGA)
+sensor.skip_frames(time = 2000)
+clock = time.clock()
+
+img_reader = None if snapshot_source else image.ImageReader("/stream.bin")
+
+while(True):
+    clock.tick()
+    img = sensor.snapshot() if snapshot_source else img_reader.next_frame(copy_to_fb=True, loop=True)
+    # Do machine vision algorithms on the image here.
+
+    print(clock.fps())

--- a/usr/examples/06-Video-Recording/image_writer.py
+++ b/usr/examples/06-Video-Recording/image_writer.py
@@ -1,0 +1,43 @@
+# Image Writer Example
+#
+# USE THIS EXAMPLE WITH A USD CARD! Reset the camera after recording to see the file.
+#
+# This example shows how to use the Image Writer object to record snapshots of what your
+# OpenMV Cam sees for later analysis using the Image Reader object. Images written to disk
+# by the Image Writer object are stored in a simple file format readable by your OpenMV Cam.
+
+import sensor, image, pyb, time
+
+record_time = 10000 # 10 seconds in milliseconds
+
+sensor.reset()
+sensor.set_pixformat(sensor.RGB565)
+sensor.set_framesize(sensor.QQVGA)
+sensor.skip_frames(time = 2000)
+clock = time.clock()
+
+img_writer = image.ImageWriter("/stream.bin")
+
+# Red LED on means we are capturing frames.
+red_led = pyb.LED(1)
+red_led.on()
+
+start = pyb.millis()
+while pyb.elapsed_millis(start) < record_time:
+    clock.tick()
+    img = sensor.snapshot()
+    # Modify the image if you feel like here...
+
+    img_writer.add_frame(img)
+    print(clock.fps())
+
+img_writer.close()
+
+# Blue LED on means we are done.
+red_led.off()
+blue_led = pyb.LED(3)
+blue_led.on()
+
+print("Done")
+while(True):
+    pyb.wfi()


### PR DESCRIPTION
These two new classes allow you to record image data for later viewing
at the same speed the image data was recorded. Unlike GIF/MJPEG the
image data is stored on the file system completely uncompressed in
native frame buffer format making super fast reading and writing
possible. Recording VGA Grayscale at ~13 FPS is possible along with
playing it back. (That's about 30 Mb/s folks).

...

The motivation for writing these scripts is so that you can record video
of something like a line following track, take that video home, and work
on computer vision algorithms for that data.

These classes should make it a lot easier to use the camera at home now.