### PR TITLE
Kwabena/sdram support

### DIFF
--- a/src/omv/boards/OPENMV2/imlib_config.h
+++ b/src/omv/boards/OPENMV2/imlib_config.h
@@ -111,6 +111,9 @@
 // Enable find_apriltags() (64 KB)
 //#define IMLIB_ENABLE_APRILTAGS
 
+// Enable high res find_apriltags() - uses more RAM
+// #define IMLIB_ENABLE_HIGH_RES_APRILTAGS
+
 // Enable find_datamatrices() (26 KB)
 //#define IMLIB_ENABLE_DATAMATRICES
 

--- a/src/omv/boards/OPENMV2/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV2/omv_boardconfig.h
@@ -48,6 +48,9 @@
 #define JPEG_QUALITY_LOW        35
 #define JPEG_QUALITY_HIGH       60
 
+// FB Heap Block Size
+#define OMV_UMM_BLOCK_SIZE      16
+
 // Linker script constants (see the linker script template stm32fxxx.ld.S).
 // Note: fb_alloc is a stack-based, dynamically allocated memory on FB.
 // The maximum available fb_alloc memory = FB_ALLOC_SIZE + FB_SIZE - (w*h*bpp).

--- a/src/omv/boards/OPENMV3/imlib_config.h
+++ b/src/omv/boards/OPENMV3/imlib_config.h
@@ -114,6 +114,9 @@
 // Enable find_apriltags() (64 KB)
 #define IMLIB_ENABLE_APRILTAGS
 
+// Enable high res find_apriltags() - uses more RAM
+// #define IMLIB_ENABLE_HIGH_RES_APRILTAGS
+
 // Enable find_datamatrices() (26 KB)
 #define IMLIB_ENABLE_DATAMATRICES
 

--- a/src/omv/boards/OPENMV3/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV3/omv_boardconfig.h
@@ -48,6 +48,9 @@
 #define JPEG_QUALITY_LOW        35
 #define JPEG_QUALITY_HIGH       60
 
+// FB Heap Block Size
+#define OMV_UMM_BLOCK_SIZE      16
+
 // Linker script constants (see the linker script template stm32fxxx.ld.S).
 // Note: fb_alloc is a stack-based, dynamically allocated memory on FB.
 // The maximum available fb_alloc memory = FB_ALLOC_SIZE + FB_SIZE - (w*h*bpp).

--- a/src/omv/boards/OPENMV4/imlib_config.h
+++ b/src/omv/boards/OPENMV4/imlib_config.h
@@ -114,6 +114,9 @@
 // Enable find_apriltags() (64 KB)
 #define IMLIB_ENABLE_APRILTAGS
 
+// Enable high res find_apriltags() - uses more RAM
+// #define IMLIB_ENABLE_HIGH_RES_APRILTAGS
+
 // Enable find_datamatrices() (26 KB)
 #define IMLIB_ENABLE_DATAMATRICES
 

--- a/src/omv/boards/OPENMV4/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4/omv_boardconfig.h
@@ -55,6 +55,9 @@
 #define JPEG_QUALITY_LOW        50
 #define JPEG_QUALITY_HIGH       90
 
+// FB Heap Block Size
+#define OMV_UMM_BLOCK_SIZE      16
+
 // Linker script constants (see the linker script template stm32fxxx.ld.S).
 // Note: fb_alloc is a stack-based, dynamically allocated memory on FB.
 // The maximum available fb_alloc memory = FB_ALLOC_SIZE + FB_SIZE - (w*h*bpp).

--- a/src/omv/boards/OPENMV4R/imlib_config.h
+++ b/src/omv/boards/OPENMV4R/imlib_config.h
@@ -114,6 +114,9 @@
 // Enable find_apriltags() (64 KB)
 #define IMLIB_ENABLE_APRILTAGS
 
+// Enable high res find_apriltags() - uses more RAM
+#define IMLIB_ENABLE_HIGH_RES_APRILTAGS
+
 // Enable find_datamatrices() (26 KB)
 #define IMLIB_ENABLE_DATAMATRICES
 

--- a/src/omv/boards/OPENMV4R/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4R/omv_boardconfig.h
@@ -55,6 +55,9 @@
 #define JPEG_QUALITY_LOW        50
 #define JPEG_QUALITY_HIGH       90
 
+// FB Heap Block Size
+#define OMV_UMM_BLOCK_SIZE      256
+
 // Linker script constants (see the linker script template stm32fxxx.ld.S).
 // Note: fb_alloc is a stack-based, dynamically allocated memory on FB.
 // The maximum available fb_alloc memory = FB_ALLOC_SIZE + FB_SIZE - (w*h*bpp).

--- a/src/omv/boards/OPENMV4R/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4R/omv_boardconfig.h
@@ -10,7 +10,7 @@
 #define __OMV_BOARDCONFIG_H__
 
 // Architecture info
-#define OMV_ARCH_STR            "OMV4R H7 16384 SDRAM" // 33 chars max
+#define OMV_ARCH_STR            "OMV4R H7 32768 SDRAM" // 33 chars max
 #define OMV_BOARD_TYPE          "H7"
 #define OMV_UNIQUE_ID_ADDR      0x1FF1E800
 
@@ -38,7 +38,7 @@
 #define OMV_BOOTLDR_LED_PORT    (GPIOC)
 
 // RAW buffer size
-#define OMV_RAW_BUF_SIZE        (409600)
+#define OMV_RAW_BUF_SIZE        (31457280)
 
 // Enable hardware JPEG
 #define OMV_HARDWARE_JPEG       (1)
@@ -49,7 +49,7 @@
 
 // If buffer size is bigger than this threshold, the quality is reduced.
 // This is only used for JPEG images sent to the IDE not normal compression.
-#define JPEG_QUALITY_THRESH     (320*240*2)
+#define JPEG_QUALITY_THRESH     (1920*1080*2)
 
 // Low and high JPEG QS.
 #define JPEG_QUALITY_LOW        50
@@ -61,19 +61,19 @@
 #define OMV_FFS_MEMORY          CCM         // Flash filesystem cache memory
 #define OMV_MAIN_MEMORY         SRAM1       // data, bss, stack and heap
 #define OMV_DMA_MEMORY          AXI_SRAM    // DMA buffers memory.
-#define OMV_FB_MEMORY           AXI_SRAM    // Framebuffer, fb_alloc
-#define OMV_JPEG_MEMORY         SRAM3       // JPEG buffer memory.
+#define OMV_FB_MEMORY           DRAM        // Framebuffer, fb_alloc
+#define OMV_FB_JPEG_MEMORY                  // JPEG buffer memory.
 #define OMV_VOSPI_MEMORY        SRAM4       // VoSPI buffer memory.
 
-#define OMV_FB_SIZE             (400K)      // FB memory: header + VGA/GS image
-#define OMV_FB_ALLOC_SIZE       (96K)       // minimum fb alloc size
+#define OMV_FB_SIZE             (30M)       // FB memory: header + VGA/GS image
+#define OMV_FB_ALLOC_SIZE       (1M)        // minimum fb alloc size
 #define OMV_STACK_SIZE          (7K)
 #define OMV_HEAP_SIZE           (240K)
 
-#define OMV_LINE_BUF_SIZE       (3K)        // Image line buffer round(640 * 2BPP * 2 buffers).
+#define OMV_LINE_BUF_SIZE       (11K)       // Image line buffer round(2592 * 2BPP * 2 buffers).
 #define OMV_MSC_BUF_SIZE        (12K)       // USB MSC bot data
 #define OMV_VFS_BUF_SIZE        (1K)        // VFS sturct + FATFS file buffer (624 bytes)
-#define OMV_JPEG_BUF_SIZE       (32 * 1024) // IDE JPEG buffer (header + data).
+#define OMV_JPEG_BUF_SIZE       (1024*1024) // IDE JPEG buffer (header + data).
 
 #define OMV_BOOT_ORIGIN         0x08000000
 #define OMV_BOOT_LENGTH         128K
@@ -89,10 +89,12 @@
 #define OMV_SRAM4_LENGTH        64K
 #define OMV_AXI_SRAM_ORIGIN     0x24000000
 #define OMV_AXI_SRAM_LENGTH     512K
+#define OMV_DRAM_ORIGIN         0xC0000000
+#define OMV_DRAM_LENGTH         32M
 
 // Use the MPU to set an uncacheable memory region.
-#define OMV_DMA_REGION_BASE     (OMV_AXI_SRAM_ORIGIN+(496*1024))
-#define OMV_DMA_REGION_SIZE     MPU_REGION_SIZE_16KB
+#define OMV_DMA_REGION_BASE     (OMV_AXI_SRAM_ORIGIN)
+#define OMV_DMA_REGION_SIZE     MPU_REGION_SIZE_32KB
 
 /* SCCB/I2C */
 #define SCCB_I2C                (I2C1)
@@ -232,5 +234,9 @@
 #define LEPTON_SPI_MISO_PORT        (GPIOB)
 #define LEPTON_SPI_MOSI_PORT        (GPIOB)
 #define LEPTON_SPI_SSEL_PORT        (GPIOA)
+
+// Enable additional GPIO banks for DRAM...
+#define ENABLE_GPIO_BANK_F
+#define ENABLE_GPIO_BANK_G
 
 #endif //__OMV_BOARDCONFIG_H__

--- a/src/omv/img/apriltag.c
+++ b/src/omv/img/apriltag.c
@@ -9134,10 +9134,14 @@ struct ufrec
 {
     // the parent of this node. If a node's parent is its own index,
     // then it is a root.
+#ifdef IMLIB_ENABLE_HIGH_RES_APRILTAGS
+    uint32_t parent;
+#else
     uint16_t parent;
+#endif
 };
 
-static inline unionfind_t *unionfind_create(uint16_t maxid)
+static inline unionfind_t *unionfind_create(uint32_t maxid)
 {
     unionfind_t *uf = (unionfind_t*) fb_alloc(sizeof(unionfind_t));
     uf->data = (struct ufrec*) fb_alloc((maxid+1) * sizeof(struct ufrec));
@@ -9154,7 +9158,7 @@ static inline void unionfind_destroy()
 }
 
 /*
-static inline uint16_t unionfind_get_representative(unionfind_t *uf, uint16_t id)
+static inline uint32_t unionfind_get_representative(unionfind_t *uf, uint32_t id)
 {
     // base case: a node is its own parent
     if (uf->data[id].parent == id)
@@ -9172,9 +9176,9 @@ static inline uint16_t unionfind_get_representative(unionfind_t *uf, uint16_t id
 
 // this one seems to be every-so-slightly faster than the recursive
 // version above.
-static inline uint16_t unionfind_get_representative(unionfind_t *uf, uint16_t id)
+static inline uint32_t unionfind_get_representative(unionfind_t *uf, uint32_t id)
 {
-    uint16_t root = id;
+    uint32_t root = id;
 
     // chase down the root
     while (uf->data[root].parent != root) {
@@ -9187,7 +9191,7 @@ static inline uint16_t unionfind_get_representative(unionfind_t *uf, uint16_t id
     // (e.g. image segmentation), we are actually faster not doing
     // this...
     while (uf->data[id].parent != root) {
-        uint16_t tmp = uf->data[id].parent;
+        uint32_t tmp = uf->data[id].parent;
         uf->data[id].parent = root;
         id = tmp;
     }
@@ -9195,10 +9199,10 @@ static inline uint16_t unionfind_get_representative(unionfind_t *uf, uint16_t id
     return root;
 }
 
-static inline uint16_t unionfind_connect(unionfind_t *uf, uint16_t aid, uint16_t bid)
+static inline uint32_t unionfind_connect(unionfind_t *uf, uint32_t aid, uint32_t bid)
 {
-    uint16_t aroot = unionfind_get_representative(uf, aid);
-    uint16_t broot = unionfind_get_representative(uf, bid);
+    uint32_t aroot = unionfind_get_representative(uf, aid);
+    uint32_t broot = unionfind_get_representative(uf, bid);
 
     if (aroot != broot)
         uf->data[broot].parent = aroot;
@@ -10475,9 +10479,11 @@ zarray_t *apriltag_quad_thresh(apriltag_detector_t *td, image_u8_t *im, bool ove
             DO_CONN(1, 0);
             DO_CONN(0, 1);
 
+#ifdef IMLIB_ENABLE_HIGH_RES_APRILTAGS
             // do 8 connectivity
-            // DO_CONN(-1, 1);
-            // DO_CONN(1, 1);
+            DO_CONN(-1, 1);
+            DO_CONN(1, 1);
+#endif
         }
     }
 #undef DO_CONN

--- a/src/omv/img/jpeg.c
+++ b/src/omv/img/jpeg.c
@@ -202,7 +202,7 @@ bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc)
     }
 
     // NOTE: output buffer size is stored in dst->bpp
-    if (HAL_JPEG_Encode(&JPEG_Handle, get_mcu(), jpeg_enc.mcu_size, dst->pixels, dst->bpp, 100) != HAL_OK) {
+    if (HAL_JPEG_Encode(&JPEG_Handle, get_mcu(), jpeg_enc.mcu_size, dst->pixels, dst->bpp, 10000) != HAL_OK) {
         // Initialization error
         return true;
     }

--- a/src/omv/py/py_image.c
+++ b/src/omv/py/py_image.c
@@ -5545,7 +5545,9 @@ static mp_obj_t py_image_find_apriltags(uint n_args, const mp_obj_t *args, mp_ma
 
     rectangle_t roi;
     py_helper_keyword_rectangle_roi(arg_img, n_args, args, 1, kw_args, &roi);
+#ifndef IMLIB_ENABLE_HIGH_RES_APRILTAGS
     PY_ASSERT_TRUE_MSG((roi.w * roi.h) < 65536, "The maximum supported resolution for find_apriltags() is < 64K pixels.");
+#endif
     if ((roi.w < 4) || (roi.h < 4)) {
         return mp_obj_new_list(0, NULL);
     }

--- a/src/omv/stm32fxxx.ld.S
+++ b/src/omv/stm32fxxx.ld.S
@@ -29,6 +29,9 @@ MEMORY
   #if defined(OMV_AXI_SRAM_ORIGIN)
   AXI_SRAM (xrw)    : ORIGIN = OMV_AXI_SRAM_ORIGIN, LENGTH = OMV_AXI_SRAM_LENGTH
   #endif
+  #if defined(OMV_DRAM_ORIGIN)
+  DRAM (xrw)        : ORIGIN = OMV_DRAM_ORIGIN,     LENGTH = OMV_DRAM_LENGTH
+  #endif
   FLASH_TEXT (rx)   : ORIGIN = OMV_TEXT_ORIGIN,     LENGTH = OMV_TEXT_LENGTH
 }
 
@@ -88,6 +91,12 @@ SECTIONS
     . = ALIGN(4);
     _fballoc = .;
 
+    #if defined(OMV_FB_JPEG_MEMORY)
+    . = ALIGN(4);
+    _jpeg_buf = .;      // IDE JPEG buffer
+    . = . + OMV_JPEG_BUF_SIZE;
+    #endif
+
   } >OMV_FB_MEMORY
 
   /* Misc DMA buffers kept in uncachable region */
@@ -111,7 +120,7 @@ SECTIONS
     . = . + OMV_FFS_BUF_SIZE;
     #endif
 
-    #if !defined(OMV_JPEG_MEMORY)
+    #if !defined(OMV_JPEG_MEMORY) && !defined(OMV_FB_JPEG_MEMORY)
     . = ALIGN(4);
     _jpeg_buf = .;      // IDE JPEG buffer
     . = . + OMV_JPEG_BUF_SIZE;

--- a/src/omv/stm32fxxx_hal_msp.c
+++ b/src/omv/stm32fxxx_hal_msp.c
@@ -84,6 +84,12 @@ void HAL_MspInit(void)
     __GPIOC_CLK_ENABLE();
     __GPIOD_CLK_ENABLE();
     __GPIOE_CLK_ENABLE();
+    #ifdef ENABLE_GPIO_BANK_F
+    __GPIOF_CLK_ENABLE();
+    #endif
+    #ifdef ENABLE_GPIO_BANK_G
+    __GPIOG_CLK_ENABLE();
+    #endif
 
     #if defined(STM32F769xx)
     __GPIOF_CLK_ENABLE();

--- a/src/omv/umm_malloc.c
+++ b/src/omv/umm_malloc.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include "fb_alloc.h"
 #include "umm_malloc.h"
+#include "omv_boardconfig.h"
 
 NORETURN  void umm_alloc_fail()
 {
@@ -109,7 +110,7 @@ UMM_H_ATTPACKPRE typedef struct umm_block_t {
   } header;
   union {
     umm_ptr free;
-    unsigned char data[16];
+    unsigned char data[OMV_UMM_BLOCK_SIZE];
   } body;
 } UMM_H_ATTPACKSUF umm_block;
 

--- a/src/uvc/stm32fxxx.ld.S
+++ b/src/uvc/stm32fxxx.ld.S
@@ -29,6 +29,9 @@ MEMORY
   #if defined(OMV_AXI_SRAM_ORIGIN)
   AXI_SRAM (xrw)    : ORIGIN = OMV_AXI_SRAM_ORIGIN, LENGTH = OMV_AXI_SRAM_LENGTH
   #endif
+  #if defined(OMV_DRAM_ORIGIN)
+  DRAM (xrw)        : ORIGIN = OMV_DRAM_ORIGIN,     LENGTH = OMV_DRAM_LENGTH
+  #endif
   FLASH_TEXT (rx)   : ORIGIN = OMV_TEXT_ORIGIN,     LENGTH = OMV_TEXT_LENGTH
 }
 
@@ -83,6 +86,12 @@ SECTIONS
     . = ALIGN(4);
     _fballoc = .;
 
+    #if defined(OMV_FB_JPEG_MEMORY)
+    . = ALIGN(4);
+    _jpeg_buf = .;      // IDE JPEG buffer
+    . = . + OMV_JPEG_BUF_SIZE;
+    #endif
+
   } >OMV_FB_MEMORY
 
   /* Misc DMA buffers kept in uncachable region */
@@ -107,7 +116,7 @@ SECTIONS
     . = . + OMV_FFS_BUF_SIZE;
     #endif
 
-    #if !defined(OMV_JPEG_MEMORY)
+    #if !defined(OMV_JPEG_MEMORY) && !defined(OMV_FB_JPEG_MEMORY)
     . = ALIGN(4);
     _jpeg_buf = .;      // IDE JPEG buffer
     . = . + OMV_JPEG_BUF_SIZE;


### PR DESCRIPTION
The jpeg compression timeout was too low initially for jpeg compressing UXGA images and etc. from the OV2640 (you can also just capture a JPG image from the OV2640 too).

High res apriltag support allows doing apriltag detection on high res images. Performance is poor because of low DRAM speed.