### PR TITLE
jpeg: ensure buffer is deallocated on compression failure

### DIFF
--- a/src/omv/py/py_image.c
+++ b/src/omv/py/py_image.c
@@ -1070,7 +1070,11 @@ static mp_obj_t py_image_compressed(uint n_args, const mp_obj_t *args, mp_map_t 
     fb_alloc_mark();
     uint8_t *buffer = fb_alloc_all(&size);
     image_t out = { .w=arg_img->w, .h=arg_img->h, .bpp=size, .data=buffer };
-    PY_ASSERT_FALSE_MSG(jpeg_compress(arg_img, &out, arg_q, false), "Out of Memory!");
+    if(jpeg_compress(arg_img, &out, arg_q, false)) {
+        // compression overflow
+        fb_alloc_free_till_mark();
+        PY_ASSERT_TRUE_MSG(false, "Compression Failed");
+    }
     uint8_t *temp = xalloc(out.bpp);
     memcpy(temp, out.data, out.bpp);
     out.data = temp;


### PR DESCRIPTION
I've had a number of situations where the jpeg compression fails due to not enough free memory, which is to be expected.
I noticed however that in these cases, the memory used during the compression attempt was not getting freed so I couldn't just re-try the compression at a lower setting.

This PR should address this issue by ensuring the allocated memory is freed before the exception is raised.