### PR TITLE
Disable WiFi debug for older boards (especially OMV3).

### DIFF
--- a/src/omv/boards/OPENMV4/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4/omv_boardconfig.h
@@ -49,6 +49,9 @@
 #define OMV_ENABLE_MT9V034      (1)
 #define OMV_ENABLE_LEPTON       (1)
 
+// Enable WiFi debug
+#define OMV_ENABLE_WIFIDBG      (1)
+
 // If buffer size is bigger than this threshold, the quality is reduced.
 // This is only used for JPEG images sent to the IDE not normal compression.
 #define JPEG_QUALITY_THRESH     (320*240*2)

--- a/src/omv/boards/OPENMV4R/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4R/omv_boardconfig.h
@@ -49,6 +49,9 @@
 #define OMV_ENABLE_MT9V034      (1)
 #define OMV_ENABLE_LEPTON       (1)
 
+// Enable WiFi debug
+#define OMV_ENABLE_WIFIDBG      (1)
+
 // If buffer size is bigger than this threshold, the quality is reduced.
 // This is only used for JPEG images sent to the IDE not normal compression.
 #define JPEG_QUALITY_THRESH     (1920*1080*2)

--- a/src/omv/main.c
+++ b/src/omv/main.c
@@ -75,6 +75,7 @@
 #include "framebuffer.h"
 
 #include "ini.h"
+#include "omv_boardconfig.h"
 
 int errno;
 extern char _vfs_buf;
@@ -560,10 +561,14 @@ soft_reset:
     memset(&openmv_config, 0, sizeof(openmv_config));
     // Parse config, and init wifi if enabled.
     ini_parse(&vfs_fat->fatfs, "/openmv.config", ini_handler_callback, &openmv_config);
+    #if defined(OMV_ENABLE_WIFIDBG)
     if (openmv_config.wifidbg == true &&
             wifidbg_init(&openmv_config.wifidbg_config) != 0) {
         openmv_config.wifidbg = false;
     }
+    #else
+        openmv_config.wifidbg = false;
+    #endif
 
     // Run boot script(s)
     if (first_soft_reset) {

--- a/src/omv/wifidbg.c
+++ b/src/omv/wifidbg.c
@@ -29,8 +29,11 @@
 #include "lib/utils/pyexec.h"
 #include "wifidbg.h"
 #include "led.h"
+#include "omv_boardconfig.h"
 
 #include STM32_HAL_H
+
+#if defined(OMV_ENABLE_WIFIDBG)
 
 #ifndef MIN
 #define MIN(x, y) ((x) < (y) ? (x) : (y))
@@ -242,3 +245,6 @@ void wifidbg_dispatch()
         }
     }
 }
+#else
+void wifidbg_dispatch(){};
+#endif // #defined(OMV_ENABLE_WIFIDBG)


### PR DESCRIPTION
* OMV3 is running out of memory because of tf global variables.