### PR TITLE
Restore MAIN_FB() size on snapshot()

### DIFF
--- a/src/omv/sensor.h
+++ b/src/omv/sensor.h
@@ -106,6 +106,7 @@ typedef struct _sensor {
     uint32_t hw_flags;          // Hardware flags (clock polarities/hw capabilities)
     uint32_t vsync_pin;
     GPIO_TypeDef *vsync_gpio;
+    int fb_w, fb_h;             // Backup for MAIN_FB().
 
     // Line pre-processing function and args
     void *line_filter_args;


### PR DESCRIPTION
This fix allows "copy_to_fb" with a different resolution than the
current frame buffer to work. It also allows the frame buffer to be
resized, etc. In particular, the pooling methods I added for optical
flow work again... you'll also be able to scale the frame buffer too.

**Make sure to rebuild after taking this. Freaking build system needs rebuild all the time...**