### PR TITLE
optimized sensor copy to allow ful res capture

### DIFF
--- a/src/omv/ov5640.c
+++ b/src/omv/ov5640.c
@@ -426,7 +426,7 @@ static int set_pixformat(sensor_t *sensor, pixformat_t pixformat)
             break;
         case PIXFORMAT_GRAYSCALE:
         case PIXFORMAT_YUV422:
-            ret |= cambus_writeb2(sensor->slv_addr, FORMAT_CONTROL, 0x30);
+            ret |= cambus_writeb2(sensor->slv_addr, FORMAT_CONTROL, 0x10);
             ret |= cambus_writeb2(sensor->slv_addr, FORMAT_CONTROL_MUX, 0x00);
             pll = (resolution[sensor->framesize][0] > 2048) ? 0x50 : 0x64; // 32 MHz vs 40 MHz
             break;
@@ -547,7 +547,7 @@ static int set_framesize(sensor_t *sensor, framesize_t framesize)
 
     // Step 5: Compute total frame time.
 
-    uint16_t sensor_hts = (sensor_w * ((sensor->pixformat == PIXFORMAT_JPEG) ? 1 : 2)) + HSYNC_TIME;
+    uint16_t sensor_hts = (sensor_w * ((sensor->pixformat == PIXFORMAT_GRAYSCALE || sensor->pixformat == PIXFORMAT_JPEG) ? 1 : 2)) + HSYNC_TIME;
     uint16_t sensor_vts = sensor_h + VYSNC_TIME;
 
     uint16_t sensor_x_inc = (((sensor_div * 2) - 1) << 4) | (1 << 0); // odd[7:4]/even[3:0] pixel inc on the bayer pattern
@@ -612,7 +612,8 @@ static int set_framesize(sensor_t *sensor, framesize_t framesize)
             break;
         case PIXFORMAT_GRAYSCALE:
         case PIXFORMAT_YUV422:
-            pll = (w > 2048) ? 0x50 : 0x64; // 32 MHz vs 40 MHz
+//            pll = (w > 2048) ? 0x50 : 0x64; // 32 MHz vs 40 MHz
+            pll = 0x64;
             break;
         case PIXFORMAT_BAYER:
             pll = (w > 2048) ? 0x64 : 0x50; // 40 MHz vs 32 MHz (jpeg can go faster at higher reses)
@@ -936,7 +937,7 @@ static int set_lens_correction(sensor_t *sensor, int enable, int radi, int coef)
 int ov5640_init(sensor_t *sensor)
 {
     // Initialize sensor structure.
-    sensor->gs_bpp              = 2;
+    sensor->gs_bpp              = 1;
     sensor->reset               = reset;
     sensor->sleep               = sleep;
     sensor->read_reg            = read_reg;

--- a/src/omv/ov5640.c
+++ b/src/omv/ov5640.c
@@ -422,23 +422,23 @@ static int set_pixformat(sensor_t *sensor, pixformat_t pixformat)
         case PIXFORMAT_RGB565:
             ret |= cambus_writeb2(sensor->slv_addr, FORMAT_CONTROL, 0x61);
             ret |= cambus_writeb2(sensor->slv_addr, FORMAT_CONTROL_MUX, 0x01);
-            pll = (resolution[sensor->framesize][0] > 2048) ? 0x50 : 0x64; // 32 MHz vs 40 MHz
+            pll = 0x64; // 40 MHz
             break;
         case PIXFORMAT_GRAYSCALE:
         case PIXFORMAT_YUV422:
             ret |= cambus_writeb2(sensor->slv_addr, FORMAT_CONTROL, 0x10);
             ret |= cambus_writeb2(sensor->slv_addr, FORMAT_CONTROL_MUX, 0x00);
-            pll = (resolution[sensor->framesize][0] > 2048) ? 0x50 : 0x64; // 32 MHz vs 40 MHz
+            pll = 0x64; // 40 MHz
             break;
         case PIXFORMAT_BAYER:
             ret |= cambus_writeb2(sensor->slv_addr, FORMAT_CONTROL, 0x00);
             ret |= cambus_writeb2(sensor->slv_addr, FORMAT_CONTROL_MUX, 0x01);
-            pll = (resolution[sensor->framesize][0] > 2048) ? 0x64 : 0x50; // 40 MHz vs 32 MHz (jpeg can go faster at higher reses)
+            pll = 0x64; // 40 MHz (jpeg can go faster at higher reses)
             break;
         case PIXFORMAT_JPEG:
             ret |= cambus_writeb2(sensor->slv_addr, FORMAT_CONTROL, 0x30);
             ret |= cambus_writeb2(sensor->slv_addr, FORMAT_CONTROL_MUX, 0x00);
-            pll = (resolution[sensor->framesize][0] > 2048) ? 0x50 : 0x64; // 32 MHz vs 40 MHz
+            pll = 0x64; // 40 MHz
             break;
         default:
             return -1;
@@ -605,25 +605,7 @@ static int set_framesize(sensor_t *sensor, framesize_t framesize)
     ret |= cambus_writeb2(sensor->slv_addr, JPEG_CTRL07, (sensor_div > 1) ? 0x4 : 0x10);
 
     // Step 8: Adjust PLL freq.
-
-    switch (sensor->pixformat) {
-        case PIXFORMAT_RGB565:
-            pll = (w > 2048) ? 0x50 : 0x64; // 32 MHz vs 40 MHz
-            break;
-        case PIXFORMAT_GRAYSCALE:
-        case PIXFORMAT_YUV422:
-//            pll = (w > 2048) ? 0x50 : 0x64; // 32 MHz vs 40 MHz
-            pll = 0x64;
-            break;
-        case PIXFORMAT_BAYER:
-            pll = (w > 2048) ? 0x64 : 0x50; // 40 MHz vs 32 MHz (jpeg can go faster at higher reses)
-            break;
-        case PIXFORMAT_JPEG:
-            pll = (w > 2048) ? 0x50 : 0x64; // 32 MHz vs 40 MHz
-            break;
-        default:
-            return -1;
-    }
+    pll = 0x64; // 40 Mhz
 
     ret |= cambus_writeb2(sensor->slv_addr, SC_PLL_CONTRL2, pll);
 

--- a/src/omv/sensor.c
+++ b/src/omv/sensor.c
@@ -908,9 +908,9 @@ void DCMI_DMAConvCpltUser(uint32_t addr)
                     break;
                 case PIXFORMAT_GRAYSCALE:
                     dst += (line - MAIN_FB()->y) * MAIN_FB()->w;
-                    src += MAIN_FB()->x;
                     if (sensor.gs_bpp == 1) {
                         // 1BPP GRAYSCALE.
+                        src += MAIN_FB()->x;
                         memcpy(dst, src, MAIN_FB()->w);
                     } else {
                         uint32_t tmp1, tmp2, pix, *s, *d;


### PR DESCRIPTION
The OV5640 sensor produces up to a 2560x1944 image. At the highest res, the dma line copy code wasn't keeping up with the output of the sensor. I optimized this by improving the memory throughput. The Cortex-M7 has a 32-bit memory bus, so the fastest movement of memory is by reading and writing 32-bits at a time on aligned addresses. The memcpy() function already has code which detects if the source and destination addresses are 32-bit aligned, so most of the work was passed to memcpy().