### PR TITLE
Frame Differencing with Shadow Removal

### DIFF
--- a/src/omv/img/imlib.c
+++ b/src/omv/img/imlib.c
@@ -430,9 +430,9 @@ void imlib_image_operation(image_t *img, const char *path, image_t *other, line_
             imlib_read_pixels(&fp, &temp, 0, can_do, &rs);
             for (int j=0; j<can_do; j++) {
                 if (!vflipped) {
-                    op(img, i+j, temp.pixels+(temp.w*temp.bpp*j), data);
+                    op(img, i+j, temp.pixels+(temp.w*temp.bpp*j), data, false);
                 } else {
-                    op(img, (img->h-i-can_do)+j, temp.pixels+(temp.w*temp.bpp*j), data);
+                    op(img, (img->h-i-can_do)+j, temp.pixels+(temp.w*temp.bpp*j), data, true);
                 }
             }
         }
@@ -444,7 +444,7 @@ void imlib_image_operation(image_t *img, const char *path, image_t *other, line_
             ff_not_equal(NULL);
         }
         for (int i=0; i<img->h; i++) {
-            op(img, i, other->pixels + (img->w * img->bpp * i), data);
+            op(img, i, other->pixels + (img->w * img->bpp * i), data, false);
         }
     }
 }
@@ -688,9 +688,9 @@ void imlib_invert(image_t *img)
     }
 }
 
-static void imlib_b_and_line_op(image_t *img, int line, uint8_t *other, void *data)
+static void imlib_b_and_line_op(image_t *img, int line, uint8_t *other, void *data, bool vflipped)
 {
-    data = data;
+    data = data; vflipped = vflipped;
 
     if (IM_IS_GS(img)) {
         uint8_t *pixels = img->pixels + (img->w * line);
@@ -710,9 +710,9 @@ void imlib_b_and(image_t *img, const char *path, image_t *other)
     imlib_image_operation(img, path, other, imlib_b_and_line_op, NULL);
 }
 
-static void imlib_b_nand_line_op(image_t *img, int line, uint8_t *other, void *data)
+static void imlib_b_nand_line_op(image_t *img, int line, uint8_t *other, void *data, bool vflipped)
 {
-    data = data;
+    data = data; vflipped = vflipped;
 
     if (IM_IS_GS(img)) {
         uint8_t *pixels = img->pixels + (img->w * line);
@@ -732,9 +732,9 @@ void imlib_b_nand(image_t *img, const char *path, image_t *other)
     imlib_image_operation(img, path, other, imlib_b_nand_line_op, NULL);
 }
 
-static void imlib_b_or_line_op(image_t *img, int line, uint8_t *other, void *data)
+static void imlib_b_or_line_op(image_t *img, int line, uint8_t *other, void *data, bool vflipped)
 {
-    data = data;
+    data = data; vflipped = vflipped;
 
     if (IM_IS_GS(img)) {
         uint8_t *pixels = img->pixels + (img->w * line);
@@ -754,9 +754,9 @@ void imlib_b_or(image_t *img, const char *path, image_t *other)
     imlib_image_operation(img, path, other, imlib_b_or_line_op, NULL);
 }
 
-static void imlib_b_nor_line_op(image_t *img, int line, uint8_t *other, void *data)
+static void imlib_b_nor_line_op(image_t *img, int line, uint8_t *other, void *data, bool vflipped)
 {
-    data = data;
+    data = data; vflipped = vflipped;
 
     if (IM_IS_GS(img)) {
         uint8_t *pixels = img->pixels + (img->w * line);
@@ -776,9 +776,9 @@ void imlib_b_nor(image_t *img, const char *path, image_t *other)
     imlib_image_operation(img, path, other, imlib_b_nor_line_op, NULL);
 }
 
-static void imlib_b_xor_line_op(image_t *img, int line, uint8_t *other, void *data)
+static void imlib_b_xor_line_op(image_t *img, int line, uint8_t *other, void *data, bool vflipped)
 {
-    data = data;
+    data = data; vflipped = vflipped;
 
     if (IM_IS_GS(img)) {
         uint8_t *pixels = img->pixels + (img->w * line);
@@ -798,9 +798,9 @@ void imlib_b_xor(image_t *img, const char *path, image_t *other)
     imlib_image_operation(img, path, other, imlib_b_xor_line_op, NULL);
 }
 
-static void imlib_b_xnor_line_op(image_t *img, int line, uint8_t *other, void *data)
+static void imlib_b_xnor_line_op(image_t *img, int line, uint8_t *other, void *data, bool vflipped)
 {
-    data = data;
+    data = data; vflipped = vflipped;
 
     if (IM_IS_GS(img)) {
         uint8_t *pixels = img->pixels + (img->w * line);
@@ -949,9 +949,9 @@ void imlib_negate(image_t *img)
     }
 }
 
-static void imlib_difference_line_op(image_t *img, int line, uint8_t *other, void *data)
+static void imlib_difference_line_op(image_t *img, int line, uint8_t *other, void *data, bool vflipped)
 {
-    data = data;
+    data = data; vflipped = vflipped;
 
     if (IM_IS_GS(img)) {
         uint8_t *pixels = img->pixels + (img->w * line);
@@ -975,9 +975,9 @@ void imlib_difference(image_t *img, const char *path, image_t *other)
     imlib_image_operation(img, path, other, imlib_difference_line_op, NULL);
 }
 
-static void imlib_replace_line_op(image_t *img, int line, uint8_t *other, void *data)
+static void imlib_replace_line_op(image_t *img, int line, uint8_t *other, void *data, bool vflipped)
 {
-    data = data;
+    data = data; vflipped = vflipped;
 
     if (IM_IS_GS(img)) {
         uint8_t *pixels = img->pixels + (img->w * line);
@@ -993,9 +993,9 @@ void imlib_replace(image_t *img, const char *path, image_t *other)
     imlib_image_operation(img, path, other, imlib_replace_line_op, NULL);
 }
 
-static void imlib_blend_line_op(image_t *img, int line, uint8_t *other, void *data)
+static void imlib_blend_line_op(image_t *img, int line, uint8_t *other, void *data, bool vflipped)
 {
-    uint32_t alpha = (uint32_t) data;
+    uint32_t alpha = (uint32_t) data; vflipped = vflipped;
 
     if (IM_IS_GS(img)) {
         uint8_t *pixels = img->pixels + (img->w * line);
@@ -1022,9 +1022,9 @@ void imlib_blend(image_t *img, const char *path, image_t *other, int alpha)
     imlib_image_operation(img, path, other, imlib_blend_line_op, (void *) __PKHBT((256-alpha), alpha, 16));
 }
 
-static void imlib_max_line_op(image_t *img, int line, uint8_t *other, void *data)
+static void imlib_max_line_op(image_t *img, int line, uint8_t *other, void *data, bool vflipped)
 {
-    data = data;
+    data = data; vflipped = vflipped;
 
     if (IM_IS_GS(img)) {
         uint8_t *pixels = img->pixels + (img->w * line);
@@ -1048,9 +1048,9 @@ void imlib_max(image_t *img, const char *path, image_t *other)
     imlib_image_operation(img, path, other, imlib_max_line_op, NULL);
 }
 
-static void imlib_min_line_op(image_t *img, int line, uint8_t *other, void *data)
+static void imlib_min_line_op(image_t *img, int line, uint8_t *other, void *data, bool vflipped)
 {
-    data = data;
+    data = data; vflipped = vflipped;
 
     if (IM_IS_GS(img)) {
         uint8_t *pixels = img->pixels + (img->w * line);
@@ -1073,6 +1073,176 @@ void imlib_min(image_t *img, const char *path, image_t *other)
 {
     imlib_image_operation(img, path, other, imlib_min_line_op, NULL);
 }
+
+// http://arma.sourceforge.net/shadows/
+// http://dx.doi.org/10.1016/j.patcog.2011.10.001
+
+#define imlib_remove_shadows_kernel_rank 1
+#define imlib_remove_shadows_kernel_size ((imlib_remove_shadows_kernel_rank * 2) + 1)
+
+typedef struct imlib_remove_shadows_line_op_state {
+    uint16_t *img_lines[imlib_remove_shadows_kernel_size];
+    uint16_t *other_lines[imlib_remove_shadows_kernel_size];
+    uint16_t *out_lines[imlib_remove_shadows_kernel_size];
+    int lines_processed;
+} imlib_remove_shadows_line_op_state_t;
+
+static void imlib_remove_shadows_sub_sub_line_op(image_t *img, int line, void *data, bool vflipped)
+{
+    imlib_remove_shadows_line_op_state_t *state = (imlib_remove_shadows_line_op_state_t *) data;
+
+    state->lines_processed += 1;
+
+    if (state->lines_processed >= imlib_remove_shadows_kernel_size) {
+        int y = vflipped ? ((line - 1) + imlib_remove_shadows_kernel_size) : ((line + 1) - imlib_remove_shadows_kernel_size);
+        int index = y % imlib_remove_shadows_kernel_size;
+        memcpy(IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(img, y), state->out_lines[index], img->w * sizeof(uint16_t));
+    }
+}
+
+static void imlib_remove_shadows_sub_line_op(image_t *img, int line, void *data, bool vflipped)
+{
+    imlib_remove_shadows_line_op_state_t *state = (imlib_remove_shadows_line_op_state_t *) data;
+
+    if (state->lines_processed >= imlib_remove_shadows_kernel_rank) {
+        int y = vflipped ? (line + imlib_remove_shadows_kernel_rank) : (line - imlib_remove_shadows_kernel_rank);
+        int index = y % imlib_remove_shadows_kernel_size;
+
+        for (int x = 0, xx = img->w; x < xx; x++) {
+            int img_pixel = IMAGE_GET_RGB565_PIXEL_FAST(state->img_lines[index], x);
+            int img_r = COLOR_RGB565_TO_R8(img_pixel);
+            int img_g = COLOR_RGB565_TO_G8(img_pixel);
+            int img_b = COLOR_RGB565_TO_B8(img_pixel);
+            float img_v = IM_MAX(IM_MAX(img_r, img_g), img_b);
+            int other_pixel = IMAGE_GET_RGB565_PIXEL_FAST(state->other_lines[index], x);
+            int other_r = COLOR_RGB565_TO_R8(other_pixel);
+            int other_g = COLOR_RGB565_TO_G8(other_pixel);
+            int other_b = COLOR_RGB565_TO_B8(other_pixel);
+            float other_v = IM_MAX(IM_MAX(other_r, other_g), other_b);
+            float ratio = img_v / other_v;
+
+            if ((0.3f < ratio) && (ratio < 1.0f)) {
+                int minY = IM_MAX(y - imlib_remove_shadows_kernel_rank, 0);
+                int maxY = IM_MIN(y + imlib_remove_shadows_kernel_rank, img->h - 1);
+                int minX = IM_MAX(x - imlib_remove_shadows_kernel_rank, 0);
+                int maxX = IM_MIN(x + imlib_remove_shadows_kernel_rank, img->w - 1);
+                int windowArea = (maxX - minX + 1) * (maxY - minY + 1);
+                int hDiffSum = 0;
+                int sDiffSum = 0;
+
+                for (int k_y = minY; k_y <= maxY; k_y++) {
+                    int k_index = k_y % imlib_remove_shadows_kernel_size;
+
+                    for (int k_x = minX; k_x <= maxX; k_x++) {
+                        int k_img_pixel = IMAGE_GET_RGB565_PIXEL_FAST(state->img_lines[k_index], k_x);
+                        int k_img_r = COLOR_RGB565_TO_R8(k_img_pixel);
+                        int k_img_g = COLOR_RGB565_TO_G8(k_img_pixel);
+                        int k_img_b = COLOR_RGB565_TO_B8(k_img_pixel);
+                        int k_img_cmax = IM_MAX(IM_MAX(k_img_r, k_img_g), k_img_b);
+                        int k_img_cmin = IM_MAX(IM_MAX(k_img_r, k_img_g), k_img_b);
+                        float k_img_cdel = k_img_cmax - k_img_cmin;
+                        float k_img_h = 0;
+                        float k_img_s = k_img_cmax ? (k_img_cdel / k_img_cmax) : 0;
+                        int k_other_pixel = IMAGE_GET_RGB565_PIXEL_FAST(state->other_lines[k_index], k_x);
+                        int k_other_r = COLOR_RGB565_TO_R8(k_other_pixel);
+                        int k_other_g = COLOR_RGB565_TO_G8(k_other_pixel);
+                        int k_other_b = COLOR_RGB565_TO_B8(k_other_pixel);
+                        int k_other_cmax = IM_MAX(IM_MAX(k_other_r, k_other_g), k_other_b);
+                        int k_other_cmin = IM_MAX(IM_MAX(k_other_r, k_other_g), k_other_b);
+                        float k_other_cdel = k_other_cmax - k_other_cmin;
+                        float k_other_h = 0;
+                        float k_other_s = k_other_cmax ? (k_other_cdel / k_other_cmax) : 0;
+
+                        if (k_img_cdel) {
+                            if (k_img_cmax == k_img_r) {
+                                k_img_h = ((k_img_g - k_img_b) / k_img_cdel) + 0;
+                            } else if (k_img_cmax == k_img_g) {
+                                k_img_h = ((k_img_b - k_img_r) / k_img_cdel) + 2;
+                            } else if (k_img_cmax == k_img_b) {
+                                k_img_h = ((k_img_r - k_img_g) / k_img_cdel) + 4;
+                            }
+                            k_img_h *= 60;
+                            if (k_img_h < 0) k_img_h += 360.0;
+                        }
+
+                        if (k_other_cdel) {
+                            if (k_other_cmax == k_other_r) {
+                                k_other_h = ((k_other_g - k_other_b) / k_other_cdel) + 0;
+                            } else if (k_other_cmax == k_other_g) {
+                                k_other_h = ((k_other_b - k_other_r) / k_other_cdel) + 2;
+                            } else if (k_other_cmax == k_other_b) {
+                                k_other_h = ((k_other_r - k_other_g) / k_other_cdel) + 4;
+                            }
+                            k_other_h *= 60;
+                            if (k_other_h < 0) k_other_h += 360.0;
+                        }
+
+                        int hDiff = abs(k_img_h - k_other_h);
+                        hDiffSum += (hDiff > 90) ? (180 - hDiff) : hDiff;
+                        sDiffSum += k_img_s - k_other_s;
+                    }
+                }
+
+                bool hIsShadow = (hDiffSum / windowArea) < 48;
+                bool sIsShadow = (sDiffSum / windowArea) < 40;
+                IMAGE_PUT_RGB565_PIXEL_FAST(state->out_lines[index], x, (hIsShadow && sIsShadow) ? other_pixel : img_pixel);
+            } else {
+                IMAGE_PUT_RGB565_PIXEL_FAST(state->out_lines[index], x, img_pixel);
+            }
+        }
+    }
+
+    imlib_remove_shadows_sub_sub_line_op(img, line, data, vflipped);
+}
+
+static void imlib_remove_shadows_line_op(image_t *img, int line, uint8_t *other, void *data, bool vflipped)
+{
+    imlib_remove_shadows_line_op_state_t *state = (imlib_remove_shadows_line_op_state_t *) data;
+
+    memcpy(state->img_lines[line % imlib_remove_shadows_kernel_size],
+            IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(img, line), img->w * sizeof(uint16_t));
+
+    memcpy(state->other_lines[line % imlib_remove_shadows_kernel_size],
+            (uint16_t *) other, img->w * sizeof(uint16_t));
+
+    imlib_remove_shadows_sub_line_op(img, line, data, vflipped);
+
+    if (state->lines_processed == img->h) {
+        for (int i = 0; i < imlib_remove_shadows_kernel_rank; i++) {
+            line += vflipped ? -1 : 1;
+            imlib_remove_shadows_sub_line_op(img, line, data, vflipped);
+        }
+
+        for (int i = 0; i < imlib_remove_shadows_kernel_rank; i++) {
+            line += vflipped ? -1 : 1;
+            imlib_remove_shadows_sub_sub_line_op(img, line, data, vflipped);
+        }
+    }
+}
+
+void imlib_remove_shadows(image_t *img, const char *path, image_t *other)
+{
+    imlib_remove_shadows_line_op_state_t state;
+
+    for (int i = 0; i < imlib_remove_shadows_kernel_size; i++) {
+        state.img_lines[i] = fb_alloc(img->w * sizeof(uint16_t));
+        state.other_lines[i] = fb_alloc(img->w * sizeof(uint16_t));
+        state.out_lines[i] = fb_alloc(img->w * sizeof(uint16_t));
+    }
+
+    state.lines_processed = 0;
+
+    imlib_image_operation(img, path, other, imlib_remove_shadows_line_op, (void *) &state);
+
+    for (int i = 0; i < imlib_remove_shadows_kernel_size; i++) {
+        fb_free();
+        fb_free();
+        fb_free();
+    }
+}
+
+#undef imlib_remove_shadows_kernel_size
+#undef imlib_remove_shadows_kernel_rank
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/omv/img/imlib.h
+++ b/src/omv/img/imlib.h
@@ -898,7 +898,7 @@ typedef struct img_read_settings {
     save_image_format_t format;
 } img_read_settings_t;
 
-typedef void (*line_op_t)(image_t*, int, uint8_t*, void*);
+typedef void (*line_op_t)(image_t*, int, uint8_t*, void*, bool);
 
 typedef enum descriptor_type {
     DESC_LBP,
@@ -1120,6 +1120,7 @@ void imlib_replace(image_t *img, const char *path, image_t *other);
 void imlib_blend(image_t *img, const char *path, image_t *other, int alpha);
 void imlib_max(image_t *img, const char *path, image_t *other);
 void imlib_min(image_t *img, const char *path, image_t *other);
+void imlib_remove_shadows(image_t *img, const char *path, image_t *other);
 
 /* Image Morphing */
 void imlib_morph(image_t *img, const int ksize, const int8_t *krn, const float m, const int b);

--- a/src/omv/img/stats.c
+++ b/src/omv/img/stats.c
@@ -11,9 +11,9 @@ typedef struct imlib_similatiry_line_op_state {
     int lines_processed;
 } imlib_similatiry_line_op_state_t;
 
-void imlib_similarity_line_op(image_t *img, int line, uint8_t *other, void *data)
+void imlib_similarity_line_op(image_t *img, int line, uint8_t *other, void *data, bool vflipped)
 {
-    imlib_similatiry_line_op_state_t *state = (imlib_similatiry_line_op_state_t *) data;
+    imlib_similatiry_line_op_state_t *state = (imlib_similatiry_line_op_state_t *) data; vflipped = vflipped;
     float c1 = 0, c2 = 0;
 
     switch(img->bpp) {

--- a/src/omv/py/py_image.c
+++ b/src/omv/py/py_image.c
@@ -1326,6 +1326,25 @@ static mp_obj_t py_image_min(mp_obj_t img_obj, mp_obj_t other_obj)
     return img_obj;
 }
 
+static mp_obj_t py_image_remove_shadows(mp_obj_t img_obj, mp_obj_t other_obj)
+{
+    image_t *arg_img = py_image_cobj(img_obj);
+    PY_ASSERT_TRUE_MSG(IM_IS_RGB565(arg_img), "Image format is not supported.");
+
+    if (MP_OBJ_IS_STR(other_obj)) {
+        fb_alloc_mark();
+        imlib_remove_shadows(arg_img, mp_obj_str_get_str(other_obj), NULL);
+        fb_alloc_mark();
+    } else {
+        image_t *arg_other = py_image_cobj(other_obj);
+        fb_alloc_mark();
+        imlib_remove_shadows(arg_img, NULL, arg_other);
+        fb_alloc_free_till_mark();
+    }
+
+    return img_obj;
+}
+
 static mp_obj_t py_image_linpolar(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
 {
     image_t *arg_img = py_image_cobj(args[0]);
@@ -4185,6 +4204,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(py_image_replace_obj, py_image_replace);
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_image_blend_obj, 2, py_image_blend);
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(py_image_max_obj, py_image_max);
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(py_image_min_obj, py_image_min);
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(py_image_remove_shadows_obj, py_image_remove_shadows);
 /* Image Morphing */
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_image_morph_obj, 3, py_image_morph);
 /* Image Filtering */
@@ -4301,6 +4321,7 @@ static const mp_map_elem_t locals_dict_table[] = {
     {MP_OBJ_NEW_QSTR(MP_QSTR_blend),               (mp_obj_t)&py_image_blend_obj},
     {MP_OBJ_NEW_QSTR(MP_QSTR_max),                 (mp_obj_t)&py_image_max_obj},
     {MP_OBJ_NEW_QSTR(MP_QSTR_min),                 (mp_obj_t)&py_image_min_obj},
+    {MP_OBJ_NEW_QSTR(MP_QSTR_remove_shadows),      (mp_obj_t)&py_image_remove_shadows_obj},
     /* Image Morphing */
     {MP_OBJ_NEW_QSTR(MP_QSTR_morph),               (mp_obj_t)&py_image_morph_obj},
     /* Image Filtering */

--- a/src/omv/py/qstrdefsomv.h
+++ b/src/omv/py/qstrdefsomv.h
@@ -355,7 +355,10 @@ Q(set_frequency)
 // Min
 // duplicate Q(min)
 
-// Log Polar
+// Shadow Removal
+Q(remove_shadows)
+
+// Linear Polar
 Q(linpolar)
 Q(reverse)
 

--- a/usr/examples/20-Frame-Differencing/in_memory_shadow_removal.py
+++ b/usr/examples/20-Frame-Differencing/in_memory_shadow_removal.py
@@ -1,0 +1,53 @@
+# In Memory Shadow Removal w/ Frame Differencing Example
+#
+# This example demonstrates using frame differencing with your OpenMV Cam using
+# shadow removal to help reduce the affects of cast shadows in your scene.
+
+import sensor, image, pyb, os, time
+
+TRIGGER_THRESHOLD = 5
+
+sensor.reset() # Initialize the camera sensor.
+sensor.set_pixformat(sensor.RGB565) # or sensor.GRAYSCALE
+sensor.set_framesize(sensor.QQVGA) # or sensor.QVGA (or others)
+if sensor.get_id() == sensor.OV7725: # Reduce sensor PLL from 6x to 4x.
+    sensor.__write_reg(0x0D, (sensor.__read_reg(0x0D) & 0x3F) | 0x40)
+sensor.skip_frames(time = 2000) # Let new settings take affect.
+sensor.set_auto_whitebal(False) # Turn off white balance.
+sensor.set_auto_gain(False) # Turn this off too.
+clock = time.clock() # Tracks FPS.
+
+# Take from the main frame buffer's RAM to allocate a second frame buffer.
+# There's a lot more RAM in the frame buffer than in the MicroPython heap.
+# However, after doing this you have a lot less RAM for some algorithms...
+# So, be aware that it's a lot easier to get out of RAM issues now. However,
+# frame differencing doesn't use a lot of the extra space in the frame buffer.
+# But, things like AprilTags do and won't work if you do this...
+extra_fb = sensor.alloc_extra_fb(sensor.width(), sensor.height(), sensor.RGB565)
+
+print("About to save background image...")
+sensor.skip_frames(time = 2000) # Give the user time to get ready.
+extra_fb.replace(sensor.snapshot())
+print("Saved background image - Now frame differencing!")
+
+while(True):
+    clock.tick() # Track elapsed milliseconds between snapshots().
+    img = sensor.snapshot() # Take a picture and return the image.
+
+    # Note that for shadow removal to work the background image must be
+    # shadow free and have the same lighting as the latest image. Unlike max()
+    # shadow removal won't remove all dark objects unless they were shadows...
+
+    # Replace the image with the "abs(NEW-OLD)" frame difference.
+    img.remove_shadows(extra_fb).difference(extra_fb)
+
+    hist = img.get_histogram()
+    # This code below works by comparing the 99th percentile value (e.g. the
+    # non-outlier max value against the 90th percentile value (e.g. a non-max
+    # value. The difference between the two values will grow as the difference
+    # image seems more pixels change.
+    diff = hist.get_percentile(0.99).l_value() - hist.get_percentile(0.90).l_value()
+    triggered = diff > TRIGGER_THRESHOLD
+
+    print(clock.fps(), triggered) # Note: Your OpenMV Cam runs about half as fast while
+    # connected to your computer. The FPS should increase once disconnected.

--- a/usr/examples/20-Frame-Differencing/on_disk_shadow_removal.py
+++ b/usr/examples/20-Frame-Differencing/on_disk_shadow_removal.py
@@ -1,0 +1,49 @@
+# In Memory Shadow Removal w/ Frame Differencing Example
+#
+# Note: You will need an SD card to run this example.
+#
+# This example demonstrates using frame differencing with your OpenMV Cam using
+# shadow removal to help reduce the affects of cast shadows in your scene.
+
+import sensor, image, pyb, os, time
+
+TRIGGER_THRESHOLD = 5
+
+sensor.reset() # Initialize the camera sensor.
+sensor.set_pixformat(sensor.RGB565) # or sensor.GRAYSCALE
+sensor.set_framesize(sensor.QQVGA) # or sensor.QVGA (or others)
+if sensor.get_id() == sensor.OV7725: # Reduce sensor PLL from 6x to 4x.
+    sensor.__write_reg(0x0D, (sensor.__read_reg(0x0D) & 0x3F) | 0x40)
+sensor.skip_frames(time = 2000) # Let new settings take affect.
+sensor.set_auto_whitebal(False) # Turn off white balance.
+sensor.set_auto_gain(False) # Turn this off too.
+clock = time.clock() # Tracks FPS.
+
+if not "temp" in os.listdir(): os.mkdir("temp") # Make a temp directory
+
+print("About to save background image...")
+sensor.skip_frames(time = 2000) # Give the user time to get ready.
+sensor.snapshot().save("temp/bg.bmp")
+print("Saved background image - Now frame differencing!")
+
+while(True):
+    clock.tick() # Track elapsed milliseconds between snapshots().
+    img = sensor.snapshot() # Take a picture and return the image.
+
+    # Note that for shadow removal to work the background image must be
+    # shadow free and have the same lighting as the latest image. Unlike max()
+    # shadow removal won't remove all dark objects unless they were shadows...
+
+    # Replace the image with the "abs(NEW-OLD)" frame difference.
+    img.remove_shadows("temp/bg.bmp").difference("temp/bg.bmp")
+
+    hist = img.get_histogram()
+    # This code below works by comparing the 99th percentile value (e.g. the
+    # non-outlier max value against the 90th percentile value (e.g. a non-max
+    # value. The difference between the two values will grow as the difference
+    # image seems more pixels change.
+    diff = hist.get_percentile(0.99).l_value() - hist.get_percentile(0.90).l_value()
+    triggered = diff > TRIGGER_THRESHOLD
+
+    print(clock.fps(), triggered) # Note: Your OpenMV Cam runs about half as fast while
+    # connected to your computer. The FPS should increase once disconnected.


### PR DESCRIPTION
Add in support for shadow removal from the current image using a shadow
free background image. Test results show the algorithm works similar to
max() while still keeping dark objects around. The preformance impact of
the algorithm is not too high. An in memory example can achieve 30 FPS.