### PR TITLE
Cleanup framebuffer code

### DIFF
--- a/src/omv/fb_alloc.c
+++ b/src/omv/fb_alloc.c
@@ -25,7 +25,7 @@ void fb_alloc_init0()
 
 uint32_t fb_avail()
 {
-    int32_t temp = pointer - ((char *) FB_PIXELS()) - sizeof(uint32_t);
+    int32_t temp = pointer - ((char *) MAIN_FB_PIXELS()) - sizeof(uint32_t);
 
     return (temp < sizeof(uint32_t)) ? 0 : temp;
 }
@@ -35,7 +35,7 @@ void fb_alloc_mark()
     char *new_pointer = pointer - sizeof(uint32_t);
 
     // Check if allocation overwrites the framebuffer pixels
-    if (new_pointer < (char *) FB_PIXELS()) {
+    if (new_pointer < (char *) MAIN_FB_PIXELS()) {
         nlr_raise_for_fb_alloc_mark(mp_obj_new_exception_msg(&mp_type_MemoryError, "FB Alloc Collision!!!"));
     }
 
@@ -67,7 +67,7 @@ void *fb_alloc(uint32_t size)
     char *new_pointer = result - sizeof(uint32_t);
 
     // Check if allocation overwrites the framebuffer pixels
-    if (new_pointer < (char *) FB_PIXELS()) {
+    if (new_pointer < (char *) MAIN_FB_PIXELS()) {
         fb_alloc_fail();
     }
 
@@ -87,7 +87,7 @@ void *fb_alloc0(uint32_t size)
 
 void *fb_alloc_all(uint32_t *size)
 {
-    int32_t temp = pointer - ((char *) FB_PIXELS()) - sizeof(uint32_t);
+    int32_t temp = pointer - ((char *) MAIN_FB_PIXELS()) - sizeof(uint32_t);
 
     if (temp < sizeof(uint32_t)) {
         *size = 0;

--- a/src/omv/framebuffer.c
+++ b/src/omv/framebuffer.c
@@ -16,6 +16,27 @@ framebuffer_t *fb_framebuffer = (framebuffer_t *) &_fb_base;
 extern char _jpeg_buf;
 jpegbuffer_t *jpeg_fb_framebuffer = (jpegbuffer_t *) &_jpeg_buf;
 
+uint32_t main_fb_image_size()
+{
+    switch (MAIN_FB()->bpp) {
+        case IMAGE_BPP_BINARY: {
+            return ((MAIN_FB()->w + UINT32_T_MASK) >> UINT32_T_SHIFT) * MAIN_FB()->h;
+        }
+        case IMAGE_BPP_GRAYSCALE: {
+            return (MAIN_FB()->w * MAIN_FB()->h) * sizeof(uint8_t);
+        }
+        case IMAGE_BPP_RGB565: {
+            return (MAIN_FB()->w * MAIN_FB()->h) * sizeof(uint16_t);
+        }
+        case IMAGE_BPP_BAYER: {
+            return MAIN_FB()->w * MAIN_FB()->h;
+        }
+        default: { // JPEG
+            return MAIN_FB()->bpp;
+        }
+    }
+}
+
 void fb_update_jpeg_buffer()
 {
     static int overflow_count = 0;

--- a/src/omv/framebuffer.h
+++ b/src/omv/framebuffer.h
@@ -30,15 +30,23 @@ typedef struct jpegbuffer {
 
 extern jpegbuffer_t *jpeg_fb_framebuffer;
 
-// Use these macros to get a pointer to main or JPEG framebuffer.
-#define MAIN_FB()       (fb_framebuffer)
-#define JPEG_FB()       (jpeg_fb_framebuffer)
+uint32_t main_fb_image_size();
 
-// Returns MAIN FB size
-#define MAIN_FB_SIZE()  (MAIN_FB()->w*MAIN_FB()->h*MAIN_FB()->bpp)
+// Use these macros to get a pointer to main or JPEG framebuffer.
+#define MAIN_FB()           (fb_framebuffer)
+#define JPEG_FB()           (jpeg_fb_framebuffer)
+
+// Returns MAIN FB size.
+#define MAIN_FB_SIZE()      (main_fb_image_size())
 
 // Use this macro to get a pointer to the free SRAM area located after the framebuffer.
-#define FB_PIXELS() (MAIN_FB()->pixels+MAIN_FB_SIZE())
+#define MAIN_FB_PIXELS()    (MAIN_FB()->pixels+4+MAIN_FB_SIZE())
+
+// Returns JPEG FB size.
+#define JPEG_FB_SIZE()      (JPEG_FB()->size)
+
+// Use this macro to get a pointer to the free SRAM area located after the framebuffer.
+#define JPEG_FB_PIXELS()    (JPEG_FB()->pixels+4+JPEG_FB_SIZE())
 
 // Transfers the frame buffer to the jpeg frame buffer if not locked.
 void fb_update_jpeg_buffer();

--- a/src/omv/img/imlib.c
+++ b/src/omv/img/imlib.c
@@ -170,6 +170,27 @@ void image_copy(image_t *dst, image_t *src)
     memcpy(dst, src, sizeof(image_t));
 }
 
+uint32_t image_size(image_t *ptr)
+{
+    switch (ptr->bpp) {
+        case IMAGE_BPP_BINARY: {
+            return ((ptr->w + UINT32_T_MASK) >> UINT32_T_SHIFT) * ptr->h;
+        }
+        case IMAGE_BPP_GRAYSCALE: {
+            return (ptr->w * ptr->h) * sizeof(uint8_t);
+        }
+        case IMAGE_BPP_RGB565: {
+            return (ptr->w * ptr->h) * sizeof(uint16_t);
+        }
+        case IMAGE_BPP_BAYER: {
+            return ptr->w * ptr->h;
+        }
+        default: { // JPEG
+            return ptr->bpp;
+        }
+    }
+}
+
 // Gamma uncompress
 extern const float xyz_table[256];
 

--- a/src/omv/img/imlib.h
+++ b/src/omv/img/imlib.h
@@ -293,6 +293,7 @@ typedef struct image {
 
 void image_init(image_t *ptr, int w, int h, int bpp, void *data);
 void image_copy(image_t *dst, image_t *src);
+uint32_t image_size(image_t *ptr);
 
 #define IMAGE_GET_BINARY_PIXEL(image, x, y) \
 ({ \

--- a/src/omv/py/py_image.c
+++ b/src/omv/py/py_image.c
@@ -3656,29 +3656,7 @@ mp_obj_t py_imagewriter_add_frame(mp_obj_t self_in, mp_obj_t img_obj)
     write_long(fp, arg_img->h);
     write_long(fp, arg_img->bpp);
 
-    uint32_t size;
-    switch (arg_img->bpp) {
-        case IMAGE_BPP_BINARY: {
-            size = ((arg_img->w + UINT32_T_MASK) >> UINT32_T_SHIFT) * arg_img->h;
-            break;
-        }
-        case IMAGE_BPP_GRAYSCALE: {
-            size = (arg_img->w * arg_img->h) * sizeof(uint8_t);
-            break;
-        }
-        case IMAGE_BPP_RGB565: {
-            size = (arg_img->w * arg_img->h) * sizeof(uint16_t);
-            break;
-        }
-        case IMAGE_BPP_BAYER: {
-            size = arg_img->w * arg_img->h;
-            break;
-        }
-        default: { // JPEG
-            size = arg_img->bpp;
-            break;
-        }
-    }
+    uint32_t size = image_size(arg_img);
 
     write_data(fp, arg_img->data, size);
     if (size % 16) write_data(fp, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 16 - (size % 16)); // Pad to multiple of 16 bytes.
@@ -3781,29 +3759,7 @@ mp_obj_t py_imagereader_next_frame(uint n_args, const mp_obj_t *args, mp_map_t *
     read_long(fp, (uint32_t *) &image.h);
     read_long(fp, (uint32_t *) &image.bpp);
 
-    uint32_t size;
-    switch (image.bpp) {
-        case IMAGE_BPP_BINARY: {
-            size = ((image.w + UINT32_T_MASK) >> UINT32_T_SHIFT) * image.h;
-            break;
-        }
-        case IMAGE_BPP_GRAYSCALE: {
-            size = (image.w * image.h) * sizeof(uint8_t);
-            break;
-        }
-        case IMAGE_BPP_RGB565: {
-            size = (image.w * image.h) * sizeof(uint16_t);
-            break;
-        }
-        case IMAGE_BPP_BAYER: {
-            size = image.w * image.h;
-            break;
-        }
-        default: { // JPEG
-            size = image.bpp;
-            break;
-        }
-    }
+    uint32_t size = image_size(&image);
 
     if (copy_to_fb) {
         PY_ASSERT_TRUE_MSG((size <= OMV_RAW_BUF_SIZE), "FB Overflow!");
@@ -3960,29 +3916,7 @@ mp_obj_t py_image_load_image(uint n_args, const mp_obj_t *args, mp_map_t *kw_arg
        file_buffer_off(&fp);
        file_close(&fp);
 
-       uint32_t size;
-       switch (image.bpp) {
-           case IMAGE_BPP_BINARY: {
-               size = ((image.w + UINT32_T_MASK) >> UINT32_T_SHIFT) * image.h;
-               break;
-           }
-           case IMAGE_BPP_GRAYSCALE: {
-               size = (image.w * image.h) * sizeof(uint8_t);
-               break;
-           }
-           case IMAGE_BPP_RGB565: {
-               size = (image.w * image.h) * sizeof(uint16_t);
-               break;
-           }
-           case IMAGE_BPP_BAYER: {
-               size = image.w * image.h;
-               break;
-           }
-           default: { // JPEG
-               size = image.bpp;
-               break;
-           }
-       }
+       uint32_t size = image_size(&image);
 
        PY_ASSERT_TRUE_MSG((size <= OMV_RAW_BUF_SIZE), "FB Overflow!");
        image.pixels = MAIN_FB()->pixels;

--- a/src/omv/py/py_image.c
+++ b/src/omv/py/py_image.c
@@ -3906,9 +3906,9 @@ mp_obj_t py_image_load_image(uint n_args, const mp_obj_t *args, mp_map_t *kw_arg
     image_t image = {0};
 
     if (copy_to_fb) {
-       MAIN_FB()->w = 4; // Need to make sure these are initialized size the file buffer
-       MAIN_FB()->h = 4; // gets turned on which expects these values to be valid.
-       MAIN_FB()->bpp = 1;
+       MAIN_FB()->w = 0;
+       MAIN_FB()->h = 0;
+       MAIN_FB()->bpp = 0;
 
        FIL fp;
        img_read_settings_t rs;


### PR DESCRIPTION
No functional changes except fixing a bug with MAIN_FB_SIZE().

Need to add a flush function for the frame buffer so you don't have to call sensor.snapshot(). That's coming next.

Yes, hog works now to... however, the script needs to be fixed since the camera init is done in the wrong order.