### PR TITLE
draw_image bi-linear interpolation, alpha palettes, and center_image

### DIFF
--- a/scripts/examples/03-Drawing/image_drawing_advanced.py
+++ b/scripts/examples/03-Drawing/image_drawing_advanced.py
@@ -26,14 +26,14 @@ x = 100
 y = 50
 
 # Bounce direction
-xd = .1
-yd = .1
+xd = 1
+yd = 1
 
 # Small image scaling
 rescale = 1.0
-rd = 0.01
+rd = 0.1
 max_rescale = 5
-min_rescale = -max_rescale
+min_rescale = rd * 2
 
 # Boundary to bounce within
 xmin = -sensor.width() / SMALL_IMAGE_SCALE - 8
@@ -81,11 +81,11 @@ while(True):
 
     apply_mask = CYCLE_MASK and ((value_mixer >> 9) & 1)
     if apply_mask:
-        img.draw_image(small_img, int(x), int(y), mask=small_img.to_bitmap(copy=True), x_scale=-rescale, y_scale=rescale, alpha=240, hint=image.IMAGE_HINT_BILINEAR | image.IMAGE_HINT_CENTER)
+        img.draw_image(small_img, int(x), int(y), mask=small_img.to_bitmap(copy=True), x_scale=rescale, y_scale=rescale, alpha=240, hint=image.IMAGE_HINT_BILINEAR | image.IMAGE_HINT_CENTER)
         status += 'alpha:240 '
         status += '+mask '
     else:
-        img.draw_image(small_img, int(x), int(y), x_scale=-rescale, y_scale=rescale, alpha=128, hint=image.IMAGE_HINT_BILINEAR | image.IMAGE_HINT_CENTER)
+        img.draw_image(small_img, int(x), int(y), x_scale=rescale, y_scale=rescale, alpha=128, hint=image.IMAGE_HINT_BILINEAR | image.IMAGE_HINT_CENTER)
         status += 'alpha:128 '
 
     img.draw_string(8, 0, status, mono_space = False)

--- a/scripts/examples/03-Drawing/image_drawing_advanced.py
+++ b/scripts/examples/03-Drawing/image_drawing_advanced.py
@@ -81,11 +81,11 @@ while(True):
 
     apply_mask = CYCLE_MASK and ((value_mixer >> 9) & 1)
     if apply_mask:
-        img.draw_image(small_img, int(x), int(y), mask=small_img.to_bitmap(copy=True), x_scale=-rescale, y_scale=rescale, alpha=240, hint=image.INTERPOLATE_BILINEAR | image.IMAGE_CENTER)
+        img.draw_image(small_img, int(x), int(y), mask=small_img.to_bitmap(copy=True), x_scale=-rescale, y_scale=rescale, alpha=240, hint=image.IMAGE_HINT_BILINEAR | image.IMAGE_HINT_CENTER)
         status += 'alpha:240 '
         status += '+mask '
     else:
-        img.draw_image(small_img, int(x), int(y), x_scale=-rescale, y_scale=rescale, alpha=128, hint=image.INTERPOLATE_BILINEAR | image.IMAGE_CENTER)
+        img.draw_image(small_img, int(x), int(y), x_scale=-rescale, y_scale=rescale, alpha=128, hint=image.IMAGE_HINT_BILINEAR | image.IMAGE_HINT_CENTER)
         status += 'alpha:128 '
 
     img.draw_string(8, 0, status, mono_space = False)

--- a/scripts/examples/03-Drawing/image_drawing_advanced.py
+++ b/scripts/examples/03-Drawing/image_drawing_advanced.py
@@ -6,7 +6,7 @@ import sensor, image, time, pyb
 
 sensor.reset()
 sensor.set_pixformat(sensor.RGB565) # or GRAYSCALE...
-sensor.set_framesize(sensor.QQVGA) # or QQVGA...
+sensor.set_framesize(sensor.QVGA) # or QQVGA...
 sensor.skip_frames(time = 2000)
 clock = time.clock()
 
@@ -22,16 +22,16 @@ CYCLE_MASK = True
 value_mixer = 0
 
 # Location of small image
-x=100
-y=50
+x = 100
+y = 50
 
 # Bounce direction
-xd=.1
-yd=.1
+xd = .1
+yd = .1
 
 # Small image scaling
 rescale = 1.0
-rd=0.01
+rd = 0.01
 max_rescale = 5
 min_rescale = -max_rescale
 
@@ -78,16 +78,14 @@ while(True):
     # Find the center of the image
     scaled_width = int(small_img.width() * abs(rescale))
     scaled_height= int(small_img.height() * abs(rescale))
-    draw_x = int(x - (scaled_width >> 1))
-    draw_y = int(y - (scaled_height >> 1))
 
     apply_mask = CYCLE_MASK and ((value_mixer >> 9) & 1)
     if apply_mask:
-        img.draw_image(small_img, draw_x, draw_y, mask=small_img.to_bitmap(copy=True), x_scale=-rescale, y_scale=rescale, alpha=240)
+        img.draw_image(small_img, int(x), int(y), mask=small_img.to_bitmap(copy=True), x_scale=-rescale, y_scale=rescale, alpha=240, hint=image.INTERPOLATE_BILINEAR | image.IMAGE_CENTER)
         status += 'alpha:240 '
         status += '+mask '
     else:
-        img.draw_image(small_img, draw_x, draw_y, x_scale=-rescale, y_scale=rescale, alpha=128)
+        img.draw_image(small_img, int(x), int(y), x_scale=-rescale, y_scale=rescale, alpha=128, hint=image.INTERPOLATE_BILINEAR | image.IMAGE_CENTER)
         status += 'alpha:128 '
 
     img.draw_string(8, 0, status, mono_space = False)

--- a/src/omv/img/draw.c
+++ b/src/omv/img/draw.c
@@ -842,7 +842,13 @@ void imlib_draw_image(image_t *img, image_t *other, int x_off, int y_off, float 
                         if (!mask || image_get_mask_pixel(mask, other_x, other_y)) {
                             uint8_t result_pixel = safe_map_pixel(IMAGE_BPP_GRAYSCALE, other_bpp, imlib_get_pixel_fast(other_bpp, other_row_ptr, other_x));
 
-                            if (alpha != 256) {
+                            if (alpha_palette) {
+                                uint32_t temp_alpha = (alpha * alpha_palette[result_pixel]) >> 8;
+                                
+                                packed_alpha = (temp_alpha << 16) + (256 - temp_alpha);
+                            }
+
+                            if (packed_alpha & 0x1ff) {
                                 uint8_t img_pixel = IMAGE_GET_GRAYSCALE_PIXEL_FAST(img_row_ptr,  x);
                                 uint32_t vgs = (result_pixel << 16) + img_pixel;
 
@@ -968,7 +974,7 @@ void imlib_draw_image(image_t *img, image_t *other, int x_off, int y_off, float 
                             }
                             result_pixel = color_palette ? color_palette[result_pixel] : safe_map_pixel(IMAGE_BPP_RGB565, other_bpp, result_pixel);
                             
-                            if (va & 0xff) {
+                            if (va & 0x1ff) {
                                 // Blend img to other pixel
                                 uint16_t img_pixel = IMAGE_GET_RGB565_PIXEL_FAST(img_row_ptr, x);
                                 uint32_t r_ta = COLOR_RGB565_TO_R5(result_pixel);

--- a/src/omv/img/imlib.h
+++ b/src/omv/img/imlib.h
@@ -1142,9 +1142,9 @@ typedef struct find_barcodes_list_lnk_data {
 } find_barcodes_list_lnk_data_t;
 
 typedef enum image_hint {
-    INTERPOLATE_BILINEAR = 1,
-    IMAGE_CENTER = 128
-} image_hint_type;
+    IMAGE_HINT_BILINEAR = 1,
+    IMAGE_HINT_CENTER = 128
+} image_hint_t;
 
 
 /* Color space functions */
@@ -1290,7 +1290,7 @@ void imlib_draw_ellipse(image_t *img, int cx, int cy, int rx, int ry, int rotati
 void imlib_draw_string(image_t *img, int x_off, int y_off, const char *str, int c, float scale, int x_spacing, int y_spacing, bool mono_space,
                        int char_rotation, bool char_hmirror, bool char_vflip, int string_rotation, bool string_hmirror, bool string_hflip);
 void imlib_draw_image(image_t *img, image_t *other, int x_off, int y_off, float x_scale, float y_scale, int alpha, image_t *mask,
-                      const uint16_t *color_palette, const uint8_t *alpha_palette, image_hint_type hint);
+                      const uint16_t *color_palette, const uint8_t *alpha_palette, image_hint_t hint);
 void imlib_flood_fill(image_t *img, int x, int y,
                       float seed_threshold, float floating_threshold,
                       int c, bool invert, bool clear_background, image_t *mask);

--- a/src/omv/img/imlib.h
+++ b/src/omv/img/imlib.h
@@ -259,7 +259,7 @@ extern const uint8_t g826_table[256];
     __typeof__ (r5) _r5 = (r5); \
     __typeof__ (g6) _g6 = (g6); \
     __typeof__ (b5) _b5 = (b5); \
-    (_r5 << 3) | (_g6 >> 3) | ((_g6 & 0x7) << 13) | (_b5 << 8); \
+    __REV16((_r5 << 11) | (_g6 << 5) | _b5); \
 })
 
 #define COLOR_R8_G8_B8_TO_RGB565(r8, g8, b8) COLOR_R5_G6_B5_TO_RGB565(COLOR_R8_TO_R5(r8), COLOR_G8_TO_G6(g8), COLOR_B8_TO_B5(b8))
@@ -1141,6 +1141,12 @@ typedef struct find_barcodes_list_lnk_data {
     int quality;
 } find_barcodes_list_lnk_data_t;
 
+typedef enum image_hint {
+    INTERPOLATE_BILINEAR = 1,
+    IMAGE_CENTER = 128
+} image_hint_type;
+
+
 /* Color space functions */
 int8_t imlib_rgb565_to_l(uint16_t pixel);
 int8_t imlib_rgb565_to_a(uint16_t pixel);
@@ -1283,7 +1289,8 @@ void imlib_draw_circle(image_t *img, int cx, int cy, int r, int c, int thickness
 void imlib_draw_ellipse(image_t *img, int cx, int cy, int rx, int ry, int rotation, int c, int thickness, bool fill);
 void imlib_draw_string(image_t *img, int x_off, int y_off, const char *str, int c, float scale, int x_spacing, int y_spacing, bool mono_space,
                        int char_rotation, bool char_hmirror, bool char_vflip, int string_rotation, bool string_hmirror, bool string_hflip);
-void imlib_draw_image(image_t *img, image_t *other, int x_off, int y_off, float x_scale, float y_scale, int alpha, image_t *mask, const uint16_t *color_palette);
+void imlib_draw_image(image_t *img, image_t *other, int x_off, int y_off, float x_scale, float y_scale, int alpha, image_t *mask,
+                      const uint16_t *color_palette, const uint8_t *alpha_palette, image_hint_type hint);
 void imlib_flood_fill(image_t *img, int x, int y,
                       float seed_threshold, float floating_threshold,
                       int c, bool invert, bool clear_background, image_t *mask);

--- a/src/omv/py/py_helper.c
+++ b/src/omv/py/py_helper.c
@@ -73,6 +73,12 @@ image_t *py_helper_keyword_to_image_mutable_color_palette(uint n_args, const mp_
     return py_helper_keyword_to_image_mutable(n_args, args, arg_index, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_color_palette), NULL);
 }
 
+image_t *py_helper_keyword_to_image_mutable_alpha_palette(uint n_args, const mp_obj_t *args, uint arg_index,
+                                                          mp_map_t *kw_args)
+{
+    return py_helper_keyword_to_image_mutable(n_args, args, arg_index, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_alpha_palette), NULL);
+}
+
 void py_helper_keyword_rectangle(image_t *img, uint n_args, const mp_obj_t *args, uint arg_index,
                                  mp_map_t *kw_args, mp_obj_t kw, rectangle_t *r)
 {

--- a/src/omv/py/py_helper.h
+++ b/src/omv/py/py_helper.h
@@ -22,7 +22,9 @@ image_t *py_helper_keyword_to_image_mutable(uint n_args, const mp_obj_t *args, u
 image_t *py_helper_keyword_to_image_mutable_mask(uint n_args, const mp_obj_t *args, uint arg_index,
                                                  mp_map_t *kw_args);
 image_t *py_helper_keyword_to_image_mutable_color_palette(uint n_args, const mp_obj_t *args, uint arg_index,
-                                            mp_map_t *kw_args);
+                                                          mp_map_t *kw_args);
+image_t *py_helper_keyword_to_image_mutable_alpha_palette(uint n_args, const mp_obj_t *args, uint arg_index,
+                                                          mp_map_t *kw_args);
 void py_helper_keyword_rectangle(image_t *img, uint n_args, const mp_obj_t *args, uint arg_index,
                                  mp_map_t *kw_args, mp_obj_t kw, rectangle_t *r);
 void py_helper_keyword_rectangle_roi(image_t *img, uint n_args, const mp_obj_t *args, uint arg_index,

--- a/src/omv/py/py_image.c
+++ b/src/omv/py/py_image.c
@@ -1933,31 +1933,62 @@ STATIC mp_obj_t py_image_draw_image(uint n_args, const mp_obj_t *args, mp_map_t 
         py_helper_keyword_to_image_mutable_mask(n_args, args, offset + 3, kw_args);
     
     const uint16_t *color_palette = NULL;
-    int palette;
-    
-    if (py_helper_keyword_int_maybe(n_args, args, offset + 4, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_color_palette), &palette)) {
-        if (palette == COLOR_PALETTE_RAINBOW) {
-            color_palette = rainbow_table;
-        } else if (palette == COLOR_PALETTE_IRONBOW) {
-            color_palette = ironbow_table;
-        } else {
-            nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Invalid color palette!"));
-        }
-    } else {
-        image_t *arg_palette = py_helper_keyword_to_image_mutable_color_palette(n_args, args, offset + 4, kw_args);
+    {
+        int palette;
         
-        if (arg_palette) {
-            if (arg_palette->bpp != IMAGE_BPP_RGB565) nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Palette must be an RGB565 format image!"));
-            if ((arg_palette->w * arg_palette->h) != 256) nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Palette image must have 256 pixels!"));
-            color_palette = (uint16_t*)arg_palette->data;
+        if (py_helper_keyword_int_maybe(n_args, args, offset + 4, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_color_palette), &palette)) {
+            if (palette == COLOR_PALETTE_RAINBOW) {
+                color_palette = rainbow_table;
+            } else if (palette == COLOR_PALETTE_IRONBOW) {
+                color_palette = ironbow_table;
+            } else {
+                nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Invalid pre-defined color palette!"));
+            }
+        } else {
+            image_t *arg_color_palette = py_helper_keyword_to_image_mutable_color_palette(n_args, args, offset + 4, kw_args);
+            
+            if (arg_color_palette) {
+                if (arg_color_palette->bpp != IMAGE_BPP_RGB565) nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Color palette must be an RGB565 format image!"));
+                if ((arg_color_palette->w * arg_color_palette->h) != 256) nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Color palette image must have 256 pixels!"));
+
+                color_palette = (uint16_t*)arg_color_palette->data;
+            }
+        }
+
+        if (color_palette) {
+            if (arg_other->bpp != IMAGE_BPP_GRAYSCALE) nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Can only specify a color palette when passing a grayscale image!"));
         }
     }
 
-    if (color_palette) {
-        if (arg_other->bpp != IMAGE_BPP_GRAYSCALE) nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Can only specify color palette when passing a grayscale image!"));
+    const uint8_t *alpha_palette = NULL;
+    {
+        image_t *arg_alpha_palette = py_helper_keyword_to_image_mutable_alpha_palette(n_args, args, offset + 5, kw_args);
+        
+        if (arg_alpha_palette) {
+            if (arg_other->bpp != IMAGE_BPP_GRAYSCALE) nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Can only specify an alpha palette when passing a grayscale image!"));
+            if (arg_alpha_palette->bpp != IMAGE_BPP_GRAYSCALE) nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Alpha palette must be an grayscale format image!"));
+            if ((arg_alpha_palette->w * arg_alpha_palette->h) != 256) nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Alpha palette image must have 256 pixels!"));
+
+            alpha_palette = (uint8_t*)arg_alpha_palette->data;
+        }
     }
 
-    imlib_draw_image(arg_img, arg_other, arg_cx, arg_cy, arg_x_scale, arg_y_scale, arg_alpha, arg_msk, color_palette);
+    if ((color_palette || alpha_palette) && arg_img->bpp != IMAGE_BPP_RGB565) {
+        nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Palettes must be used with color images!"));
+    }
+
+    image_hint_type hint =
+        py_helper_keyword_int(n_args, args, offset + 6, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_hint), 0);
+
+    if (hint && arg_msk) {
+        // This check is only performed if there is a hint for backwards compatiblity with old draw image where dimesions were not enforced.
+        if (arg_msk->w != arg_other->w || arg_msk->h != arg_other->h) {
+            nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Mask must have same dimensions as image"));
+        }
+    }
+
+    imlib_draw_image(arg_img, arg_other, arg_cx, arg_cy, arg_x_scale, arg_y_scale, arg_alpha, arg_msk, color_palette, alpha_palette, hint);
+    
     return args[0];
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_image_draw_image_obj, 3, py_image_draw_image);
@@ -7594,6 +7625,8 @@ static const mp_rom_map_elem_t globals_dict_table[] = {
     {MP_ROM_QSTR(MP_QSTR_CODE93),              MP_ROM_INT(BARCODE_CODE93)},
     {MP_ROM_QSTR(MP_QSTR_CODE128),             MP_ROM_INT(BARCODE_CODE128)},
 #endif
+    {MP_ROM_QSTR(MP_QSTR_INTERPOLATE_BILINEAR),MP_ROM_INT(INTERPOLATE_BILINEAR)},
+    {MP_ROM_QSTR(MP_QSTR_IMAGE_CENTER),        MP_ROM_INT(IMAGE_CENTER)},
     {MP_ROM_QSTR(MP_QSTR_ImageWriter),         MP_ROM_PTR(&py_image_imagewriter_obj)},
     {MP_ROM_QSTR(MP_QSTR_ImageReader),         MP_ROM_PTR(&py_image_imagereader_obj)},
     {MP_ROM_QSTR(MP_QSTR_binary_to_grayscale), MP_ROM_PTR(&py_image_binary_to_grayscale_obj)},

--- a/src/omv/py/py_image.c
+++ b/src/omv/py/py_image.c
@@ -1964,6 +1964,10 @@ STATIC mp_obj_t py_image_draw_image(uint n_args, const mp_obj_t *args, mp_map_t 
         }
     }
 
+    if (color_palette && arg_img->bpp != IMAGE_BPP_RGB565) {
+        nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Color palettes must be used with color images!"));
+    }
+
     const uint8_t *alpha_palette = NULL;
     {
         image_t *arg_alpha_palette = py_helper_keyword_to_image_mutable_alpha_palette(n_args, args, offset + 5, kw_args);
@@ -1972,13 +1976,10 @@ STATIC mp_obj_t py_image_draw_image(uint n_args, const mp_obj_t *args, mp_map_t 
             if (arg_other->bpp != IMAGE_BPP_GRAYSCALE) nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Can only specify an alpha palette when passing a grayscale image!"));
             if (arg_alpha_palette->bpp != IMAGE_BPP_GRAYSCALE) nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Alpha palette must be an grayscale format image!"));
             if ((arg_alpha_palette->w * arg_alpha_palette->h) != 256) nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Alpha palette image must have 256 pixels!"));
+            if (arg_img->bpp != IMAGE_BPP_GRAYSCALE && arg_img->bpp != IMAGE_BPP_RGB565) nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Alpha palettes must be used with color images!"));
 
             alpha_palette = (uint8_t*)arg_alpha_palette->data;
         }
-    }
-
-    if ((color_palette || alpha_palette) && arg_img->bpp != IMAGE_BPP_RGB565) {
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Palettes must be used with color images!"));
     }
 
     image_hint_t hint =

--- a/src/omv/py/py_image.c
+++ b/src/omv/py/py_image.c
@@ -1924,8 +1924,12 @@ STATIC mp_obj_t py_image_draw_image(uint n_args, const mp_obj_t *args, mp_map_t 
 
     float arg_x_scale =
         py_helper_keyword_float(n_args, args, offset + 0, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_x_scale), 1.0f);
+    PY_ASSERT_TRUE_MSG((0.0f <= arg_x_scale), "Error: 0.0 <= x_scale!");
+
     float arg_y_scale =
         py_helper_keyword_float(n_args, args, offset + 1, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_y_scale), 1.0f);
+    PY_ASSERT_TRUE_MSG((0.0f <= arg_y_scale), "Error: 0.0 <= y_scale!");
+    
     int arg_alpha =
         py_helper_keyword_int(n_args, args, offset + 2, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_alpha), 256);
     PY_ASSERT_TRUE_MSG((0 <= arg_alpha) && (arg_alpha <= 256), "Error: 0 <= alpha <= 256!");

--- a/src/omv/py/py_image.c
+++ b/src/omv/py/py_image.c
@@ -1977,7 +1977,7 @@ STATIC mp_obj_t py_image_draw_image(uint n_args, const mp_obj_t *args, mp_map_t 
         nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Palettes must be used with color images!"));
     }
 
-    image_hint_type hint =
+    image_hint_t hint =
         py_helper_keyword_int(n_args, args, offset + 6, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_hint), 0);
 
     if (hint && arg_msk) {
@@ -7625,8 +7625,8 @@ static const mp_rom_map_elem_t globals_dict_table[] = {
     {MP_ROM_QSTR(MP_QSTR_CODE93),              MP_ROM_INT(BARCODE_CODE93)},
     {MP_ROM_QSTR(MP_QSTR_CODE128),             MP_ROM_INT(BARCODE_CODE128)},
 #endif
-    {MP_ROM_QSTR(MP_QSTR_INTERPOLATE_BILINEAR),MP_ROM_INT(INTERPOLATE_BILINEAR)},
-    {MP_ROM_QSTR(MP_QSTR_IMAGE_CENTER),        MP_ROM_INT(IMAGE_CENTER)},
+    {MP_ROM_QSTR(MP_QSTR_IMAGE_HINT_BILINEAR),MP_ROM_INT(IMAGE_HINT_BILINEAR)},
+    {MP_ROM_QSTR(MP_QSTR_IMAGE_HINT_CENTER),        MP_ROM_INT(IMAGE_HINT_CENTER)},
     {MP_ROM_QSTR(MP_QSTR_ImageWriter),         MP_ROM_PTR(&py_image_imagewriter_obj)},
     {MP_ROM_QSTR(MP_QSTR_ImageReader),         MP_ROM_PTR(&py_image_imagereader_obj)},
     {MP_ROM_QSTR(MP_QSTR_binary_to_grayscale), MP_ROM_PTR(&py_image_binary_to_grayscale_obj)},

--- a/src/omv/py/qstrdefsomv.h
+++ b/src/omv/py/qstrdefsomv.h
@@ -553,8 +553,8 @@ Q(draw_image)
 Q(alpha)
 // duplicate Q(mask)
 Q(hint)
-Q(INTERPOLATE_BILINEAR)
-Q(IMAGE_CENTER)
+Q(IMAGE_HINT_BILINEAR)
+Q(IMAGE_HINT_CENTER)
 
 // Draw Keypoints
 Q(draw_keypoints)

--- a/src/omv/py/qstrdefsomv.h
+++ b/src/omv/py/qstrdefsomv.h
@@ -450,6 +450,7 @@ Q(to_rainbow)
 // duplicate Q(copy)
 // duplicate Q(rgb_channel)
 Q(color_palette)
+Q(alpha_palette)
 
 // Compress (in place)
 Q(compress)
@@ -551,6 +552,9 @@ Q(draw_image)
 // duplicate Q(y_scale)
 Q(alpha)
 // duplicate Q(mask)
+Q(hint)
+Q(INTERPOLATE_BILINEAR)
+Q(IMAGE_CENTER)
 
 // Draw Keypoints
 Q(draw_keypoints)


### PR DESCRIPTION
There's an extra parameter on draw_image called hint.
It can take the values:
image.BILINEAR_INTERPOLATION which smooths images
image.IMAGE_CENTER which makes x,y coordinates relative to the center of the image.
e.g. hint=image.BILINEAR_INTERPOLATION | image.IMAGE_CENTER 

There's an extra parameter on draw_image called alpha_pallete
This works the same as color palette except it creates an alpha value based on the grayscale image.
This is very useful for combining thermal images to sensor when you want some areas to be clear with smoothed edges.