### PR TITLE
Fix DrawImage with alpha and add color palettes for grayscale

### DIFF
--- a/src/omv/img/draw.c
+++ b/src/omv/img/draw.c
@@ -480,9 +480,11 @@ void imlib_draw_image(image_t *img, image_t *other, int x_off, int y_off, float 
 
     const float neg_alpha = 1.0f - alpha;
     const int img_bpp = img->bpp;
+    const int other_bpp = other->bpp;
     const int xx = fast_floorf(other->w * x_scale);
+    const int yy = fast_floorf(other->h * y_scale);
 
-    for (int y = 0, yy = fast_floorf(other->h * y_scale); y < yy; y++) {
+    for (int y = 0; y < yy; y++) {
         int other_y = fast_floorf(y * over_yscale);
 
         for (int x = 0; x < xx; x++) {
@@ -492,8 +494,8 @@ void imlib_draw_image(image_t *img, image_t *other, int x_off, int y_off, float 
 
                 int other_pixel = imlib_get_pixel(other, other_x, other_y);
                 other_pixel = color_palette
-                    ? safe_map_pixel(img_bpp, IMAGE_BPP_RGB565, color_palette[other_pixel] )
-                    : safe_map_pixel(img_bpp, other->bpp, other_pixel);
+                    ? safe_map_pixel(img_bpp, IMAGE_BPP_RGB565, color_palette[other_pixel])
+                    : safe_map_pixel(img_bpp, other_bpp, other_pixel);
                 int img_pixel = imlib_get_pixel(img, x_off + x, y_off + y);
 				
                 int result_pixel;

--- a/src/omv/img/imlib.h
+++ b/src/omv/img/imlib.h
@@ -1281,7 +1281,7 @@ void imlib_draw_circle(image_t *img, int cx, int cy, int r, int c, int thickness
 void imlib_draw_ellipse(image_t *img, int cx, int cy, int rx, int ry, int rotation, int c, int thickness, bool fill);
 void imlib_draw_string(image_t *img, int x_off, int y_off, const char *str, int c, float scale, int x_spacing, int y_spacing, bool mono_space,
                        int char_rotation, bool char_hmirror, bool char_vflip, int string_rotation, bool string_hmirror, bool string_hflip);
-void imlib_draw_image(image_t *img, image_t *other, int x_off, int y_off, float x_scale, float y_scale, float alpha, image_t *mask);
+void imlib_draw_image(image_t *img, image_t *other, int x_off, int y_off, float x_scale, float y_scale, float alpha, image_t *mask, const uint16_t *color_palette);
 void imlib_flood_fill(image_t *img, int x, int y,
                       float seed_threshold, float floating_threshold,
                       int c, bool invert, bool clear_background, image_t *mask);

--- a/src/omv/py/py_image.c
+++ b/src/omv/py/py_image.c
@@ -1933,11 +1933,11 @@ STATIC mp_obj_t py_image_draw_image(uint n_args, const mp_obj_t *args, mp_map_t 
     PY_ASSERT_TRUE_MSG((0 <= arg_alpha) && (arg_alpha <= 1), "Error: 0 <= alpha <= 256!");
     image_t *arg_msk =
         py_helper_keyword_to_image_mutable_mask(n_args, args, offset + 3, kw_args);
-    int palette = py_helper_keyword_int(n_args, args, offset + 3, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_color_palette), -1);
+    int palette = py_helper_keyword_int(n_args, args, offset + 4, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_color_palette), -1);
 
     const uint16_t *color_palette = NULL;
 
-    if(palette!=-1) {
+    if (palette != -1) {
         if (palette == COLOR_PALETTE_RAINBOW) {
             color_palette = rainbow_table;
         } else if (palette == COLOR_PALETTE_IRONBOW) {

--- a/src/omv/py/py_image.c
+++ b/src/omv/py/py_image.c
@@ -1933,8 +1933,23 @@ STATIC mp_obj_t py_image_draw_image(uint n_args, const mp_obj_t *args, mp_map_t 
     PY_ASSERT_TRUE_MSG((0 <= arg_alpha) && (arg_alpha <= 1), "Error: 0 <= alpha <= 256!");
     image_t *arg_msk =
         py_helper_keyword_to_image_mutable_mask(n_args, args, offset + 3, kw_args);
+    int palette = py_helper_keyword_int(n_args, args, offset + 3, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_color_palette), -1);
 
-    imlib_draw_image(arg_img, arg_other, arg_cx, arg_cy, arg_x_scale, arg_y_scale, arg_alpha, arg_msk);
+    const uint16_t *color_palette = NULL;
+
+    if(palette!=-1) {
+        if (palette == COLOR_PALETTE_RAINBOW) {
+            color_palette = rainbow_table;
+        } else if (palette == COLOR_PALETTE_IRONBOW) {
+            color_palette = ironbow_table;
+        } else {
+            nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Invalid color palette!"));
+        }
+
+        if (arg_other->bpp != IMAGE_BPP_GRAYSCALE) nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Can only specify color palette when passing a grayscale image!"));
+    }
+
+    imlib_draw_image(arg_img, arg_other, arg_cx, arg_cy, arg_x_scale, arg_y_scale, arg_alpha, arg_msk, color_palette);
     return args[0];
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_image_draw_image_obj, 3, py_image_draw_image);


### PR DESCRIPTION
1/ image.draw_image fails to apply alpha correctly on anything other than grayscale images, this fixes that.
2/ it also adds a new parameter to image.draw_image, color_palette. The palette is used when the other image is a grayscale image such as thermographic when you want an e.g. rainbow palette to be applied. This saves allocating extra memory for a separate buffer for the color thermograph then using a function such as image.blend to blend to the camera. If you pass a color_palette and the other image is not grayscale an exception is raised.

