### PR TITLE
changing sign of z_rotation() to follow conventions of a right-handed coordinate system...

### DIFF
--- a/src/omv/img/apriltag.c
+++ b/src/omv/img/apriltag.c
@@ -11943,7 +11943,7 @@ void imlib_find_apriltags(list_t *out, image_t *ptr, rectangle_t *roi, apriltag_
         lnk_data.z_translation = MATD_EL(pose, 2, 3);
         lnk_data.x_rotation = fast_atan2f(MATD_EL(pose, 2, 1), MATD_EL(pose, 2, 2));
         lnk_data.y_rotation = fast_atan2f(-MATD_EL(pose, 2, 0), fast_sqrtf(sq(MATD_EL(pose, 2, 1)) + sq(MATD_EL(pose, 2, 2))));
-        lnk_data.z_rotation = -fast_atan2f(MATD_EL(pose, 1, 0), MATD_EL(pose, 0, 0));
+        lnk_data.z_rotation = fast_atan2f(MATD_EL(pose, 1, 0), MATD_EL(pose, 0, 0));
 
         matd_destroy(pose);
 


### PR DESCRIPTION
...with yaw, pitch and roll defined as right-handed rotations about z-, y- and x-axis (http://nghiaho.com/?page_id=846, http://planning.cs.uiuc.edu/node102.html)

This commit partly reverts pull request #200: https://github.com/openmv/openmv/pull/200/files

This commit relates to a discussion in the OpenMV forum: http://forums.openmv.io/viewtopic.php?f=6&t=538

Note that `apriltag.rotation()` is probably effected by this change. But it should rather remain being a clockwise rotation.

The documentation should now read as follows:

---

**Coordinate frame of OpenMV Camera:**

Origin: projection center of the camera
X-axis: pointing to the right (with respect to camera image)
Y-axis: pointing up (with respect to camera image)
Z-axis: pointing towards the camera (Z coordinate corresponds to negative distance, completing a right-handed coordinate frame)

**Coordinate frame of an AprilTag:**

Origin: marker center
X-axis: pointing to the right
Y-axis: pointing down
Z-axis: pointing into the marker (completing a right-handed coordinate frame)

The directions refer to an "upright" AprilTag as shown here: https://april.eecs.umich.edu/software/apriltag.html.

**Translation and rotation of a detected AprilTag:**

x_translation: translation from left to right with respect to the camera projection center as seen by the camera
y_translation: translation from bottom to top with respect to the camera projection center as seen by the camera
z_translation: negative z-distance between AprilTag and camera projection center, increases towards 0 when getting closer
x_rotation: rotation around the AprilTag's left-to-right x-axis, increases when lifting its upper half
y_rotation: rotation around the AprilTag's top-to-bottom y-axis, increases when lifting its left half
z_rotation: rotation around the AprilTag's z-axis, increases when turning counterclockwise

The concatenated translation and rotation of the AprilTag can be imagined like this:
Start with both coordinate frames aligned to each other. Translate the AprilTag to its (x, y, z) location within the camera frame. Rotate it around its z-axis, then its y-axis and finally its x-axis - using a so-called body-fixed frame of reference.