### PR TITLE
Fix MT set_framesize.

### DIFF
--- a/src/omv/mt9v034.c
+++ b/src/omv/mt9v034.c
@@ -183,10 +183,6 @@ static int set_framesize(sensor_t *sensor, framesize_t framesize)
     uint16_t width = resolution[framesize][0];
     uint16_t height = resolution[framesize][1];
 
-    if (sensor->pixformat == PIXFORMAT_INVALID) {
-        return -1;
-    }
-
     if ((width > MT9V034_MAX_WIDTH) || (height > MT9V034_MAX_HEIGHT)) {
         return -1;
     }


### PR DESCRIPTION
* Fix exception if the order of functions call is swapped (set_framesize before set_pixformat)
* The order of functions shouldn't matter, if necessary this check should be done in snapshot.
* This fixes issue #444