### PR TITLE
Disable 8-way connectivity

### DIFF
--- a/src/omv/boards/OPENMV2/imlib_config.h
+++ b/src/omv/boards/OPENMV2/imlib_config.h
@@ -113,6 +113,9 @@
 // Enable find_apriltags() (64 KB)
 //#define IMLIB_ENABLE_APRILTAGS
 
+// Enable fine find_apriltags() - (8-way connectivity versus 4-way connectivity)
+// #define IMLIB_ENABLE_FINE_APRILTAGS
+
 // Enable high res find_apriltags() - uses more RAM
 // #define IMLIB_ENABLE_HIGH_RES_APRILTAGS
 

--- a/src/omv/boards/OPENMV3/imlib_config.h
+++ b/src/omv/boards/OPENMV3/imlib_config.h
@@ -116,6 +116,9 @@
 // Enable find_apriltags() (64 KB)
 #define IMLIB_ENABLE_APRILTAGS
 
+// Enable fine find_apriltags() - (8-way connectivity versus 4-way connectivity)
+// #define IMLIB_ENABLE_FINE_APRILTAGS
+
 // Enable high res find_apriltags() - uses more RAM
 // #define IMLIB_ENABLE_HIGH_RES_APRILTAGS
 

--- a/src/omv/boards/OPENMV4/imlib_config.h
+++ b/src/omv/boards/OPENMV4/imlib_config.h
@@ -116,6 +116,9 @@
 // Enable find_apriltags() (64 KB)
 #define IMLIB_ENABLE_APRILTAGS
 
+// Enable fine find_apriltags() - (8-way connectivity versus 4-way connectivity)
+// #define IMLIB_ENABLE_FINE_APRILTAGS
+
 // Enable high res find_apriltags() - uses more RAM
 // #define IMLIB_ENABLE_HIGH_RES_APRILTAGS
 

--- a/src/omv/boards/OPENMV4R/imlib_config.h
+++ b/src/omv/boards/OPENMV4R/imlib_config.h
@@ -116,6 +116,9 @@
 // Enable find_apriltags() (64 KB)
 #define IMLIB_ENABLE_APRILTAGS
 
+// Enable fine find_apriltags() - (8-way connectivity versus 4-way connectivity)
+// #define IMLIB_ENABLE_FINE_APRILTAGS
+
 // Enable high res find_apriltags() - uses more RAM
 #define IMLIB_ENABLE_HIGH_RES_APRILTAGS
 

--- a/src/omv/img/apriltag.c
+++ b/src/omv/img/apriltag.c
@@ -10478,7 +10478,7 @@ zarray_t *apriltag_quad_thresh(apriltag_detector_t *td, image_u8_t *im, bool ove
             DO_CONN(1, 0);
             DO_CONN(0, 1);
 
-#ifdef IMLIB_ENABLE_HIGH_RES_APRILTAGS
+#ifdef IMLIB_ENABLE_FINE_APRILTAGS
             // do 8 connectivity
             DO_CONN(-1, 1);
             DO_CONN(1, 1);


### PR DESCRIPTION
Not neccessarily needed and takes 2-4x more processing power. If FPS is
not a concern enable it.