### PR TITLE
Overhaul Binary Functions

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -144,6 +144,7 @@ FIRM_OBJ += $(addprefix $(BUILD)/$(OMV_DIR)/, \
 	)
 
 FIRM_OBJ += $(addprefix $(BUILD)/$(OMV_DIR)/img/,\
+	binary.o                                \
 	blob.o                                  \
 	qrcode.o                                \
 	apriltag.o                              \

--- a/src/omv/Makefile
+++ b/src/omv/Makefile
@@ -22,6 +22,7 @@ SRCS += $(addprefix ,   \
    )
 
 SRCS += $(addprefix img/,   \
+	binary.c                \
 	blob.c                  \
 	qrcode.c                \
 	apriltag.c              \

--- a/src/omv/img/binary.c
+++ b/src/omv/img/binary.c
@@ -1,0 +1,713 @@
+/* This file is part of the OpenMV project.
+ * Copyright (c) 2013-2018 Ibrahim Abdelkader <iabdalkader@openmv.io> & Kwabena W. Agyeman <kwagyeman@openmv.io>
+ * This work is licensed under the MIT license, see the file LICENSE for details.
+ */
+
+#include "imlib.h"
+
+void imlib_binary(image_t *img, list_t *thresholds, bool invert, bool zero)
+{
+    for (list_lnk_t *it = iterator_start_from_head(thresholds); it; it = iterator_next(it)) {
+        color_thresholds_list_lnk_data_t lnk_data;
+        iterator_get(thresholds, it, &lnk_data);
+
+        switch(img->bpp) {
+            case IMAGE_BPP_BINARY: {
+                break;
+            }
+            case IMAGE_BPP_GRAYSCALE: {
+                if (!zero) {
+                    for (uint8_t *start = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(img, 0),
+                         *end = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(img, img->h);
+                         start < end; start++) {
+                        *start = COLOR_THRESHOLD_GRAYSCALE(*start, &lnk_data, invert)
+                            ? COLOR_GRAYSCALE_BINARY_MAX : COLOR_GRAYSCALE_BINARY_MIN;
+                    }
+                } else {
+                    for (uint8_t *start = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(img, 0),
+                         *end = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(img, img->h);
+                         start < end; start++) {
+                        if (COLOR_THRESHOLD_GRAYSCALE(*start, &lnk_data, invert)) *start =
+                            COLOR_GRAYSCALE_BINARY_MIN;
+                    }
+                }
+                break;
+            }
+            case IMAGE_BPP_RGB565: {
+                if (!zero) {
+                    for (uint16_t *start = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(img, 0),
+                         *end = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(img, img->h);
+                         start < end; start++) {
+                        *start = COLOR_THRESHOLD_RGB565(*start, &lnk_data, invert)
+                            ? COLOR_RGB565_BINARY_MAX : COLOR_RGB565_BINARY_MIN;
+                    }
+                } else {
+                    for (uint16_t *start = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(img, 0),
+                         *end = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(img, img->h);
+                         start < end; start++) {
+                        if (COLOR_THRESHOLD_RGB565(*start, &lnk_data, invert)) *start =
+                            COLOR_RGB565_BINARY_MIN;
+                    }
+                }
+                break;
+            }
+            default: {
+                break;
+            }
+        }
+    }
+}
+
+void imlib_invert(image_t *img)
+{
+    switch(img->bpp) {
+        case IMAGE_BPP_BINARY: {
+            for (uint32_t *start = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(img, 0),
+                 *end = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(img, img->h);
+                 start < end; start++) {
+                *start = ~*start;
+            }
+            break;
+        }
+        case IMAGE_BPP_GRAYSCALE: {
+            for (uint8_t *start = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(img, 0),
+                 *end = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(img, img->h);
+                 start < end; start++) {
+                *start = ~*start;
+            }
+            break;
+        }
+        case IMAGE_BPP_RGB565: {
+            for (uint16_t *start = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(img, 0),
+                 *end = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(img, img->h);
+                 start < end; start++) {
+                *start = ~*start;
+            }
+            break;
+        }
+        default: {
+            break;
+        }
+    }
+}
+
+static void imlib_b_and_line_op(image_t *img, int line, uint8_t *other, void *data, bool vflipped)
+{
+    image_t *mask = (image_t *) data;
+
+    switch(img->bpp) {
+        case IMAGE_BPP_BINARY: {
+            uint32_t *data = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(img, line);
+
+            if(!mask) {
+                for (int i = 0, j = IMAGE_BINARY_LINE_LEN(img); i < j; i++) {
+                    data[i] &= ((uint32_t *) other)[i];
+                }
+            } else {
+                for (int i = 0, j = img->w; i < j; i++) {
+                    if (image_get_mask_pixel(mask, i, line)) {
+                        IMAGE_PUT_BINARY_PIXEL_FAST(data, i,
+                            (IMAGE_GET_BINARY_PIXEL_FAST(data, i)
+                             & IMAGE_GET_BINARY_PIXEL_FAST(((uint32_t *) other), i)));
+                    }
+                }
+            }
+            break;
+        }
+        case IMAGE_BPP_GRAYSCALE: {
+            uint8_t *data = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(img, line);
+
+            if(!mask) {
+                for (int i = 0, j = IMAGE_GRAYSCALE_LINE_LEN(img); i < j; i++) {
+                    data[i] &= ((uint8_t *) other)[i];
+                }
+            } else {
+                for (int i = 0, j = img->w; i < j; i++) {
+                    if (image_get_mask_pixel(mask, i, line)) {
+                        IMAGE_PUT_GRAYSCALE_PIXEL_FAST(data, i,
+                            (IMAGE_GET_GRAYSCALE_PIXEL_FAST(data, i)
+                             & IMAGE_GET_GRAYSCALE_PIXEL_FAST(((uint8_t *) other), i)));
+                    }
+                }
+            }
+            break;
+        }
+        case IMAGE_BPP_RGB565: {
+            uint16_t *data = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(img, line);
+
+            if(!mask) {
+                for (int i = 0, j = IMAGE_RGB565_LINE_LEN(img); i < j; i++) {
+                    data[i] &= ((uint16_t *) other)[i];
+                }
+            } else {
+                for (int i = 0, j = img->w; i < j; i++) {
+                    if (image_get_mask_pixel(mask, i, line)) {
+                        IMAGE_PUT_RGB565_PIXEL_FAST(data, i,
+                            (IMAGE_GET_RGB565_PIXEL_FAST(data, i)
+                             & IMAGE_GET_RGB565_PIXEL_FAST(((uint16_t *) other), i)));
+                    }
+                }
+            }
+            break;
+        }
+        default: {
+            break;
+        }
+    }
+}
+
+void imlib_b_and(image_t *img, const char *path, image_t *other, image_t *mask)
+{
+    imlib_image_operation(img, path, other, imlib_b_and_line_op, mask);
+}
+
+static void imlib_b_nand_line_op(image_t *img, int line, uint8_t *other, void *data, bool vflipped)
+{
+    image_t *mask = (image_t *) data;
+
+    switch(img->bpp) {
+        case IMAGE_BPP_BINARY: {
+            uint32_t *data = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(img, line);
+
+            if(!mask) {
+                for (int i = 0, j = IMAGE_BINARY_LINE_LEN(img); i < j; i++) {
+                    data[i] &= ~((uint32_t *) other)[i];
+                }
+            } else {
+                for (int i = 0, j = img->w; i < j; i++) {
+                    if (image_get_mask_pixel(mask, i, line)) {
+                        IMAGE_PUT_BINARY_PIXEL_FAST(data, i,
+                            (IMAGE_GET_BINARY_PIXEL_FAST(data, i)
+                             & ~IMAGE_GET_BINARY_PIXEL_FAST(((uint32_t *) other), i)));
+                    }
+                }
+            }
+            break;
+        }
+        case IMAGE_BPP_GRAYSCALE: {
+            uint8_t *data = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(img, line);
+
+            if(!mask) {
+                for (int i = 0, j = IMAGE_GRAYSCALE_LINE_LEN(img); i < j; i++) {
+                    data[i] &= ~((uint8_t *) other)[i];
+                }
+            } else {
+                for (int i = 0, j = img->w; i < j; i++) {
+                    if (image_get_mask_pixel(mask, i, line)) {
+                        IMAGE_PUT_GRAYSCALE_PIXEL_FAST(data, i,
+                            (IMAGE_GET_GRAYSCALE_PIXEL_FAST(data, i)
+                             & ~IMAGE_GET_GRAYSCALE_PIXEL_FAST(((uint8_t *) other), i)));
+                    }
+                }
+            }
+            break;
+        }
+        case IMAGE_BPP_RGB565: {
+            uint16_t *data = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(img, line);
+
+            if(!mask) {
+                for (int i = 0, j = IMAGE_RGB565_LINE_LEN(img); i < j; i++) {
+                    data[i] &= ~((uint16_t *) other)[i];
+                }
+            } else {
+                for (int i = 0, j = img->w; i < j; i++) {
+                    if (image_get_mask_pixel(mask, i, line)) {
+                        IMAGE_PUT_RGB565_PIXEL_FAST(data, i,
+                            (IMAGE_GET_RGB565_PIXEL_FAST(data, i)
+                             & ~IMAGE_GET_RGB565_PIXEL_FAST(((uint16_t *) other), i)));
+                    }
+                }
+            }
+            break;
+        }
+        default: {
+            break;
+        }
+    }
+}
+
+void imlib_b_nand(image_t *img, const char *path, image_t *other, image_t *mask)
+{
+    imlib_image_operation(img, path, other, imlib_b_nand_line_op, mask);
+}
+
+static void imlib_b_or_line_op(image_t *img, int line, uint8_t *other, void *data, bool vflipped)
+{
+    image_t *mask = (image_t *) data;
+
+    switch(img->bpp) {
+        case IMAGE_BPP_BINARY: {
+            uint32_t *data = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(img, line);
+
+            if(!mask) {
+                for (int i = 0, j = IMAGE_BINARY_LINE_LEN(img); i < j; i++) {
+                    data[i] |= ((uint32_t *) other)[i];
+                }
+            } else {
+                for (int i = 0, j = img->w; i < j; i++) {
+                    if (image_get_mask_pixel(mask, i, line)) {
+                        IMAGE_PUT_BINARY_PIXEL_FAST(data, i,
+                            (IMAGE_GET_BINARY_PIXEL_FAST(data, i)
+                             | IMAGE_GET_BINARY_PIXEL_FAST(((uint32_t *) other), i)));
+                    }
+                }
+            }
+            break;
+        }
+        case IMAGE_BPP_GRAYSCALE: {
+            uint8_t *data = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(img, line);
+
+            if(!mask) {
+                for (int i = 0, j = IMAGE_GRAYSCALE_LINE_LEN(img); i < j; i++) {
+                    data[i] |= ((uint8_t *) other)[i];
+                }
+            } else {
+                for (int i = 0, j = img->w; i < j; i++) {
+                    if (image_get_mask_pixel(mask, i, line)) {
+                        IMAGE_PUT_GRAYSCALE_PIXEL_FAST(data, i,
+                            (IMAGE_GET_GRAYSCALE_PIXEL_FAST(data, i)
+                             | IMAGE_GET_GRAYSCALE_PIXEL_FAST(((uint8_t *) other), i)));
+                    }
+                }
+            }
+            break;
+        }
+        case IMAGE_BPP_RGB565: {
+            uint16_t *data = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(img, line);
+
+            if(!mask) {
+                for (int i = 0, j = IMAGE_RGB565_LINE_LEN(img); i < j; i++) {
+                    data[i] |= ((uint16_t *) other)[i];
+                }
+            } else {
+                for (int i = 0, j = img->w; i < j; i++) {
+                    if (image_get_mask_pixel(mask, i, line)) {
+                        IMAGE_PUT_RGB565_PIXEL_FAST(data, i,
+                            (IMAGE_GET_RGB565_PIXEL_FAST(data, i)
+                             | IMAGE_GET_RGB565_PIXEL_FAST(((uint16_t *) other), i)));
+                    }
+                }
+            }
+            break;
+        }
+        default: {
+            break;
+        }
+    }
+}
+
+void imlib_b_or(image_t *img, const char *path, image_t *other, image_t *mask)
+{
+    imlib_image_operation(img, path, other, imlib_b_or_line_op, mask);
+}
+
+static void imlib_b_nor_line_op(image_t *img, int line, uint8_t *other, void *data, bool vflipped)
+{
+    image_t *mask = (image_t *) data;
+
+    switch(img->bpp) {
+        case IMAGE_BPP_BINARY: {
+            uint32_t *data = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(img, line);
+
+            if(!mask) {
+                for (int i = 0, j = IMAGE_BINARY_LINE_LEN(img); i < j; i++) {
+                    data[i] |= ~((uint32_t *) other)[i];
+                }
+            } else {
+                for (int i = 0, j = img->w; i < j; i++) {
+                    if (image_get_mask_pixel(mask, i, line)) {
+                        IMAGE_PUT_BINARY_PIXEL_FAST(data, i,
+                            (IMAGE_GET_BINARY_PIXEL_FAST(data, i)
+                             | ~IMAGE_GET_BINARY_PIXEL_FAST(((uint32_t *) other), i)));
+                    }
+                }
+            }
+            break;
+        }
+        case IMAGE_BPP_GRAYSCALE: {
+            uint8_t *data = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(img, line);
+
+            if(!mask) {
+                for (int i = 0, j = IMAGE_GRAYSCALE_LINE_LEN(img); i < j; i++) {
+                    data[i] |= ~((uint8_t *) other)[i];
+                }
+            } else {
+                for (int i = 0, j = img->w; i < j; i++) {
+                    if (image_get_mask_pixel(mask, i, line)) {
+                        IMAGE_PUT_GRAYSCALE_PIXEL_FAST(data, i,
+                            (IMAGE_GET_GRAYSCALE_PIXEL_FAST(data, i)
+                             | ~IMAGE_GET_GRAYSCALE_PIXEL_FAST(((uint8_t *) other), i)));
+                    }
+                }
+            }
+            break;
+        }
+        case IMAGE_BPP_RGB565: {
+            uint16_t *data = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(img, line);
+
+            if(!mask) {
+                for (int i = 0, j = IMAGE_RGB565_LINE_LEN(img); i < j; i++) {
+                    data[i] |= ~((uint16_t *) other)[i];
+                }
+            } else {
+                for (int i = 0, j = img->w; i < j; i++) {
+                    if (image_get_mask_pixel(mask, i, line)) {
+                        IMAGE_PUT_RGB565_PIXEL_FAST(data, i,
+                            (IMAGE_GET_RGB565_PIXEL_FAST(data, i)
+                             | ~IMAGE_GET_RGB565_PIXEL_FAST(((uint16_t *) other), i)));
+                    }
+                }
+            }
+            break;
+        }
+        default: {
+            break;
+        }
+    }
+}
+
+void imlib_b_nor(image_t *img, const char *path, image_t *other, image_t *mask)
+{
+    imlib_image_operation(img, path, other, imlib_b_nor_line_op, mask);
+}
+
+static void imlib_b_xor_line_op(image_t *img, int line, uint8_t *other, void *data, bool vflipped)
+{
+    image_t *mask = (image_t *) data;
+
+    switch(img->bpp) {
+        case IMAGE_BPP_BINARY: {
+            uint32_t *data = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(img, line);
+
+            if(!mask) {
+                for (int i = 0, j = IMAGE_BINARY_LINE_LEN(img); i < j; i++) {
+                    data[i] ^= ((uint32_t *) other)[i];
+                }
+            } else {
+                for (int i = 0, j = img->w; i < j; i++) {
+                    if (image_get_mask_pixel(mask, i, line)) {
+                        IMAGE_PUT_BINARY_PIXEL_FAST(data, i,
+                            (IMAGE_GET_BINARY_PIXEL_FAST(data, i)
+                             ^ IMAGE_GET_BINARY_PIXEL_FAST(((uint32_t *) other), i)));
+                    }
+                }
+            }
+            break;
+        }
+        case IMAGE_BPP_GRAYSCALE: {
+            uint8_t *data = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(img, line);
+
+            if(!mask) {
+                for (int i = 0, j = IMAGE_GRAYSCALE_LINE_LEN(img); i < j; i++) {
+                    data[i] ^= ((uint8_t *) other)[i];
+                }
+            } else {
+                for (int i = 0, j = img->w; i < j; i++) {
+                    if (image_get_mask_pixel(mask, i, line)) {
+                        IMAGE_PUT_GRAYSCALE_PIXEL_FAST(data, i,
+                            (IMAGE_GET_GRAYSCALE_PIXEL_FAST(data, i)
+                             ^ IMAGE_GET_GRAYSCALE_PIXEL_FAST(((uint8_t *) other), i)));
+                    }
+                }
+            }
+            break;
+        }
+        case IMAGE_BPP_RGB565: {
+            uint16_t *data = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(img, line);
+
+            if(!mask) {
+                for (int i = 0, j = IMAGE_RGB565_LINE_LEN(img); i < j; i++) {
+                    data[i] ^= ((uint16_t *) other)[i];
+                }
+            } else {
+                for (int i = 0, j = img->w; i < j; i++) {
+                    if (image_get_mask_pixel(mask, i, line)) {
+                        IMAGE_PUT_RGB565_PIXEL_FAST(data, i,
+                            (IMAGE_GET_RGB565_PIXEL_FAST(data, i)
+                             ^ IMAGE_GET_RGB565_PIXEL_FAST(((uint16_t *) other), i)));
+                    }
+                }
+            }
+            break;
+        }
+        default: {
+            break;
+        }
+    }
+}
+
+void imlib_b_xor(image_t *img, const char *path, image_t *other, image_t *mask)
+{
+    imlib_image_operation(img, path, other, imlib_b_xor_line_op, mask);
+}
+
+static void imlib_b_xnor_line_op(image_t *img, int line, uint8_t *other, void *data, bool vflipped)
+{
+    image_t *mask = (image_t *) data;
+
+    switch(img->bpp) {
+        case IMAGE_BPP_BINARY: {
+            uint32_t *data = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(img, line);
+
+            if(!mask) {
+                for (int i = 0, j = IMAGE_BINARY_LINE_LEN(img); i < j; i++) {
+                    data[i] ^= ~((uint32_t *) other)[i];
+                }
+            } else {
+                for (int i = 0, j = img->w; i < j; i++) {
+                    if (image_get_mask_pixel(mask, i, line)) {
+                        IMAGE_PUT_BINARY_PIXEL_FAST(data, i,
+                            (IMAGE_GET_BINARY_PIXEL_FAST(data, i)
+                             ^ ~IMAGE_GET_BINARY_PIXEL_FAST(((uint32_t *) other), i)));
+                    }
+                }
+            }
+            break;
+        }
+        case IMAGE_BPP_GRAYSCALE: {
+            uint8_t *data = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(img, line);
+
+            if(!mask) {
+                for (int i = 0, j = IMAGE_GRAYSCALE_LINE_LEN(img); i < j; i++) {
+                    data[i] ^= ~((uint8_t *) other)[i];
+                }
+            } else {
+                for (int i = 0, j = img->w; i < j; i++) {
+                    if (image_get_mask_pixel(mask, i, line)) {
+                        IMAGE_PUT_GRAYSCALE_PIXEL_FAST(data, i,
+                            (IMAGE_GET_GRAYSCALE_PIXEL_FAST(data, i)
+                             ^ ~IMAGE_GET_GRAYSCALE_PIXEL_FAST(((uint8_t *) other), i)));
+                    }
+                }
+            }
+            break;
+        }
+        case IMAGE_BPP_RGB565: {
+            uint16_t *data = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(img, line);
+
+            if(!mask) {
+                for (int i = 0, j = IMAGE_RGB565_LINE_LEN(img); i < j; i++) {
+                    data[i] ^= ~((uint16_t *) other)[i];
+                }
+            } else {
+                for (int i = 0, j = img->w; i < j; i++) {
+                    if (image_get_mask_pixel(mask, i, line)) {
+                        IMAGE_PUT_RGB565_PIXEL_FAST(data, i,
+                            (IMAGE_GET_RGB565_PIXEL_FAST(data, i)
+                             ^ ~IMAGE_GET_RGB565_PIXEL_FAST(((uint16_t *) other), i)));
+                    }
+                }
+            }
+            break;
+        }
+        default: {
+            break;
+        }
+    }
+}
+
+void imlib_b_xnor(image_t *img, const char *path, image_t *other, image_t *mask)
+{
+    imlib_image_operation(img, path, other, imlib_b_xnor_line_op, mask);
+}
+
+static void imlib_erode_dilate(image_t *img, int ksize, int threshold, int e_or_d, image_t *mask)
+{
+    int brows = ksize + 1;
+    image_t buf;
+    buf.w = img->w;
+    buf.h = brows;
+    buf.bpp = img->bpp;
+
+    switch(img->bpp) {
+        case IMAGE_BPP_BINARY: {
+            buf.data = fb_alloc(IMAGE_BINARY_LINE_LEN_BYTES(img) * brows);
+
+            for (int y = 0, yy = img->h; y < yy; y++) {
+                uint32_t *row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(img, y);
+                uint32_t *buf_row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(&buf, (y % brows));
+
+                for (int x = 0, xx = img->w; x < xx; x++) {
+                    int pixel = IMAGE_GET_BINARY_PIXEL_FAST(row_ptr, x);
+                    IMAGE_PUT_BINARY_PIXEL_FAST(buf_row_ptr, x, pixel);
+
+                    if ((mask && (!image_get_mask_pixel(mask, x, y)))
+                    || (pixel == e_or_d)) {
+                        continue; // Short circuit.
+                    }
+
+                    int acc = e_or_d ? 0 : -1; // Don't count center pixel...
+
+                    for (int j = -ksize; j <= ksize; j++) {
+                        uint32_t *k_row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(img,
+                            IM_MIN(IM_MAX(y + j, 0), (img->h - 1)));
+
+                        for (int k = -ksize; k <= ksize; k++) {
+                            acc += IMAGE_GET_BINARY_PIXEL_FAST(k_row_ptr,
+                                IM_MIN(IM_MAX(x + k, 0), (img->w - 1)));
+                        }
+                    }
+
+                    if (!e_or_d) {
+                        // Preserve original pixel value... or clear it.
+                        if (acc < threshold) IMAGE_CLEAR_BINARY_PIXEL_FAST(buf_row_ptr, x);
+                    } else {
+                        // Preserve original pixel value... or set it.
+                        if (acc > threshold) IMAGE_SET_BINARY_PIXEL_FAST(buf_row_ptr, x);
+                    }
+                }
+
+                if (y >= ksize) { // Transfer buffer lines...
+                    memcpy(IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(img, (y - ksize)),
+                           IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(&buf, ((y - ksize) % brows)),
+                           IMAGE_BINARY_LINE_LEN_BYTES(img));
+                }
+            }
+
+            // Copy any remaining lines from the buffer image...
+            for (int y = img->h - ksize, yy = img->h; y < yy; y++) {
+                memcpy(IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(img, y),
+                       IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(&buf, (y % brows)),
+                       IMAGE_BINARY_LINE_LEN_BYTES(img));
+            }
+
+            fb_free();
+            break;
+        }
+        case IMAGE_BPP_GRAYSCALE: {
+            buf.data = fb_alloc(IMAGE_GRAYSCALE_LINE_LEN_BYTES(img) * brows);
+
+            for (int y = 0, yy = img->h; y < yy; y++) {
+                uint8_t *row_ptr = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(img, y);
+                uint8_t *buf_row_ptr = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(&buf, (y % brows));
+
+                for (int x = 0, xx = img->w; x < xx; x++) {
+                    int pixel = IMAGE_GET_GRAYSCALE_PIXEL_FAST(row_ptr, x);
+                    IMAGE_PUT_GRAYSCALE_PIXEL_FAST(buf_row_ptr, x, pixel);
+
+                    if ((mask && (!image_get_mask_pixel(mask, x, y)))
+                    || (COLOR_GRAYSCALE_TO_BINARY(pixel) == e_or_d)) {
+                        continue; // Short circuit.
+                    }
+
+                    int acc = e_or_d ? 0 : -1; // Don't count center pixel...
+
+                    for (int j = -ksize; j <= ksize; j++) {
+                        uint8_t *k_row_ptr = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(img,
+                            IM_MIN(IM_MAX(y + j, 0), (img->h - 1)));
+
+                        for (int k = -ksize; k <= ksize; k++) {
+                            acc += COLOR_GRAYSCALE_TO_BINARY(IMAGE_GET_GRAYSCALE_PIXEL_FAST(k_row_ptr,
+                                IM_MIN(IM_MAX(x + k, 0), (img->w - 1))));
+                        }
+                    }
+
+                    if (!e_or_d) {
+                        // Preserve original pixel value... or clear it.
+                        if (acc < threshold) IMAGE_PUT_GRAYSCALE_PIXEL_FAST(buf_row_ptr, x,
+                                                                            COLOR_GRAYSCALE_BINARY_MIN);
+                    } else {
+                        // Preserve original pixel value... or set it.
+                        if (acc > threshold) IMAGE_PUT_GRAYSCALE_PIXEL_FAST(buf_row_ptr, x,
+                                                                            COLOR_GRAYSCALE_BINARY_MAX);
+                    }
+                }
+
+                if (y >= ksize) { // Transfer buffer lines...
+                    memcpy(IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(img, (y - ksize)),
+                           IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(&buf, ((y - ksize) % brows)),
+                           IMAGE_GRAYSCALE_LINE_LEN_BYTES(img));
+                }
+            }
+
+            // Copy any remaining lines from the buffer image...
+            for (int y = img->h - ksize, yy = img->h; y < yy; y++) {
+                memcpy(IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(img, y),
+                       IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(&buf, (y % brows)),
+                       IMAGE_GRAYSCALE_LINE_LEN_BYTES(img));
+            }
+
+            fb_free();
+            break;
+        }
+        case IMAGE_BPP_RGB565: {
+            buf.data = fb_alloc(IMAGE_RGB565_LINE_LEN_BYTES(img) * brows);
+
+            for (int y = 0, yy = img->h; y < yy; y++) {
+                uint16_t *row_ptr = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(img, y);
+                uint16_t *buf_row_ptr = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(&buf, (y % brows));
+
+                for (int x = 0, xx = img->w; x < xx; x++) {
+                    int pixel = IMAGE_GET_RGB565_PIXEL_FAST(row_ptr, x);
+                    IMAGE_PUT_RGB565_PIXEL_FAST(buf_row_ptr, x, pixel);
+
+                    if ((mask && (!image_get_mask_pixel(mask, x, y)))
+                    || (COLOR_RGB565_TO_BINARY(pixel) == e_or_d)) {
+                        continue; // Short circuit.
+                    }
+
+                    int acc = e_or_d ? 0 : -1; // Don't count center pixel...
+
+                    for (int j = -ksize; j <= ksize; j++) {
+                        uint16_t *k_row_ptr = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(img,
+                            IM_MIN(IM_MAX(y + j, 0), (img->h - 1)));
+
+                        for (int k = -ksize; k <= ksize; k++) {
+                            acc += COLOR_RGB565_TO_BINARY(IMAGE_GET_RGB565_PIXEL_FAST(k_row_ptr,
+                                IM_MIN(IM_MAX(x + k, 0), (img->w - 1))));
+                        }
+                    }
+
+                    if (!e_or_d) {
+                        // Preserve original pixel value... or clear it.
+                        if (acc < threshold) IMAGE_PUT_RGB565_PIXEL_FAST(buf_row_ptr, x,
+                                                                         COLOR_RGB565_BINARY_MIN);
+                    } else {
+                        // Preserve original pixel value... or set it.
+                        if (acc > threshold) IMAGE_PUT_RGB565_PIXEL_FAST(buf_row_ptr, x,
+                                                                         COLOR_RGB565_BINARY_MAX);
+                    }
+                }
+
+                if (y >= ksize) { // Transfer buffer lines...
+                    memcpy(IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(img, (y - ksize)),
+                           IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(&buf, ((y - ksize) % brows)),
+                           IMAGE_RGB565_LINE_LEN_BYTES(img));
+                }
+            }
+
+            // Copy any remaining lines from the buffer image...
+            for (int y = img->h - ksize, yy = img->h; y < yy; y++) {
+                memcpy(IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(img, y),
+                       IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(&buf, (y % brows)),
+                       IMAGE_RGB565_LINE_LEN_BYTES(img));
+            }
+
+            fb_free();
+            break;
+        }
+        default: {
+            break;
+        }
+    }
+}
+
+void imlib_erode(image_t *img, int ksize, int threshold, image_t *mask)
+{
+    // Threshold should be equal to (((ksize*2)+1)*((ksize*2)+1))-1
+    // for normal operation. E.g. for ksize==3 -> threshold==8
+    // Basically you're adjusting the number of data that
+    // must be set in the kernel (besides the center) for the output to be 1.
+    // Erode normally requires all data to be 1.
+    imlib_erode_dilate(img, ksize, threshold, 0, mask);
+}
+
+void imlib_dilate(image_t *img, int ksize, int threshold, image_t *mask)
+{
+    // Threshold should be equal to 0
+    // for normal operation. E.g. for ksize==3 -> threshold==0
+    // Basically you're adjusting the number of data that
+    // must be set in the kernel (besides the center) for the output to be 1.
+    // Dilate normally requires one pixel to be 1.
+    imlib_erode_dilate(img, ksize, threshold, 1, mask);
+}

--- a/src/omv/img/edge.c
+++ b/src/omv/img/edge.c
@@ -20,10 +20,15 @@ typedef struct gvec {
 void imlib_edge_simple(image_t *src, rectangle_t *roi, int low_thresh, int high_thresh)
 {
     imlib_morph(src, 1, kernel_high_pass_3, 1.0f, 0.0f);
-    simple_color_t lt = {.G=low_thresh};
-    simple_color_t ht = {.G=high_thresh};
-    imlib_binary(src, 1, &lt, &ht, false);
-    imlib_erode(src, 1, 2);
+    list_t thresholds;
+    list_init(&thresholds, sizeof(color_thresholds_list_lnk_data_t));
+    color_thresholds_list_lnk_data_t lnk_data;
+    lnk_data.LMin=low_thresh;
+    lnk_data.LMax=high_thresh;
+    list_push_back(&thresholds, &lnk_data);
+    imlib_binary(src, &thresholds, false, false);
+    list_free(&thresholds);
+    imlib_erode(src, 1, 2, NULL);
 }
 
 void imlib_edge_canny(image_t *src, rectangle_t *roi, int low_thresh, int high_thresh)

--- a/src/omv/img/shadow_removal.c
+++ b/src/omv/img/shadow_removal.c
@@ -218,17 +218,21 @@ void imlib_remove_shadows(image_t *img, const char *path, image_t *other)
             threshold_t t;
             imlib_get_threshold(&t, temp_image.bpp, &h);
 
-            simple_color_t t_l, t_h;
-            t_l.L = COLOR_L_MIN;
-            t_l.A = COLOR_A_MIN;
-            t_l.B = COLOR_B_MIN;
-            t_h.L = t.LValue;
-            t_h.A = COLOR_A_MAX;
-            t_h.B = COLOR_B_MAX;
-            imlib_binary(&temp_image, 1, &t_l, &t_h, false);
+            list_t thresholds;
+            list_init(&thresholds, sizeof(color_thresholds_list_lnk_data_t));
+            color_thresholds_list_lnk_data_t lnk_data;
+            lnk_data.LMin = COLOR_L_MIN;
+            lnk_data.AMin = COLOR_A_MIN;
+            lnk_data.BMin = COLOR_B_MIN;
+            lnk_data.LMax = t.LValue;
+            lnk_data.AMax = COLOR_A_MAX;
+            lnk_data.BMax = COLOR_B_MAX;
+            list_push_back(&thresholds, &lnk_data);
+            imlib_binary(&temp_image, &thresholds, false, false);
+            list_free(&thresholds);
 
-            imlib_erode(&temp_image, 3, 30);
-            imlib_dilate(&temp_image, 1, 1);
+            imlib_erode(&temp_image, 3, 30, NULL);
+            imlib_dilate(&temp_image, 1, 1, NULL);
 
             // Get Shadow Average
 
@@ -239,7 +243,7 @@ void imlib_remove_shadows(image_t *img, const char *path, image_t *other)
             temp_image_2.data = fb_alloc(image_size(&temp_image));
 
             memcpy(temp_image_2.data, temp_image.data, image_size(&temp_image));
-            imlib_erode(&temp_image_2, 3, 48);
+            imlib_erode(&temp_image_2, 3, 48, NULL);
 
             int shadow_r_sum = 0;
             int shadow_g_sum = 0;
@@ -266,10 +270,10 @@ void imlib_remove_shadows(image_t *img, const char *path, image_t *other)
 
             memcpy(temp_image_2.data, temp_image.data, image_size(&temp_image));
             imlib_invert(&temp_image_2);
-            imlib_erode(&temp_image_2, 5, 120);
+            imlib_erode(&temp_image_2, 5, 120, NULL);
             imlib_invert(&temp_image_2);
-            imlib_b_xor(&temp_image_2, NULL, &temp_image);
-            imlib_erode(&temp_image_2, 2, 24);
+            imlib_b_xor(&temp_image_2, NULL, &temp_image, NULL);
+            imlib_erode(&temp_image_2, 2, 24, NULL);
 
             int not_shadow_r_sum = 0;
             int not_shadow_g_sum = 0;
@@ -337,9 +341,9 @@ void imlib_remove_shadows(image_t *img, const char *path, image_t *other)
 
             memcpy(temp_image.data, temp_image_2.data, image_size(&temp_image_2));
 
-            imlib_erode(&temp_image_2, 1, 8);
-            imlib_b_xor(&temp_image, NULL, &temp_image_2);
-            imlib_dilate(&temp_image, 3, 0);
+            imlib_erode(&temp_image_2, 1, 8, NULL);
+            imlib_b_xor(&temp_image, NULL, &temp_image_2, NULL);
+            imlib_dilate(&temp_image, 3, 0, NULL);
             imlib_median_filter(img, 2, 12, false, 0, false, &temp_image);
 
             fb_free(); // temp_image_2

--- a/src/omv/py/qstrdefsomv.h
+++ b/src/omv/py/qstrdefsomv.h
@@ -46,22 +46,6 @@ Q(draw_circle)
 Q(draw_string)
 Q(draw_cross)
 Q(draw_keypoints)
-Q(binary)
-Q(invert)
-Q(and)
-Q(b_and)
-Q(nand)
-Q(b_nand)
-Q(or)
-Q(b_or)
-Q(nor)
-Q(b_nor)
-Q(xor)
-Q(b_xor)
-Q(xnor)
-Q(b_xnor)
-Q(erode)
-Q(dilate)
 Q(negate)
 Q(difference)
 Q(replace)
@@ -348,6 +332,54 @@ Q(CPUFREQ_192MHZ)
 Q(CPUFREQ_216MHZ)
 Q(get_frequency)
 Q(set_frequency)
+
+// Binary
+Q(binary)
+Q(invert)
+Q(zero)
+
+// Invert
+// duplicate Q(invert)
+
+// And
+Q(and)
+Q(b_and)
+Q(mask)
+
+// Nand
+Q(nand)
+Q(b_nand)
+// duplicate Q(mask)
+
+// Or
+Q(or)
+Q(b_or)
+// duplicate Q(mask)
+
+// Nor
+Q(nor)
+Q(b_nor)
+// duplicate Q(mask)
+
+// Xor
+Q(xor)
+Q(b_xor)
+// duplicate Q(mask)
+
+// Xnor
+Q(xnor)
+Q(b_xnor)
+// duplicate Q(mask)
+
+// Erode
+Q(erode)
+// duplicate Q(threshold)
+// duplicate Q(mask)
+
+// Dilate
+Q(dilate)
+// duplicate Q(threshold)
+// duplicate Q(mask)
 
 // Max
 // duplicate Q(max)

--- a/usr/examples/04-Image-Filters/color_binary_filter.py
+++ b/usr/examples/04-Image-Filters/color_binary_filter.py
@@ -1,14 +1,17 @@
 # Color Binary Filter Example
 #
-# This script shows off the binary image filter. This script was originally a
-# test script... but, it can be useful for showing how to use binary.
+# This script shows off the binary image filter. You may pass binary any
+# number of thresholds to segment the image by.
 
-import pyb, sensor, image, math
+import sensor, image, time
 
 sensor.reset()
 sensor.set_framesize(sensor.QVGA)
 sensor.set_pixformat(sensor.RGB565)
+sensor.skip_frames(time = 2000)
+clock = time.clock()
 
+# Use the Tools -> Machine Vision -> Threshold Edtor to pick better thresholds.
 red_threshold = (0,100,   0,127,   0,127) # L A B
 green_threshold = (0,100,   -128,0,   0,127) # L A B
 blue_threshold = (0,100,   -128,127,   -128,0) # L A B
@@ -17,25 +20,42 @@ while(True):
 
     # Test red threshold
     for i in range(100):
+        clock.tick()
         img = sensor.snapshot()
         img.binary([red_threshold])
+        print(clock.fps())
+
     # Test green threshold
     for i in range(100):
+        clock.tick()
         img = sensor.snapshot()
         img.binary([green_threshold])
+        print(clock.fps())
+
     # Test blue threshold
     for i in range(100):
+        clock.tick()
         img = sensor.snapshot()
         img.binary([blue_threshold])
+        print(clock.fps())
+
     # Test not red threshold
     for i in range(100):
+        clock.tick()
         img = sensor.snapshot()
         img.binary([red_threshold], invert = 1)
+        print(clock.fps())
+
     # Test not green threshold
     for i in range(100):
+        clock.tick()
         img = sensor.snapshot()
         img.binary([green_threshold], invert = 1)
+        print(clock.fps())
+
     # Test not blue threshold
     for i in range(100):
+        clock.tick()
         img = sensor.snapshot()
         img.binary([blue_threshold], invert = 1)
+        print(clock.fps())

--- a/usr/examples/04-Image-Filters/color_light_removal.py
+++ b/usr/examples/04-Image-Filters/color_light_removal.py
@@ -1,0 +1,25 @@
+# Color Light Removal
+#
+# This example shows off how to remove bright lights from the image.
+# You can do this using the binary() method with the "zero=" argument.
+#
+# Removing bright lights from the image allows you to now use
+# histeq() on the image without outliers from oversaturated
+# parts of the image breaking the algorithm...
+
+import sensor, image, time
+
+sensor.reset() # Initialize the camera sensor.
+sensor.set_pixformat(sensor.RGB565) # or sensor.GRAYSCALE
+sensor.set_framesize(sensor.QQVGA) # or sensor.QVGA (or others)
+sensor.skip_frames(time = 2000) # Let new settings take affect.
+clock = time.clock() # Tracks FPS.
+
+thresholds = (90, 100, -128, 127, -128, 127)
+
+while(True):
+    clock.tick() # Track elapsed milliseconds between snapshots().
+    img = sensor.snapshot().binary([thresholds], invert=False, zero=True)
+
+    print(clock.fps()) # Note: Your OpenMV Cam runs about half as fast while
+    # connected to your computer. The FPS should increase once disconnected.

--- a/usr/examples/04-Image-Filters/grayscale_binary_filter.py
+++ b/usr/examples/04-Image-Filters/grayscale_binary_filter.py
@@ -1,31 +1,45 @@
 # Grayscale Binary Filter Example
 #
-# This script shows off the binary image filter. This script was originally a
-# test script... but, it can be useful for showing how to use binary.
+# This script shows off the binary image filter. You may pass binary any
+# number of thresholds to segment the image by.
 
-import pyb, sensor, image, math
+import sensor, image, time
 
 sensor.reset()
 sensor.set_framesize(sensor.QVGA)
 sensor.set_pixformat(sensor.GRAYSCALE)
+sensor.skip_frames(time = 2000)
+clock = time.clock()
 
 low_threshold = (0, 50)
 high_threshold = (205, 255)
 
 while(True):
+
     # Test low threshold
     for i in range(100):
+        clock.tick()
         img = sensor.snapshot()
         img.binary([low_threshold])
+        print(clock.fps())
+
     # Test high threshold
     for i in range(100):
+        clock.tick()
         img = sensor.snapshot()
         img.binary([high_threshold])
+        print(clock.fps())
+
     # Test not low threshold
     for i in range(100):
+        clock.tick()
         img = sensor.snapshot()
         img.binary([low_threshold], invert = 1)
+        print(clock.fps())
+
     # Test not high threshold
     for i in range(100):
+        clock.tick()
         img = sensor.snapshot()
         img.binary([high_threshold], invert = 1)
+        print(clock.fps())

--- a/usr/examples/04-Image-Filters/grayscale_light_removal.py
+++ b/usr/examples/04-Image-Filters/grayscale_light_removal.py
@@ -1,0 +1,25 @@
+# Grayscale Light Removal
+#
+# This example shows off how to remove bright lights from the image.
+# You can do this using the binary() method with the "zero=" argument.
+#
+# Removing bright lights from the image allows you to now use
+# histeq() on the image without outliers from oversaturated
+# parts of the image breaking the algorithm...
+
+import sensor, image, time
+
+sensor.reset() # Initialize the camera sensor.
+sensor.set_pixformat(sensor.GRAYSCALE) # or sensor.RGB565
+sensor.set_framesize(sensor.QQVGA) # or sensor.QVGA (or others)
+sensor.skip_frames(time = 2000) # Let new settings take affect.
+clock = time.clock() # Tracks FPS.
+
+thresholds = (220, 255)
+
+while(True):
+    clock.tick() # Track elapsed milliseconds between snapshots().
+    img = sensor.snapshot().binary([thresholds], invert=False, zero=True)
+
+    print(clock.fps()) # Note: Your OpenMV Cam runs about half as fast while
+    # connected to your computer. The FPS should increase once disconnected.


### PR DESCRIPTION
Binary() can now zero things so you can remove bright lights. All the
line ops (and/or/xor/etc) accept masks. Erode and dilate now accept
masks. And finally, you can now pass arguments versus keywords for folks
who don't read the documentation. Also, the binary image type is now
supported for these methods.

I'm putting in all this work because I saw the need for it when I was
doing shadow removal. It will come in handy very soon when impmementing
a state-of-the-art shadow removal method.

Note: Some effort needs to be put into optimizing the py_image.c code
soon. This is on the todo list before the next release. Need to make the helper
methods smarter and add more of them.