### PR TITLE
Move flag setting inside the curly braces.

### DIFF
--- a/src/omv/fb_alloc.c
+++ b/src/omv/fb_alloc.c
@@ -170,8 +170,8 @@ void *fb_alloc_all(uint32_t *size, int hints)
         // Return overlay memory instead.
         pointer_overlay -= *size;
         result = pointer_overlay;
+        *new_pointer |= FB_OVERLAY_MEMORY_FLAG; // Add flag.
     }
-    *new_pointer |= FB_OVERLAY_MEMORY_FLAG; // Add flag.
     #endif
     return result;
 }


### PR DESCRIPTION
Found this bug because the tensorflow code does fb_alloc all and then frees it and then allocs again. Should not have missed this before.