### PR TITLE
include frozen_mpy.o when compiling a frozen module.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -313,6 +313,11 @@ FIRM_OBJ += $(addprefix $(BUILD)/$(MICROPY_DIR)/,\
 	mpthreadport.o          \
 	)
 
+# object file for frozen bytecode (frozen .mpy files)
+ifneq ($(FROZEN_MPY_DIR),)
+FIRM_OBJ += $(addprefix $(BUILD)/$(MICROPY_DIR)/,frozen_mpy.o)
+endif
+
 #------------- MicroPy Objects ----------------#
 FIRM_OBJ += $(addprefix $(BUILD)/$(MICROPY_DIR)/lib/,\
 	utils/pyexec.o          \


### PR DESCRIPTION
when compiling a frozen module, include `frozen_mpy.o` object to prevent error 
```
undefined reference to 'mp_frozen_mpy_names'
undefined reference to 'mp_frozen_mpy_names'
undefined reference to 'mp_frozen_mpy_content'
undefined reference to 'mp_qstr_frozen_const_pool'
```

reference issues #456 