### PR TITLE
Fix exceptions from freeing fb_alloc_mark

### DIFF
--- a/src/omv/py/py_lcd.c
+++ b/src/omv/py/py_lcd.c
@@ -310,6 +310,7 @@ static mp_obj_t py_lcd_display(uint n_args, const mp_obj_t *args, mp_map_t *kw_a
             return mp_const_none;
         case LCD_SHIELD:
             lcd_write_command_byte(0x2C);
+            fb_alloc_mark();
             uint8_t *zero = fb_alloc0(width*2);
             uint16_t *line = fb_alloc(width*2);
             for (int i=0; i<t_pad; i++) {
@@ -339,6 +340,7 @@ static mp_obj_t py_lcd_display(uint n_args, const mp_obj_t *args, mp_map_t *kw_a
             }
             fb_free();
             fb_free();
+            fb_alloc_free_till_mark();
             return mp_const_none;
     }
     return mp_const_none;
@@ -351,11 +353,13 @@ static mp_obj_t py_lcd_clear()
             return mp_const_none;
         case LCD_SHIELD:
             lcd_write_command_byte(0x2C);
+            fb_alloc_mark();
             uint8_t *zero = fb_alloc0(width*2);
             for (int i=0; i<height; i++) {
                 lcd_write_data(width*2, zero);
             }
             fb_free();
+            fb_alloc_free_till_mark();
             return mp_const_none;
     }
     return mp_const_none;

--- a/src/omv/py/py_sensor.c
+++ b/src/omv/py/py_sensor.c
@@ -149,15 +149,17 @@ static mp_obj_t py_sensor_alloc_extra_fb(mp_obj_t w_obj, mp_obj_t h_obj, mp_obj_
             break;
     }
 
-    fb_alloc_mark();
-    img.pixels = fb_alloc0(image_size(&img));
-    return py_image_from_struct(&img);
+    // Alloc image first (could fail) then alloc RAM so that there's no leak on failure.
+    mp_obj_t r = py_image_from_struct(&img);
+    // Don't mark before on purpose.
+    ((image_t *) py_image_cobj(r))->pixels = fb_alloc0(image_size(&img));
+    return r;
 }
 
 static mp_obj_t py_sensor_dealloc_extra_fb()
 {
     fb_free();
-    fb_alloc_free_till_mark();
+    // Don't free till mark aftwards on purpose.
     return mp_const_none;
 }
 

--- a/src/omv/py/py_tv.c
+++ b/src/omv/py/py_tv.c
@@ -555,6 +555,7 @@ static mp_obj_t py_tv_display(uint n_args, const mp_obj_t *args, mp_map_t *kw_ar
     uint16_t x = x1;
     uint16_t y = y1;
 
+    fb_alloc_mark();
     uint8_t *line = fb_alloc(w*2);
 
     while (y < y2) {
@@ -586,6 +587,7 @@ static mp_obj_t py_tv_display(uint n_args, const mp_obj_t *args, mp_map_t *kw_ar
         y++;
     }
     fb_free();
+    fb_alloc_free_till_mark();
     return mp_const_none;
 }
 static mp_obj_t py_tv_palettes()


### PR DESCRIPTION
This fix creates a flag that prevents fb_alloc_free_till_mark() from
doing anything unless there was a previous fb_alloc_mark(). Once
fb_alloc_free_till_mark() is called it will no longer do anything until
there's another fb_alloc_mark().

This means that if an exception is triggered while in code that
previously did fb_alloc_mark() the stack will be cleaned up.

If the fb_alloc_mark() method is not called then the stack will not be
cleaned up and that memory fb_alloc()'ed will remain until a soft reset.

All OpenMV Cam library code is designed to fb_alloc_mark() before using
the fb stack and then fb_alloc_free_till_mark() when complete. However,
in the case of py_sensor_alloc_extra_fb() it doesn't mark first such
that the RAM it allocates stays across exceptions and is only free'd via
py_sensor_dealloc_extra_fb() or via a soft reset.

...

Summary of changes:

fb_alloc.c -> Added a semaphore lock to prevent
fb_alloc_free_till_mark() from doing anything unless fb_alloc_mark() was
called first.

py_sensor.c -> Removed calling fb_alloc_mark() and
fb_alloc_free_till_mark() and re-arranged code calls to prevent a trival
leak sitatuion on heap exhaustion.

py_image.c, py_fir.c, py_lcd.c py_tv.c -> Added fb_alloc_mark() and
fb_alloc_free_till_mark() to methods originally coded without using it.

...

Note - I coded the mark semaphore lock in such a way things work even if
fb_alloc_mark() and fb_alloc_free_till_mark() calls are nested. This
allows the find_blobs() call-back methods to call py_image.c methods
still and also allows us to add more call-backs in the future without
worry if we need to.

...

Finally, if you have an exception in an interrupt handler all this above
breaks terribly. Given MP already breaks if you try to allocate memory
in an exception this is a "won't fix problem". Don't call code that can
have exceptions or needs memory in an interrupt handler.