### PR TITLE
Add memory offsets for FFS, JPEG and VOSPI buffers.

### DIFF
--- a/src/omv/boards/OPENMV4R/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4R/omv_boardconfig.h
@@ -65,7 +65,8 @@
 #define OMV_MAIN_MEMORY         SRAM1       // data, bss, stack and heap
 #define OMV_DMA_MEMORY          AXI_SRAM    // DMA buffers memory.
 #define OMV_FB_MEMORY           DRAM        // Framebuffer, fb_alloc
-#define OMV_FB_JPEG_MEMORY                  // JPEG buffer memory.
+#define OMV_JPEG_MEMORY         DRAM        // JPEG buffer memory buffer.
+#define OMV_JPEG_MEMORY_OFFSET  (31M)       // JPEG buffer is placed after FB/fballoc memory.
 #define OMV_VOSPI_MEMORY        SRAM4       // VoSPI buffer memory.
 
 #define OMV_FB_SIZE             (30M)       // FB memory: header + VGA/GS image

--- a/src/omv/stm32fxxx.ld.S
+++ b/src/omv/stm32fxxx.ld.S
@@ -39,15 +39,24 @@ _estack     = ORIGIN(OMV_MAIN_MEMORY) + LENGTH(OMV_MAIN_MEMORY);
 _ram_end    = ORIGIN(OMV_MAIN_MEMORY) + LENGTH(OMV_MAIN_MEMORY);
 
 #if defined(OMV_FFS_MEMORY)
-_ffs_cache  = ORIGIN(OMV_FFS_MEMORY);
+#if !defined(OMV_FFS_MEMORY_OFFSET)
+#define OMV_FFS_MEMORY_OFFSET   (0)
+#endif
+_ffs_cache  = ORIGIN(OMV_FFS_MEMORY) + OMV_FFS_MEMORY_OFFSET;
 #endif
 
 #if defined(OMV_JPEG_MEMORY)
-_jpeg_buf  = ORIGIN(OMV_JPEG_MEMORY);
+#if !defined(OMV_JPEG_MEMORY_OFFSET)
+#define OMV_JPEG_MEMORY_OFFSET   (0)
+#endif
+_jpeg_buf  = ORIGIN(OMV_JPEG_MEMORY) + OMV_JPEG_MEMORY_OFFSET;
 #endif
 
 #if defined(OMV_VOSPI_MEMORY)
-_vospi_buf  = ORIGIN(OMV_VOSPI_MEMORY);
+#if !defined(OMV_VOSPI_MEMORY_OFFSET)
+#define OMV_VOSPI_MEMORY_OFFSET   (0)
+#endif
+_vospi_buf  = ORIGIN(OMV_VOSPI_MEMORY) + OMV_VOSPI_MEMORY_OFFSET;
 #endif
 
 _heap_size  = OMV_HEAP_SIZE;    /* required amount of heap */
@@ -90,13 +99,7 @@ SECTIONS
 
     . = ALIGN(4);
     _fballoc = .;
-
-    #if defined(OMV_FB_JPEG_MEMORY)
     . = ALIGN(4);
-    _jpeg_buf = .;      // IDE JPEG buffer
-    . = . + OMV_JPEG_BUF_SIZE;
-    #endif
-
   } >OMV_FB_MEMORY
 
   /* Misc DMA buffers kept in uncachable region */
@@ -120,7 +123,7 @@ SECTIONS
     . = . + OMV_FFS_BUF_SIZE;
     #endif
 
-    #if !defined(OMV_JPEG_MEMORY) && !defined(OMV_FB_JPEG_MEMORY)
+    #if !defined(OMV_JPEG_MEMORY)
     . = ALIGN(4);
     _jpeg_buf = .;      // IDE JPEG buffer
     . = . + OMV_JPEG_BUF_SIZE;


### PR DESCRIPTION
* Allow FFS, JPEG and VOSPI buffers to be moved to any dedicated region with an offset.