### PR TITLE
Wifi updates

### DIFF
--- a/scripts/examples/14-WiFi-Shield/http_client.py
+++ b/scripts/examples/14-WiFi-Shield/http_client.py
@@ -1,12 +1,13 @@
-# TCP Client Example
-#
-# This example shows how to send and receive TCP traffic with the WiFi shield.
+# Simple HTTP client example.
 
 import network, usocket
 
 # AP info
 SSID='' # Network SSID
 KEY=''  # Network key
+
+PORT = 80
+HOST = "www.google.com"
 
 # Init wlan module and connect to network
 print("Trying to connect... (may take a while)...")
@@ -18,17 +19,18 @@ wlan.connect(SSID, key=KEY, security=wlan.WPA_PSK)
 print(wlan.ifconfig())
 
 # Get addr info via DNS
-addr = usocket.getaddrinfo("www.google.com", 80)[0][4]
+addr = usocket.getaddrinfo(HOST, PORT)[0][4]
+print(addr)
 
 # Create a new socket and connect to addr
 client = usocket.socket(usocket.AF_INET, usocket.SOCK_STREAM)
 client.connect(addr)
 
-# Set timeout to 1s
-client.settimeout(1.0)
+# Set timeout
+client.settimeout(3.0)
 
 # Send HTTP request and recv response
-client.send("GET / HTTP/1.0\r\n\r\n")
+client.send("GET / HTTP/1.1\r\nHost: %s\r\n\r\n"%(HOST))
 print(client.recv(1024))
 
 # Close socket

--- a/scripts/examples/14-WiFi-Shield/http_client_ssl.py
+++ b/scripts/examples/14-WiFi-Shield/http_client_ssl.py
@@ -1,0 +1,48 @@
+# Simple HTTPS client example.
+
+import network, usocket, ussl
+
+# AP info
+SSID="" # Network SSID
+KEY=""  # Network key
+
+PORT = 443
+HOST = "www.google.com"
+
+# Init wlan module and connect to network
+print("Trying to connect... (may take a while)...")
+
+wlan = network.WINC()
+wlan.connect(SSID, key=KEY, security=wlan.WPA_PSK)
+
+# We should have a valid IP now via DHCP
+print(wlan.ifconfig())
+
+# Get addr info via DNS
+addr = usocket.getaddrinfo(HOST, PORT)[0][4]
+print(addr)
+
+# Create a new socket and connect to addr
+client = usocket.socket(usocket.AF_INET, usocket.SOCK_STREAM)
+
+client.connect(addr)
+
+# Set timeout
+client.settimeout(3.0)
+
+client = ussl.wrap_socket(client, server_hostname=HOST)
+
+# Send HTTP request and recv response
+request = "GET / HTTP/1.1\r\n"
+request += "HOST: %s\r\n"
+request += "User-Agent: Mozilla/5.0\r\n"
+request += "Connection: keep-alive\r\n\r\n"
+# Add more headers if needed.
+client.write(request%(HOST)+"\r\n")
+
+response = client.read(1024)
+for l in response.split(b"\r\n"):
+    print(l.decode())
+
+# Close socket
+client.close()

--- a/src/Makefile
+++ b/src/Makefile
@@ -91,6 +91,7 @@ CFLAGS += -DFB_ALLOC_STATS
 endif
 
 # Compiler Flags
+include $(MP_BOARD_CONFIG_DIR)/mpconfigboard.mk
 include $(OMV_BOARD_CONFIG_DIR)/omv_boardconfig.mk
 CFLAGS += -std=gnu99 -Wall -Werror -Warray-bounds -mthumb -nostartfiles -fdata-sections -ffunction-sections
 CFLAGS += -D$(MCU) -D$(CFLAGS_MCU) -D$(ARM_MATH) -DARM_NN_TRUNCATE\
@@ -336,6 +337,7 @@ FIRM_OBJ += $(addprefix $(BUILD)/$(MICROPY_DIR)/,\
 	pybthread.o             \
 	mpthreadport.o          \
 	posix_helpers.o         \
+	mbedtls/mbedtls_port.o  \
 	)
 
 # board object files
@@ -348,18 +350,18 @@ endif
 
 #------------- MicroPy Objects ----------------#
 FIRM_OBJ += $(addprefix $(BUILD)/$(MICROPY_DIR)/lib/,\
-	utils/mpirq.o           \
-	utils/pyexec.o          \
-	utils/printf.o          \
-	utils/interrupt_char.o  \
-	utils/sys_stdio_mphal.o \
-	utils/gchelper_m3.o     \
-	libc/string0.o          \
-	netutils/netutils.o     \
-	timeutils/timeutils.o   \
-	berkeley-db-1.xx/btree/*.o \
-	berkeley-db-1.xx/mpool/*.o \
-	embed/abort_.o             \
+	utils/mpirq.o               \
+	utils/pyexec.o              \
+	utils/printf.o              \
+	utils/interrupt_char.o      \
+	utils/sys_stdio_mphal.o     \
+	utils/gchelper_m3.o         \
+	libc/string0.o              \
+	netutils/netutils.o         \
+	timeutils/timeutils.o       \
+	berkeley-db-1.xx/btree/*.o  \
+	berkeley-db-1.xx/mpool/*.o  \
+	embed/abort_.o              \
 	)
 
 FIRM_OBJ += $(addprefix $(BUILD)/$(MICROPY_DIR)/lib/libm/,\
@@ -396,6 +398,8 @@ FIRM_OBJ += $(addprefix $(BUILD)/$(MICROPY_DIR)/lib/mp-readline/,\
 	readline.o               \
 	)
 
+#------------- mbedtls -------------------#
+FIRM_OBJ += $(wildcard $(BUILD)/$(MICROPY_DIR)/lib/mbedtls/library/*.o)
 
 FIRM_OBJ += $(addprefix $(BUILD)/$(MICROPY_DIR)/usbdev/, \
 	core/src/usbd_core.o                \
@@ -435,6 +439,8 @@ FIRM_OBJ += $(addprefix $(BUILD)/$(MICROPY_DIR)/extmod/,\
 	uos_dupterm.o       \
 	modframebuf.o       \
 	modbtree.o          \
+	moducryptolib.o     \
+	modussl_mbedtls.o   \
 	)
 
 FIRM_OBJ += $(addprefix $(BUILD)/$(MICROPY_DIR)/lib/oofatfs/,\
@@ -447,6 +453,7 @@ FIRM_OBJ += $(addprefix $(BUILD)/$(MICROPY_DIR)/drivers/,\
 	dht/dht.o           \
 	memory/spiflash.o   \
 	)
+
 
 ifeq ($(CUBEAI), 1)
 include $(TOP_DIR)/stm32cubeai/cube.mk

--- a/src/winc1500/include/winc.h
+++ b/src/winc1500/include/winc.h
@@ -17,7 +17,12 @@
 #define WINC_MAX_SSID_LEN       (33)
 #define WINC_MAX_PSK_LEN        (65)
 #define WINC_MAX_BOARD_NAME_LEN (33)
-#define WINC_SOCKBUF_SIZE       (1400)
+// NOTE: Due to the way the WINC1500 HIF is designed, a single recv() call reads all the data received on the socket, which
+// can result in multiple callbacks if the received data is more than the buffer size passed to the recv() call. As a result,
+// the async call handler will keep overwriting the user-provided buffer in subsequent callbacks. The socket buffer is used
+// as workaround to this issue to allow receiving partial packets. Note the maximum size of WINC internal socket buffer seems
+// to change with host-driver/firmware updates. It's very important to make sure this value is still valid after an update.
+#define WINC_SOCKBUF_MAX_SIZE   (1480)
 #define WINC_REQUEST_TIMEOUT    (5000)
 
 #define MAKE_SOCKADDR(addr, ip, port) \
@@ -97,7 +102,7 @@ typedef struct {
 typedef struct {
     int idx;
     int size;
-    uint8_t buf[WINC_SOCKBUF_SIZE];
+    uint8_t buf[WINC_SOCKBUF_MAX_SIZE];
 } winc_socket_buf_t;
 
 typedef struct sockaddr sockaddr;

--- a/src/winc1500/src/winc.c
+++ b/src/winc1500/src/winc.c
@@ -849,7 +849,7 @@ int winc_socket_recv(int fd, uint8_t *buf, uint32_t len, winc_socket_buf_t *sock
 
         int recv_bytes;
         // Set recv to the maximum possible packet size.
-        int ret = WINC1500_EXPORT(recv)(fd, sockbuf->buf, SOCKET_BUFFER_MAX_LENGTH, timeout);
+        int ret = WINC1500_EXPORT(recv)(fd, sockbuf->buf, WINC_SOCKBUF_MAX_SIZE, timeout);
         if (ret == SOCK_ERR_NO_ERROR) {
             // Do async request
             // sockbuf->size is the actual size of the recv'd packet.


### PR DESCRIPTION
Fix recv() bug introduced after WINC1500 host driver/firmware updates.
Enable modussl via mbedtls.
Update HTTP client example.
Add HTTPS client example.
Fixes #348 