### PR TITLE
Kwabena/ov2640 final

### DIFF
--- a/src/omv/framebuffer.c
+++ b/src/omv/framebuffer.c
@@ -6,15 +6,54 @@
  * Framebuffer stuff.
  *
  */
-#include "imlib.h"
-#include "omv_boardconfig.h"
+#include "mpprint.h"
 #include "framebuffer.h"
+#include "omv_boardconfig.h"
 
 extern char _fb_base;
 framebuffer_t *fb_framebuffer = (framebuffer_t *) &_fb_base;
 
 extern char _jpeg_buf;
 jpegbuffer_t *jpeg_fb_framebuffer = (jpegbuffer_t *) &_jpeg_buf;
+
+int encode_for_ide_new_size(image_t *img)
+{
+    return (((img->bpp * 8) + 5) / 6) + 2;
+}
+
+void encode_for_ide(uint8_t *ptr, image_t *img)
+{
+    *ptr++ = 0xFE;
+
+    for(int i = 0, j = (img->bpp / 3) * 3; i < j; i += 3) {
+        int x = 0;
+        x |= img->data[i + 0] << 0;
+        x |= img->data[i + 1] << 8;
+        x |= img->data[i + 2] << 16;
+        *ptr++ = 0x80 | ((x >> 0) & 0x3F);
+        *ptr++ = 0x80 | ((x >> 6) & 0x3F);
+        *ptr++ = 0x80 | ((x >> 12) & 0x3F);
+        *ptr++ = 0x80 | ((x >> 18) & 0x3F);
+    }
+
+    if((img->bpp % 3) == 2) { // 2 bytes -> 16-bits -> 24-bits sent
+        int x = 0;
+        x |= img->data[img->bpp - 2] << 0;
+        x |= img->data[img->bpp - 1] << 8;
+        *ptr++ = 0x80 | ((x >> 0) & 0x3F);
+        *ptr++ = 0x80 | ((x >> 6) & 0x3F);
+        *ptr++ = 0x80 | ((x >> 12) & 0x3F);
+    }
+
+    if((img->bpp % 3) == 1) { // 1 byte -> 8-bits -> 16-bits sent
+        int x = 0;
+        x |= img->data[img->bpp - 1] << 0;
+        *ptr++ = 0x80 | ((x >> 0) & 0x3F);
+        *ptr++ = 0x80 | ((x >> 6) & 0x3F);
+    }
+
+    *ptr++ = 0xFE;
+}
 
 uint32_t fb_buffer_size()
 {
@@ -42,11 +81,13 @@ void fb_update_jpeg_buffer()
     static int overflow_count = 0;
 
     if ((MAIN_FB()->bpp > 3) && JPEG_FB()->enabled) {
+        bool does_not_fit = false;
         // Lock FB
         if (mutex_try_lock(&JPEG_FB()->lock, MUTEX_TID_OMV)) {
             if((OMV_JPEG_BUF_SIZE-64) < MAIN_FB()->bpp) {
                 // image won't fit. so don't copy.
                 JPEG_FB()->w = 0; JPEG_FB()->h = 0; JPEG_FB()->size = 0;
+                does_not_fit = true;
             } else {
                 memcpy(JPEG_FB()->pixels, MAIN_FB()->pixels, MAIN_FB()->bpp);
                 JPEG_FB()->w = MAIN_FB()->w; JPEG_FB()->h = MAIN_FB()->h; JPEG_FB()->size = MAIN_FB()->bpp;
@@ -54,6 +95,15 @@ void fb_update_jpeg_buffer()
 
             // Unlock the framebuffer mutex
             mutex_unlock(&JPEG_FB()->lock, MUTEX_TID_OMV);
+        }
+        if (does_not_fit) {
+            image_t out = { .w=MAIN_FB()->w, .h=MAIN_FB()->h, .bpp=MAIN_FB()->bpp, .data=MAIN_FB()->pixels };
+            int new_size = encode_for_ide_new_size(&out);
+            fb_alloc_mark();
+            uint8_t *temp = fb_alloc(new_size);
+            encode_for_ide(temp, &out);
+            (MP_PYTHON_PRINTER)->print_strn((MP_PYTHON_PRINTER)->data, (const char *) temp, new_size);
+            fb_alloc_free_till_mark();
         }
     } else if ((MAIN_FB()->bpp >= 0) && JPEG_FB()->enabled) {
         // Lock FB

--- a/src/omv/framebuffer.h
+++ b/src/omv/framebuffer.h
@@ -9,6 +9,7 @@
 #ifndef __FRAMEBUFFER_H__
 #define __FRAMEBUFFER_H__
 #include <stdint.h>
+#include "imlib.h"
 #include "mutex.h"
 
 typedef struct framebuffer {
@@ -43,6 +44,10 @@ extern jpegbuffer_t *jpeg_fb_framebuffer;
 
 // Use this macro to get a pointer to the free SRAM area located after the framebuffer.
 #define JPEG_FB_PIXELS()    (JPEG_FB()->pixels + JPEG_FB()->size)
+
+// Encode jpeg data for transmission over a text channel.
+int encode_for_ide_new_size(image_t *img);
+void encode_for_ide(uint8_t *ptr, image_t *img);
 
 // Returns the main frame buffer size, factoring in pixel formats.
 uint32_t fb_buffer_size();

--- a/src/omv/py/qstrdefsomv.h
+++ b/src/omv/py/qstrdefsomv.h
@@ -446,6 +446,12 @@ Q(compressed)
 Q(compressed_for_ide)
 // duplicate Q(quality)
 
+// Encode for IDE (in place)
+Q(jpeg_encode_for_ide)
+
+// Encoded for IDE (out of place)
+Q(jpeg_encoded_for_ide)
+
 // Copy
 // duplicate Q(copy)
 Q(crop)

--- a/src/uvc/src/main.c
+++ b/src/uvc/src/main.c
@@ -50,6 +50,20 @@ int printf(const char *fmt, ...)
     return 0;
 }
 
+NORETURN void nlr_jump(void *val)
+{
+    __fatal_error();
+}
+
+void *mp_obj_new_exception_msg(const void *exc_type, const char *msg)
+{
+    return NULL;
+}
+
+const void *mp_type_MemoryError = NULL;
+
+const void *mp_sys_stdout_print = NULL;
+
 static uint8_t frame_index = 0;
 static uint8_t format_index = 0;
 


### PR DESCRIPTION
Two commits
* The first commit makes jpeg mode work even when the jpeg image is larger than the jpeg buffer. Frame rate takes a noise dive however. Also, added methods for sending jpeg data to the IDE over serial.
* The second commit fixes the resolution errors previous with the OV2640. Setting the resolution works right now.

All features of the OV2640 driver appear to work except for AEC control. Turning AEC off/on doesn't appear to do anything. Not sure how to fix. We can definitely change the exposure value but the camera doesn't really care what we write and stays in auto mode. Without new information this is a won't fix.