### PR TITLE
Disable YUV table for OMV4 and OMV4R.

### DIFF
--- a/src/omv/boards/OPENMV4/imlib_config.h
+++ b/src/omv/boards/OPENMV4/imlib_config.h
@@ -15,7 +15,7 @@
 #define IMLIB_ENABLE_LAB_LUT
 
 // Enable YUV LUT
-#define IMLIB_ENABLE_YUV_LUT
+//#define IMLIB_ENABLE_YUV_LUT
 
 // Enable mean pooling
 #define IMLIB_ENABLE_MEAN_POOLING

--- a/src/omv/boards/OPENMV4R/imlib_config.h
+++ b/src/omv/boards/OPENMV4R/imlib_config.h
@@ -15,7 +15,7 @@
 #define IMLIB_ENABLE_LAB_LUT
 
 // Enable YUV LUT
-#define IMLIB_ENABLE_YUV_LUT
+//#define IMLIB_ENABLE_YUV_LUT
 
 // Enable mean pooling
 #define IMLIB_ENABLE_MEAN_POOLING


### PR DESCRIPTION
* Disable YUV tables for H7 cameras to temporarily save FLASH.
* Since H7 cameras have and use the HW JPEG encoder the side effects are minimal.