### PR TITLE
Add wifi_dbg stub.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -131,6 +131,7 @@ FIRM_OBJ += $(addprefix $(BUILD)/$(OMV_DIR)/, \
 	framebuffer.o                           \
 	array.o                                 \
 	usbdbg.o                                \
+	wifi_dbg.o                              \
 	cambus.o                                \
 	ov9650.o                                \
 	ov2640.o                                \

--- a/src/omv/Makefile
+++ b/src/omv/Makefile
@@ -9,6 +9,7 @@ SRCS += $(addprefix ,   \
 	framebuffer.c       \
 	array.c             \
 	usbdbg.c            \
+	wifi_dbg.c          \
 	cambus.c            \
 	ov9650.c            \
 	ov2640.c            \

--- a/src/omv/wifi_dbg.c
+++ b/src/omv/wifi_dbg.c
@@ -1,0 +1,65 @@
+/* This file is part of the OpenMV project.
+ * Copyright (c) 2013-2018 Ibrahim Abdelkader <iabdalkader@openmv.io> & Kwabena W. Agyeman <kwagyeman@openmv.io>
+ * This work is licensed under the MIT license, see the file LICENSE for details.
+ */
+
+#include <stdint.h>
+#include "wifi_dbg.h"
+
+// To avoid writing extra code just re-use the USBDBG code as the interface that does the actual work.
+// The only tricky part is that you don't have USB transactions anymore. So, you need to buffer 6 bytes
+// in a fifo until you have 6 of them to execute a control phase. Then, push the rest into the data phase
+// as described by the length in the control phase header. Buffering on the wifi network will definately
+// cause all RX bytes to be in one long giant burst. You have to write the code to handle this...
+
+extern void usbdbg_data_in(void *buffer, int length);
+extern void usbdbg_data_out(void *buffer, int length);
+extern void usbdbg_control(void *buffer, uint8_t brequest, uint32_t wlength);
+
+void wifi_dbg_init()
+{
+    // Get wifi debug into a known state. Since this is called by all OpenMV Cams you should not toggle any
+    // pins unless you detect the wifi module was previously setup...
+    // Also, reset regular USB CDC DBG access if things were setup before.
+}
+
+void wifi_dbg_apply_settings(wifi_dbg_settings_t *settings)
+{
+    switch(settings->wifi_mode) {
+        case WIFI_DBG_DISABLED: // Don't init anything.
+            break;
+        case WIFI_DBG_ENABLED_CLIENT_MODE:
+            // Start the wifi module up in client mode.
+            // Additionally, make network.WINC() return a python object of the setup wifi module and make
+            // winc.connect()/winc.disconnect() do nothing. This should allow the user to use the wifi module
+            // normally in their scripts in debug mode.
+            // You should have all the settings you need to init the wifi module in the settings struct.
+            // Disable regular USB CDC DBG if this works... two folks can't share the interface.
+            // For data transfer create a TCP server after setting up the wifi. You will then UDP broadcast
+            // your IP address along with the port you chose for the TCP server. OpenMV IDE will connect to this.
+            break;
+        case WIFI_DBG_ENABLED_AP_MODE:
+            // Start the wifi module up in ap mode.
+            // Additionally, make network.WINC() return a python object of the setup wifi module and make
+            // winc.connect()/winc.disconnect() do nothing. This should allow the user to use the wifi module
+            // normally in their scripts in debug mode.
+            // You should have all the settings you need to init the wifi module in the settings struct.
+            // Disable regular USB CDC DBG if this works... two folks can't share the interface.
+            // For data transfer create a TCP server after setting up the wifi. You will then UDP broadcast
+            // your IP address along with the port you chose for the TCP server. OpenMV IDE will connect to this.
+            break;
+        default: // Don't init anything.
+            break;
+    }
+}
+
+void wifi_dbg_beacon()
+{
+    // Call this every second via a timer calback or something if wifi is enabled.
+    // You need to broadcast a UDP message on the OPENMVCAM_BROADCAST_PORT port.
+    // The contents of the message should be "ip:port:board_name", e.g. "192.168.2.1:4321:Ibrahim's cam".
+    // OpenMV splits the message using the ":" character. The port can by anything (whatever the module picks randomly).
+    // The IP address must be in dot format. Finally, the string can have whatever in it.
+    // If broadcasting is working the IDE should display a new board option to connect to when you hit connect.
+    // I'd get this working first for both AP and client mode before working on the rest of the code.
+}

--- a/src/omv/wifi_dbg.h
+++ b/src/omv/wifi_dbg.h
@@ -1,0 +1,47 @@
+/* This file is part of the OpenMV project.
+ * Copyright (c) 2013-2018 Ibrahim Abdelkader <iabdalkader@openmv.io> & Kwabena W. Agyeman <kwagyeman@openmv.io>
+ * This work is licensed under the MIT license, see the file LICENSE for details.
+ */
+#ifndef __WIFI_DBG_H__
+#define __WIFI_DBG_H__
+
+#define SSID_MAX 63
+#define PASS_MAX 63
+#define NAME_MAX 63
+
+#define OPENMVCAM_BROADCAST_PORT 0xABD1
+
+typedef enum wifi_dbg_wifi_mode
+{
+    WIFI_DBG_DISABLED = 0,
+    WIFI_DBG_ENABLED_CLIENT_MODE = 1,
+    WIFI_DBG_ENABLED_AP_MODE = 2
+}
+wifi_dbg_wifi_mode_t;
+
+typedef enum wifi_dbg_wifi_type
+{
+    WIFI_DBG_OPEN,
+    WIFI_DBG_WPA,
+    WIFI_DBG_WEP
+}
+wifi_dbg_wifi_type_t;
+
+typedef struct wifi_dbg_settings
+{
+    wifi_dbg_wifi_mode_t wifi_mode;
+    char wifi_client_ssid[SSID_MAX+1];
+    char wifi_client_pass[PASS_MAX+1];
+    wifi_dbg_wifi_type_t wifi_client_type;
+    char wifi_ap_ssid[SSID_MAX+1];
+    char wifi_ap_pass[PASS_MAX+1];
+    wifi_dbg_wifi_type_t wifi_ap_type;
+    char wifi_board_name[NAME_MAX+1];
+}
+wifi_dbg_settings_t;
+
+void wifi_dbg_init();
+void wifi_dbg_apply_settings(wifi_dbg_settings_t *settings);
+void wifi_dbg_beacon();
+
+#endif /* __WIFI_DBG_H__ */


### PR DESCRIPTION
All the notes about how to implement wifi programming are in the code.
Steps:

1. Get wifi_apply_settings() working first and make sure you can turn
the wifi shield on in the right mode. Then add the necessary hooks into
the network code to make it such that previous user wifi code still
works. Also, make sure to handle start and shutdown gracefully.

Basically, get all the lifecycle code working first before moving to the
next step so notning gets in a weird state and bugs creep in...

2. Get the beacon method working. Once this works OpenMV IDE should see
the camera when you hit the connect button.

3. Do the code to turn off the regular usbdbg interface and swtich to
having the data come from wifi_dbg. This isn't a lot of code... but,
will be tricky since you no longer will have USB frames to work with.
All bytes are just going to come randomly and in bursts so you have to
handle the serial stream yourself... (Kwabena can help writing a
statemachine for dealing with this type of stuff if you want. I do it
all the time).