### PR TITLE
Avoid invalid mem access by validating post-rounded indices

### DIFF
--- a/src/omv/img/apriltag.c
+++ b/src/omv/img/apriltag.c
@@ -12078,7 +12078,7 @@ void imlib_rotation_corr(image_t *img, float x_rotation, float y_rotation, float
                     int sourceX2 = round(sourceX);
                     int sourceY2 = round(sourceY);
 
-                    if ((0 <= sourceX) && (sourceX < img->w) && (0 <= sourceY) && (sourceY < img->h)) {
+                    if ((0 <= sourceX2) && (sourceX2 < img->w) && (0 <= sourceY2) && (sourceY2 < img->h)) {
                         uint32_t *ptr = tmp + (((img->w + UINT32_T_MASK) >> UINT32_T_SHIFT) * sourceY2);
                         int pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, sourceX2);
                         IMAGE_PUT_BINARY_PIXEL_FAST(row_ptr, x, pixel);
@@ -12102,7 +12102,7 @@ void imlib_rotation_corr(image_t *img, float x_rotation, float y_rotation, float
                     int sourceX2 = round(sourceX);
                     int sourceY2 = round(sourceY);
 
-                    if ((0 <= sourceX) && (sourceX < img->w) && (0 <= sourceY) && (sourceY < img->h)) {
+                    if ((0 <= sourceX2) && (sourceX2 < img->w) && (0 <= sourceY2) && (sourceY2 < img->h)) {
                         uint8_t *ptr = tmp + (img->w * sourceY2);
                         int pixel = IMAGE_GET_GRAYSCALE_PIXEL_FAST(ptr, sourceX2);
                         IMAGE_PUT_GRAYSCALE_PIXEL_FAST(row_ptr, x, pixel);
@@ -12126,7 +12126,7 @@ void imlib_rotation_corr(image_t *img, float x_rotation, float y_rotation, float
                     int sourceX2 = round(sourceX);
                     int sourceY2 = round(sourceY);
 
-                    if ((0 <= sourceX) && (sourceX < img->w) && (0 <= sourceY) && (sourceY < img->h)) {
+                    if ((0 <= sourceX2) && (sourceX2 < img->w) && (0 <= sourceY2) && (sourceY2 < img->h)) {
                         uint16_t *ptr = tmp + (img->w * sourceY2);
                         int pixel = IMAGE_GET_RGB565_PIXEL_FAST(ptr, sourceX2);
                         IMAGE_PUT_RGB565_PIXEL_FAST(row_ptr, x, pixel);


### PR DESCRIPTION
These bounds checks were incorrect if sourceX/Y rounds up. In this situation, the unrounded source will be smaller than the limit by a factional amount (C will elevate the int bounds to a float for comparison), but the post-rounded version will equal the limit.

E.g.,
sourceX = 10.5
img->w = 11 (i.e., valid indices are [0-10])
sourceX2 = 11, which is invalid memory