### PR TITLE
Started improving python argument argument passing.

### DIFF
--- a/src/omv/img/imlib.h
+++ b/src/omv/img/imlib.h
@@ -67,6 +67,9 @@
 #define UINT64_T_MASK   (UINT64_T_BITS - 1)
 #define UINT64_T_SHIFT  IM_LOG2(UINT64_T_MASK)
 
+#define IM_DEG2RAD(x)   (((x)*M_PI)/180)
+#define IM_RAD2DEG(x)   (((x)*180)/M_PI)
+
 /////////////////
 // Point Stuff //
 /////////////////
@@ -358,6 +361,14 @@ void image_init(image_t *ptr, int w, int h, int bpp, void *data);
 void image_copy(image_t *dst, image_t *src);
 size_t image_size(image_t *ptr);
 bool image_get_mask_pixel(image_t *ptr, int x, int y);
+
+#define IMAGE_IS_MUTABLE(image) \
+({ \
+    __typeof__ (image) _image = (image); \
+    (_image->bpp == IMAGE_BPP_BINARY) || \
+    (_image->bpp == IMAGE_BPP_GRAYSCALE) || \
+    (_image->bpp == IMAGE_BPP_RGB565); \
+})
 
 #define IMAGE_BINARY_LINE_LEN(image) (((image)->w + UINT32_T_MASK) >> UINT32_T_SHIFT)
 #define IMAGE_BINARY_LINE_LEN_BYTES(image) (IMAGE_BINARY_LINE_LEN(image) * sizeof(uint32_t))

--- a/src/omv/py/py_assert.h
+++ b/src/omv/py/py_assert.h
@@ -8,6 +8,7 @@
  */
 #ifndef __PY_ASSERT_H__
 #define __PY_ASSERT_H__
+#include "mp.h"
 #define PY_ASSERT_TRUE(cond)                            \
     do {                                                \
         if ((cond) == 0) {                              \

--- a/src/omv/py/py_helper.h
+++ b/src/omv/py/py_helper.h
@@ -1,15 +1,29 @@
-/*
- * This file is part of the OpenMV project.
- * Copyright (c) 2013/2014 Ibrahim Abdelkader <i.abdalkader@gmail.com>
+/* This file is part of the OpenMV project.
+ * Copyright (c) 2013-2018 Ibrahim Abdelkader <iabdalkader@openmv.io> & Kwabena W. Agyeman <kwagyeman@openmv.io>
  * This work is licensed under the MIT license, see the file LICENSE for details.
- *
- * MicroPython helper functions.
- *
  */
+
 #ifndef __PY_HELPER_H__
 #define __PY_HELPER_H__
-#include <mp.h>
+#include "py_assert.h"
 #include "imlib.h"
+
+image_t *py_helper_arg_to_image_mutable(const mp_obj_t arg);
+image_t *py_helper_keyword_to_image_mutable(uint n_args, const mp_obj_t *args, uint arg_index,
+                                            mp_map_t *kw_args, mp_obj_t kw, image_t *default_val);
+image_t *py_helper_arg_to_image_grayscale(const mp_obj_t arg);
+image_t *py_helper_arg_to_image_color(const mp_obj_t arg);
+void py_helper_arg_to_thresholds(const mp_obj_t arg, list_t *thresholds);
+void py_helper_keyword_thresholds(mp_map_t *kw_args, mp_obj_t kw, list_t *thresholds);
+int py_helper_keyword_int(uint n_args, const mp_obj_t *args, uint arg_index,
+                          mp_map_t *kw_args, mp_obj_t kw, int default_val);
+float py_helper_keyword_float(uint n_args, const mp_obj_t *args, uint arg_index,
+                              mp_map_t *kw_args, mp_obj_t kw, float default_val);
+int py_helper_arg_to_ksize(const mp_obj_t arg);
+int py_helper_ksize_to_n(int ksize);
+uint py_helper_consume_array(uint n_args, const mp_obj_t *args, uint arg_index, size_t len, const mp_obj_t **items);
+int py_helper_keyword_color(image_t *img, uint n_args, const mp_obj_t *args, uint arg_index,
+                            mp_map_t *kw_args, int default_val);
 int py_helper_lookup_int(mp_map_t *kw_args, mp_obj_t kw, int default_val);
 float py_helper_lookup_float(mp_map_t *kw_args, mp_obj_t kw, float default_val);
 void py_helper_lookup_int_array(mp_map_t *kw_args, mp_obj_t kw, int *x, int size);
@@ -18,6 +32,7 @@ int py_helper_lookup_color(mp_map_t *kw_args, int default_color);
 void py_helper_lookup_offset(mp_map_t *kw_args, image_t *img, point_t *p);
 void py_helper_lookup_rectangle(mp_map_t *kw_args, image_t *img, rectangle_t *r);
 void py_helper_lookup_rectangle_2(mp_map_t *kw_args, mp_obj_t kw, image_t *img, rectangle_t *r);
-void py_helper_arg_to_thresholds(const mp_obj_t arg, list_t *thresholds);
-void py_helper_keyword_thresholds(mp_map_t *kw_args, mp_obj_t kw, list_t *thresholds);
+
+
+
 #endif // __PY_HELPER__


### PR DESCRIPTION
In this commit I fixed up about half of the image library method
argument parsing front ends. The fixed up methods now:

1. Handle both standard and keyword arguments. If the user forgets to
pass the argument as a keyword but passes it in the right position the
method will "do the right" thing. If the user passes an argument twice
the method will take the keyword version of the value. Note that python
requires users to pass positional arguments first followed by keywords.

2. If a drawing method takes an array the method can handle that array
being passed as a list of numbers now. This makes the drawing methods
much easier for newbies to use.

Anyway, I've managed to get about half way through the code. Need to
pivot to other things now. But, I will get back to this later. This fix
will in general allow us to remove all the warnings in the API about
having to call methods with keywords (if you look int he API you will see these warnings everywhere).