### PR TITLE
Disable rotation when pitch is wrong

### DIFF
--- a/src/omv/py/py_sensor.c
+++ b/src/omv/py/py_sensor.c
@@ -51,23 +51,26 @@ static mp_obj_t py_sensor_snapshot(uint n_args, const mp_obj_t *args, mp_map_t *
     // To prevent oscillation there is a 20 degree dead-zone between each state.
     // This means there is a 70 degree active-zone.
     if (sensor_get_auto_rotation()) {
-        float roll = py_imu_roll_rotation();
-        if ((325 < roll) || (roll < 35) ) { // center is 0/360, upright
-            sensor_set_hmirror(false);
-            sensor_set_vflip(false);
-            sensor_set_transpose(false);
-        } else if ((235 < roll) && (roll < 305)) { // center is 270, rotated right
-            sensor_set_hmirror(true);
-            sensor_set_vflip(false);
-            sensor_set_transpose(true);
-        } else if ((145 < roll) && (roll < 215)) { // center is 180, upside down
-            sensor_set_hmirror(true);
-            sensor_set_vflip(true);
-            sensor_set_transpose(false);
-        } else if ((55 < roll) && (roll < 125)) { // center is 90, rotated left
-            sensor_set_hmirror(false);
-            sensor_set_vflip(true);
-            sensor_set_transpose(true);
+        float pitch = py_imu_pitch_rotation();
+        if (((pitch < 80) || (100 < pitch)) && ((pitch < 260) || (280 < pitch))) { // disable when 90 or 270
+            float roll = py_imu_roll_rotation();
+            if ((325 < roll) || (roll < 35) ) { // center is 0/360, upright
+                sensor_set_hmirror(false);
+                sensor_set_vflip(false);
+                sensor_set_transpose(false);
+            } else if ((235 < roll) && (roll < 305)) { // center is 270, rotated right
+                sensor_set_hmirror(true);
+                sensor_set_vflip(false);
+                sensor_set_transpose(true);
+            } else if ((145 < roll) && (roll < 215)) { // center is 180, upside down
+                sensor_set_hmirror(true);
+                sensor_set_vflip(true);
+                sensor_set_transpose(false);
+            } else if ((55 < roll) && (roll < 125)) { // center is 90, rotated left
+                sensor_set_hmirror(false);
+                sensor_set_vflip(true);
+                sensor_set_transpose(true);
+            }
         }
     }
 #endif //MICROPY_PY_IMU


### PR DESCRIPTION
Stops auto rotation when +-10 degrees from 90 (face down) and 270 (face up). This has to be done because the roll is unstable when at these pitches.