### PR TITLE
Add raw data RD/WR access to the image object.

### DIFF
--- a/src/omv/py/py_image.c
+++ b/src/omv/py/py_image.c
@@ -633,6 +633,13 @@ static mp_obj_t py_image_size(mp_obj_t img_obj)
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_image_size_obj, py_image_size);
 
+static mp_obj_t py_image_bytearray(mp_obj_t img_obj)
+{
+    image_t *arg_img = (image_t *) py_image_cobj(img_obj);
+    return mp_obj_new_bytearray_by_ref(image_size(arg_img), arg_img->data);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_image_bytearray_obj, py_image_bytearray);
+
 STATIC mp_obj_t py_image_get_pixel(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
 {
     image_t *arg_img = py_helper_arg_to_image_mutable_bayer(args[0]);
@@ -6377,6 +6384,7 @@ static const mp_rom_map_elem_t locals_dict_table[] = {
     {MP_ROM_QSTR(MP_QSTR_height),              MP_ROM_PTR(&py_image_height_obj)},
     {MP_ROM_QSTR(MP_QSTR_format),              MP_ROM_PTR(&py_image_format_obj)},
     {MP_ROM_QSTR(MP_QSTR_size),                MP_ROM_PTR(&py_image_size_obj)},
+    {MP_ROM_QSTR(MP_QSTR_bytearray),           MP_ROM_PTR(&py_image_bytearray_obj)},
     {MP_ROM_QSTR(MP_QSTR_get_pixel),           MP_ROM_PTR(&py_image_get_pixel_obj)},
     {MP_ROM_QSTR(MP_QSTR_set_pixel),           MP_ROM_PTR(&py_image_set_pixel_obj)},
 #ifdef IMLIB_ENABLE_MEAN_POOLING


### PR DESCRIPTION
Do .bytearray() to get an object pointing to the image bytes which
allows you to manipulate the RAW data of an image.

This feature allows you to transfer images over a wire and load them back into memory again. Once cast to a bytearray() you can slice 16KB byte chunks for example from an image and transfer them one at a time. Additionally, you can also assign slices of data to an image. You can use alloc_extra_fb() to create a space to store an extra image.

...

That said, I'm just using this for easily transferring large jpeg images.