### PR TITLE
Add disable_fb.

### DIFF
--- a/src/omv/framebuffer.h
+++ b/src/omv/framebuffer.h
@@ -19,7 +19,7 @@ typedef struct framebuffer {
     int32_t w,h;
     int32_t u,v;
     int32_t bpp;
-    int32_t padding;
+    int32_t fb_streaming_disable;
     // NOTE: This buffer must be aligned on a 16 byte boundary
     uint8_t pixels[];
 } framebuffer_t;
@@ -46,6 +46,10 @@ extern jpegbuffer_t *jpeg_fb_framebuffer;
 
 // Use this macro to get a pointer to the free SRAM area located after the framebuffer.
 #define JPEG_FB_PIXELS()    (JPEG_FB()->pixels + JPEG_FB()->size)
+
+// Force fb streaming to the IDE off.
+void set_fb_streaming_disabled(bool en);
+bool is_fb_streaming_disabled();
 
 // Encode jpeg data for transmission over a text channel.
 int encode_for_ide_new_size(image_t *img);

--- a/src/omv/py/py_omv.c
+++ b/src/omv/py/py_omv.c
@@ -10,6 +10,7 @@
  */
 #include <mp.h>
 #include "usbdbg.h"
+#include "framebuffer.h"
 #include "omv_boardconfig.h"
 
 static mp_obj_t py_omv_version_string()
@@ -48,6 +49,16 @@ static mp_obj_t py_omv_board_id()
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_omv_board_id_obj, py_omv_board_id);
 
+static mp_obj_t py_omv_disable_fb(uint n_args, const mp_obj_t *args)
+{
+    if (!n_args) {
+        return mp_obj_new_bool(is_fb_streaming_disabled());
+    }
+    set_fb_streaming_disabled(mp_obj_get_int(args[0]));
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(py_omv_disable_fb_obj, 0, 1, py_omv_disable_fb);
+
 static const mp_rom_map_elem_t globals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),        MP_OBJ_NEW_QSTR(MP_QSTR_omv) },
     { MP_ROM_QSTR(MP_QSTR_version_major),   MP_ROM_INT(FIRMWARE_VERSION_MAJOR) },
@@ -56,7 +67,8 @@ static const mp_rom_map_elem_t globals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_version_string),  MP_ROM_PTR(&py_omv_version_string_obj) },
     { MP_ROM_QSTR(MP_QSTR_arch),            MP_ROM_PTR(&py_omv_arch_obj) },
     { MP_ROM_QSTR(MP_QSTR_board_type),      MP_ROM_PTR(&py_omv_board_type_obj) },
-    { MP_ROM_QSTR(MP_QSTR_board_id),        MP_ROM_PTR(&py_omv_board_id_obj) }
+    { MP_ROM_QSTR(MP_QSTR_board_id),        MP_ROM_PTR(&py_omv_board_id_obj) },
+    { MP_ROM_QSTR(MP_QSTR_disable_fb),      MP_ROM_PTR(&py_omv_disable_fb_obj) }
 };
 
 STATIC MP_DEFINE_CONST_DICT(globals_dict, globals_dict_table);

--- a/src/omv/py/qstrdefsomv.h
+++ b/src/omv/py/qstrdefsomv.h
@@ -18,6 +18,7 @@ Q(version_string)
 Q(arch)
 Q(board_type)
 Q(board_id)
+Q(disable_fb)
 
 // Image module
 Q(image)


### PR DESCRIPTION
Allow user control to disable the frame buffer. Necessary for high manual
jpeg image streaming.