### PR TITLE
Port ffwrapper and other omv file operations to the micropython vfs

### DIFF
--- a/src/omv/ff_wrapper.h
+++ b/src/omv/ff_wrapper.h
@@ -9,46 +9,64 @@
 #ifndef __FF_WRAPPER_H__
 #define __FF_WRAPPER_H__
 #include <stdint.h>
-#include <ff.h>
+#include <py/obj.h>
+#include <extmod/vfs.h>
+#include <py/stream.h>
+#include <lib/oofatfs/ff.h>
+
+typedef struct _FILE {
+    mp_obj_t file;
+    uint8_t flag;
+} file_t;
+
 extern const char *ffs_strerror(FRESULT res);
 
 //OOFATFS wrappers
-FRESULT f_open_helper(FIL *fp, const TCHAR *path, BYTE mode);
+FRESULT f_open_helper(file_t *fp, const TCHAR *path, BYTE mode);
 FRESULT f_opendir_helper(FF_DIR *dp, const TCHAR *path);
 FRESULT f_stat_helper(const TCHAR *path, FILINFO *fno);
 FRESULT f_mkdir_helper(const TCHAR *path);
 FRESULT f_unlink_helper(const TCHAR *path);
 FRESULT f_rename_helper(const TCHAR *path_old, const TCHAR *path_new);
 
-void ff_unsupported_format(FIL *fp);
-void ff_file_corrupted(FIL *fp);
-void ff_not_equal(FIL *fp);
-void ff_no_intersection(FIL *fp);
-void file_read_open(FIL *fp, const char *path);
-void file_write_open(FIL *fp, const char *path);
-void file_close(FIL *fp);
-void file_seek(FIL *fp, UINT offset);
-void file_truncate(FIL *fp);
-void file_sync(FIL *fp);
+void ff_unsupported_format(file_t *fp);
+void ff_file_corrupted(file_t *fp);
+void ff_not_equal(file_t *fp);
+void ff_no_intersection(file_t *fp);
+void file_read_open(file_t *fp, const char *path);
+void file_write_open(file_t *fp, const char *path);
+void file_close(file_t *fp);
+ssize_t file_write(file_t *fp, const void *buf, size_t len);
+ssize_t file_read(file_t *fp, void *buf, size_t len);
+off_t file_lseek(file_t *fp, off_t offset, int whence);
+void file_seek(file_t *fp, UINT offset);
+#if 0
+void file_truncate(file_t *fp);
+#endif
+void file_sync(file_t *fp);
+bool file_eof(file_t *fp);
+int file_size(file_t *fp);
+int file_tell(file_t *fp);
 
 // File buffer functions.
 void file_buffer_init0();
-void file_buffer_on(FIL *fp); // does fb_alloc_all
-uint32_t file_tell_w_buf(FIL *fp); // valid between on and off
-uint32_t file_size_w_buf(FIL *fp); // valid between on and off
-void file_buffer_off(FIL *fp); // does fb_free
-void read_byte(FIL *fp, uint8_t *value);
-void read_byte_expect(FIL *fp, uint8_t value);
-void read_byte_ignore(FIL *fp);
-void read_word(FIL *fp, uint16_t *value);
-void read_word_expect(FIL *fp, uint16_t value);
-void read_word_ignore(FIL *fp);
-void read_long(FIL *fp, uint32_t *value);
-void read_long_expect(FIL *fp, uint32_t value);
-void read_long_ignore(FIL *fp);
-void read_data(FIL *fp, void *data, UINT size);
-void write_byte(FIL *fp, uint8_t value);
-void write_word(FIL *fp, uint16_t value);
-void write_long(FIL *fp, uint32_t value);
-void write_data(FIL *fp, const void *data, UINT size);
+void file_buffer_on(file_t *fp); // does fb_alloc_all
+uint32_t file_tell_w_buf(file_t *fp); // valid between on and off
+uint32_t file_size_w_buf(file_t *fp); // valid between on and off
+void file_buffer_off(file_t *fp); // does fb_free
+void file_read_byte(file_t *fp, uint8_t *value);
+void file_read_byte_expect(file_t *fp, uint8_t value);
+void file_read_byte_ignore(file_t *fp);
+void file_read_word(file_t *fp, uint16_t *value);
+void file_read_word_expect(file_t *fp, uint16_t value);
+void file_read_word_ignore(file_t *fp);
+void file_read_long(file_t *fp, uint32_t *value);
+void file_read_long_expect(file_t *fp, uint32_t value);
+void file_read_long_ignore(file_t *fp);
+void file_read_data(file_t *fp, void *data, UINT size);
+void file_write_byte(file_t *fp, uint8_t value);
+void file_write_word(file_t *fp, uint16_t value);
+void file_write_long(file_t *fp, uint32_t value);
+void file_write_data(file_t *fp, const void *data, UINT size);
+
 #endif /* __FF_WRAPPER_H__ */

--- a/src/omv/img/bmp.c
+++ b/src/omv/img/bmp.c
@@ -14,62 +14,62 @@
 #include "imlib.h"
 
 // This function inits the geometry values of an image (opens file).
-bool bmp_read_geometry(FIL *fp, image_t *img, const char *path, bmp_read_settings_t *rs)
+bool bmp_read_geometry(file_t *fp, image_t *img, const char *path, bmp_read_settings_t *rs)
 {
-    read_byte_expect(fp, 'B');
-    read_byte_expect(fp, 'M');
+    file_read_byte_expect(fp, 'B');
+    file_read_byte_expect(fp, 'M');
 
     uint32_t file_size;
-    read_long(fp, &file_size);
-    read_word_ignore(fp);
-    read_word_ignore(fp);
+    file_read_long(fp, &file_size);
+    file_read_word_ignore(fp);
+    file_read_word_ignore(fp);
 
     uint32_t header_size;
-    read_long(fp, &header_size);
+    file_read_long(fp, &header_size);
     if (file_size <= header_size) ff_file_corrupted(fp);
 
     uint32_t data_size = file_size - header_size;
     if (data_size % 4) ff_file_corrupted(fp);
 
-    read_long_expect(fp, 40);
-    read_long(fp, (uint32_t*) &rs->bmp_w);
-    read_long(fp, (uint32_t*) &rs->bmp_h);
+    file_read_long_expect(fp, 40);
+    file_read_long(fp, (uint32_t*) &rs->bmp_w);
+    file_read_long(fp, (uint32_t*) &rs->bmp_h);
     if ((rs->bmp_w == 0) || (rs->bmp_h == 0)) ff_file_corrupted(fp);
     img->w = abs(rs->bmp_w);
     img->h = abs(rs->bmp_h);
 
-    read_word_expect(fp, 1);
-    read_word(fp, &rs->bmp_bpp);
+    file_read_word_expect(fp, 1);
+    file_read_word(fp, &rs->bmp_bpp);
     if ((rs->bmp_bpp != 8) && (rs->bmp_bpp != 16) && (rs->bmp_bpp != 24)) ff_unsupported_format(fp);
     img->bpp = (rs->bmp_bpp == 8) ? 1 : 2;
 
-    read_long(fp, &rs->bmp_fmt);
+    file_read_long(fp, &rs->bmp_fmt);
     if ((rs->bmp_fmt != 0) && (rs->bmp_fmt != 3)) ff_unsupported_format(fp);
 
-    read_long_expect(fp, data_size);
-    read_long_ignore(fp);
-    read_long_ignore(fp);
-    read_long_ignore(fp);
-    read_long_ignore(fp);
+    file_read_long_expect(fp, data_size);
+    file_read_long_ignore(fp);
+    file_read_long_ignore(fp);
+    file_read_long_ignore(fp);
+    file_read_long_ignore(fp);
 
     if (rs->bmp_bpp == 8) {
         if (rs->bmp_fmt != 0) ff_unsupported_format(fp);
         // Color Table (1024 bytes)
         for (int i = 0; i < 256; i++) {
-            read_long_expect(fp, ((i) << 16) | ((i) << 8) | i);
+            file_read_long_expect(fp, ((i) << 16) | ((i) << 8) | i);
         }
     } else if (rs->bmp_bpp == 16) {
         if (rs->bmp_fmt != 3) ff_unsupported_format(fp);
         // Bit Masks (12 bytes)
-        read_long_expect(fp, 0x1F << 11);
-        read_long_expect(fp, 0x3F << 5);
-        read_long_expect(fp, 0x1F);
+        file_read_long_expect(fp, 0x1F << 11);
+        file_read_long_expect(fp, 0x3F << 5);
+        file_read_long_expect(fp, 0x1F);
     } else if (rs->bmp_bpp == 24) {
         if (rs->bmp_fmt == 3) {
             // Bit Masks (12 bytes)
-            read_long_expect(fp, 0xFF << 16);
-            read_long_expect(fp, 0xFF << 8);
-            read_long_expect(fp, 0xFF);
+            file_read_long_expect(fp, 0xFF << 16);
+            file_read_long_expect(fp, 0xFF << 8);
+            file_read_long_expect(fp, 0xFF);
         }
     }
 
@@ -79,18 +79,18 @@ bool bmp_read_geometry(FIL *fp, image_t *img, const char *path, bmp_read_setting
 }
 
 // This function reads the pixel values of an image.
-void bmp_read_pixels(FIL *fp, image_t *img, int line_start, int line_end, bmp_read_settings_t *rs)
+void bmp_read_pixels(file_t *fp, image_t *img, int line_start, int line_end, bmp_read_settings_t *rs)
 {
     if (rs->bmp_bpp == 8) {
         if ((rs->bmp_h < 0) && (rs->bmp_w >= 0) && (img->w == rs->bmp_row_bytes)) {
-            read_data(fp, // Super Fast - Zoom, Zoom!
+            file_read_data(fp, // Super Fast - Zoom, Zoom!
                       img->pixels + (line_start * img->w),
                       (line_end - line_start) * img->w);
         } else {
             for (int i = line_start; i < line_end; i++) {
                 for (int j = 0; j < rs->bmp_row_bytes; j++) {
                     uint8_t pixel;
-                    read_byte(fp, &pixel);
+                    file_read_byte(fp, &pixel);
                     if (j < img->w) {
                         if (rs->bmp_h < 0) { // vertical flip (BMP file perspective)
                             if (rs->bmp_w < 0) { // horizontal flip (BMP file perspective)
@@ -113,7 +113,7 @@ void bmp_read_pixels(FIL *fp, image_t *img, int line_start, int line_end, bmp_re
         for (int i = line_start; i < line_end; i++) {
             for (int j = 0, jj = rs->bmp_row_bytes / 2; j < jj; j++) {
                 uint16_t pixel;
-                read_word(fp, &pixel);
+                file_read_word(fp, &pixel);
                 pixel = IM_SWAP16(pixel);
                 if (j < img->w) {
                     if (rs->bmp_h < 0) { // vertical flip (BMP file perspective)
@@ -136,9 +136,9 @@ void bmp_read_pixels(FIL *fp, image_t *img, int line_start, int line_end, bmp_re
         for (int i = line_start; i < line_end; i++) {
             for (int j = 0, jj = rs->bmp_row_bytes / 3; j < jj; j++) {
                 uint8_t r, g, b;
-                read_byte(fp, &r);
-                read_byte(fp, &g);
-                read_byte(fp, &b);
+                file_read_byte(fp, &r);
+                file_read_byte(fp, &g);
+                file_read_byte(fp, &b);
                 uint16_t pixel = IM_RGB565(IM_R825(r), IM_G826(g), IM_B825(b));
                 if (j < img->w) {
                     if (rs->bmp_h < 0) { // vertical flip
@@ -157,7 +157,7 @@ void bmp_read_pixels(FIL *fp, image_t *img, int line_start, int line_end, bmp_re
                 }
             }
             for (int j = 0, jj = rs->bmp_row_bytes % 3; j < jj; j++) {
-                read_byte_ignore(fp);
+                file_read_byte_ignore(fp);
             }
         }
     }
@@ -165,7 +165,7 @@ void bmp_read_pixels(FIL *fp, image_t *img, int line_start, int line_end, bmp_re
 
 void bmp_read(image_t *img, const char *path)
 {
-    FIL fp;
+    file_t fp;
     bmp_read_settings_t rs;
     file_read_open(&fp, path);
     file_buffer_on(&fp);
@@ -180,7 +180,7 @@ void bmp_write_subimg(image_t *img, const char *path, rectangle_t *r)
 {
     rectangle_t rect;
     if (!rectangle_subimg(img, r, &rect)) ff_no_intersection(NULL);
-    FIL fp;
+    file_t fp;
     file_write_open(&fp, path);
 
     file_buffer_on(&fp);
@@ -189,37 +189,37 @@ void bmp_write_subimg(image_t *img, const char *path, rectangle_t *r)
         const int data_size = (row_bytes * rect.h);
         const int waste = (row_bytes / sizeof(uint8_t)) - rect.w;
         // File Header (14 bytes)
-        write_byte(&fp, 'B');
-        write_byte(&fp, 'M');
-        write_long(&fp, 14 + 40 + 1024 + data_size);
-        write_word(&fp, 0);
-        write_word(&fp, 0);
-        write_long(&fp, 14 + 40 + 1024);
+        file_write_byte(&fp, 'B');
+        file_write_byte(&fp, 'M');
+        file_write_long(&fp, 14 + 40 + 1024 + data_size);
+        file_write_word(&fp, 0);
+        file_write_word(&fp, 0);
+        file_write_long(&fp, 14 + 40 + 1024);
         // Info Header (40 bytes)
-        write_long(&fp, 40);
-        write_long(&fp, rect.w);
-        write_long(&fp, -rect.h); // store the image flipped (correctly)
-        write_word(&fp, 1);
-        write_word(&fp, 8);
-        write_long(&fp, 0);
-        write_long(&fp, data_size);
-        write_long(&fp, 0);
-        write_long(&fp, 0);
-        write_long(&fp, 0);
-        write_long(&fp, 0);
+        file_write_long(&fp, 40);
+        file_write_long(&fp, rect.w);
+        file_write_long(&fp, -rect.h); // store the image flipped (correctly)
+        file_write_word(&fp, 1);
+        file_write_word(&fp, 8);
+        file_write_long(&fp, 0);
+        file_write_long(&fp, data_size);
+        file_write_long(&fp, 0);
+        file_write_long(&fp, 0);
+        file_write_long(&fp, 0);
+        file_write_long(&fp, 0);
         // Color Table (1024 bytes)
         for (int i = 0; i < 256; i++) {
-            write_long(&fp, ((i) << 16) | ((i) << 8) | i);
+            file_write_long(&fp, ((i) << 16) | ((i) << 8) | i);
         }
         if ((rect.x == 0) && (rect.w == img->w) && (img->w == row_bytes)) {
-            write_data(&fp, // Super Fast - Zoom, Zoom!
+            file_write_data(&fp, // Super Fast - Zoom, Zoom!
                        img->pixels + (rect.y * img->w),
                        rect.w * rect.h);
         } else {
             for (int i = 0; i < rect.h; i++) {
-                write_data(&fp, img->pixels+((rect.y+i)*img->w)+rect.x, rect.w);
+                file_write_data(&fp, img->pixels+((rect.y+i)*img->w)+rect.x, rect.w);
                 for (int j = 0; j < waste; j++) {
-                    write_byte(&fp, 0);
+                    file_write_byte(&fp, 0);
                 }
             }
         }
@@ -228,34 +228,34 @@ void bmp_write_subimg(image_t *img, const char *path, rectangle_t *r)
         const int data_size = (row_bytes * rect.h);
         const int waste = (row_bytes / sizeof(uint16_t)) - rect.w;
         // File Header (14 bytes)
-        write_byte(&fp, 'B');
-        write_byte(&fp, 'M');
-        write_long(&fp, 14 + 40 + 12 + data_size);
-        write_word(&fp, 0);
-        write_word(&fp, 0);
-        write_long(&fp, 14 + 40 + 12);
+        file_write_byte(&fp, 'B');
+        file_write_byte(&fp, 'M');
+        file_write_long(&fp, 14 + 40 + 12 + data_size);
+        file_write_word(&fp, 0);
+        file_write_word(&fp, 0);
+        file_write_long(&fp, 14 + 40 + 12);
         // Info Header (40 bytes)
-        write_long(&fp, 40);
-        write_long(&fp, rect.w);
-        write_long(&fp, -rect.h); // store the image flipped (correctly)
-        write_word(&fp, 1);
-        write_word(&fp, 16);
-        write_long(&fp, 3);
-        write_long(&fp, data_size);
-        write_long(&fp, 0);
-        write_long(&fp, 0);
-        write_long(&fp, 0);
-        write_long(&fp, 0);
+        file_write_long(&fp, 40);
+        file_write_long(&fp, rect.w);
+        file_write_long(&fp, -rect.h); // store the image flipped (correctly)
+        file_write_word(&fp, 1);
+        file_write_word(&fp, 16);
+        file_write_long(&fp, 3);
+        file_write_long(&fp, data_size);
+        file_write_long(&fp, 0);
+        file_write_long(&fp, 0);
+        file_write_long(&fp, 0);
+        file_write_long(&fp, 0);
         // Bit Masks (12 bytes)
-        write_long(&fp, 0x1F << 11);
-        write_long(&fp, 0x3F << 5);
-        write_long(&fp, 0x1F);
+        file_write_long(&fp, 0x1F << 11);
+        file_write_long(&fp, 0x3F << 5);
+        file_write_long(&fp, 0x1F);
         for (int i = 0; i < rect.h; i++) {
             for (int j = 0; j < rect.w; j++) {
-                write_word(&fp, IM_SWAP16(IM_GET_RGB565_PIXEL(img, (rect.x + j), (rect.y + i))));
+                file_write_word(&fp, IM_SWAP16(IM_GET_RGB565_PIXEL(img, (rect.x + j), (rect.y + i))));
             }
             for (int j = 0; j < waste; j++) {
-                write_word(&fp, 0);
+                file_write_word(&fp, 0);
             }
         }
     }

--- a/src/omv/img/gif.c
+++ b/src/omv/img/gif.c
@@ -12,53 +12,53 @@
 #include "imlib.h"
 #define BLOCK_SIZE (126) // (2^7) - 2 // (DO NOT CHANGE!)
 
-void gif_open(FIL *fp, int width, int height, bool color, bool loop)
+void gif_open(file_t *fp, int width, int height, bool color, bool loop)
 {
     file_buffer_on(fp);
 
-    write_data(fp, "GIF89a", 6);
-    write_word(fp, width);
-    write_word(fp, height);
-    write_data(fp, (uint8_t []) {0xF6, 0x00, 0x00}, 3);
+    file_write_data(fp, "GIF89a", 6);
+    file_write_word(fp, width);
+    file_write_word(fp, height);
+    file_write_data(fp, (uint8_t []) {0xF6, 0x00, 0x00}, 3);
 
     if (color) {
         for (int i=0; i<128; i++) {
             int red =   ((((i & 0x60) >> 5) * 255) + 1.5) / 3;
             int green = ((((i & 0x1C) >> 2) * 255) + 3.5) / 7;
             int blue =   (((i & 0x3)        * 255) + 1.5) / 3;
-            write_data(fp, (uint8_t []) {red, green, blue}, 3);
+            file_write_data(fp, (uint8_t []) {red, green, blue}, 3);
         }
     } else {
         for (int i=0; i<128; i++) {
             int gray = ((i * 255) + 63.5) / 127;
-            write_data(fp, (uint8_t []) {gray, gray, gray}, 3);
+            file_write_data(fp, (uint8_t []) {gray, gray, gray}, 3);
         }
     }
 
     if (loop) {
-        write_data(fp, (uint8_t []) {'!', 0xFF, 0x0B}, 3);
-        write_data(fp, "NETSCAPE2.0", 11);
-        write_data(fp, (uint8_t []) {0x03, 0x01, 0x00, 0x00, 0x00}, 5);
+        file_write_data(fp, (uint8_t []) {'!', 0xFF, 0x0B}, 3);
+        file_write_data(fp, "NETSCAPE2.0", 11);
+        file_write_data(fp, (uint8_t []) {0x03, 0x01, 0x00, 0x00, 0x00}, 5);
     }
 
     file_buffer_off(fp);
 }
 
-void gif_add_frame(FIL *fp, image_t *img, uint16_t delay)
+void gif_add_frame(file_t *fp, image_t *img, uint16_t delay)
 {
     file_buffer_on(fp);
 
     if (delay) {
-        write_data(fp, (uint8_t []) {'!', 0xF9, 0x04, 0x04}, 4);
-        write_word(fp, delay);
-        write_word(fp, 0); // end
+        file_write_data(fp, (uint8_t []) {'!', 0xF9, 0x04, 0x04}, 4);
+        file_write_word(fp, delay);
+        file_write_word(fp, 0); // end
     }
 
-    write_byte(fp, 0x2C);
-    write_long(fp, 0);
-    write_word(fp, img->w);
-    write_word(fp, img->h);
-    write_data(fp, (uint8_t []) {0x00, 0x07}, 2); // 7-bits
+    file_write_byte(fp, 0x2C);
+    file_write_long(fp, 0);
+    file_write_word(fp, img->w);
+    file_write_word(fp, img->h);
+    file_write_data(fp, (uint8_t []) {0x00, 0x07}, 2); // 7-bits
 
     int bytes  = img->h * img->w;
     int blocks = (bytes + BLOCK_SIZE - 1) / BLOCK_SIZE;
@@ -66,30 +66,30 @@ void gif_add_frame(FIL *fp, image_t *img, uint16_t delay)
     if (IM_IS_GS(img)) {
         for (int y=0; y<blocks; y++) {
             int block_size = IM_MIN(BLOCK_SIZE, bytes - (y*BLOCK_SIZE));
-            write_byte(fp, 1 + block_size);
-            write_byte(fp, 0x80); // clear code
+            file_write_byte(fp, 1 + block_size);
+            file_write_byte(fp, 0x80); // clear code
             for (int x=0; x<block_size; x++) {
-                write_byte(fp, img->pixels[(y*BLOCK_SIZE)+x]>>1);
+                file_write_byte(fp, img->pixels[(y*BLOCK_SIZE)+x]>>1);
             }
         }
     } else if (IM_IS_RGB565(img)) {
         for (int y=0; y<blocks; y++) {
             int block_size = IM_MIN(BLOCK_SIZE, bytes - (y*BLOCK_SIZE));
-            write_byte(fp, 1 + block_size);
-            write_byte(fp, 0x80); // clear code
+            file_write_byte(fp, 1 + block_size);
+            file_write_byte(fp, 0x80); // clear code
             for (int x=0; x<block_size; x++) {
                 int pixel = ((uint16_t *) img->pixels)[(y*BLOCK_SIZE)+x];
                 int red = IM_R565(pixel)>>3;
                 int green = IM_G565(pixel)>>3;
                 int blue = IM_B565(pixel)>>3;
-                write_byte(fp, (red<<5) | (green<<2) | blue);
+                file_write_byte(fp, (red<<5) | (green<<2) | blue);
             }
         }
     } else if (IM_IS_BAYER(img)) {
         for (int y=0; y<blocks; y++) {
             int block_size = IM_MIN(BLOCK_SIZE, bytes - (y*BLOCK_SIZE));
-            write_byte(fp, 1 + block_size);
-            write_byte(fp, 0x80); // clear code
+            file_write_byte(fp, 1 + block_size);
+            file_write_byte(fp, 0x80); // clear code
             for (int x=0; x<block_size; x++) {
                 int r=0, g=0, b=0;
                 int x_offs = ((y*BLOCK_SIZE) + x) % img->w;
@@ -98,19 +98,19 @@ void gif_add_frame(FIL *fp, image_t *img, uint16_t delay)
                     COLOR_BAYER_TO_RGB565(img, x_offs, y_offs, r, g, b);
                 }
                 r >>=3; g >>=3; b >>=3;
-                write_byte(fp, (r<<5) | (g<<2) | b);
+                file_write_byte(fp, (r<<5) | (g<<2) | b);
             }
         }
     }
 
 
-    write_data(fp, (uint8_t []) {0x01, 0x81, 0x00}, 3); // end code
+    file_write_data(fp, (uint8_t []) {0x01, 0x81, 0x00}, 3); // end code
 
     file_buffer_off(fp);
 }
 
-void gif_close(FIL *fp)
+void gif_close(file_t *fp)
 {
-    write_byte(fp, ';');
+    file_write_byte(fp, ';');
     file_close(fp);
 }

--- a/src/omv/img/haar.c
+++ b/src/omv/img/haar.c
@@ -164,17 +164,17 @@ array_t *imlib_detect_objects(image_t *image, cascade_t *cascade, rectangle_t *r
 int imlib_load_cascade_from_file(cascade_t *cascade, const char *path)
 {
     int i;
-    FIL fp;
+    file_t fp;
     FRESULT res=FR_OK;
 
     file_read_open(&fp, path);
     file_buffer_on(&fp);
 
     /* read detection window size */
-    read_data(&fp, &cascade->window, sizeof(cascade->window));
+    file_read_data(&fp, &cascade->window, sizeof(cascade->window));
 
     /* read num stages */
-    read_data(&fp, &cascade->n_stages, sizeof(cascade->n_stages));
+    file_read_data(&fp, &cascade->n_stages, sizeof(cascade->n_stages));
 
     cascade->stages_array = xalloc (sizeof(*cascade->stages_array) * cascade->n_stages);
     cascade->stages_thresh_array = xalloc (sizeof(*cascade->stages_thresh_array) * cascade->n_stages);
@@ -185,7 +185,7 @@ int imlib_load_cascade_from_file(cascade_t *cascade, const char *path)
     }
 
     /* read num features in each stages */
-    read_data(&fp, cascade->stages_array, sizeof(uint8_t) * cascade->n_stages);
+    file_read_data(&fp, cascade->stages_array, sizeof(uint8_t) * cascade->n_stages);
 
     /* sum num of features in each stages*/
     for (i=0, cascade->n_features=0; i<cascade->n_stages; i++) {
@@ -207,19 +207,19 @@ int imlib_load_cascade_from_file(cascade_t *cascade, const char *path)
     }
 
     /* read stages thresholds */
-    read_data(&fp, cascade->stages_thresh_array, sizeof(int16_t)*cascade->n_stages);
+    file_read_data(&fp, cascade->stages_thresh_array, sizeof(int16_t)*cascade->n_stages);
 
     /* read features thresholds */
-    read_data(&fp, cascade->tree_thresh_array, sizeof(*cascade->tree_thresh_array)*cascade->n_features);
+    file_read_data(&fp, cascade->tree_thresh_array, sizeof(*cascade->tree_thresh_array)*cascade->n_features);
 
     /* read alpha 1 */
-    read_data(&fp, cascade->alpha1_array, sizeof(*cascade->alpha1_array)*cascade->n_features);
+    file_read_data(&fp, cascade->alpha1_array, sizeof(*cascade->alpha1_array)*cascade->n_features);
 
     /* read alpha 2 */
-    read_data(&fp, cascade->alpha2_array, sizeof(*cascade->alpha2_array)*cascade->n_features);
+    file_read_data(&fp, cascade->alpha2_array, sizeof(*cascade->alpha2_array)*cascade->n_features);
 
     /* read num rectangles per feature*/
-    read_data(&fp, cascade->num_rectangles_array, sizeof(*cascade->num_rectangles_array)*cascade->n_features);
+    file_read_data(&fp, cascade->num_rectangles_array, sizeof(*cascade->num_rectangles_array)*cascade->n_features);
 
     /* sum num of recatngles per feature*/
     for (i=0, cascade->n_rectangles=0; i<cascade->n_features; i++) {
@@ -236,10 +236,10 @@ int imlib_load_cascade_from_file(cascade_t *cascade, const char *path)
     }
 
     /* read rectangles weights */
-    read_data(&fp, cascade->weights_array, sizeof(*cascade->weights_array)*cascade->n_rectangles);
+    file_read_data(&fp, cascade->weights_array, sizeof(*cascade->weights_array)*cascade->n_rectangles);
 
     /* read rectangles num rectangles * 4 points */
-    read_data(&fp, cascade->rectangles_array, sizeof(*cascade->rectangles_array)*cascade->n_rectangles *4);
+    file_read_data(&fp, cascade->rectangles_array, sizeof(*cascade->rectangles_array)*cascade->n_rectangles *4);
 
 error:
     file_buffer_off(&fp);

--- a/src/omv/img/imlib.c
+++ b/src/omv/img/imlib.c
@@ -437,11 +437,11 @@ static save_image_format_t imblib_parse_extension(image_t *img, const char *path
     return FORMAT_DONT_CARE;
 }
 
-bool imlib_read_geometry(FIL *fp, image_t *img, const char *path, img_read_settings_t *rs)
+bool imlib_read_geometry(file_t *fp, image_t *img, const char *path, img_read_settings_t *rs)
 {
     file_read_open(fp, path);
     char magic[2];
-    read_data(fp, &magic, 2);
+    file_read_data(fp, &magic, 2);
     file_close(fp);
 
     bool vflipped = false;
@@ -464,7 +464,7 @@ bool imlib_read_geometry(FIL *fp, image_t *img, const char *path, img_read_setti
     return vflipped;
 }
 
-static void imlib_read_pixels(FIL *fp, image_t *img, int line_start, int line_end, img_read_settings_t *rs)
+static void imlib_read_pixels(file_t *fp, image_t *img, int line_start, int line_end, img_read_settings_t *rs)
 {
     switch (rs->format) {
         case FORMAT_BMP:
@@ -487,7 +487,7 @@ void imlib_image_operation(image_t *img, const char *path, image_t *other, int s
         // the line operation on each line in that window before moving to the
         // next window. The vflipped part is here because BMP files can be saved
         // vertically flipped resulting in us reading the image backwards.
-        FIL fp;
+        file_t fp;
         image_t temp;
         img_read_settings_t rs;
         bool vflipped = imlib_read_geometry(&fp, &temp, path, &rs);
@@ -599,10 +599,10 @@ void imlib_image_operation(image_t *img, const char *path, image_t *other, int s
 
 void imlib_load_image(image_t *img, const char *path)
 {
-    FIL fp;
+    file_t fp;
     file_read_open(&fp, path);
     char magic[2];
-    read_data(&fp, &magic, 2);
+    file_read_data(&fp, &magic, 2);
     file_close(&fp);
 
     if ((magic[0]=='P')
@@ -629,9 +629,9 @@ void imlib_save_image(image_t *img, const char *path, rectangle_t *roi, int qual
             ppm_write_subimg(img, path, roi);
             break;
         case FORMAT_RAW: {
-            FIL fp;
+            file_t fp;
             file_write_open(&fp, path);
-            write_data(&fp, img->pixels, img->w * img->h);
+            file_write_data(&fp, img->pixels, img->w * img->h);
             file_close(&fp);
             break;
         }
@@ -645,10 +645,10 @@ void imlib_save_image(image_t *img, const char *path, rectangle_t *roi, int qual
                 jpeg_write(img, new_path, quality);
                 fb_free();
             } else if (IM_IS_BAYER(img)) {
-                FIL fp;
+                file_t fp;
                 char *new_path = strcat(strcpy(fb_alloc(strlen(path)+5), path), ".raw");
                 file_write_open(&fp, new_path);
-                write_data(&fp, img->pixels, img->w * img->h);
+                file_write_data(&fp, img->pixels, img->w * img->h);
                 file_close(&fp);
                 fb_free();
             } else { // RGB or GS, save as BMP.

--- a/src/omv/img/imlib.h
+++ b/src/omv/img/imlib.h
@@ -5,6 +5,8 @@
 
 #ifndef __IMLIB_H__
 #define __IMLIB_H__
+#include <py/mpconfig.h>
+#include <py/mphal.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdlib.h>
@@ -14,11 +16,11 @@
 #include <float.h>
 #include <math.h>
 #include <arm_math.h>
-#include <ff.h>
-#include "fb_alloc.h"
-#include "umm_malloc.h"
-#include "xalloc.h"
-#include "array.h"
+#include "../ff_wrapper.h"
+#include "../fb_alloc.h"
+#include "../umm_malloc.h"
+#include "../xalloc.h"
+#include "../array.h"
 #include "fmath.h"
 #include "collections.h"
 #include "imlib_config.h"
@@ -1150,33 +1152,33 @@ uint16_t imlib_yuv_to_rgb(uint8_t y, int8_t u, int8_t v);
 void imlib_bayer_to_rgb565(image_t *img, int w, int h, int xoffs, int yoffs, uint16_t *rgbbuf);
 
 /* Image file functions */
-void ppm_read_geometry(FIL *fp, image_t *img, const char *path, ppm_read_settings_t *rs);
-void ppm_read_pixels(FIL *fp, image_t *img, int line_start, int line_end, ppm_read_settings_t *rs);
+void ppm_read_geometry(file_t *fp, image_t *img, const char *path, ppm_read_settings_t *rs);
+void ppm_read_pixels(file_t *fp, image_t *img, int line_start, int line_end, ppm_read_settings_t *rs);
 void ppm_read(image_t *img, const char *path);
 void ppm_write_subimg(image_t *img, const char *path, rectangle_t *r);
-bool bmp_read_geometry(FIL *fp, image_t *img, const char *path, bmp_read_settings_t *rs);
-void bmp_read_pixels(FIL *fp, image_t *img, int line_start, int line_end, bmp_read_settings_t *rs);
+bool bmp_read_geometry(file_t *fp, image_t *img, const char *path, bmp_read_settings_t *rs);
+void bmp_read_pixels(file_t *fp, image_t *img, int line_start, int line_end, bmp_read_settings_t *rs);
 void bmp_read(image_t *img, const char *path);
 void bmp_write_subimg(image_t *img, const char *path, rectangle_t *r);
 bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc);
-void jpeg_read_geometry(FIL *fp, image_t *img, const char *path);
-void jpeg_read_pixels(FIL *fp, image_t *img);
+void jpeg_read_geometry(file_t *fp, image_t *img, const char *path);
+void jpeg_read_pixels(file_t *fp, image_t *img);
 void jpeg_read(image_t *img, const char *path);
 void jpeg_write(image_t *img, const char *path, int quality);
-bool imlib_read_geometry(FIL *fp, image_t *img, const char *path, img_read_settings_t *rs);
+bool imlib_read_geometry(file_t *fp, image_t *img, const char *path, img_read_settings_t *rs);
 void imlib_image_operation(image_t *img, const char *path, image_t *other, int scalar, line_op_t op, void *data);
 void imlib_load_image(image_t *img, const char *path);
 void imlib_save_image(image_t *img, const char *path, rectangle_t *roi, int quality);
 
 /* GIF functions */
-void gif_open(FIL *fp, int width, int height, bool color, bool loop);
-void gif_add_frame(FIL *fp, image_t *img, uint16_t delay);
-void gif_close(FIL *fp);
+void gif_open(file_t *fp, int width, int height, bool color, bool loop);
+void gif_add_frame(file_t *fp, image_t *img, uint16_t delay);
+void gif_close(file_t *fp);
 
 /* MJPEG functions */
-void mjpeg_open(FIL *fp, int width, int height);
-void mjpeg_add_frame(FIL *fp, uint32_t *frames, uint32_t *bytes, image_t *img, int quality);
-void mjpeg_close(FIL *fp, uint32_t *frames, uint32_t *bytes, float fps);
+void mjpeg_open(file_t *fp, int width, int height);
+void mjpeg_add_frame(file_t *fp, uint32_t *frames, uint32_t *bytes, image_t *img, int quality);
+void mjpeg_close(file_t *fp, uint32_t *frames, uint32_t *bytes, float fps);
 
 /* Point functions */
 point_t *point_alloc(int16_t x, int16_t y);
@@ -1240,15 +1242,15 @@ array_t *orb_find_keypoints(image_t *image, bool normalized, int threshold,
         float scale_factor, int max_keypoints, corner_detector_t corner_detector, rectangle_t *roi);
 int orb_match_keypoints(array_t *kpts1, array_t *kpts2, int *match, int threshold, rectangle_t *r, point_t *c, int *angle);
 int orb_filter_keypoints(array_t *kpts, rectangle_t *r, point_t *c);
-int orb_save_descriptor(FIL *fp, array_t *kpts);
-int orb_load_descriptor(FIL *fp, array_t *kpts);
+int orb_save_descriptor(file_t *fp, array_t *kpts);
+int orb_load_descriptor(file_t *fp, array_t *kpts);
 float orb_cluster_dist(int cx, int cy, void *kp);
 
 /* LBP Operator */
 uint8_t *imlib_lbp_desc(image_t *image, rectangle_t *roi);
 int imlib_lbp_desc_distance(uint8_t *d0, uint8_t *d1);
-int imlib_lbp_desc_save(FIL *fp, uint8_t *desc);
-int imlib_lbp_desc_load(FIL *fp, uint8_t **desc);
+int imlib_lbp_desc_save(file_t *fp, uint8_t *desc);
+int imlib_lbp_desc_load(file_t *fp, uint8_t **desc);
 
 /* Iris detector */
 void imlib_find_iris(image_t *src, point_t *iris, rectangle_t *roi);

--- a/src/omv/img/lbp.c
+++ b/src/omv/img/lbp.c
@@ -90,14 +90,14 @@ int imlib_lbp_desc_distance(uint8_t *d0, uint8_t *d1)
     return sum;
 }
 
-int imlib_lbp_desc_save(FIL *fp, uint8_t *desc)
+int imlib_lbp_desc_save(file_t *fp, uint8_t *desc)
 {
-    UINT bytes;
     // Write descriptor
-    return f_write(fp, desc, LBP_DESC_SIZE, &bytes);
+    file_write(fp, desc, LBP_DESC_SIZE);
+    return FR_OK;
 }
 
-int imlib_lbp_desc_load(FIL *fp, uint8_t **desc)
+int imlib_lbp_desc_load(file_t *fp, uint8_t **desc)
 {
     UINT bytes;
     FRESULT res=FR_OK;
@@ -106,7 +106,8 @@ int imlib_lbp_desc_load(FIL *fp, uint8_t **desc)
     uint8_t *hist = xalloc(LBP_DESC_SIZE);
 
     // Read descriptor
-    res = f_read(fp, hist, LBP_DESC_SIZE, &bytes);
+    res = FR_OK;
+    bytes = file_read(fp, hist, LBP_DESC_SIZE);
     if (res != FR_OK || bytes != LBP_DESC_SIZE) {
         *desc = NULL;
         xfree(hist);

--- a/src/omv/img/mjpeg.c
+++ b/src/omv/img/mjpeg.c
@@ -19,84 +19,84 @@
 #define LENGTH_1_OFFSET         (35*4)
 #define MOVI_OFFSET             (54*4)
 
-void mjpeg_open(FIL *fp, int width, int height)
+void mjpeg_open(file_t *fp, int width, int height)
 {
-    write_data(fp, "RIFF", 4); // FOURCC fcc; - 0
-    write_long(fp, 0); // DWORD cb; size - updated on close - 1
-    write_data(fp, "AVI ", 4); // FOURCC fcc; - 2
+    file_write_data(fp, "RIFF", 4); // FOURCC fcc; - 0
+    file_write_long(fp, 0); // DWORD cb; size - updated on close - 1
+    file_write_data(fp, "AVI ", 4); // FOURCC fcc; - 2
 
-    write_data(fp, "LIST", 4); // FOURCC fcc; - 3
-    write_long(fp, 192); // DWORD cb; - 4
-    write_data(fp, "hdrl", 4); // FOURCC fcc; - 5
+    file_write_data(fp, "LIST", 4); // FOURCC fcc; - 3
+    file_write_long(fp, 192); // DWORD cb; - 4
+    file_write_data(fp, "hdrl", 4); // FOURCC fcc; - 5
 
-    write_data(fp, "avih", 4); // FOURCC fcc; - 6
-    write_long(fp, 56); // DWORD cb; - 7
-    write_long(fp, 0); // DWORD dwMicroSecPerFrame; micros - updated on close - 8
-    write_long(fp, 0); // DWORD dwMaxBytesPerSec; updated on close - 9
-    write_long(fp, 4); // DWORD dwPaddingGranularity; - 10
-    write_long(fp, 0); // DWORD dwFlags; - 11
-    write_long(fp, 0); // DWORD dwTotalFrames; frames - updated on close - 12
-    write_long(fp, 0); // DWORD dwInitialFrames; - 13
-    write_long(fp, 1); // DWORD dwStreams; - 14
-    write_long(fp, 0); // DWORD dwSuggestedBufferSize; - 15
-    write_long(fp, width); // DWORD dwWidth; - 16
-    write_long(fp, height); // DWORD dwHeight; - 17
-    write_long(fp, 1000); // DWORD dwScale; - 18
-    write_long(fp, 0); // DWORD dwRate; rate - updated on close - 19
-    write_long(fp, 0); // DWORD dwStart; - 20
-    write_long(fp, 0); // DWORD dwLength; length - updated on close - 21
+    file_write_data(fp, "avih", 4); // FOURCC fcc; - 6
+    file_write_long(fp, 56); // DWORD cb; - 7
+    file_write_long(fp, 0); // DWORD dwMicroSecPerFrame; micros - updated on close - 8
+    file_write_long(fp, 0); // DWORD dwMaxBytesPerSec; updated on close - 9
+    file_write_long(fp, 4); // DWORD dwPaddingGranularity; - 10
+    file_write_long(fp, 0); // DWORD dwFlags; - 11
+    file_write_long(fp, 0); // DWORD dwTotalFrames; frames - updated on close - 12
+    file_write_long(fp, 0); // DWORD dwInitialFrames; - 13
+    file_write_long(fp, 1); // DWORD dwStreams; - 14
+    file_write_long(fp, 0); // DWORD dwSuggestedBufferSize; - 15
+    file_write_long(fp, width); // DWORD dwWidth; - 16
+    file_write_long(fp, height); // DWORD dwHeight; - 17
+    file_write_long(fp, 1000); // DWORD dwScale; - 18
+    file_write_long(fp, 0); // DWORD dwRate; rate - updated on close - 19
+    file_write_long(fp, 0); // DWORD dwStart; - 20
+    file_write_long(fp, 0); // DWORD dwLength; length - updated on close - 21
 
-    write_data(fp, "LIST", 4); // FOURCC fcc; - 22
-    write_long(fp, 116); // DWORD cb; - 23
-    write_data(fp, "strl", 4); // FOURCC fcc; - 24
+    file_write_data(fp, "LIST", 4); // FOURCC fcc; - 22
+    file_write_long(fp, 116); // DWORD cb; - 23
+    file_write_data(fp, "strl", 4); // FOURCC fcc; - 24
 
-    write_data(fp, "strh", 4); // FOURCC fcc; - 25
-    write_long(fp, 56); // DWORD cb; - 26
-    write_data(fp, "vids", 4); // FOURCC fccType; - 27
-    write_data(fp, "MJPG", 4); // FOURCC fccHandler; - 28
-    write_long(fp, 0); // DWORD dwFlags; - 29
-    write_word(fp, 0); // WORD wPriority; - 30
-    write_word(fp, 0); // WORD wLanguage; - 30.5
-    write_long(fp, 0); // DWORD dwInitialFrames; - 31
-    write_long(fp, 1000); // DWORD dwScale; - 32
-    write_long(fp, 0); // DWORD dwRate; rate - updated on close - 33
-    write_long(fp, 0); // DWORD dwStart; - 34
-    write_long(fp, 0); // DWORD dwLength; length - updated on close - 35
-    write_long(fp, 0); // DWORD dwSuggestedBufferSize; - 36
-    write_long(fp, 10000); // DWORD dwQuality; - 37
-    write_long(fp, 0); // DWORD dwSampleSize; - 38
-    write_word(fp, 0); // short int left; - 39
-    write_word(fp, 0); // short int top; - 39.5
-    write_word(fp, 0); // short int right; - 40
-    write_word(fp, 0); // short int bottom; - 40.5
+    file_write_data(fp, "strh", 4); // FOURCC fcc; - 25
+    file_write_long(fp, 56); // DWORD cb; - 26
+    file_write_data(fp, "vids", 4); // FOURCC fccType; - 27
+    file_write_data(fp, "MJPG", 4); // FOURCC fccHandler; - 28
+    file_write_long(fp, 0); // DWORD dwFlags; - 29
+    file_write_word(fp, 0); // WORD wPriority; - 30
+    file_write_word(fp, 0); // WORD wLanguage; - 30.5
+    file_write_long(fp, 0); // DWORD dwInitialFrames; - 31
+    file_write_long(fp, 1000); // DWORD dwScale; - 32
+    file_write_long(fp, 0); // DWORD dwRate; rate - updated on close - 33
+    file_write_long(fp, 0); // DWORD dwStart; - 34
+    file_write_long(fp, 0); // DWORD dwLength; length - updated on close - 35
+    file_write_long(fp, 0); // DWORD dwSuggestedBufferSize; - 36
+    file_write_long(fp, 10000); // DWORD dwQuality; - 37
+    file_write_long(fp, 0); // DWORD dwSampleSize; - 38
+    file_write_word(fp, 0); // short int left; - 39
+    file_write_word(fp, 0); // short int top; - 39.5
+    file_write_word(fp, 0); // short int right; - 40
+    file_write_word(fp, 0); // short int bottom; - 40.5
 
-    write_data(fp, "strf", 4); // FOURCC fcc; - 41
-    write_long(fp, 40); // DWORD cb; - 42
-    write_long(fp, 40); // DWORD biSize; - 43
-    write_long(fp, width); // LONG biWidth; - 44
-    write_long(fp, height); // LONG biHeight; - 45
-    write_word(fp, 1); // WORD biPlanes; - 46
-    write_word(fp, 24); // WORD biBitCount; - 46.5
-    write_data(fp, "MJPG", 4); // DWORD biCompression; - 47
-    write_long(fp, 0); // DWORD biSizeImage; - 48
-    write_long(fp, 0); // LONG biXPelsPerMeter; - 49
-    write_long(fp, 0); // LONG biYPelsPerMeter; - 50
-    write_long(fp, 0); // DWORD biClrUsed; - 51
-    write_long(fp, 0); // DWORD biClrImportant; - 52
+    file_write_data(fp, "strf", 4); // FOURCC fcc; - 41
+    file_write_long(fp, 40); // DWORD cb; - 42
+    file_write_long(fp, 40); // DWORD biSize; - 43
+    file_write_long(fp, width); // LONG biWidth; - 44
+    file_write_long(fp, height); // LONG biHeight; - 45
+    file_write_word(fp, 1); // WORD biPlanes; - 46
+    file_write_word(fp, 24); // WORD biBitCount; - 46.5
+    file_write_data(fp, "MJPG", 4); // DWORD biCompression; - 47
+    file_write_long(fp, 0); // DWORD biSizeImage; - 48
+    file_write_long(fp, 0); // LONG biXPelsPerMeter; - 49
+    file_write_long(fp, 0); // LONG biYPelsPerMeter; - 50
+    file_write_long(fp, 0); // DWORD biClrUsed; - 51
+    file_write_long(fp, 0); // DWORD biClrImportant; - 52
 
-    write_data(fp, "LIST", 4); // FOURCC fcc; - 53
-    write_long(fp, 0); // DWORD cb; movi - updated on close - 54
-    write_data(fp, "movi", 4); // FOURCC fcc; - 55
+    file_write_data(fp, "LIST", 4); // FOURCC fcc; - 53
+    file_write_long(fp, 0); // DWORD cb; movi - updated on close - 54
+    file_write_data(fp, "movi", 4); // FOURCC fcc; - 55
 }
 
-void mjpeg_add_frame(FIL *fp, uint32_t *frames, uint32_t *bytes, image_t *img, int quality)
+void mjpeg_add_frame(file_t *fp, uint32_t *frames, uint32_t *bytes, image_t *img, int quality)
 {
-    write_data(fp, "00dc", 4); // FOURCC fcc;
+    file_write_data(fp, "00dc", 4); // FOURCC fcc;
     *frames += 1;
     if (IM_IS_JPEG(img)) {
         int pad = (((img->bpp + 3) / 4) * 4) - img->bpp;
-        write_long(fp, img->bpp + pad); // DWORD cb;
-        write_data(fp, img->pixels, img->bpp + pad); // reading past okay
+        file_write_long(fp, img->bpp + pad); // DWORD cb;
+        file_write_data(fp, img->pixels, img->bpp + pad); // reading past okay
         *bytes += img->bpp + pad;
     } else {
         uint32_t size;
@@ -107,43 +107,43 @@ void mjpeg_add_frame(FIL *fp, uint32_t *frames, uint32_t *bytes, image_t *img, i
         // the heap and return NULL which will cause an out of memory error.
         jpeg_compress(img, &out, quality, true);
         int pad = (((out.bpp + 3) / 4) * 4) - out.bpp;
-        write_long(fp, out.bpp + pad); // DWORD cb;
-        write_data(fp, out.pixels, out.bpp + pad); // reading past okay
+        file_write_long(fp, out.bpp + pad); // DWORD cb;
+        file_write_data(fp, out.pixels, out.bpp + pad); // reading past okay
         *bytes += out.bpp + pad;
         fb_free();
     }
 }
 
-void mjpeg_close(FIL *fp, uint32_t *frames, uint32_t *bytes, float fps)
+void mjpeg_close(file_t *fp, uint32_t *frames, uint32_t *bytes, float fps)
 {
     // Needed
     file_seek(fp, SIZE_OFFSET);
-    write_long(fp, 216 + (*frames * 8) + *bytes);
+    file_write_long(fp, 216 + (*frames * 8) + *bytes);
     // Needed
     file_seek(fp, MICROS_OFFSET);
-    write_long(fp, (!fast_roundf(fps)) ? 0 :
+    file_write_long(fp, (!fast_roundf(fps)) ? 0 :
             fast_roundf(1000000 / fps));
-    write_long(fp, (!(*frames)) ? 0 :
+    file_write_long(fp, (!(*frames)) ? 0 :
             fast_roundf((((*frames * 8) + *bytes) * fps) / *frames));
     // Needed
     file_seek(fp, FRAMES_OFFSET);
-    write_long(fp, *frames);
+    file_write_long(fp, *frames);
     // Probably not needed but writing it just in case.
     file_seek(fp, RATE_0_OFFSET);
-    write_long(fp, fast_roundf(fps * 1000));
+    file_write_long(fp, fast_roundf(fps * 1000));
     // Probably not needed but writing it just in case.
     file_seek(fp, LENGTH_0_OFFSET);
-    write_long(fp, (!fast_roundf(fps)) ? 0 :
+    file_write_long(fp, (!fast_roundf(fps)) ? 0 :
             fast_roundf((*frames * 1000) / fps));
     // Probably not needed but writing it just in case.
     file_seek(fp, RATE_1_OFFSET);
-    write_long(fp, fast_roundf(fps * 1000));
+    file_write_long(fp, fast_roundf(fps * 1000));
     // Probably not needed but writing it just in case.
     file_seek(fp, LENGTH_1_OFFSET);
-    write_long(fp, (!fast_roundf(fps)) ? 0 :
+    file_write_long(fp, (!fast_roundf(fps)) ? 0 :
             fast_roundf((*frames * 1000) / fps));
     // Needed
     file_seek(fp, MOVI_OFFSET);
-    write_long(fp, 4 + (*frames * 8) + *bytes);
+    file_write_long(fp, 4 + (*frames * 8) + *bytes);
     file_close(fp);
 }

--- a/src/omv/img/orb.c
+++ b/src/omv/img/orb.c
@@ -673,7 +673,7 @@ int orb_filter_keypoints(array_t *kpts, rectangle_t *r, point_t *c)
     return matches;
 }
 
-int orb_save_descriptor(FIL *fp, array_t *kpts)
+int orb_save_descriptor(file_t *fp, array_t *kpts)
 {
     UINT bytes;
     FRESULT res;
@@ -681,7 +681,8 @@ int orb_save_descriptor(FIL *fp, array_t *kpts)
     int kpts_size = array_length(kpts);
 
     // Write the number of keypoints
-    res = f_write(fp, &kpts_size, sizeof(kpts_size), &bytes);
+    res = FR_OK; 
+    bytes = file_write(fp, &kpts_size, sizeof(kpts_size));
     if (res != FR_OK || bytes != sizeof(kpts_size)) {
         goto error;
     }
@@ -691,37 +692,43 @@ int orb_save_descriptor(FIL *fp, array_t *kpts)
         kp_t *kp = array_at(kpts, i);
 
         // Write X
-        res = f_write(fp, &kp->x, sizeof(kp->x), &bytes);
+        res = FR_OK; 
+        bytes = file_write(fp, &kp->x, sizeof(kp->x));
         if (res != FR_OK || bytes != sizeof(kp->x)) {
             goto error;
         }
 
         // Write Y
-        res = f_write(fp, &kp->y, sizeof(kp->y), &bytes);
+        res = FR_OK; 
+        bytes = file_write(fp, &kp->y, sizeof(kp->y));
         if (res != FR_OK || bytes != sizeof(kp->y)) {
             goto error;
         }
 
         // Write Score
-        res = f_write(fp, &kp->score, sizeof(kp->score), &bytes);
+        res = FR_OK; 
+        bytes = file_write(fp, &kp->score, sizeof(kp->score));
         if (res != FR_OK || bytes != sizeof(kp->score)) {
             goto error;
         }
 
         // Write Octave
-        res = f_write(fp, &kp->octave, sizeof(kp->octave), &bytes);
+        res = FR_OK; 
+        bytes = file_write(fp, &kp->octave, sizeof(kp->octave));
         if (res != FR_OK || bytes != sizeof(kp->octave)) {
             goto error;
         }
 
         // Write Angle
-        res = f_write(fp, &kp->angle, sizeof(kp->angle), &bytes);
+        res = FR_OK; 
+        bytes = file_write(fp, &kp->angle, sizeof(kp->angle));
         if (res != FR_OK || bytes != sizeof(kp->angle)) {
             goto error;
         }
 
         // Write descriptor
-        res = f_write(fp, kp->desc, KDESC_SIZE, &bytes);
+        res = FR_OK; 
+        bytes = file_write(fp, kp->desc, KDESC_SIZE);
         if (res != FR_OK || bytes != KDESC_SIZE) {
             goto error;
         }
@@ -731,7 +738,7 @@ error:
     return res;
 }
 
-int orb_load_descriptor(FIL *fp, array_t *kpts)
+int orb_load_descriptor(file_t *fp, array_t *kpts)
 {
     UINT bytes;
     FRESULT res=FR_OK;
@@ -739,7 +746,8 @@ int orb_load_descriptor(FIL *fp, array_t *kpts)
     int kpts_size=0;
 
     // Read number of keypoints
-    res = f_read(fp, &kpts_size, sizeof(kpts_size), &bytes);
+    res = FR_OK; 
+    bytes = file_read(fp, &kpts_size, sizeof(kpts_size));
     if (res != FR_OK || bytes != sizeof(kpts_size)) {
         goto error;
     }
@@ -750,37 +758,43 @@ int orb_load_descriptor(FIL *fp, array_t *kpts)
         kp->matched = 0;
 
         // Read X
-        res = f_read(fp, &kp->x, sizeof(kp->x), &bytes);
+        res = FR_OK; 
+        bytes = file_read(fp, &kp->x, sizeof(kp->x));
         if (res != FR_OK || bytes != sizeof(kp->x)) {
             goto error;
         }
 
         // Read Y
-        res = f_read(fp, &kp->y, sizeof(kp->y), &bytes);
+        res = FR_OK; 
+        bytes = file_read(fp, &kp->y, sizeof(kp->y));
         if (res != FR_OK || bytes != sizeof(kp->y)) {
             goto error;
         }
 
         // Read Score
-        res = f_read(fp, &kp->score, sizeof(kp->score), &bytes);
+        res = FR_OK; 
+        bytes = file_read(fp, &kp->score, sizeof(kp->score));
         if (res != FR_OK || bytes != sizeof(kp->score)) {
             goto error;
         }
 
         // Read Octave
-        res = f_read(fp, &kp->octave, sizeof(kp->octave), &bytes);
+        res = FR_OK; 
+        bytes = file_read(fp, &kp->octave, sizeof(kp->octave));
         if (res != FR_OK || bytes != sizeof(kp->octave)) {
             goto error;
         }
 
         // Read Angle
-        res = f_read(fp, &kp->angle, sizeof(kp->angle), &bytes);
+        res = FR_OK; 
+        bytes = file_read(fp, &kp->angle, sizeof(kp->angle));
         if (res != FR_OK || bytes != sizeof(kp->angle)) {
             goto error;
         }
 
         // Read descriptor
-        res = f_read(fp, kp->desc,  KDESC_SIZE, &bytes);
+        res = FR_OK; 
+        bytes = file_read(fp, kp->desc,  KDESC_SIZE);
         if (res != FR_OK || bytes != KDESC_SIZE) {
             goto error;
         }

--- a/src/omv/img/ppm.c
+++ b/src/omv/img/ppm.c
@@ -17,13 +17,13 @@ static void read_int_reset(ppm_read_settings_t *rs)
     rs->read_int_c_valid = false;
 }
 
-static void read_int(FIL *fp, uint32_t *i, ppm_read_settings_t *rs)
+static void file_read_int(file_t *fp, uint32_t *i, ppm_read_settings_t *rs)
 {
     enum { EAT_WHITESPACE, EAT_COMMENT, EAT_NUMBER } mode = EAT_WHITESPACE;
     for(*i = 0;;) {
         if (!rs->read_int_c_valid) {
             if (file_tell_w_buf(fp) == file_size_w_buf(fp)) return;
-            read_byte(fp, &rs->read_int_c);
+            file_read_byte(fp, &rs->read_int_c);
             rs->read_int_c_valid = true;
         }
         if (mode == EAT_WHITESPACE) {
@@ -49,31 +49,31 @@ static void read_int(FIL *fp, uint32_t *i, ppm_read_settings_t *rs)
 }
 
 // This function inits the geometry values of an image.
-void ppm_read_geometry(FIL *fp, image_t *img, const char *path, ppm_read_settings_t *rs)
+void ppm_read_geometry(file_t *fp, image_t *img, const char *path, ppm_read_settings_t *rs)
 {
     read_int_reset(rs);
-    read_byte_expect(fp, 'P');
-    read_byte(fp, &rs->ppm_fmt);
+    file_read_byte_expect(fp, 'P');
+    file_read_byte(fp, &rs->ppm_fmt);
     if ((rs->ppm_fmt!='2') && (rs->ppm_fmt!='3') && (rs->ppm_fmt!='5') && (rs->ppm_fmt!='6')) ff_unsupported_format(fp);
     img->bpp = ((rs->ppm_fmt == '2') || (rs->ppm_fmt == '5')) ? 1 : 2;
 
-    read_int(fp, (uint32_t *) &img->w, rs);
-    read_int(fp, (uint32_t *) &img->h, rs);
+    file_read_int(fp, (uint32_t *) &img->w, rs);
+    file_read_int(fp, (uint32_t *) &img->h, rs);
     if ((img->w == 0) || (img->h == 0)) ff_file_corrupted(fp);
 
     uint32_t max;
-    read_int(fp, &max, rs);
+    file_read_int(fp, &max, rs);
     if (max != 255) ff_unsupported_format(fp);
 }
 
 // This function reads the pixel values of an image.
-void ppm_read_pixels(FIL *fp, image_t *img, int line_start, int line_end, ppm_read_settings_t *rs)
+void ppm_read_pixels(file_t *fp, image_t *img, int line_start, int line_end, ppm_read_settings_t *rs)
 {
     if (rs->ppm_fmt == '2') {
         for (int i = line_start; i < line_end; i++) {
             for (int j = 0; j < img->w; j++) {
                 uint32_t pixel;
-                read_int(fp, &pixel, rs);
+                file_read_int(fp, &pixel, rs);
                 IM_SET_GS_PIXEL(img, j, i, pixel);
             }
         }
@@ -81,25 +81,25 @@ void ppm_read_pixels(FIL *fp, image_t *img, int line_start, int line_end, ppm_re
         for (int i = line_start; i < line_end; i++) {
             for (int j = 0; j < img->w; j++) {
                 uint32_t r, g, b;
-                read_int(fp, &r, rs);
-                read_int(fp, &g, rs);
-                read_int(fp, &b, rs);
+                file_read_int(fp, &r, rs);
+                file_read_int(fp, &g, rs);
+                file_read_int(fp, &b, rs);
                 IM_SET_RGB565_PIXEL(img, j, i, IM_RGB565(IM_R825(r),
                                                          IM_G826(g),
                                                          IM_B825(b)));
             }
         }
     } else if (rs->ppm_fmt == '5') {
-        read_data(fp, // Super Fast - Zoom, Zoom!
+        file_read_data(fp, // Super Fast - Zoom, Zoom!
                   img->pixels + (line_start * img->w),
                   (line_end - line_start) * img->w);
     } else if (rs->ppm_fmt == '6') {
         for (int i = line_start; i < line_end; i++) {
             for (int j = 0; j < img->w; j++) {
                 uint8_t r, g, b;
-                read_byte(fp, &r);
-                read_byte(fp, &g);
-                read_byte(fp, &b);
+                file_read_byte(fp, &r);
+                file_read_byte(fp, &g);
+                file_read_byte(fp, &b);
                 IM_SET_RGB565_PIXEL(img, j, i, IM_RGB565(IM_R825(r),
                                                          IM_G826(g),
                                                          IM_B825(b)));
@@ -110,7 +110,7 @@ void ppm_read_pixels(FIL *fp, image_t *img, int line_start, int line_end, ppm_re
 
 void ppm_read(image_t *img, const char *path)
 {
-    FIL fp;
+    file_t fp;
     ppm_read_settings_t rs;
     file_read_open(&fp, path);
     file_buffer_on(&fp);
@@ -125,27 +125,27 @@ void ppm_write_subimg(image_t *img, const char *path, rectangle_t *r)
 {
     rectangle_t rect;
     if (!rectangle_subimg(img, r, &rect)) ff_no_intersection(NULL);
-    FIL fp;
+    file_t fp;
     file_write_open(&fp, path);
 
     file_buffer_on(&fp);
     if (IM_IS_GS(img)) {
         char buffer[20]; // exactly big enough for 5-digit w/h
         int len = snprintf(buffer, 20, "P5\n%d %d\n255\n", rect.w, rect.h);
-        write_data(&fp, buffer, len);
+        file_write_data(&fp, buffer, len);
         if ((rect.x == 0) && (rect.w == img->w)) {
-            write_data(&fp, // Super Fast - Zoom, Zoom!
+            file_write_data(&fp, // Super Fast - Zoom, Zoom!
                        img->pixels + (rect.y * img->w),
                        rect.w * rect.h);
         } else {
             for (int i = 0; i < rect.h; i++) {
-                write_data(&fp, img->pixels+((rect.y+i)*img->w)+rect.x, rect.w);
+                file_write_data(&fp, img->pixels+((rect.y+i)*img->w)+rect.x, rect.w);
             }
         }
     } else {
         char buffer[20]; // exactly big enough for 5-digit w/h
         int len = snprintf(buffer, 20, "P6\n%d %d\n255\n", rect.w, rect.h);
-        write_data(&fp, buffer, len);
+        file_write_data(&fp, buffer, len);
         for (int i = 0; i < rect.h; i++) {
             for (int j = 0; j < rect.w; j++) {
                 int pixel = IM_GET_RGB565_PIXEL(img, (rect.x + j), (rect.y + i));
@@ -153,7 +153,7 @@ void ppm_write_subimg(image_t *img, const char *path, rectangle_t *r)
                 buff[0] = IM_R528(IM_R565(pixel));
                 buff[1] = IM_G628(IM_G565(pixel));
                 buff[2] = IM_B528(IM_B565(pixel));
-                write_data(&fp, buff, 3);
+                file_write_data(&fp, buff, 3);
             }
         }
     }

--- a/src/omv/ini.c
+++ b/src/omv/ini.c
@@ -225,12 +225,12 @@ strncpy(char *dst, const char *src, size_t n)
 /**  ini_fgetc(fp) -- get char from stream */
 
 int
-ini_fgetc(FIL *fp)
+ini_fgetc(file_t *fp)
 {
     char c;
     UINT b;
-
-    if (f_read (fp, &c, 1, &b) != FR_OK || b != 1)
+    b = file_read(fp, &c, 1);
+    if (b != 1)
         return (EOF);
     return (c);
 }
@@ -269,7 +269,7 @@ ini_fgetc(FIL *fp)
 /**  char *ini_fgets(dst,max,fp) -- get string from stream */
 
 char *
-ini_fgets(char *dst, int max, FIL *fp)
+ini_fgets(char *dst, int max, file_t *fp)
 {
     int c;
     char *p;
@@ -501,24 +501,22 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
 }
 
 /* See documentation in header file. */
-int ini_parse_file(FIL* file, ini_handler handler, void* user)
+int ini_parse_file(file_t* file, ini_handler handler, void* user)
 {
     return ini_parse_stream((ini_reader)ini_fgets, file, handler, user);
 }
 
 /* See documentation in header file. */
-int ini_parse(FATFS *fs, const char* filename, ini_handler handler, void* user)
+int ini_parse(const char* filename, ini_handler handler, void* user)
 {
-    FIL file;
+    file_t file;
     int error;
 
-    FRESULT res = f_open(fs, &file, filename, FA_READ | FA_OPEN_EXISTING);
+    FRESULT res = f_open_helper(&file, filename, FA_READ | FA_OPEN_EXISTING);
     if (res != FR_OK)
         return -1;
     error = ini_parse_file(&file, handler, user);
-    res = f_close(&file);
-    if (res != FR_OK)
-        return -1;
+    file_close(&file);
     return error;
 }
 

--- a/src/omv/ini.h
+++ b/src/omv/ini.h
@@ -56,11 +56,11 @@ typedef char* (*ini_reader)(char* str, int num, void* stream);
    stop on first error), -1 on file open error, or -2 on memory allocation
    error (only when INI_USE_STACK is zero).
 */
-int ini_parse(FATFS *fs, const char* filename, ini_handler handler, void* user);
+int ini_parse(const char* filename, ini_handler handler, void* user);
 
-/* Same as ini_parse(), but takes a FIL* instead of filename. This doesn't
+/* Same as ini_parse(), but takes a file_t* instead of filename. This doesn't
    close the file when it's finished -- the caller must do that. */
-int ini_parse_file(FIL* file, ini_handler handler, void* user);
+int ini_parse_file(file_t* file, ini_handler handler, void* user);
 
 /* Same as ini_parse(), but takes an ini_reader function pointer instead of
    filename. Used for implementing custom or string-based I/O (see also

--- a/src/omv/main.c
+++ b/src/omv/main.c
@@ -9,7 +9,7 @@
 #include <stdio.h>
 #include <stdbool.h>
 #include <string.h>
-#include STM32_HAL_H
+#include <mphalport.h>
 #include "mpconfig.h"
 #include "systick.h"
 #include "pendsv.h"
@@ -203,15 +203,15 @@ void flash_error(int n) {
 }
 
 void NORETURN __fatal_error(const char *msg) {
-    FIL fp;
+    file_t fp;
     if (f_open(&vfs_fat->fatfs, &fp, "ERROR.LOG",
                FA_WRITE|FA_CREATE_ALWAYS) == FR_OK) {
         UINT bytes;
         const char *hdr = "FATAL ERROR:\n";
-        f_write(&fp, hdr, strlen(hdr), &bytes);
-        f_write(&fp, msg, strlen(msg), &bytes);
+        bytes = file_write(&fp, hdr, strlen(hdr));
+        bytes = file_write(&fp, msg, strlen(msg));
     }
-    f_close(&fp);
+    file_close(&fp);
     storage_flush();
 
     for (uint i = 0;;) {
@@ -237,7 +237,7 @@ void __attribute__((weak))
 
 void make_flash_fs()
 {
-    FIL fp;
+    file_t fp;
     UINT n;
 
     led_state(LED_RED, 1);
@@ -249,18 +249,18 @@ void make_flash_fs()
 
     // Create default main.py
     f_open(&vfs_fat->fatfs, &fp, "/main.py", FA_WRITE | FA_CREATE_ALWAYS);
-    f_write(&fp, fresh_main_py, sizeof(fresh_main_py) - 1 /* don't count null terminator */, &n);
-    f_close(&fp);
+    n = file_write(&fp, fresh_main_py, sizeof(fresh_main_py) - 1 /* don't count null terminator */);
+    file_close(&fp);
 
     // Create readme file
     f_open(&vfs_fat->fatfs, &fp, "/README.txt", FA_WRITE | FA_CREATE_ALWAYS);
-    f_write(&fp, fresh_readme_txt, sizeof(fresh_readme_txt) - 1 /* don't count null terminator */, &n);
-    f_close(&fp);
+    n = file_write(&fp, fresh_readme_txt, sizeof(fresh_readme_txt) - 1 /* don't count null terminator */);
+    file_close(&fp);
 
     // Create default selftest.py
     f_open(&vfs_fat->fatfs, &fp, "/selftest.py", FA_WRITE | FA_CREATE_ALWAYS);
-    f_write(&fp, fresh_selftest_py, sizeof(fresh_selftest_py) - 1 /* don't count null terminator */, &n);
-    f_close(&fp);
+    n = file_write(&fp, fresh_selftest_py, sizeof(fresh_selftest_py) - 1 /* don't count null terminator */);
+    file_close(&fp);
 
     led_state(LED_RED, 0);
 }

--- a/src/omv/nn/nn.c
+++ b/src/omv/nn/nn.c
@@ -79,17 +79,17 @@ int nn_dump_network(nn_t *net)
 
 int nn_load_network(nn_t *net, const char *path)
 {
-    FIL fp;
+    file_t fp;
     int res = 0;
 
     file_read_open(&fp, path);
     file_buffer_on(&fp);
 
     // Read network type
-    read_data(&fp, net->type, 4);
+    file_read_data(&fp, net->type, 4);
 
     // Read number of layers
-    read_data(&fp, &net->n_layers, 4);
+    file_read_data(&fp, &net->n_layers, 4);
 
     layer_t *prev_layer = NULL;
     for (int i=0; i<net->n_layers; i++) {
@@ -97,7 +97,7 @@ int nn_load_network(nn_t *net, const char *path)
         layer_type_t layer_type;
 
         // Read layer type
-        read_data(&fp, &layer_type, 4);
+        file_read_data(&fp, &layer_type, 4);
         switch (layer_type) {
             case LAYER_TYPE_DATA:
                 layer = xalloc0(sizeof(data_layer_t));
@@ -131,41 +131,41 @@ int nn_load_network(nn_t *net, const char *path)
         layer->type = layer_type;
 
         // Read layer shape (NCHW)
-        read_data(&fp, &layer->n, 4);
-        read_data(&fp, &layer->c, 4);
-        read_data(&fp, &layer->h, 4);
-        read_data(&fp, &layer->w, 4);
+        file_read_data(&fp, &layer->n, 4);
+        file_read_data(&fp, &layer->c, 4);
+        file_read_data(&fp, &layer->h, 4);
+        file_read_data(&fp, &layer->w, 4);
 
         switch (layer_type) {
             case LAYER_TYPE_DATA: {
                 data_layer_t *data_layer = (data_layer_t *) layer;
                 // Read data layer R, G, B mean and input scale
-                read_data(&fp, &data_layer->r_mean, 4);
-                read_data(&fp, &data_layer->g_mean, 4);
-                read_data(&fp, &data_layer->b_mean, 4);
-                read_data(&fp, &data_layer->scale, 4);
+                file_read_data(&fp, &data_layer->r_mean, 4);
+                file_read_data(&fp, &data_layer->g_mean, 4);
+                file_read_data(&fp, &data_layer->b_mean, 4);
+                file_read_data(&fp, &data_layer->scale, 4);
                 break;
             }
 
             case LAYER_TYPE_CONV: {
                 conv_layer_t *conv_layer = (conv_layer_t *) layer;
                 // Read layer l_shift, r_shift
-                read_data(&fp, &conv_layer->l_shift, 4);
-                read_data(&fp, &conv_layer->r_shift, 4);
+                file_read_data(&fp, &conv_layer->l_shift, 4);
+                file_read_data(&fp, &conv_layer->r_shift, 4);
                 // Read krnel dim, stride and padding
-                read_data(&fp, &conv_layer->krn_dim, 4);
-                read_data(&fp, &conv_layer->krn_pad, 4);
-                read_data(&fp, &conv_layer->krn_str, 4);
+                file_read_data(&fp, &conv_layer->krn_dim, 4);
+                file_read_data(&fp, &conv_layer->krn_pad, 4);
+                file_read_data(&fp, &conv_layer->krn_str, 4);
 
                 // Alloc and read weights array
-                read_data(&fp, &conv_layer->w_size, 4);
+                file_read_data(&fp, &conv_layer->w_size, 4);
                 conv_layer->wt = xalloc(conv_layer->w_size);
-                read_data(&fp, conv_layer->wt, conv_layer->w_size);
+                file_read_data(&fp, conv_layer->wt, conv_layer->w_size);
 
                 // Alloc and read bias array
-                read_data(&fp, &conv_layer->b_size, 4);
+                file_read_data(&fp, &conv_layer->b_size, 4);
                 conv_layer->bias = xalloc(conv_layer->b_size);
-                read_data(&fp, conv_layer->bias, conv_layer->b_size);
+                file_read_data(&fp, conv_layer->bias, conv_layer->b_size);
                 break;
             }
 
@@ -177,29 +177,29 @@ int nn_load_network(nn_t *net, const char *path)
             case LAYER_TYPE_POOL: {
                 pool_layer_t *pool_layer = (pool_layer_t *) layer;
                 // Read pooling layer type
-                read_data(&fp, &pool_layer->ptype, 4);
+                file_read_data(&fp, &pool_layer->ptype, 4);
                 // Read krnel dim, stride and padding
-                read_data(&fp, &pool_layer->krn_dim, 4);
-                read_data(&fp, &pool_layer->krn_pad, 4);
-                read_data(&fp, &pool_layer->krn_str, 4);
+                file_read_data(&fp, &pool_layer->krn_dim, 4);
+                file_read_data(&fp, &pool_layer->krn_pad, 4);
+                file_read_data(&fp, &pool_layer->krn_str, 4);
                 break;
             }
 
             case LAYER_TYPE_IP: {
                 ip_layer_t *ip_layer = (ip_layer_t *) layer;
                 // Read layer l_shift, r_shift
-                read_data(&fp, &ip_layer->l_shift, 4);
-                read_data(&fp, &ip_layer->r_shift, 4);
+                file_read_data(&fp, &ip_layer->l_shift, 4);
+                file_read_data(&fp, &ip_layer->r_shift, 4);
 
                 // Alloc and read weights array
-                read_data(&fp, &ip_layer->w_size, 4);
+                file_read_data(&fp, &ip_layer->w_size, 4);
                 ip_layer->wt = xalloc(ip_layer->w_size);
-                read_data(&fp, ip_layer->wt, ip_layer->w_size);
+                file_read_data(&fp, ip_layer->wt, ip_layer->w_size);
 
                 // Alloc and read bias array
-                read_data(&fp, &ip_layer->b_size, 4);
+                file_read_data(&fp, &ip_layer->b_size, 4);
                 ip_layer->bias = xalloc(ip_layer->b_size);
-                read_data(&fp, ip_layer->bias, ip_layer->b_size);
+                file_read_data(&fp, ip_layer->bias, ip_layer->b_size);
                 break;
             }
         }

--- a/src/omv/py/py_gif.c
+++ b/src/omv/py/py_gif.c
@@ -22,7 +22,7 @@ typedef struct py_gif_obj {
     int height;
     bool color;
     bool loop;
-    FIL fp;
+    file_t fp;
 } py_gif_obj_t;
 
 static mp_obj_t py_gif_open(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)

--- a/src/omv/py/py_mjpeg.c
+++ b/src/omv/py/py_mjpeg.c
@@ -22,7 +22,7 @@ typedef struct py_mjpeg_obj {
     int height;
     uint32_t frames;
     uint32_t bytes;
-    FIL fp;
+    file_t fp;
 } py_mjpeg_obj_t;
 
 static mp_obj_t py_mjpeg_open(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
@@ -54,7 +54,7 @@ static mp_obj_t py_mjpeg_height(mp_obj_t mjpeg_obj)
 static mp_obj_t py_mjpeg_size(mp_obj_t mjpeg_obj)
 {
     py_mjpeg_obj_t *arg_mjpeg = mjpeg_obj;
-    return mp_obj_new_int(f_size(&arg_mjpeg->fp));
+    return mp_obj_new_int(file_size(&arg_mjpeg->fp));
 }
 
 static mp_obj_t py_mjpeg_add_frame(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)


### PR DESCRIPTION
The existing implementation goes directly to oofatfs which limits file operations to stm32 port  and files on the the fatfs drives only.

This change allows any micropython filesystem to be used for all file IO in the omv subsystem, including virtual file systems defined via a python interface (eg mprepl)

This patch has not been tested explicitly in this submitted form, however it's been used a fair bit in my omv_module repo form (see below). 
This pr is intended as a hopefully useful contribution though even if it needs some further fixes, but also as a conversation starter.

At work I'm building a product which includes much of the omv folder as a submodule built directly against upstream micropython, as described in:  
https://github.com/micropython/micropython/pull/4195
https://gitlab.com/alelec/mp_omv
https://gitlab.com/alelec/omv
This has been restructured as such partly as a test case, but mostly as we need to use other features from mainline micropython (and I'm on a personal mission to reduce the need for micropython forks :-)

I've got a bunch of other changes in the omv repo above which may be of use to you too, most of which are for compatibility both with mainline stm32 but also to add support for use with the unix port for automated unit testing of imaging functions. I'm happy to help with anything there of interest.

Note: my mp_omv system currently breaks support for the openmv ide but I'd like to add it back using the second cdc port now optionally available in mainline micropython, rather than the existing method of interleaving it into the main cdc... this hasn't been started yet though.

On our private work fork we've also got initial support for a 12bit 1.3mp image sensor (ar0130) which I could discuss pushing up if there's any value for you (it needs the sdram support too to fit the larger images). Thanks for your fantastic platform!