### PR TITLE
WINC1500: Fix timeout bugs.

### DIFF
--- a/scripts/examples/14-WiFi-Shield/mjpeg_streamer.py
+++ b/scripts/examples/14-WiFi-Shield/mjpeg_streamer.py
@@ -37,8 +37,8 @@ s = usocket.socket(usocket.AF_INET, usocket.SOCK_STREAM)
 s.bind([HOST, PORT])
 s.listen(5)
 
-# Set server socket to non-blocking
-s.settimeout(0)
+# Set server socket to blocking
+s.setblocking(True)
 
 def start_streaming(s):
     print ('Waiting for connections..')

--- a/src/winc1500/include/winc.h
+++ b/src/winc1500/include/winc.h
@@ -18,6 +18,7 @@
 #define WINC_MAX_PSK_LEN        (65)
 #define WINC_MAX_BOARD_NAME_LEN (33)
 #define WINC_SOCKBUF_SIZE       (1400)
+#define WINC_REQUEST_TIMEOUT    (5000)
 
 #define MAKE_SOCKADDR(addr, ip, port) \
     struct sockaddr addr; \


### PR DESCRIPTION
* Setting timeout to 0 (from MicroPython) makes the socket blocking instead of non-blocking.
* Sockets were closed on recv/recvfrom timeout.