### PR TITLE
Various drawing, binary, and mathop fixes

### DIFF
--- a/scripts/examples/03-Drawing/keypoints_drawing.py
+++ b/scripts/examples/03-Drawing/keypoints_drawing.py
@@ -1,0 +1,31 @@
+# Keypoints Drawing
+#
+# This example shows off drawing keypoints on the OpenMV Cam. Usually you call draw_keypoints()
+# on a keypoints object but you can also call it on a list of 3-value tuples...
+
+import sensor, image, time, pyb
+
+sensor.reset()
+sensor.set_pixformat(sensor.RGB565) # or GRAYSCALE...
+sensor.set_framesize(sensor.QVGA) # or QQVGA...
+sensor.skip_frames(time = 2000)
+clock = time.clock()
+
+while(True):
+    clock.tick()
+
+    img = sensor.snapshot()
+
+    for i in range(20):
+        x = (pyb.rng() % (2*img.width())) - (img.width()//2)
+        y = (pyb.rng() % (2*img.height())) - (img.height()//2)
+        rot = pyb.rng() % 360
+
+        r = (pyb.rng() % 127) + 128
+        g = (pyb.rng() % 127) + 128
+        b = (pyb.rng() % 127) + 128
+
+        # This method draws a keypoints object or a list of (x, y, rot) tuples...
+        img.draw_keypoints([(x, y, rot)], color = (r, g, b), size = 20, thickness = 2, fill = False)
+
+    print(clock.fps())

--- a/scripts/examples/04-Image-Filters/gamma_correction.py
+++ b/scripts/examples/04-Image-Filters/gamma_correction.py
@@ -1,0 +1,21 @@
+# Gamma Correction
+#
+# This example shows off gamma correction to make the image brighter. The gamma
+# correction method can also fix contrast and brightness too.
+
+import sensor, image, time
+
+sensor.reset()
+sensor.set_pixformat(sensor.RGB565)
+sensor.set_framesize(sensor.QVGA)
+sensor.skip_frames(time = 2000)
+clock = time.clock()
+
+while(True):
+    clock.tick()
+
+    # Gamma, contrast, and brightness correction are applied to each color channel. The
+    # values are scaled to the range per color channel per image type...
+    img = sensor.snapshot().gamma_corr(gamma = 0.5, contrast = 1.0, brightness = 0.0)
+
+    print(clock.fps())

--- a/scripts/examples/04-Image-Filters/negative.py
+++ b/scripts/examples/04-Image-Filters/negative.py
@@ -1,0 +1,19 @@
+# Negative Example
+#
+# This example shows off negating the image. This is not a particularly
+# useful method but it can come in handy once in a while.
+
+import sensor, image, time
+
+sensor.reset() # Initialize the camera sensor.
+sensor.set_pixformat(sensor.RGB565) # or sensor.GRAYSCALE
+sensor.set_framesize(sensor.QVGA) # or sensor.QQVGA (or others)
+sensor.skip_frames(time = 2000) # Let new settings take affect.
+clock = time.clock() # Tracks FPS.
+
+while(True):
+    clock.tick() # Track elapsed milliseconds between snapshots().
+    img = sensor.snapshot().negate()
+
+    print(clock.fps()) # Note: Your OpenMV Cam runs about half as fast while
+    # connected to your computer. The FPS should increase once disconnected.

--- a/scripts/examples/04-Image-Filters/vflip_hmirror_transpose.py
+++ b/scripts/examples/04-Image-Filters/vflip_hmirror_transpose.py
@@ -1,0 +1,35 @@
+# Vertical Flip - Horizontal Mirror - Transpose
+#
+# This example shows off how to vertically flip, horizontally mirror, or
+# transpose an image. Note that:
+#
+# vflip=False, hmirror=False, transpose=False -> 0 degree rotation
+# vflip=True,  hmirror=False, transpose=True  -> 90 degree rotation
+# vflip=True,  hmirror=True,  transpose=False -> 180 degree rotation
+# vflip=False, hmirror=True,  transpose=True  -> 270 degree rotation
+
+import sensor, image, time, pyb
+
+sensor.reset()
+sensor.set_pixformat(sensor.RGB565)
+sensor.set_framesize(sensor.QVGA)
+sensor.skip_frames(time = 2000)
+clock = time.clock()
+
+mills = pyb.millis()
+counter = 0
+
+while(True):
+    clock.tick()
+
+    img = sensor.snapshot()
+    # You can also use "set" or "assign".
+    img.replace(img, vflip=(counter//2)%2,
+                     hmirror=(counter//4)%2,
+                     transpose=(counter//8)%2)
+
+    if (pyb.millis() > (mills + 1000)):
+        mills = pyb.millis()
+        counter += 1
+
+    print(clock.fps())

--- a/scripts/examples/04-Image-Filters/vflip_hmirror_transpose.py
+++ b/scripts/examples/04-Image-Filters/vflip_hmirror_transpose.py
@@ -22,11 +22,9 @@ counter = 0
 while(True):
     clock.tick()
 
-    img = sensor.snapshot()
-    # You can also use "set" or "assign".
-    img.replace(img, vflip=(counter//2)%2,
-                     hmirror=(counter//4)%2,
-                     transpose=(counter//8)%2)
+    img = sensor.snapshot().replace(vflip=(counter//2)%2,
+                                    hmirror=(counter//4)%2,
+                                    transpose=(counter//8)%2)
 
     if (pyb.millis() > (mills + 1000)):
         mills = pyb.millis()

--- a/src/omv/img/draw.c
+++ b/src/omv/img/draw.c
@@ -268,7 +268,7 @@ void imlib_draw_ellipse(image_t *img, int cx, int cy, int rx, int ry, int rotati
     scratch_draw_rotated_ellipse(img, cx, cy, rx * 2, ry * 2, rotation, fill, c, thickness);
 }
 
-void imlib_draw_string(image_t *img, int x_off, int y_off, const char *str, int c, int scale, int x_spacing, int y_spacing, bool mono_space)
+void imlib_draw_string(image_t *img, int x_off, int y_off, const char *str, int c, float scale, int x_spacing, int y_spacing, bool mono_space)
 {
     const int anchor = x_off;
 
@@ -280,17 +280,17 @@ void imlib_draw_string(image_t *img, int x_off, int y_off, const char *str, int 
 
         if ((ch == '\n') || (ch == '\r')) { // handle '\n' or '\r' strings
             x_off = anchor;
-            y_off += (font[0].h * scale) + y_spacing; // newline height == space height
+            y_off += fast_roundf(font[0].h * scale) + y_spacing; // newline height == space height
             continue;
         }
 
         if ((ch < ' ') || (ch > '~')) { // handle unknown characters
             imlib_draw_rectangle(img,
-                x_off + ((scale * 3) / 2),
-                y_off + ((scale * 3) / 2),
-                (font[0].w * scale) - (((scale * 3) / 2) * 2),
-                (font[0].h * scale) - (((scale * 3) / 2) * 2),
-                c, scale, false);
+                x_off + (fast_roundf(scale * 3) / 2),
+                y_off + (fast_roundf(scale * 3) / 2),
+                fast_roundf(font[0].w * scale) - ((fast_roundf(scale * 3) / 2) * 2),
+                fast_roundf(font[0].h * scale) - ((fast_roundf(scale * 3) / 2) * 2),
+                c, fast_roundf(scale), false);
             continue;
         }
 
@@ -303,7 +303,7 @@ void imlib_draw_string(image_t *img, int x_off, int y_off, const char *str, int 
             for (int x = 0, xx = g->w; x < xx; x++) {
                 for (int y = 0, yy = g->h; y < yy; y++) {
                     if (g->data[y] & (1 << (g->w - 1 - x))) {
-                        x_off -= x * scale;
+                        x_off -= fast_roundf(x * scale);
                         exit = true;
                         break;
                     }
@@ -313,16 +313,16 @@ void imlib_draw_string(image_t *img, int x_off, int y_off, const char *str, int 
             }
         }
 
-        for (int y = 0, yy = g->h * scale; y < yy; y++) {
-            for (int x = 0, xx = g->w * scale; x < xx; x++) {
-                if (g->data[y / scale] & (1 << (g->w - 1 - (x / scale)))) {
+        for (int y = 0, yy = fast_roundf(g->h * scale); y < yy; y++) {
+            for (int x = 0, xx = fast_roundf(g->w * scale); x < xx; x++) {
+                if (g->data[fast_roundf(y / scale)] & (1 << (g->w - 1 - fast_roundf(x / scale)))) {
                     imlib_set_pixel(img, (x_off + x), (y_off + y), c);
                 }
             }
         }
 
         if (mono_space) {
-            x_off += (g->w * scale) + x_spacing;
+            x_off += fast_roundf(g->w * scale) + x_spacing;
         } else {
             // Find the last pixel set and offset to that.
             bool exit = false;
@@ -330,7 +330,7 @@ void imlib_draw_string(image_t *img, int x_off, int y_off, const char *str, int 
             for (int x = g->w - 1; x >= 0; x--) {
                 for (int y = g->h - 1; y >= 0; y--) {
                     if (g->data[y] & (1 << (g->w - 1 - x))) {
-                        x_off += ((x + 2) * scale) + x_spacing;
+                        x_off += fast_roundf((x + 2) * scale) + x_spacing;
                         exit = true;
                         break;
                     }
@@ -339,7 +339,7 @@ void imlib_draw_string(image_t *img, int x_off, int y_off, const char *str, int 
                 if (exit) break;
             }
 
-            if (!exit) x_off += scale * 3; // space char
+            if (!exit) x_off += fast_roundf(scale * 3); // space char
         }
     }
 }

--- a/src/omv/img/draw.c
+++ b/src/omv/img/draw.c
@@ -401,9 +401,9 @@ static int safe_map_pixel(image_t *dst, image_t *src, int pixel)
     }
 }
 
-void imlib_draw_image(image_t *img, image_t *other, int x_off, int y_off, float x_scale, float y_scale, image_t *mask)
+void imlib_draw_image(image_t *img, image_t *other, int x_off, int y_off, float x_scale, float y_scale, float alpha, image_t *mask)
 {
-    float over_xscale = IM_DIV(1.0, x_scale), over_yscale = IM_DIV(1.0f, y_scale);
+    float over_xscale = IM_DIV(1.0, x_scale), over_yscale = IM_DIV(1.0f, y_scale), beta = 1 - alpha;
 
     for (int y = 0, yy = fast_roundf(other->h * y_scale); y < yy; y++) {
         int other_y = fast_roundf(y * over_yscale);
@@ -412,7 +412,9 @@ void imlib_draw_image(image_t *img, image_t *other, int x_off, int y_off, float 
             int other_x = fast_roundf(x * over_xscale);
 
             if ((!mask) || image_get_mask_pixel(mask, other_x, other_y)) {
-                imlib_set_pixel(img, x_off + x, y_off + y, safe_map_pixel(img, other, imlib_get_pixel(other, other_x, other_y)));
+                int pixel = safe_map_pixel(img, other, imlib_get_pixel(other, other_x, other_y));
+                imlib_set_pixel(img, x_off + x, y_off + y, (alpha == 1) ? pixel :
+                                (pixel * alpha) + (imlib_get_pixel(img, x_off + x, y_off + y) * beta));
             }
         }
     }

--- a/src/omv/img/draw.c
+++ b/src/omv/img/draw.c
@@ -179,8 +179,8 @@ static void scratch_draw_pixel(image_t *img, int x0, int y0, int dx, int dy, flo
 // https://scratch.mit.edu/projects/50039326/
 static void scratch_draw_line(image_t *img, int x0, int y0, int dx, int dy0, int dy1, float shear_dx, float shear_dy, int c)
 {
-    imlib_draw_line(img, x0 + dx, y0 + dy0 + fast_floorf((dx * shear_dy) / shear_dx),
-                         x0 + dx, y0 + dy1 + fast_floorf((dx * shear_dy) / shear_dx), c, 1);
+    int y = y0 + fast_floorf((dx * shear_dy) / shear_dx);
+    yLine(img, x0 + dx, y + dy0, y + dy1, c);
 }
 
 // https://scratch.mit.edu/projects/50039326/

--- a/src/omv/img/fmath.c
+++ b/src/omv/img/fmath.c
@@ -189,3 +189,10 @@ float fast_log(float x)
 {
   return 0.69314718f * fast_log2 (x);
 }
+
+float fast_powf(float a, float b)
+{
+    union { float d; int x; } u = { a };
+    u.x = (int)((b * (u.x - 1064866805)) + 1064866805);
+    return u.d;
+}

--- a/src/omv/img/fmath.h
+++ b/src/omv/img/fmath.h
@@ -20,6 +20,7 @@ float fast_cbrtf(float d);
 float fast_fabsf(float d);
 float fast_log(float x);
 float fast_log2(float x);
+float fast_powf(float a, float b);
 extern const float cos_table[360];
 extern const float sin_table[360];
 #endif // __FMATH_H__

--- a/src/omv/img/imlib.h
+++ b/src/omv/img/imlib.h
@@ -1276,7 +1276,7 @@ void imlib_draw_rectangle(image_t *img, int rx, int ry, int rw, int rh, int c, i
 void imlib_draw_circle(image_t *img, int cx, int cy, int r, int c, int thickness, bool fill);
 void imlib_draw_ellipse(image_t *img, int cx, int cy, int rx, int ry, int rotation, int c, int thickness, bool fill);
 void imlib_draw_string(image_t *img, int x_off, int y_off, const char *str, int c, float scale, int x_spacing, int y_spacing, bool mono_space);
-void imlib_draw_image(image_t *img, image_t *other, int x_off, int y_off, float x_scale, float y_scale, image_t *mask);
+void imlib_draw_image(image_t *img, image_t *other, int x_off, int y_off, float x_scale, float y_scale, float alpha, image_t *mask);
 void imlib_flood_fill(image_t *img, int x, int y,
                       float seed_threshold, float floating_threshold,
                       int c, bool invert, bool clear_background, image_t *mask);

--- a/src/omv/img/imlib.h
+++ b/src/omv/img/imlib.h
@@ -1275,7 +1275,7 @@ void imlib_draw_line(image_t *img, int x0, int y0, int x1, int y1, int c, int th
 void imlib_draw_rectangle(image_t *img, int rx, int ry, int rw, int rh, int c, int thickness, bool fill);
 void imlib_draw_circle(image_t *img, int cx, int cy, int r, int c, int thickness, bool fill);
 void imlib_draw_ellipse(image_t *img, int cx, int cy, int rx, int ry, int rotation, int c, int thickness, bool fill);
-void imlib_draw_string(image_t *img, int x_off, int y_off, const char *str, int c, int scale, int x_spacing, int y_spacing, bool mono_space);
+void imlib_draw_string(image_t *img, int x_off, int y_off, const char *str, int c, float scale, int x_spacing, int y_spacing, bool mono_space);
 void imlib_draw_image(image_t *img, image_t *other, int x_off, int y_off, float x_scale, float y_scale, image_t *mask);
 void imlib_flood_fill(image_t *img, int x, int y,
                       float seed_threshold, float floating_threshold,

--- a/src/omv/img/imlib.h
+++ b/src/omv/img/imlib.h
@@ -361,7 +361,7 @@ extern const int8_t yuv_table[196608];
 })
 
 #define COLOR_BINARY_TO_GRAYSCALE(pixel) ((pixel) * COLOR_GRAYSCALE_MAX)
-#define COLOR_BINARY_TO_RGB565(pixel) COLOR_YUV_TO_RGB565((pixel) * 127, 0, 0)
+#define COLOR_BINARY_TO_RGB565(pixel) COLOR_YUV_TO_RGB565((pixel) ? 127 : -128, 0, 0)
 #define COLOR_RGB565_TO_BINARY(pixel) (COLOR_RGB565_TO_Y(pixel) > (((COLOR_Y_MAX - COLOR_Y_MIN) / 2) + COLOR_Y_MIN))
 #define COLOR_RGB565_TO_GRAYSCALE(pixel) (COLOR_RGB565_TO_Y(pixel) + 128)
 #define COLOR_GRAYSCALE_TO_BINARY(pixel) ((pixel) > (((COLOR_GRAYSCALE_MAX - COLOR_GRAYSCALE_MIN) / 2) + COLOR_GRAYSCALE_MIN))

--- a/src/omv/img/imlib.h
+++ b/src/omv/img/imlib.h
@@ -1296,6 +1296,7 @@ void imlib_close(image_t *img, int ksize, int threshold, image_t *mask);
 void imlib_top_hat(image_t *img, int ksize, int threshold, image_t *mask);
 void imlib_black_hat(image_t *img, int ksize, int threshold, image_t *mask);
 // Math Functions
+void imlib_gamma_corr(image_t *img, float gamma, float scale, float offset);
 void imlib_negate(image_t *img);
 void imlib_replace(image_t *img, const char *path, image_t *other, int scalar, bool hmirror, bool vflip, image_t *mask);
 void imlib_add(image_t *img, const char *path, image_t *other, int scalar, image_t *mask);

--- a/src/omv/img/imlib.h
+++ b/src/omv/img/imlib.h
@@ -1302,7 +1302,7 @@ void imlib_replace(image_t *img, const char *path, image_t *other, int scalar, b
 void imlib_add(image_t *img, const char *path, image_t *other, int scalar, image_t *mask);
 void imlib_sub(image_t *img, const char *path, image_t *other, int scalar, bool reverse, image_t *mask);
 void imlib_mul(image_t *img, const char *path, image_t *other, int scalar, bool invert, image_t *mask);
-void imlib_div(image_t *img, const char *path, image_t *other, int scalar, bool invert, image_t *mask);
+void imlib_div(image_t *img, const char *path, image_t *other, int scalar, bool invert, bool mod, image_t *mask);
 void imlib_min(image_t *img, const char *path, image_t *other, int scalar, image_t *mask);
 void imlib_max(image_t *img, const char *path, image_t *other, int scalar, image_t *mask);
 void imlib_difference(image_t *img, const char *path, image_t *other, int scalar, image_t *mask);

--- a/src/omv/img/imlib.h
+++ b/src/omv/img/imlib.h
@@ -1298,7 +1298,7 @@ void imlib_black_hat(image_t *img, int ksize, int threshold, image_t *mask);
 // Math Functions
 void imlib_gamma_corr(image_t *img, float gamma, float scale, float offset);
 void imlib_negate(image_t *img);
-void imlib_replace(image_t *img, const char *path, image_t *other, int scalar, bool hmirror, bool vflip, image_t *mask);
+void imlib_replace(image_t *img, const char *path, image_t *other, int scalar, bool hmirror, bool vflip, bool transpose, image_t *mask);
 void imlib_add(image_t *img, const char *path, image_t *other, int scalar, image_t *mask);
 void imlib_sub(image_t *img, const char *path, image_t *other, int scalar, bool reverse, image_t *mask);
 void imlib_mul(image_t *img, const char *path, image_t *other, int scalar, bool invert, image_t *mask);

--- a/src/omv/img/mathop.c
+++ b/src/omv/img/mathop.c
@@ -6,6 +6,102 @@
 #include "imlib.h"
 
 #ifdef IMLIB_ENABLE_MATH_OPS
+void imlib_gamma_corr(image_t *img, float gamma, float contrast, float brightness)
+{
+    gamma = IM_DIV(1.0, gamma);
+    switch(img->bpp) {
+        case IMAGE_BPP_BINARY: {
+            float pScale = COLOR_BINARY_MAX - COLOR_BINARY_MIN;
+            float pDiv = 1 / pScale;
+            int *p_lut = fb_alloc((COLOR_BINARY_MAX - COLOR_BINARY_MIN + 1) * sizeof(int));
+
+            for (int i = COLOR_BINARY_MIN; i <= COLOR_BINARY_MAX; i++) {
+                int p = ((fast_powf(i * pDiv, gamma) * contrast) + brightness) * pScale;
+                p_lut[i] = IM_MIN(IM_MAX(p , COLOR_BINARY_MIN), COLOR_BINARY_MAX);
+            }
+
+            for (int y = 0, yy = img->h; y < yy; y++) {
+                uint32_t *data = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(img, y);
+                for (int x = 0, xx = img->w; x < xx; x++) {
+                    int dataPixel = IMAGE_GET_BINARY_PIXEL_FAST(data, x);
+                    int p = p_lut[dataPixel];
+                    IMAGE_PUT_BINARY_PIXEL_FAST(data, x, p);
+                }
+            }
+
+            fb_free();
+            break;
+        }
+        case IMAGE_BPP_GRAYSCALE: {
+            float pScale = COLOR_GRAYSCALE_MAX - COLOR_GRAYSCALE_MIN;
+            float pDiv = 1 / pScale;
+            int *p_lut = fb_alloc((COLOR_GRAYSCALE_MAX - COLOR_GRAYSCALE_MIN + 1) * sizeof(int));
+
+            for (int i = COLOR_GRAYSCALE_MIN; i <= COLOR_GRAYSCALE_MAX; i++) {
+                int p = ((fast_powf(i * pDiv, gamma) * contrast) + brightness) * pScale;
+                p_lut[i] = IM_MIN(IM_MAX(p , COLOR_GRAYSCALE_MIN), COLOR_GRAYSCALE_MAX);
+            }
+
+            for (int y = 0, yy = img->h; y < yy; y++) {
+                uint8_t *data = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(img, y);
+                for (int x = 0, xx = img->w; x < xx; x++) {
+                    int dataPixel = IMAGE_GET_GRAYSCALE_PIXEL_FAST(data, x);
+                    int p = p_lut[dataPixel];
+                    IMAGE_PUT_GRAYSCALE_PIXEL_FAST(data, x, p);
+                }
+            }
+
+            fb_free();
+            break;
+        }
+        case IMAGE_BPP_RGB565: {
+            float rScale = COLOR_R5_MAX - COLOR_R5_MIN;
+            float gScale = COLOR_G6_MAX - COLOR_G6_MIN;
+            float bScale = COLOR_B5_MAX - COLOR_B5_MIN;
+            float rDiv = 1 / rScale;
+            float gDiv = 1 / gScale;
+            float bDiv = 1 / bScale;
+            int *r_lut = fb_alloc((COLOR_R5_MAX - COLOR_R5_MIN + 1) * sizeof(int));
+            int *g_lut = fb_alloc((COLOR_G6_MAX - COLOR_G6_MIN + 1) * sizeof(int));
+            int *b_lut = fb_alloc((COLOR_B5_MAX - COLOR_B5_MIN + 1) * sizeof(int));
+
+            for (int i = COLOR_R5_MIN; i <= COLOR_R5_MAX; i++) {
+                int r = ((fast_powf(i * rDiv, gamma) * contrast) + brightness) * rScale;
+                r_lut[i] = IM_MIN(IM_MAX(r , COLOR_R5_MIN), COLOR_R5_MAX);
+            }
+
+            for (int i = COLOR_G6_MIN; i <= COLOR_G6_MAX; i++) {
+                int g = ((fast_powf(i * gDiv, gamma) * contrast) + brightness) * gScale;
+                g_lut[i] = IM_MIN(IM_MAX(g , COLOR_G6_MIN), COLOR_G6_MAX);
+            }
+
+            for (int i = COLOR_B5_MIN; i <= COLOR_B5_MAX; i++) {
+                int b = ((fast_powf(i * bDiv, gamma) * contrast) + brightness) * bScale;
+                b_lut[i] = IM_MIN(IM_MAX(b , COLOR_B5_MIN), COLOR_B5_MAX);
+            }
+
+            for (int y = 0, yy = img->h; y < yy; y++) {
+                uint16_t *data = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(img, y);
+                for (int x = 0, xx = img->w; x < xx; x++) {
+                    int dataPixel = IMAGE_GET_RGB565_PIXEL_FAST(data, x);
+                    int r = r_lut[COLOR_RGB565_TO_R5(dataPixel)];
+                    int g = g_lut[COLOR_RGB565_TO_G6(dataPixel)];
+                    int b = b_lut[COLOR_RGB565_TO_B5(dataPixel)];
+                    IMAGE_PUT_RGB565_PIXEL_FAST(data, x, COLOR_R5_G6_B5_TO_RGB565(r, g, b));
+                }
+            }
+
+            fb_free();
+            fb_free();
+            fb_free();
+            break;
+        }
+        default: {
+            break;
+        }
+    }
+}
+
 void imlib_negate(image_t *img)
 {
     switch(img->bpp) {

--- a/src/omv/py/py_image.c
+++ b/src/omv/py/py_image.c
@@ -1348,6 +1348,7 @@ STATIC mp_obj_t py_image_draw_string(uint n_args, const mp_obj_t *args, mp_map_t
         py_helper_keyword_color(arg_img, n_args, args, offset + 0, kw_args, -1); // White.
     float arg_scale =
         py_helper_keyword_float(n_args, args, offset + 1, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_scale), 1.0);
+    PY_ASSERT_TRUE_MSG(0 < arg_scale, "Error: 0 < scale!");
     int arg_x_spacing =
         py_helper_keyword_int(n_args, args, offset + 2, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_x_spacing), 0);
     int arg_y_spacing =

--- a/src/omv/py/py_image.c
+++ b/src/omv/py/py_image.c
@@ -1866,16 +1866,19 @@ STATIC mp_obj_t py_image_replace(uint n_args, const mp_obj_t *args, mp_map_t *kw
         size_t size1 = image_size(arg_img);
         arg_img->w = w;
         arg_img->h = h;
-        PY_ASSERT_TRUE_MSG(size1 <= size0, "Unable to transpose the image because it would grow in size!");
+        PY_ASSERT_TRUE_MSG(size1 <= size0,
+                           "Unable to transpose the image because it would grow in size!");
     }
 
     fb_alloc_mark();
 
-    if (MP_OBJ_IS_STR(args[1])) {
-        imlib_replace(arg_img, mp_obj_str_get_str(args[1]), NULL, 0,
+    mp_obj_t arg_1 = (n_args > 1) ? args[1] : args[0];
+
+    if (MP_OBJ_IS_STR(arg_1)) {
+        imlib_replace(arg_img, mp_obj_str_get_str(arg_1), NULL, 0,
                       arg_hmirror, arg_vflip, arg_transpose, arg_msk);
-    } else if (MP_OBJ_IS_TYPE(args[1], &py_image_type)) {
-        imlib_replace(arg_img, NULL, py_helper_arg_to_image_mutable(args[1]), 0,
+    } else if (MP_OBJ_IS_TYPE(arg_1, &py_image_type)) {
+        imlib_replace(arg_img, NULL, py_helper_arg_to_image_mutable(arg_1), 0,
                       arg_hmirror, arg_vflip, arg_transpose, arg_msk);
     } else {
         imlib_replace(arg_img, NULL, NULL,
@@ -1892,7 +1895,7 @@ STATIC mp_obj_t py_image_replace(uint n_args, const mp_obj_t *args, mp_map_t *kw
 
     return args[0];
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_image_replace_obj, 2, py_image_replace);
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_image_replace_obj, 1, py_image_replace);
 
 STATIC mp_obj_t py_image_add(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
 {

--- a/src/omv/py/py_image.c
+++ b/src/omv/py/py_image.c
@@ -1346,8 +1346,8 @@ STATIC mp_obj_t py_image_draw_string(uint n_args, const mp_obj_t *args, mp_map_t
 
     int arg_c =
         py_helper_keyword_color(arg_img, n_args, args, offset + 0, kw_args, -1); // White.
-    int arg_scale =
-        py_helper_keyword_int(n_args, args, offset + 1, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_scale), 1);
+    float arg_scale =
+        py_helper_keyword_float(n_args, args, offset + 1, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_scale), 1.0);
     int arg_x_spacing =
         py_helper_keyword_int(n_args, args, offset + 2, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_x_spacing), 0);
     int arg_y_spacing =

--- a/src/omv/py/py_image.c
+++ b/src/omv/py/py_image.c
@@ -1823,6 +1823,25 @@ STATIC mp_obj_t py_image_black_hat(uint n_args, const mp_obj_t *args, mp_map_t *
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_image_black_hat_obj, 2, py_image_black_hat);
 
+STATIC mp_obj_t py_image_gamma_corr(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
+{
+    image_t *arg_img =
+        py_helper_arg_to_image_mutable(args[0]);
+    float arg_gamma =
+        py_helper_keyword_float(n_args, args, 1, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_gamma), 1.0f);
+    float arg_contrast =
+        py_helper_keyword_float(n_args, args, 2, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_contrast), 1.0f);
+    float arg_brightness =
+        py_helper_keyword_float(n_args, args, 3, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_brightness), 0.0f);
+
+    fb_alloc_mark();
+    imlib_gamma_corr(arg_img, arg_gamma, arg_contrast, arg_brightness);
+    fb_alloc_free_till_mark();
+
+    return args[0];
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_image_gamma_corr_obj, 1, py_image_gamma_corr);
+
 STATIC mp_obj_t py_image_negate(mp_obj_t img_obj)
 {
     fb_alloc_mark();
@@ -5349,6 +5368,7 @@ static const mp_rom_map_elem_t locals_dict_table[] = {
     {MP_ROM_QSTR(MP_QSTR_top_hat),             MP_ROM_PTR(&py_image_top_hat_obj)},
     {MP_ROM_QSTR(MP_QSTR_black_hat),           MP_ROM_PTR(&py_image_black_hat_obj)},
     /* Math Methods */
+    {MP_ROM_QSTR(MP_QSTR_gamma_corr),          MP_ROM_PTR(&py_image_gamma_corr_obj)},
     {MP_ROM_QSTR(MP_QSTR_negate),              MP_ROM_PTR(&py_image_negate_obj)},
     {MP_ROM_QSTR(MP_QSTR_replace),             MP_ROM_PTR(&py_image_replace_obj)},
     {MP_ROM_QSTR(MP_QSTR_add),                 MP_ROM_PTR(&py_image_add_obj)},

--- a/src/omv/py/py_image.c
+++ b/src/omv/py/py_image.c
@@ -1547,9 +1547,7 @@ STATIC mp_obj_t py_image_binary(uint n_args, const mp_obj_t *args, mp_map_t *kw_
     out.bpp = arg_to_bitmap ? IMAGE_BPP_BINARY : arg_img->bpp;
     out.data = arg_copy ? xalloc(image_size(&out)) : arg_img->data;
 
-    fb_alloc_mark();
     imlib_binary(&out, arg_img, &arg_thresholds, arg_invert, arg_zero, arg_msk);
-    fb_alloc_free_till_mark();
     list_free(&arg_thresholds);
 
     if ((!arg_copy) && (MAIN_FB()->pixels == out.data)) {
@@ -1562,9 +1560,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_image_binary_obj, 2, py_image_binary);
 
 STATIC mp_obj_t py_image_invert(mp_obj_t img_obj)
 {
-    fb_alloc_mark();
     imlib_invert(py_helper_arg_to_image_mutable(img_obj));
-    fb_alloc_free_till_mark();
     return img_obj;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_image_invert_obj, py_image_invert);
@@ -1837,16 +1833,13 @@ STATIC mp_obj_t py_image_gamma_corr(uint n_args, const mp_obj_t *args, mp_map_t 
     fb_alloc_mark();
     imlib_gamma_corr(arg_img, arg_gamma, arg_contrast, arg_brightness);
     fb_alloc_free_till_mark();
-
     return args[0];
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_image_gamma_corr_obj, 1, py_image_gamma_corr);
 
 STATIC mp_obj_t py_image_negate(mp_obj_t img_obj)
 {
-    fb_alloc_mark();
     imlib_negate(py_helper_arg_to_image_mutable(img_obj));
-    fb_alloc_free_till_mark();
     return img_obj;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_image_negate_obj, py_image_negate);

--- a/src/omv/py/py_image.c
+++ b/src/omv/py/py_image.c
@@ -1979,19 +1979,23 @@ STATIC mp_obj_t py_image_div(uint n_args, const mp_obj_t *args, mp_map_t *kw_arg
         py_helper_arg_to_image_mutable(args[0]);
     bool arg_invert =
         py_helper_keyword_int(n_args, args, 2, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_invert), false);
+    bool arg_mod =
+        py_helper_keyword_int(n_args, args, 3, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_mod), false);
     image_t *arg_msk =
-        py_helper_keyword_to_image_mutable_mask(n_args, args, 3, kw_args);
+        py_helper_keyword_to_image_mutable_mask(n_args, args, 4, kw_args);
 
     fb_alloc_mark();
 
     if (MP_OBJ_IS_STR(args[1])) {
-        imlib_div(arg_img, mp_obj_str_get_str(args[1]), NULL, 0, arg_invert, arg_msk);
+        imlib_div(arg_img, mp_obj_str_get_str(args[1]), NULL, 0,
+                  arg_invert, arg_mod, arg_msk);
     } else if (MP_OBJ_IS_TYPE(args[1], &py_image_type)) {
-        imlib_div(arg_img, NULL, py_helper_arg_to_image_mutable(args[1]), 0, arg_invert, arg_msk);
+        imlib_div(arg_img, NULL, py_helper_arg_to_image_mutable(args[1]), 0,
+                  arg_invert, arg_mod, arg_msk);
     } else {
         imlib_div(arg_img, NULL, NULL,
                   py_helper_keyword_color(arg_img, n_args, args, 1, NULL, 0),
-                  arg_invert, arg_msk);
+                  arg_invert, arg_mod, arg_msk);
     }
 
     fb_alloc_free_till_mark();

--- a/src/omv/py/py_image.c
+++ b/src/omv/py/py_image.c
@@ -1442,10 +1442,13 @@ STATIC mp_obj_t py_image_draw_image(uint n_args, const mp_obj_t *args, mp_map_t 
     float arg_y_scale =
         py_helper_keyword_float(n_args, args, offset + 1, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_y_scale), 1.0f);
     PY_ASSERT_TRUE_MSG((0.0f <= arg_y_scale), "Error: 0.0 <= y_scale!");
+    float arg_alpha =
+        py_helper_keyword_int(n_args, args, offset + 2, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_alpha), 256) / 256.0f;
+    PY_ASSERT_TRUE_MSG((0 <= arg_alpha) && (arg_alpha <= 1), "Error: 0 <= alpha <= 256!");
     image_t *arg_msk =
-        py_helper_keyword_to_image_mutable_mask(n_args, args, offset + 2, kw_args);
+        py_helper_keyword_to_image_mutable_mask(n_args, args, offset + 3, kw_args);
 
-    imlib_draw_image(arg_img, arg_other, arg_cx, arg_cy, arg_x_scale, arg_y_scale, arg_msk);
+    imlib_draw_image(arg_img, arg_other, arg_cx, arg_cy, arg_x_scale, arg_y_scale, arg_alpha, arg_msk);
     return args[0];
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_image_draw_image_obj, 3, py_image_draw_image);

--- a/src/omv/py/qstrdefsomv.h
+++ b/src/omv/py/qstrdefsomv.h
@@ -429,6 +429,7 @@ Q(draw_arrow)
 Q(draw_image)
 Q(x_scale)
 Q(y_scale)
+Q(alpha)
 Q(mask)
 
 // Draw Keypoints
@@ -570,7 +571,7 @@ Q(difference)
 
 // Blend
 Q(blend)
-Q(alpha)
+// duplicate Q(alpha)
 // duplicate Q(mask)
 
 // Histogram Equalization

--- a/src/omv/py/qstrdefsomv.h
+++ b/src/omv/py/qstrdefsomv.h
@@ -527,10 +527,13 @@ Q(brightness)
 // Negate
 Q(negate)
 
-// Replace
+// Assign/Replace/Set
+Q(assign)
 Q(replace)
+Q(set)
 Q(hmirror)
 Q(vflip)
+Q(transpose)
 // duplicate Q(mask)
 
 // Add Op

--- a/src/omv/py/qstrdefsomv.h
+++ b/src/omv/py/qstrdefsomv.h
@@ -553,6 +553,7 @@ Q(mul)
 // Div Op
 Q(div)
 // duplicate Q(invert)
+Q(mod)
 // duplicate Q(mask)
 
 // Min

--- a/src/omv/py/qstrdefsomv.h
+++ b/src/omv/py/qstrdefsomv.h
@@ -518,6 +518,12 @@ Q(black_hat)
 // duplicate Q(threshold)
 // duplicate Q(mask)
 
+// Gamma Correct
+Q(gamma_corr)
+Q(gamma)
+Q(contrast)
+Q(brightness)
+
 // Negate
 Q(negate)
 


### PR DESCRIPTION
This PR contains various fixes to the drawing, binary, and math op methods. I discovered many of the fixes while implementing the user requested ellipse method and gamma/contrast/brightness correction. Here's the fix list:

* Added a gamma/contrast/brightness correction method which can fix the image extremely fast (uses a LUT to apply the correction).
* Add transpose support to replace allowing you now to rotate the frame buffer by 90/180/270 degrees.
* Added another image blend mode to div.
* Allow non-integer scaling on draw_string.
* Add alpha blending to draw_image (making it useful for thermal image overlays now).
* Restored the ability of draw_keypoints to take a list of 3-value tuples to draw in.
* Fixed a major bug in binary that caused it to ignore all thresholds passed in except the first.
* Added more code examples per the above stuff.

Anyway, the commits are mostly atomic following git protocol. Working on adding in min_area_rect code to binary next per a user request on the forums.