### PR TITLE
Add support for image segmentation.

### DIFF
--- a/src/omv/py/qstrdefsomv.h
+++ b/src/omv/py/qstrdefsomv.h
@@ -1179,6 +1179,7 @@ Q(pixformat)
 Q(tf)
 // duplicate Q(load)
 Q(classify)
+Q(segment)
 // Model Object
 Q(tf_model)
 // duplicate Q(len)
@@ -1201,3 +1202,7 @@ Q(tf_classification)
 // duplicate Q(w)
 // duplicate Q(h)
 Q(output)
+
+// Segment
+// duplicate Q(segment)
+// duplicate Q(roi)


### PR DESCRIPTION
With the segment method you can execute the CNN on an image and get the list of images back (per channel) that represent the CNN output mask.

This is cool because for DIY robocars we can make a really light-weight CNN that segments the image between line and no-line and gives back an image you can then call get_regression() on. 