### PR TITLE
Add chrominace and illuminace invariant image generators.

### DIFF
--- a/src/omv/img/imlib.h
+++ b/src/omv/img/imlib.h
@@ -1202,6 +1202,9 @@ void imlib_edge_canny(image_t *src, rectangle_t *roi, int low_thresh, int high_t
 // HoG
 void imlib_find_hog(image_t *src, rectangle_t *roi, int cell_size);
 
+// Image Correction
+void imlib_chrominvar(image_t *img);
+void imlib_illuminvar(image_t *img);
 // Lens/Rotation Correction
 void imlib_lens_corr(image_t *img, float strength, float zoom);
 void imlib_rotation_corr(image_t *img, float x_rotation, float y_rotation,

--- a/src/omv/py/py_image.c
+++ b/src/omv/py/py_image.c
@@ -1229,6 +1229,24 @@ static mp_obj_t py_image_gaussian(uint n_args, const mp_obj_t *args, mp_map_t *k
     return args[0];
 }
 
+static mp_obj_t py_image_chrominvar(mp_obj_t img_obj)
+{
+    image_t *arg_img = py_image_cobj(img_obj);
+    PY_ASSERT_TRUE_MSG(IM_IS_RGB565(arg_img), "Image format is not supported.");
+
+    imlib_chrominvar(arg_img);
+    return img_obj;
+}
+
+static mp_obj_t py_image_illuminvar(mp_obj_t img_obj)
+{
+    image_t *arg_img = py_image_cobj(img_obj);
+    PY_ASSERT_TRUE_MSG(IM_IS_RGB565(arg_img), "Image format is not supported.");
+
+    imlib_illuminvar(arg_img);
+    return img_obj;
+}
+
 static mp_obj_t py_image_histeq(mp_obj_t img_obj)
 {
     image_t *arg_img = py_image_cobj(img_obj);
@@ -3853,6 +3871,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(py_image_mean_obj, py_image_mean);
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(py_image_mode_obj, py_image_mode);
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_image_median_obj, 2, py_image_median);
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_image_gaussian_obj, 1, py_image_gaussian);
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_image_chrominvar_obj, py_image_chrominvar);
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_image_illuminvar_obj, py_image_illuminvar);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_image_histeq_obj, py_image_histeq);
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_image_lens_corr_obj, 1, py_image_lens_corr);
 #ifdef OMV_ENABLE_ROTATION_CORR
@@ -3960,6 +3980,8 @@ static const mp_map_elem_t locals_dict_table[] = {
     {MP_OBJ_NEW_QSTR(MP_QSTR_mode),                (mp_obj_t)&py_image_mode_obj},
     {MP_OBJ_NEW_QSTR(MP_QSTR_median),              (mp_obj_t)&py_image_median_obj},
     {MP_OBJ_NEW_QSTR(MP_QSTR_gaussian),            (mp_obj_t)&py_image_gaussian_obj},
+    {MP_OBJ_NEW_QSTR(MP_QSTR_chrominvar),          (mp_obj_t)&py_image_chrominvar_obj},
+    {MP_OBJ_NEW_QSTR(MP_QSTR_illuminvar),          (mp_obj_t)&py_image_illuminvar_obj},
     {MP_OBJ_NEW_QSTR(MP_QSTR_histeq),              (mp_obj_t)&py_image_histeq_obj},
     {MP_OBJ_NEW_QSTR(MP_QSTR_lens_corr),           (mp_obj_t)&py_image_lens_corr_obj},
 #ifdef OMV_ENABLE_ROTATION_CORR

--- a/src/omv/py/qstrdefsomv.h
+++ b/src/omv/py/qstrdefsomv.h
@@ -339,6 +339,12 @@ Q(CPUFREQ_216MHZ)
 Q(get_frequency)
 Q(set_frequency)
 
+// Chromination Invariant
+Q(chrominvar)
+
+// Illumination Invariant
+Q(illuminvar)
+
 // Lens Correction
 Q(lens_corr)
 Q(strength)


### PR DESCRIPTION
Both algorithms were tested on the OpenMV Cam using images loaded from a
file and work correctly. However, shot noise from the sensor.snapshot()
makes the output value somewhat worthless except in a situation unless
you've controlled for it. Anyway, the illuminvar method works best when the
image is constrained to a very particular view point looking at a flat
scene without shadow and then a shadow enters.

(Not adding demo's for these methods since the output looks bad
unless you've put some work into constraining the scene... need to add
HDR code and other stuff to the sensor module to get better images).