### PR TITLE
Make cambus functions accept I2C handle.

### DIFF
--- a/src/lepton/src/LEPTON_I2C_Service.c
+++ b/src/lepton/src/LEPTON_I2C_Service.c
@@ -71,7 +71,9 @@
 #include "LEPTON_Types.h"
 #include "LEPTON_ErrorCodes.h"
 #include "LEPTON_I2C_Service.h"
+#include "sensor.h"
 #include "cambus.h"
+extern sensor_t sensor;
 
 /******************************************************************************/
 /** LOCAL DEFINES                                                            **/
@@ -163,7 +165,7 @@ LEP_RESULT LEP_I2C_MasterReadData(LEP_UINT16 portID,
     LEP_RESULT result = LEP_OK;
 
     for (int i = 0; i < dataLength; i++) {
-        if (cambus_readw2(deviceAddress << 1, subAddress + (i * 2), &dataPtr[i])) return LEP_ERROR;
+        if (cambus_readw2(&sensor.i2c, deviceAddress << 1, subAddress + (i * 2), &dataPtr[i])) return LEP_ERROR;
     }
 
     return(result);
@@ -191,7 +193,7 @@ LEP_RESULT LEP_I2C_MasterWriteData(LEP_UINT16 portID,
     LEP_RESULT result = LEP_OK;
 
     for (int i = 0; i < dataLength; i++) {
-        if (cambus_writew2(deviceAddress << 1, subAddress + (i * 2), dataPtr[i])) return LEP_ERROR;
+        if (cambus_writew2(&sensor.i2c, deviceAddress << 1, subAddress + (i * 2), dataPtr[i])) return LEP_ERROR;
     }
 
     return(result);
@@ -205,7 +207,7 @@ LEP_RESULT LEP_I2C_MasterReadRegister(LEP_UINT16 portID,
 {
     LEP_RESULT result = LEP_OK;
 
-    if (cambus_readw2(deviceAddress << 1, regAddress, regValue)) return LEP_ERROR;
+    if (cambus_readw2(&sensor.i2c, deviceAddress << 1, regAddress, regValue)) return LEP_ERROR;
 
     return(result);
 }
@@ -218,7 +220,7 @@ LEP_RESULT LEP_I2C_MasterWriteRegister(LEP_UINT16 portID,
 {
     LEP_RESULT result = LEP_OK;
 
-    if (cambus_writew2(deviceAddress << 1, regAddress, regValue)) return LEP_ERROR;
+    if (cambus_writew2(&sensor.i2c, deviceAddress << 1, regAddress, regValue)) return LEP_ERROR;
 
     return(result);
 }

--- a/src/omv/boards/OPENMV2/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV2/omv_boardconfig.h
@@ -107,6 +107,7 @@
 #define SCCB_PORT               (GPIOB)
 #define SCCB_SCL_PIN            (GPIO_PIN_8)
 #define SCCB_SDA_PIN            (GPIO_PIN_9)
+#define SCCB_TIMING             (0) // ignored
 
 /* DCMI */
 #define DCMI_TIM                (TIM1)

--- a/src/omv/cambus.h
+++ b/src/omv/cambus.h
@@ -11,14 +11,17 @@
 #ifndef __CAMBUS_H__
 #define __CAMBUS_H__
 #include <stdint.h>
-int cambus_init();
-int cambus_scan();
-int cambus_readb(uint8_t slv_addr, uint8_t reg_addr,  uint8_t *reg_data);
-int cambus_writeb(uint8_t slv_addr, uint8_t reg_addr, uint8_t reg_data);
-int cambus_readb2(uint8_t slv_addr, uint16_t reg_addr,  uint8_t *reg_data);
-int cambus_writeb2(uint8_t slv_addr, uint16_t reg_addr, uint8_t reg_data);
-int cambus_readw(uint8_t slv_addr, uint8_t reg_addr,  uint16_t *reg_data);
-int cambus_writew(uint8_t slv_addr, uint8_t reg_addr, uint16_t reg_data);
-int cambus_readw2(uint8_t slv_addr, uint16_t reg_addr,  uint16_t *reg_data);
-int cambus_writew2(uint8_t slv_addr, uint16_t reg_addr, uint16_t reg_data);
+#include STM32_HAL_H
+
+int cambus_init(I2C_HandleTypeDef *i2c, I2C_TypeDef *instance, uint32_t timing);
+int cambus_deinit(I2C_HandleTypeDef *i2c);
+int cambus_scan(I2C_HandleTypeDef *i2c);
+int cambus_readb(I2C_HandleTypeDef *i2c, uint8_t slv_addr, uint8_t reg_addr,  uint8_t *reg_data);
+int cambus_writeb(I2C_HandleTypeDef *i2c, uint8_t slv_addr, uint8_t reg_addr, uint8_t reg_data);
+int cambus_readb2(I2C_HandleTypeDef *i2c, uint8_t slv_addr, uint16_t reg_addr,  uint8_t *reg_data);
+int cambus_writeb2(I2C_HandleTypeDef *i2c, uint8_t slv_addr, uint16_t reg_addr, uint8_t reg_data);
+int cambus_readw(I2C_HandleTypeDef *i2c, uint8_t slv_addr, uint8_t reg_addr,  uint16_t *reg_data);
+int cambus_writew(I2C_HandleTypeDef *i2c, uint8_t slv_addr, uint8_t reg_addr, uint16_t reg_data);
+int cambus_readw2(I2C_HandleTypeDef *i2c, uint8_t slv_addr, uint16_t reg_addr,  uint16_t *reg_data);
+int cambus_writew2(I2C_HandleTypeDef *i2c, uint8_t slv_addr, uint16_t reg_addr, uint16_t reg_data);
 #endif // __CAMBUS_H__

--- a/src/omv/hm01b0.c
+++ b/src/omv/hm01b0.c
@@ -119,12 +119,12 @@ static int reset(sensor_t *sensor)
         if (retry == 0) {
             return -1;
         }
-        if (cambus_writeb2(sensor->slv_addr, SW_RESET, HIMAX_RESET) != 0) {
+        if (cambus_writeb2(&sensor->i2c, sensor->slv_addr, SW_RESET, HIMAX_RESET) != 0) {
             return -1;
         }
         // Delay for 1ms.
         systick_sleep(1);
-        if (cambus_readb2(sensor->slv_addr, MODE_SELECT, &reg) != 0) {
+        if (cambus_readb2(&sensor->i2c, sensor->slv_addr, MODE_SELECT, &reg) != 0) {
             return -1;
         }
     }
@@ -132,14 +132,14 @@ static int reset(sensor_t *sensor)
     // Write default regsiters
     int ret = 0;
     for (int i=0; default_regs[i][0] && ret == 0; i++) {
-        ret |= cambus_writeb2(sensor->slv_addr, default_regs[i][0], default_regs[i][1]);
+        ret |= cambus_writeb2(&sensor->i2c, sensor->slv_addr, default_regs[i][0], default_regs[i][1]);
     }
 
     // Set PCLK polarity.
-    ret |= cambus_writeb2(sensor->slv_addr, PCLK_POLARITY, (0x20 | PCLK_FALLING_EDGE));
+    ret |= cambus_writeb2(&sensor->i2c, sensor->slv_addr, PCLK_POLARITY, (0x20 | PCLK_FALLING_EDGE));
     
     // Set mode to streaming
-    ret |= cambus_writeb2(sensor->slv_addr, MODE_SELECT, HIMAX_MODE_STREAMING);
+    ret |= cambus_writeb2(&sensor->i2c, sensor->slv_addr, MODE_SELECT, HIMAX_MODE_STREAMING);
 
     return ret;
 }
@@ -147,7 +147,7 @@ static int reset(sensor_t *sensor)
 static int read_reg(sensor_t *sensor, uint16_t reg_addr)
 {
     uint8_t reg_data;
-    if (cambus_readb2(sensor->slv_addr, reg_addr, &reg_data) != 0) {
+    if (cambus_readb2(&sensor->i2c, sensor->slv_addr, reg_addr, &reg_data) != 0) {
         return -1;
     }
     return reg_data;
@@ -155,7 +155,7 @@ static int read_reg(sensor_t *sensor, uint16_t reg_addr)
 
 static int write_reg(sensor_t *sensor, uint16_t reg_addr, uint16_t reg_data)
 {
-    return cambus_writeb2(sensor->slv_addr, reg_addr, reg_data);
+    return cambus_writeb2(&sensor->i2c, sensor->slv_addr, reg_addr, reg_data);
 }
 
 static int set_pixformat(sensor_t *sensor, pixformat_t pixformat)
@@ -185,16 +185,16 @@ static int set_framesize(sensor_t *sensor, framesize_t framesize)
 static int set_hmirror(sensor_t *sensor, int enable)
 {
     uint8_t reg;
-    int ret = cambus_readb2(sensor->slv_addr, IMG_ORIENTATION, &reg);
-    ret |= cambus_writeb2(sensor->slv_addr, IMG_ORIENTATION, HIMAX_SET_HMIRROR(reg, enable)) ;
+    int ret = cambus_readb2(&sensor->i2c, sensor->slv_addr, IMG_ORIENTATION, &reg);
+    ret |= cambus_writeb2(&sensor->i2c, sensor->slv_addr, IMG_ORIENTATION, HIMAX_SET_HMIRROR(reg, enable)) ;
     return ret;
 }
 
 static int set_vflip(sensor_t *sensor, int enable)
 {
     uint8_t reg;
-    int ret = cambus_readb2(sensor->slv_addr, IMG_ORIENTATION, &reg);
-    ret |= cambus_writeb2(sensor->slv_addr, IMG_ORIENTATION, HIMAX_SET_VMIRROR(reg, enable)) ;
+    int ret = cambus_readb2(&sensor->i2c, sensor->slv_addr, IMG_ORIENTATION, &reg);
+    ret |= cambus_writeb2(&sensor->i2c, sensor->slv_addr, IMG_ORIENTATION, HIMAX_SET_VMIRROR(reg, enable)) ;
     return ret;
 }
 

--- a/src/omv/lepton.c
+++ b/src/omv/lepton.c
@@ -119,7 +119,7 @@ static int sleep(sensor_t *sensor, int enable)
 static int read_reg(sensor_t *sensor, uint16_t reg_addr)
 {
     uint16_t reg_data;
-    if (cambus_readw2(sensor->slv_addr, reg_addr, &reg_data)) {
+    if (cambus_readw2(&sensor->i2c, sensor->slv_addr, reg_addr, &reg_data)) {
         return -1;
     }
     return reg_data;
@@ -127,7 +127,7 @@ static int read_reg(sensor_t *sensor, uint16_t reg_addr)
 
 static int write_reg(sensor_t *sensor, uint16_t reg_addr, uint16_t reg_data)
 {
-    return cambus_writew2(sensor->slv_addr, reg_addr, reg_data);
+    return cambus_writew2(&sensor->i2c, sensor->slv_addr, reg_addr, reg_data);
 }
 
 static int set_pixformat(sensor_t *sensor, pixformat_t pixformat)

--- a/src/omv/mt9v034.c
+++ b/src/omv/mt9v034.c
@@ -126,12 +126,12 @@ static int reset(sensor_t *sensor)
     int ret = 0;
 
     uint16_t chip_control;
-    ret |= cambus_readw(sensor->slv_addr, MT9V034_CHIP_CONTROL, &chip_control);
-    ret |= cambus_writew(sensor->slv_addr, MT9V034_CHIP_CONTROL, (chip_control & (~MT9V034_CHIP_CONTROL_RESERVED)));
+    ret |= cambus_readw(&sensor->i2c, sensor->slv_addr, MT9V034_CHIP_CONTROL, &chip_control);
+    ret |= cambus_writew(&sensor->i2c, sensor->slv_addr, MT9V034_CHIP_CONTROL, (chip_control & (~MT9V034_CHIP_CONTROL_RESERVED)));
 
     uint16_t read_mode;
-    ret |= cambus_readw(sensor->slv_addr, MT9V034_READ_MODE, &read_mode);
-    ret |= cambus_writew(sensor->slv_addr, MT9V034_READ_MODE, read_mode | MT9V034_READ_MODE_ROW_FLIP | MT9V034_READ_MODE_COL_FLIP);
+    ret |= cambus_readw(&sensor->i2c, sensor->slv_addr, MT9V034_READ_MODE, &read_mode);
+    ret |= cambus_writew(&sensor->i2c, sensor->slv_addr, MT9V034_READ_MODE, read_mode | MT9V034_READ_MODE_ROW_FLIP | MT9V034_READ_MODE_COL_FLIP);
 
     return ret;
 }
@@ -153,7 +153,7 @@ static int read_reg(sensor_t *sensor, uint16_t reg_addr)
 {
     uint16_t reg_data;
 
-    if (cambus_readw(sensor->slv_addr, reg_addr, &reg_data) != 0) {
+    if (cambus_readw(&sensor->i2c, sensor->slv_addr, reg_addr, &reg_data) != 0) {
         return -1;
     }
 
@@ -162,7 +162,7 @@ static int read_reg(sensor_t *sensor, uint16_t reg_addr)
 
 static int write_reg(sensor_t *sensor, uint16_t reg_addr, uint16_t reg_data)
 {
-    return cambus_writew(sensor->slv_addr, reg_addr, reg_data);
+    return cambus_writew(&sensor->i2c, sensor->slv_addr, reg_addr, reg_data);
 }
 
 static int set_pixformat(sensor_t *sensor, pixformat_t pixformat)
@@ -184,7 +184,7 @@ static int set_framesize(sensor_t *sensor, framesize_t framesize)
 
     uint16_t read_mode;
 
-    if (cambus_readw(sensor->slv_addr, MT9V034_READ_MODE, &read_mode) != 0) {
+    if (cambus_readw(&sensor->i2c, sensor->slv_addr, MT9V034_READ_MODE, &read_mode) != 0) {
         return -1;
     }
 
@@ -201,12 +201,12 @@ static int set_framesize(sensor_t *sensor, framesize_t framesize)
 
     int ret = 0;
 
-    ret |= cambus_writew(sensor->slv_addr, MT9V034_COL_START,
+    ret |= cambus_writew(&sensor->i2c, sensor->slv_addr, MT9V034_COL_START,
             ((MT9V034_MAX_WIDTH - (width * read_mode_mul)) / 2) + MT9V034_COL_START_MIN);
-    ret |= cambus_writew(sensor->slv_addr, MT9V034_ROW_START,
+    ret |= cambus_writew(&sensor->i2c, sensor->slv_addr, MT9V034_ROW_START,
             ((MT9V034_MAX_HEIGHT - (height * read_mode_mul)) / 2) + MT9V034_ROW_START_MIN);
-    ret |= cambus_writew(sensor->slv_addr, MT9V034_WINDOW_WIDTH, width * read_mode_mul);
-    ret |= cambus_writew(sensor->slv_addr, MT9V034_WINDOW_HEIGHT, height * read_mode_mul);
+    ret |= cambus_writew(&sensor->i2c, sensor->slv_addr, MT9V034_WINDOW_WIDTH, width * read_mode_mul);
+    ret |= cambus_writew(&sensor->i2c, sensor->slv_addr, MT9V034_WINDOW_HEIGHT, height * read_mode_mul);
 
     // Notes: 1. The MT9V034 uses column parallel analog-digital converters, thus short row timing is not possible.
     // The minimum total row time is 690 columns (horizontal width + horizontal blanking). The minimum
@@ -214,14 +214,14 @@ static int set_framesize(sensor_t *sensor, framesize_t framesize)
     // must be increased.
     //
     // The STM32H7 needs more than 94+(752-640) clocks between rows otherwise it can't keep up with the pixel rate.
-    ret |= cambus_writew(sensor->slv_addr, MT9V034_HORIZONTAL_BLANKING,
+    ret |= cambus_writew(&sensor->i2c, sensor->slv_addr, MT9V034_HORIZONTAL_BLANKING,
             MT9V034_HORIZONTAL_BLANKING_DEF + (MT9V034_MAX_WIDTH - IM_MIN(width * read_mode_mul, 640)));
 
-    ret |= cambus_writew(sensor->slv_addr, MT9V034_READ_MODE, read_mode);
-    ret |= cambus_writew(sensor->slv_addr, MT9V034_PIXEL_COUNT, (width * height) / 8);
+    ret |= cambus_writew(&sensor->i2c, sensor->slv_addr, MT9V034_READ_MODE, read_mode);
+    ret |= cambus_writew(&sensor->i2c, sensor->slv_addr, MT9V034_PIXEL_COUNT, (width * height) / 8);
 
     // We need more setup time for the pixel_clk at the full data rate...
-    ret |= cambus_writew(sensor->slv_addr, MT9V034_PIXEL_CLOCK, (read_mode_mul == 1) ? MT9V034_PIXEL_CLOCK_INV_PXL_CLK : 0);
+    ret |= cambus_writew(&sensor->i2c, sensor->slv_addr, MT9V034_PIXEL_CLOCK, (read_mode_mul == 1) ? MT9V034_PIXEL_CLOCK_INV_PXL_CLK : 0);
 
     return ret;
 }
@@ -254,8 +254,8 @@ static int set_quality(sensor_t *sensor, int quality)
 static int set_colorbar(sensor_t *sensor, int enable)
 {
     uint16_t test;
-    int ret = cambus_readw(sensor->slv_addr, MT9V034_TEST_PATTERN, &test);
-    ret |= cambus_writew(sensor->slv_addr, MT9V034_TEST_PATTERN,
+    int ret = cambus_readw(&sensor->i2c, sensor->slv_addr, MT9V034_TEST_PATTERN, &test);
+    ret |= cambus_writew(&sensor->i2c, sensor->slv_addr, MT9V034_TEST_PATTERN,
             (test & (~(MT9V034_TEST_PATTERN_ENABLE | MT9V034_TEST_PATTERN_GRAY_MASK)))
           | ((enable != 0) ? (MT9V034_TEST_PATTERN_ENABLE | MT9V034_TEST_PATTERN_GRAY_VERTICAL) : 0));
     ret |= sensor->snapshot(sensor, NULL, NULL); // Force shadow mode register to update...
@@ -270,21 +270,21 @@ static int set_special_effect(sensor_t *sensor, sde_t sde)
 static int set_auto_gain(sensor_t *sensor, int enable, float gain_db, float gain_db_ceiling)
 {
     uint16_t reg;
-    int ret = cambus_readw(sensor->slv_addr, MT9V034_AEC_AGC_ENABLE, &reg);
-    ret |= cambus_writew(sensor->slv_addr, MT9V034_AEC_AGC_ENABLE,
+    int ret = cambus_readw(&sensor->i2c, sensor->slv_addr, MT9V034_AEC_AGC_ENABLE, &reg);
+    ret |= cambus_writew(&sensor->i2c, sensor->slv_addr, MT9V034_AEC_AGC_ENABLE,
             (reg & (~MT9V034_AGC_ENABLE)) | ((enable != 0) ? MT9V034_AGC_ENABLE : 0));
     ret |= sensor->snapshot(sensor, NULL, NULL); // Force shadow mode register to update...
 
     if ((enable == 0) && (!isnanf(gain_db)) && (!isinff(gain_db))) {
         int gain = IM_MAX(IM_MIN(fast_roundf(fast_expf((gain_db / 20.0) * fast_log(10.0)) * 16.0), 127), 0);
 
-        ret |= cambus_readw(sensor->slv_addr, MT9V034_ANALOG_GAIN, &reg);
-        ret |= cambus_writew(sensor->slv_addr, MT9V034_ANALOG_GAIN, (reg & 0xFF80) | gain);
+        ret |= cambus_readw(&sensor->i2c, sensor->slv_addr, MT9V034_ANALOG_GAIN, &reg);
+        ret |= cambus_writew(&sensor->i2c, sensor->slv_addr, MT9V034_ANALOG_GAIN, (reg & 0xFF80) | gain);
     } else if ((enable != 0) && (!isnanf(gain_db_ceiling)) && (!isinff(gain_db_ceiling))) {
         int gain_ceiling = IM_MAX(IM_MIN(fast_roundf(fast_expf((gain_db_ceiling / 20.0) * fast_log(10.0)) * 16.0), 127), 16);
 
-        ret |= cambus_readw(sensor->slv_addr, MT9V034_MAX_GAIN, &reg);
-        ret |= cambus_writew(sensor->slv_addr, MT9V034_MAX_GAIN, (reg & 0xFF80) | gain_ceiling);
+        ret |= cambus_readw(&sensor->i2c, sensor->slv_addr, MT9V034_MAX_GAIN, &reg);
+        ret |= cambus_writew(&sensor->i2c, sensor->slv_addr, MT9V034_MAX_GAIN, (reg & 0xFF80) | gain_ceiling);
     }
 
     return ret;
@@ -293,7 +293,7 @@ static int set_auto_gain(sensor_t *sensor, int enable, float gain_db, float gain
 static int get_gain_db(sensor_t *sensor, float *gain_db)
 {
     uint16_t gain;
-    int ret = cambus_readw(sensor->slv_addr, MT9V034_ANALOG_GAIN, &gain);
+    int ret = cambus_readw(&sensor->i2c, sensor->slv_addr, MT9V034_ANALOG_GAIN, &gain);
 
     *gain_db = 20.0 * (fast_log((gain & 0x7F) / 16.0) / fast_log(10.0));
 
@@ -303,31 +303,31 @@ static int get_gain_db(sensor_t *sensor, float *gain_db)
 static int set_auto_exposure(sensor_t *sensor, int enable, int exposure_us)
 {
     uint16_t reg, row_time_0, row_time_1;
-    int ret = cambus_readw(sensor->slv_addr, MT9V034_AEC_AGC_ENABLE, &reg);
-    ret |= cambus_writew(sensor->slv_addr, MT9V034_AEC_AGC_ENABLE,
+    int ret = cambus_readw(&sensor->i2c, sensor->slv_addr, MT9V034_AEC_AGC_ENABLE, &reg);
+    ret |= cambus_writew(&sensor->i2c, sensor->slv_addr, MT9V034_AEC_AGC_ENABLE,
             (reg & (~MT9V034_AEC_ENABLE)) | ((enable != 0) ? MT9V034_AEC_ENABLE : 0));
     ret |= sensor->snapshot(sensor, NULL, NULL); // Force shadow mode register to update...
 
     if ((enable == 0) && (exposure_us >= 0)) {
-        ret |= cambus_readw(sensor->slv_addr, MT9V034_WINDOW_WIDTH, &row_time_0);
-        ret |= cambus_readw(sensor->slv_addr, MT9V034_HORIZONTAL_BLANKING, &row_time_1);
+        ret |= cambus_readw(&sensor->i2c, sensor->slv_addr, MT9V034_WINDOW_WIDTH, &row_time_0);
+        ret |= cambus_readw(&sensor->i2c, sensor->slv_addr, MT9V034_HORIZONTAL_BLANKING, &row_time_1);
 
         int exposure = IM_MIN(exposure_us, MICROSECOND_CLKS / 2) * (MT9V034_XCLK_FREQ / MICROSECOND_CLKS);
         int row_time = row_time_0 + row_time_1;
         int coarse_time = exposure / row_time;
         int fine_time = exposure % row_time;
 
-        ret |= cambus_writew(sensor->slv_addr, MT9V034_TOTAL_SHUTTER_WIDTH, coarse_time);
-        ret |= cambus_writew(sensor->slv_addr, MT9V034_FINE_SHUTTER_WIDTH_TOTAL, fine_time);
+        ret |= cambus_writew(&sensor->i2c, sensor->slv_addr, MT9V034_TOTAL_SHUTTER_WIDTH, coarse_time);
+        ret |= cambus_writew(&sensor->i2c, sensor->slv_addr, MT9V034_FINE_SHUTTER_WIDTH_TOTAL, fine_time);
     } else if ((enable != 0) && (exposure_us >= 0)) {
-        ret |= cambus_readw(sensor->slv_addr, MT9V034_WINDOW_WIDTH, &row_time_0);
-        ret |= cambus_readw(sensor->slv_addr, MT9V034_HORIZONTAL_BLANKING, &row_time_1);
+        ret |= cambus_readw(&sensor->i2c, sensor->slv_addr, MT9V034_WINDOW_WIDTH, &row_time_0);
+        ret |= cambus_readw(&sensor->i2c, sensor->slv_addr, MT9V034_HORIZONTAL_BLANKING, &row_time_1);
 
         int exposure = IM_MIN(exposure_us, MICROSECOND_CLKS / 2) * (MT9V034_XCLK_FREQ / MICROSECOND_CLKS);
         int row_time = row_time_0 + row_time_1;
         int coarse_time = exposure / row_time;
 
-        ret |= cambus_writew(sensor->slv_addr, MT9V034_MAX_EXPOSE, coarse_time);
+        ret |= cambus_writew(&sensor->i2c, sensor->slv_addr, MT9V034_MAX_EXPOSE, coarse_time);
     }
 
     return ret;
@@ -336,10 +336,10 @@ static int set_auto_exposure(sensor_t *sensor, int enable, int exposure_us)
 static int get_exposure_us(sensor_t *sensor, int *exposure_us)
 {
     uint16_t int_rows, int_pixels, row_time_0, row_time_1;
-    int ret = cambus_readw(sensor->slv_addr, MT9V034_TOTAL_SHUTTER_WIDTH, &int_rows);
-    ret |= cambus_readw(sensor->slv_addr, MT9V034_FINE_SHUTTER_WIDTH_TOTAL, &int_pixels);
-    ret |= cambus_readw(sensor->slv_addr, MT9V034_WINDOW_WIDTH, &row_time_0);
-    ret |= cambus_readw(sensor->slv_addr, MT9V034_HORIZONTAL_BLANKING, &row_time_1);
+    int ret = cambus_readw(&sensor->i2c, sensor->slv_addr, MT9V034_TOTAL_SHUTTER_WIDTH, &int_rows);
+    ret |= cambus_readw(&sensor->i2c, sensor->slv_addr, MT9V034_FINE_SHUTTER_WIDTH_TOTAL, &int_pixels);
+    ret |= cambus_readw(&sensor->i2c, sensor->slv_addr, MT9V034_WINDOW_WIDTH, &row_time_0);
+    ret |= cambus_readw(&sensor->i2c, sensor->slv_addr, MT9V034_HORIZONTAL_BLANKING, &row_time_1);
 
     *exposure_us = ((int_rows * (row_time_0 + row_time_1)) + int_pixels) / (MT9V034_XCLK_FREQ / MICROSECOND_CLKS);
 
@@ -359,8 +359,8 @@ static int get_rgb_gain_db(sensor_t *sensor, float *r_gain_db, float *g_gain_db,
 static int set_hmirror(sensor_t *sensor, int enable)
 {
     uint16_t read_mode;
-    int ret = cambus_readw(sensor->slv_addr, MT9V034_READ_MODE, &read_mode);
-    ret |= cambus_writew(sensor->slv_addr, MT9V034_READ_MODE, // inverted behavior
+    int ret = cambus_readw(&sensor->i2c, sensor->slv_addr, MT9V034_READ_MODE, &read_mode);
+    ret |= cambus_writew(&sensor->i2c, sensor->slv_addr, MT9V034_READ_MODE, // inverted behavior
             (read_mode & (~MT9V034_READ_MODE_COL_FLIP)) | ((enable == 0) ? MT9V034_READ_MODE_COL_FLIP : 0));
     ret |= sensor->snapshot(sensor, NULL, NULL); // Force shadow mode register to update...
     return ret;
@@ -369,8 +369,8 @@ static int set_hmirror(sensor_t *sensor, int enable)
 static int set_vflip(sensor_t *sensor, int enable)
 {
     uint16_t read_mode;
-    int ret = cambus_readw(sensor->slv_addr, MT9V034_READ_MODE, &read_mode);
-    ret |= cambus_writew(sensor->slv_addr, MT9V034_READ_MODE, // inverted behavior
+    int ret = cambus_readw(&sensor->i2c, sensor->slv_addr, MT9V034_READ_MODE, &read_mode);
+    ret |= cambus_writew(&sensor->i2c, sensor->slv_addr, MT9V034_READ_MODE, // inverted behavior
             (read_mode & (~MT9V034_READ_MODE_ROW_FLIP)) | ((enable == 0) ? MT9V034_READ_MODE_ROW_FLIP : 0));
     ret |= sensor->snapshot(sensor, NULL, NULL); // Force shadow mode register to update...
     return ret;
@@ -389,8 +389,8 @@ static int ioctl(sensor_t *sensor, int request, va_list ap)
     switch (request) {
         case IOCTL_SET_TRIGGERED_MODE: {
             int enable = va_arg(ap, int);
-            ret  = cambus_readw(sensor->slv_addr, MT9V034_CHIP_CONTROL, &chip_control);
-            ret |= cambus_writew(sensor->slv_addr, MT9V034_CHIP_CONTROL,
+            ret  = cambus_readw(&sensor->i2c, sensor->slv_addr, MT9V034_CHIP_CONTROL, &chip_control);
+            ret |= cambus_writew(&sensor->i2c, sensor->slv_addr, MT9V034_CHIP_CONTROL,
                     (chip_control & (~MT9V034_CHIP_CONTROL_MODE_MASK))
                     | ((enable != 0) ? MT9V034_CHIP_CONTROL_SNAP_MODE : MT9V034_CHIP_CONTROL_MASTER_MODE));
             ret |= sensor->snapshot(sensor, NULL, NULL); // Force shadow mode register to update...
@@ -398,7 +398,7 @@ static int ioctl(sensor_t *sensor, int request, va_list ap)
         }
         case IOCTL_GET_TRIGGERED_MODE: {
             int *enable = va_arg(ap, int *);
-            ret = cambus_readw(sensor->slv_addr, MT9V034_CHIP_CONTROL, &chip_control);
+            ret = cambus_readw(&sensor->i2c, sensor->slv_addr, MT9V034_CHIP_CONTROL, &chip_control);
             if (ret >= 0) {
                 *enable = ((chip_control & MT9V034_CHIP_CONTROL_MODE_MASK) == MT9V034_CHIP_CONTROL_SNAP_MODE);
             }

--- a/src/omv/ov2640.c
+++ b/src/omv/ov2640.c
@@ -345,15 +345,15 @@ static const uint8_t saturation_regs[NUM_SATURATION_LEVELS + 1][5] = {
 static int reset(sensor_t *sensor)
 {
     // Reset all registers
-    int ret = cambus_writeb(sensor->slv_addr, BANK_SEL, BANK_SEL_SENSOR);
-    ret |= cambus_writeb(sensor->slv_addr, COM7, COM7_SRST);
+    int ret = cambus_writeb(&sensor->i2c, sensor->slv_addr, BANK_SEL, BANK_SEL_SENSOR);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, COM7, COM7_SRST);
 
     // Delay 5 ms
     systick_sleep(5);
 
     // Write default regsiters
     for (int i = 0; default_regs[i][0]; i++) {
-        ret |= cambus_writeb(sensor->slv_addr, default_regs[i][0], default_regs[i][1]);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, default_regs[i][0], default_regs[i][1]);
     }
 
     // Delay 300 ms
@@ -365,7 +365,7 @@ static int reset(sensor_t *sensor)
 static int sleep(sensor_t *sensor, int enable)
 {
     uint8_t reg;
-    int ret = cambus_readb(sensor->slv_addr, COM2, &reg);
+    int ret = cambus_readb(&sensor->i2c, sensor->slv_addr, COM2, &reg);
 
     if (enable) {
         reg |= COM2_STDBY;
@@ -374,13 +374,13 @@ static int sleep(sensor_t *sensor, int enable)
     }
 
     // Write back register
-    return cambus_writeb(sensor->slv_addr, COM2, reg) | ret;
+    return cambus_writeb(&sensor->i2c, sensor->slv_addr, COM2, reg) | ret;
 }
 
 static int read_reg(sensor_t *sensor, uint16_t reg_addr)
 {
     uint8_t reg_data;
-    if (cambus_readb(sensor->slv_addr, reg_addr, &reg_data) != 0) {
+    if (cambus_readb(&sensor->i2c, sensor->slv_addr, reg_addr, &reg_data) != 0) {
         return -1;
     }
     return reg_data;
@@ -388,7 +388,7 @@ static int read_reg(sensor_t *sensor, uint16_t reg_addr)
 
 static int write_reg(sensor_t *sensor, uint16_t reg_addr, uint16_t reg_data)
 {
-    return cambus_writeb(sensor->slv_addr, reg_addr, reg_data);
+    return cambus_writeb(&sensor->i2c, sensor->slv_addr, reg_addr, reg_data);
 }
 
 static int set_pixformat(sensor_t *sensor, pixformat_t pixformat)
@@ -416,7 +416,7 @@ static int set_pixformat(sensor_t *sensor, pixformat_t pixformat)
 
     // Write regsiters
     for (int i = 0; regs[i][0]; i++) {
-        ret |= cambus_writeb(sensor->slv_addr, regs[i][0], regs[i][1]);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, regs[i][0], regs[i][1]);
     }
 
     // Delay 300 ms
@@ -455,7 +455,7 @@ static int set_framesize(sensor_t *sensor, framesize_t framesize)
 
     // Write setup regsiters
     for (int i = 0; regs[i][0]; i++) {
-        ret |= cambus_writeb(sensor->slv_addr, regs[i][0], regs[i][1]);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, regs[i][0], regs[i][1]);
     }
 
     uint64_t tmp_div = IM_MIN(sensor_w / w, sensor_h / h);
@@ -466,18 +466,18 @@ static int set_framesize(sensor_t *sensor, framesize_t framesize)
     uint16_t x_off = (sensor_w - w_mul) / 2;
     uint16_t y_off = (sensor_h - h_mul) / 2;
 
-    ret |= cambus_writeb(sensor->slv_addr, CTRLI, CTRLI_LP_DP | CTRLI_V_DIV_SET(log_div) | CTRLI_H_DIV_SET(log_div));
-    ret |= cambus_writeb(sensor->slv_addr, HSIZE, HSIZE_SET(w_mul));
-    ret |= cambus_writeb(sensor->slv_addr, VSIZE, VSIZE_SET(h_mul));
-    ret |= cambus_writeb(sensor->slv_addr, XOFFL, XOFFL_SET(x_off));
-    ret |= cambus_writeb(sensor->slv_addr, YOFFL, YOFFL_SET(y_off));
-    ret |= cambus_writeb(sensor->slv_addr, VHYX, VHYX_HSIZE_SET(w_mul) | VHYX_VSIZE_SET(h_mul) | VHYX_XOFF_SET(x_off) | VHYX_YOFF_SET(y_off));
-    ret |= cambus_writeb(sensor->slv_addr, TEST, TEST_HSIZE_SET(w_mul));
-    ret |= cambus_writeb(sensor->slv_addr, ZMOW, ZMOW_OUTW_SET(w));
-    ret |= cambus_writeb(sensor->slv_addr, ZMOH, ZMOH_OUTH_SET(h));
-    ret |= cambus_writeb(sensor->slv_addr, ZMHH, ZMHH_OUTW_SET(w) | ZMHH_OUTH_SET(h));
-    ret |= cambus_writeb(sensor->slv_addr, R_DVP_SP, div);
-    ret |= cambus_writeb(sensor->slv_addr, RESET, 0x00);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, CTRLI, CTRLI_LP_DP | CTRLI_V_DIV_SET(log_div) | CTRLI_H_DIV_SET(log_div));
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, HSIZE, HSIZE_SET(w_mul));
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, VSIZE, VSIZE_SET(h_mul));
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, XOFFL, XOFFL_SET(x_off));
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, YOFFL, YOFFL_SET(y_off));
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, VHYX, VHYX_HSIZE_SET(w_mul) | VHYX_VSIZE_SET(h_mul) | VHYX_XOFF_SET(x_off) | VHYX_YOFF_SET(y_off));
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, TEST, TEST_HSIZE_SET(w_mul));
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, ZMOW, ZMOW_OUTW_SET(w));
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, ZMOH, ZMOH_OUTH_SET(h));
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, ZMHH, ZMHH_OUTW_SET(w) | ZMHH_OUTH_SET(h));
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, R_DVP_SP, div);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, RESET, 0x00);
 
     // Delay 300 ms
     systick_sleep(300);
@@ -495,11 +495,11 @@ static int set_contrast(sensor_t *sensor, int level)
     }
 
     /* Switch to DSP register bank */
-    ret |= cambus_writeb(sensor->slv_addr, BANK_SEL, BANK_SEL_DSP);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, BANK_SEL, BANK_SEL_DSP);
 
     /* Write contrast registers */
     for (int i=0; i<sizeof(contrast_regs[0])/sizeof(contrast_regs[0][0]); i++) {
-        ret |= cambus_writeb(sensor->slv_addr, contrast_regs[0][i], contrast_regs[level][i]);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, contrast_regs[0][i], contrast_regs[level][i]);
     }
 
     return ret;
@@ -515,11 +515,11 @@ static int set_brightness(sensor_t *sensor, int level)
     }
 
     /* Switch to DSP register bank */
-    ret |= cambus_writeb(sensor->slv_addr, BANK_SEL, BANK_SEL_DSP);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, BANK_SEL, BANK_SEL_DSP);
 
     /* Write brightness registers */
     for (int i=0; i<sizeof(brightness_regs[0])/sizeof(brightness_regs[0][0]); i++) {
-        ret |= cambus_writeb(sensor->slv_addr, brightness_regs[0][i], brightness_regs[level][i]);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, brightness_regs[0][i], brightness_regs[level][i]);
     }
 
     return ret;
@@ -535,11 +535,11 @@ static int set_saturation(sensor_t *sensor, int level)
     }
 
     /* Switch to DSP register bank */
-    ret |= cambus_writeb(sensor->slv_addr, BANK_SEL, BANK_SEL_DSP);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, BANK_SEL, BANK_SEL_DSP);
 
     /* Write saturation registers */
     for (int i=0; i<sizeof(saturation_regs[0])/sizeof(saturation_regs[0][0]); i++) {
-        ret |= cambus_writeb(sensor->slv_addr, saturation_regs[0][i], saturation_regs[level][i]);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, saturation_regs[0][i], saturation_regs[level][i]);
     }
 
     return ret;
@@ -550,10 +550,10 @@ static int set_gainceiling(sensor_t *sensor, gainceiling_t gainceiling)
     int ret=0;
 
     /* Switch to SENSOR register bank */
-    ret |= cambus_writeb(sensor->slv_addr, BANK_SEL, BANK_SEL_SENSOR);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, BANK_SEL, BANK_SEL_SENSOR);
 
     /* Write gain ceiling register */
-    ret |= cambus_writeb(sensor->slv_addr, COM9, COM9_AGC_SET(gainceiling));
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, COM9, COM9_AGC_SET(gainceiling));
 
     return ret;
 }
@@ -563,10 +563,10 @@ static int set_quality(sensor_t *sensor, int qs)
     int ret=0;
 
     /* Switch to DSP register bank */
-    ret |= cambus_writeb(sensor->slv_addr, BANK_SEL, BANK_SEL_DSP);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, BANK_SEL, BANK_SEL_DSP);
 
     /* Write QS register */
-    ret |= cambus_writeb(sensor->slv_addr, QS, qs);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, QS, qs);
 
     return ret;
 }
@@ -574,8 +574,8 @@ static int set_quality(sensor_t *sensor, int qs)
 static int set_colorbar(sensor_t *sensor, int enable)
 {
     uint8_t reg;
-    int ret = cambus_writeb(sensor->slv_addr, BANK_SEL, BANK_SEL_SENSOR);
-    ret |= cambus_readb(sensor->slv_addr, COM7, &reg);
+    int ret = cambus_writeb(&sensor->i2c, sensor->slv_addr, BANK_SEL, BANK_SEL_SENSOR);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, COM7, &reg);
 
     if (enable) {
         reg |= COM7_COLOR_BAR;
@@ -583,15 +583,15 @@ static int set_colorbar(sensor_t *sensor, int enable)
         reg &= ~COM7_COLOR_BAR;
     }
 
-    return cambus_writeb(sensor->slv_addr, COM7, reg) | ret;
+    return cambus_writeb(&sensor->i2c, sensor->slv_addr, COM7, reg) | ret;
 }
 
 static int set_auto_gain(sensor_t *sensor, int enable, float gain_db, float gain_db_ceiling)
 {
     uint8_t reg;
-    int ret = cambus_writeb(sensor->slv_addr, BANK_SEL, BANK_SEL_SENSOR);
-    ret |= cambus_readb(sensor->slv_addr, COM8, &reg);
-    ret |= cambus_writeb(sensor->slv_addr, COM8, (reg & (~COM8_AGC_EN)) | ((enable != 0) ? COM8_AGC_EN : 0));
+    int ret = cambus_writeb(&sensor->i2c, sensor->slv_addr, BANK_SEL, BANK_SEL_SENSOR);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, COM8, &reg);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, COM8, (reg & (~COM8_AGC_EN)) | ((enable != 0) ? COM8_AGC_EN : 0));
 
     if ((enable == 0) && (!isnanf(gain_db)) && (!isinff(gain_db))) {
         float gain = IM_MAX(IM_MIN(fast_expf((gain_db / 20.0) * fast_log(10.0)), 32.0), 1.0);
@@ -600,12 +600,12 @@ static int set_auto_gain(sensor_t *sensor, int enable, float gain_db, float gain
         int gain_hi = 0xF >> (4 - gain_temp);
         int gain_lo = IM_MIN(fast_roundf(((gain / (1 << gain_temp)) - 1.0) * 16.0), 15);
 
-        ret |= cambus_writeb(sensor->slv_addr, GAIN, (gain_hi << 4) | (gain_lo << 0));
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, GAIN, (gain_hi << 4) | (gain_lo << 0));
     } else if ((enable != 0) && (!isnanf(gain_db_ceiling)) && (!isinff(gain_db_ceiling))) {
         float gain_ceiling = IM_MAX(IM_MIN(fast_expf((gain_db_ceiling / 20.0) * fast_log(10.0)), 128.0), 2.0);
 
-        ret |= cambus_readb(sensor->slv_addr, COM9, &reg);
-        ret |= cambus_writeb(sensor->slv_addr, COM9, (reg & 0x1F) | ((fast_ceilf(fast_log2(gain_ceiling)) - 1) << 5));
+        ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, COM9, &reg);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, COM9, (reg & 0x1F) | ((fast_ceilf(fast_log2(gain_ceiling)) - 1) << 5));
     }
 
     return ret;
@@ -614,20 +614,20 @@ static int set_auto_gain(sensor_t *sensor, int enable, float gain_db, float gain
 static int get_gain_db(sensor_t *sensor, float *gain_db)
 {
     uint8_t reg, gain;
-    int ret = cambus_writeb(sensor->slv_addr, BANK_SEL, BANK_SEL_SENSOR);
-    ret |= cambus_readb(sensor->slv_addr, COM8, &reg);
+    int ret = cambus_writeb(&sensor->i2c, sensor->slv_addr, BANK_SEL, BANK_SEL_SENSOR);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, COM8, &reg);
 
     // DISABLED
     // if (reg & COM8_AGC_EN) {
-    //     ret |= cambus_writeb(sensor->slv_addr, COM8, reg & (~COM8_AGC_EN));
+    //     ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, COM8, reg & (~COM8_AGC_EN));
     // }
     // DISABLED
 
-    ret |= cambus_readb(sensor->slv_addr, GAIN, &gain);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, GAIN, &gain);
 
     // DISABLED
     // if (reg & COM8_AGC_EN) {
-    //     ret |= cambus_writeb(sensor->slv_addr, COM8, reg | COM8_AGC_EN);
+    //     ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, COM8, reg | COM8_AGC_EN);
     // }
     // DISABLED
 
@@ -641,24 +641,24 @@ static int get_gain_db(sensor_t *sensor, float *gain_db)
 static int set_auto_exposure(sensor_t *sensor, int enable, int exposure_us)
 {
     uint8_t reg;
-    int ret = cambus_writeb(sensor->slv_addr, BANK_SEL, BANK_SEL_SENSOR);
-    ret |= cambus_readb(sensor->slv_addr, COM8, &reg);
-    ret |= cambus_writeb(sensor->slv_addr, COM8, COM8_SET_AEC(reg, (enable != 0)));
+    int ret = cambus_writeb(&sensor->i2c, sensor->slv_addr, BANK_SEL, BANK_SEL_SENSOR);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, COM8, &reg);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, COM8, COM8_SET_AEC(reg, (enable != 0)));
 
     if ((enable == 0) && (exposure_us >= 0)) {
-        ret |= cambus_readb(sensor->slv_addr, COM7, &reg);
+        ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, COM7, &reg);
         int t_line = 0;
 
         if (COM7_GET_RES(reg) == COM7_RES_UXGA) t_line = 1600 + 322;
         if (COM7_GET_RES(reg) == COM7_RES_SVGA) t_line = 800 + 390;
         if (COM7_GET_RES(reg) == COM7_RES_CIF) t_line = 400 + 195;
 
-        ret |= cambus_readb(sensor->slv_addr, CLKRC, &reg);
+        ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, CLKRC, &reg);
         int pll_mult = ((reg & CLKRC_DOUBLE) ? 2 : 1) * 3;
         int clk_rc = (reg & CLKRC_DIVIDER_MASK) + 2;
 
-        ret |= cambus_writeb(sensor->slv_addr, BANK_SEL, BANK_SEL_DSP);
-        ret |= cambus_readb(sensor->slv_addr, IMAGE_MODE, &reg);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, BANK_SEL, BANK_SEL_DSP);
+        ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, IMAGE_MODE, &reg);
         int t_pclk = 0;
 
         if (IMAGE_MODE_GET_FMT(reg) == IMAGE_MODE_YUV422) t_pclk = 2;
@@ -667,16 +667,16 @@ static int set_auto_exposure(sensor_t *sensor, int enable, int exposure_us)
 
         int exposure = IM_MAX(IM_MIN(((exposure_us*(((OMV_XCLK_FREQUENCY/clk_rc)*pll_mult)/1000000))/t_pclk)/t_line,0xFFFF),0x0000);
 
-        ret |= cambus_writeb(sensor->slv_addr, BANK_SEL, BANK_SEL_SENSOR);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, BANK_SEL, BANK_SEL_SENSOR);
 
-        ret |= cambus_readb(sensor->slv_addr, REG04, &reg);
-        ret |= cambus_writeb(sensor->slv_addr, REG04, (reg & 0xFC) | ((exposure >> 0) & 0x3));
+        ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, REG04, &reg);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, REG04, (reg & 0xFC) | ((exposure >> 0) & 0x3));
 
-        ret |= cambus_readb(sensor->slv_addr, AEC, &reg);
-        ret |= cambus_writeb(sensor->slv_addr, AEC, (reg & 0x00) | ((exposure >> 2) & 0xFF));
+        ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, AEC, &reg);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, AEC, (reg & 0x00) | ((exposure >> 2) & 0xFF));
 
-        ret |= cambus_readb(sensor->slv_addr, REG45, &reg);
-        ret |= cambus_writeb(sensor->slv_addr, REG45, (reg & 0xC0) | ((exposure >> 10) & 0x3F));
+        ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, REG45, &reg);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, REG45, (reg & 0xC0) | ((exposure >> 10) & 0x3F));
     }
 
     return ret;
@@ -685,38 +685,38 @@ static int set_auto_exposure(sensor_t *sensor, int enable, int exposure_us)
 static int get_exposure_us(sensor_t *sensor, int *exposure_us)
 {
     uint8_t reg, aec_10, aec_92, aec_1510;
-    int ret = cambus_writeb(sensor->slv_addr, BANK_SEL, BANK_SEL_SENSOR);
-    ret |= cambus_readb(sensor->slv_addr, COM8, &reg);
+    int ret = cambus_writeb(&sensor->i2c, sensor->slv_addr, BANK_SEL, BANK_SEL_SENSOR);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, COM8, &reg);
 
     // DISABLED
     // if (reg & COM8_AEC_EN) {
-    //     ret |= cambus_writeb(sensor->slv_addr, COM8, reg & (~COM8_AEC_EN));
+    //     ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, COM8, reg & (~COM8_AEC_EN));
     // }
     // DISABLED
 
-    ret |= cambus_readb(sensor->slv_addr, REG04, &aec_10);
-    ret |= cambus_readb(sensor->slv_addr, AEC, &aec_92);
-    ret |= cambus_readb(sensor->slv_addr, REG45, &aec_1510);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, REG04, &aec_10);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, AEC, &aec_92);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, REG45, &aec_1510);
 
     // DISABLED
     // if (reg & COM8_AEC_EN) {
-    //     ret |= cambus_writeb(sensor->slv_addr, COM8, reg | COM8_AEC_EN);
+    //     ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, COM8, reg | COM8_AEC_EN);
     // }
     // DISABLED
 
-    ret |= cambus_readb(sensor->slv_addr, COM7, &reg);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, COM7, &reg);
     int t_line = 0;
 
     if (COM7_GET_RES(reg) == COM7_RES_UXGA) t_line = 1600 + 322;
     if (COM7_GET_RES(reg) == COM7_RES_SVGA) t_line = 800 + 390;
     if (COM7_GET_RES(reg) == COM7_RES_CIF) t_line = 400 + 195;
 
-    ret |= cambus_readb(sensor->slv_addr, CLKRC, &reg);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, CLKRC, &reg);
     int pll_mult = ((reg & CLKRC_DOUBLE) ? 2 : 1) * 3;
     int clk_rc = (reg & CLKRC_DIVIDER_MASK) + 2;
 
-    ret |= cambus_writeb(sensor->slv_addr, BANK_SEL, BANK_SEL_DSP);
-    ret |= cambus_readb(sensor->slv_addr, IMAGE_MODE, &reg);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, BANK_SEL, BANK_SEL_DSP);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, IMAGE_MODE, &reg);
     int t_pclk = 0;
 
     if (IMAGE_MODE_GET_FMT(reg) == IMAGE_MODE_YUV422) t_pclk = 2;
@@ -732,9 +732,9 @@ static int get_exposure_us(sensor_t *sensor, int *exposure_us)
 static int set_auto_whitebal(sensor_t *sensor, int enable, float r_gain_db, float g_gain_db, float b_gain_db)
 {
     uint8_t reg;
-    int ret = cambus_writeb(sensor->slv_addr, BANK_SEL, BANK_SEL_DSP);
-    ret |= cambus_readb(sensor->slv_addr, CTRL1, &reg);
-    ret |= cambus_writeb(sensor->slv_addr, CTRL1, (reg & (~CTRL1_AWB)) | ((enable != 0) ? CTRL1_AWB : 0));
+    int ret = cambus_writeb(&sensor->i2c, sensor->slv_addr, BANK_SEL, BANK_SEL_DSP);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, CTRL1, &reg);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, CTRL1, (reg & (~CTRL1_AWB)) | ((enable != 0) ? CTRL1_AWB : 0));
 
     if ((enable == 0) && (!isnanf(r_gain_db)) && (!isnanf(g_gain_db)) && (!isnanf(b_gain_db))
                       && (!isinff(r_gain_db)) && (!isinff(g_gain_db)) && (!isinff(b_gain_db))) {
@@ -746,18 +746,18 @@ static int set_auto_whitebal(sensor_t *sensor, int enable, float r_gain_db, floa
 static int get_rgb_gain_db(sensor_t *sensor, float *r_gain_db, float *g_gain_db, float *b_gain_db)
 {
     uint8_t reg;
-    int ret = cambus_writeb(sensor->slv_addr, BANK_SEL, BANK_SEL_DSP);
-    ret |= cambus_readb(sensor->slv_addr, CTRL1, &reg);
+    int ret = cambus_writeb(&sensor->i2c, sensor->slv_addr, BANK_SEL, BANK_SEL_DSP);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, CTRL1, &reg);
 
     // DISABLED
     // if (reg & CTRL1_AWB) {
-    //     ret |= cambus_writeb(sensor->slv_addr, CTRL1, reg & (~CTRL1_AWB));
+    //     ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, CTRL1, reg & (~CTRL1_AWB));
     // }
     // DISABLED
 
     // DISABLED
     // if (reg & CTRL1_AWB) {
-    //     ret |= cambus_writeb(sensor->slv_addr, CTRL1, reg | CTRL1_AWB);
+    //     ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, CTRL1, reg | CTRL1_AWB);
     // }
     // DISABLED
 
@@ -771,8 +771,8 @@ static int get_rgb_gain_db(sensor_t *sensor, float *r_gain_db, float *g_gain_db,
 static int set_hmirror(sensor_t *sensor, int enable)
 {
     uint8_t reg;
-    int ret = cambus_writeb(sensor->slv_addr, BANK_SEL, BANK_SEL_SENSOR);
-    ret |= cambus_readb(sensor->slv_addr, REG04, &reg);
+    int ret = cambus_writeb(&sensor->i2c, sensor->slv_addr, BANK_SEL, BANK_SEL_SENSOR);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, REG04, &reg);
 
     if (!enable) { // Already mirrored.
         reg |= REG04_HFLIP_IMG;
@@ -780,14 +780,14 @@ static int set_hmirror(sensor_t *sensor, int enable)
         reg &= ~REG04_HFLIP_IMG;
     }
 
-    return cambus_writeb(sensor->slv_addr, REG04, reg) | ret;
+    return cambus_writeb(&sensor->i2c, sensor->slv_addr, REG04, reg) | ret;
 }
 
 static int set_vflip(sensor_t *sensor, int enable)
 {
     uint8_t reg;
-    int ret = cambus_writeb(sensor->slv_addr, BANK_SEL, BANK_SEL_SENSOR);
-    ret |= cambus_readb(sensor->slv_addr, REG04, &reg);
+    int ret = cambus_writeb(&sensor->i2c, sensor->slv_addr, BANK_SEL, BANK_SEL_SENSOR);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, REG04, &reg);
 
     if (!enable) { // Already flipped.
         reg |= REG04_VFLIP_IMG | REG04_VREF_EN;
@@ -795,7 +795,7 @@ static int set_vflip(sensor_t *sensor, int enable)
         reg &= ~(REG04_VFLIP_IMG | REG04_VREF_EN);
     }
 
-    return cambus_writeb(sensor->slv_addr, REG04, reg) | ret;
+    return cambus_writeb(&sensor->i2c, sensor->slv_addr, REG04, reg) | ret;
 }
 
 static int set_special_effect(sensor_t *sensor, sde_t sde)
@@ -804,20 +804,20 @@ static int set_special_effect(sensor_t *sensor, sde_t sde)
 
     switch (sde) {
         case SDE_NEGATIVE:
-            ret |= cambus_writeb(sensor->slv_addr, BANK_SEL, BANK_SEL_DSP);
-            ret |= cambus_writeb(sensor->slv_addr, BPADDR, 0x00);
-            ret |= cambus_writeb(sensor->slv_addr, BPDATA, 0x40);
-            ret |= cambus_writeb(sensor->slv_addr, BPADDR, 0x05);
-            ret |= cambus_writeb(sensor->slv_addr, BPDATA, 0x80);
-            ret |= cambus_writeb(sensor->slv_addr, BPDATA, 0x80);
+            ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, BANK_SEL, BANK_SEL_DSP);
+            ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, BPADDR, 0x00);
+            ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, BPDATA, 0x40);
+            ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, BPADDR, 0x05);
+            ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, BPDATA, 0x80);
+            ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, BPDATA, 0x80);
             break;
         case SDE_NORMAL:
-            ret |= cambus_writeb(sensor->slv_addr, BANK_SEL, BANK_SEL_DSP);
-            ret |= cambus_writeb(sensor->slv_addr, BPADDR, 0x00);
-            ret |= cambus_writeb(sensor->slv_addr, BPDATA, 0x00);
-            ret |= cambus_writeb(sensor->slv_addr, BPADDR, 0x05);
-            ret |= cambus_writeb(sensor->slv_addr, BPDATA, 0x80);
-            ret |= cambus_writeb(sensor->slv_addr, BPDATA, 0x80);
+            ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, BANK_SEL, BANK_SEL_DSP);
+            ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, BPADDR, 0x00);
+            ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, BPDATA, 0x00);
+            ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, BPADDR, 0x05);
+            ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, BPDATA, 0x80);
+            ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, BPDATA, 0x80);
             break;
         default:
             return -1;

--- a/src/omv/ov7725.c
+++ b/src/omv/ov7725.c
@@ -150,14 +150,14 @@ static const uint8_t saturation_regs[NUM_SATURATION_LEVELS][2] = {
 static int reset(sensor_t *sensor)
 {
     // Reset all registers
-    int ret = cambus_writeb(sensor->slv_addr, COM7, COM7_RESET);
+    int ret = cambus_writeb(&sensor->i2c, sensor->slv_addr, COM7, COM7_RESET);
 
     // Delay 2 ms
     systick_sleep(2);
 
     // Write default regsiters
     for (int i = 0; default_regs[i][0]; i++) {
-        ret |= cambus_writeb(sensor->slv_addr, default_regs[i][0], default_regs[i][1]);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, default_regs[i][0], default_regs[i][1]);
     }
 
     // Delay 300 ms
@@ -169,7 +169,7 @@ static int reset(sensor_t *sensor)
 static int sleep(sensor_t *sensor, int enable)
 {
     uint8_t reg;
-    int ret = cambus_readb(sensor->slv_addr, COM2, &reg);
+    int ret = cambus_readb(&sensor->i2c, sensor->slv_addr, COM2, &reg);
 
     if (enable) {
         reg |= COM2_SOFT_SLEEP;
@@ -178,13 +178,13 @@ static int sleep(sensor_t *sensor, int enable)
     }
 
     // Write back register
-    return cambus_writeb(sensor->slv_addr, COM2, reg) | ret;
+    return cambus_writeb(&sensor->i2c, sensor->slv_addr, COM2, reg) | ret;
 }
 
 static int read_reg(sensor_t *sensor, uint16_t reg_addr)
 {
     uint8_t reg_data;
-    if (cambus_readb(sensor->slv_addr, reg_addr, &reg_data) != 0) {
+    if (cambus_readb(&sensor->i2c, sensor->slv_addr, reg_addr, &reg_data) != 0) {
         return -1;
     }
     return reg_data;
@@ -192,34 +192,34 @@ static int read_reg(sensor_t *sensor, uint16_t reg_addr)
 
 static int write_reg(sensor_t *sensor, uint16_t reg_addr, uint16_t reg_data)
 {
-    return cambus_writeb(sensor->slv_addr, reg_addr, reg_data);
+    return cambus_writeb(&sensor->i2c, sensor->slv_addr, reg_addr, reg_data);
 }
 
 static int set_pixformat(sensor_t *sensor, pixformat_t pixformat)
 {
     uint8_t reg;
-    int ret = cambus_readb(sensor->slv_addr, COM7, &reg);
+    int ret = cambus_readb(&sensor->i2c, sensor->slv_addr, COM7, &reg);
 
     switch (pixformat) {
         case PIXFORMAT_RGB565:
             reg = COM7_SET_FMT(reg, COM7_FMT_RGB);
-            ret |= cambus_writeb(sensor->slv_addr, DSP_CTRL4, DSP_CTRL4_YUV_RGB);
+            ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, DSP_CTRL4, DSP_CTRL4_YUV_RGB);
             break;
         case PIXFORMAT_YUV422:
         case PIXFORMAT_GRAYSCALE:
             reg = COM7_SET_FMT(reg, COM7_FMT_YUV);
-            ret |= cambus_writeb(sensor->slv_addr, DSP_CTRL4, DSP_CTRL4_YUV_RGB);
+            ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, DSP_CTRL4, DSP_CTRL4_YUV_RGB);
             break;
         case PIXFORMAT_BAYER:
             reg = COM7_SET_FMT(reg, COM7_FMT_P_BAYER);
-            ret |= cambus_writeb(sensor->slv_addr, DSP_CTRL4, DSP_CTRL4_RAW8);
+            ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, DSP_CTRL4, DSP_CTRL4_RAW8);
             break;
         default:
             return -1;
     }
 
     // Write back register
-    return cambus_writeb(sensor->slv_addr, COM7, reg) | ret;
+    return cambus_writeb(&sensor->i2c, sensor->slv_addr, COM7, reg) | ret;
 }
 
 static int set_framesize(sensor_t *sensor, framesize_t framesize)
@@ -229,47 +229,47 @@ static int set_framesize(sensor_t *sensor, framesize_t framesize)
     uint16_t h = resolution[framesize][1];
 
     // Write MSBs
-    ret |= cambus_writeb(sensor->slv_addr, HOUTSIZE, w>>2);
-    ret |= cambus_writeb(sensor->slv_addr, VOUTSIZE, h>>1);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, HOUTSIZE, w>>2);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, VOUTSIZE, h>>1);
 
     // Write LSBs
-    ret |= cambus_writeb(sensor->slv_addr, EXHCH, ((w&0x3) | ((h&0x1) << 2)));
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, EXHCH, ((w&0x3) | ((h&0x1) << 2)));
 
     if ((w <= 320) && (h <= 240)) {
         // Set QVGA Resolution
         uint8_t reg;
-        int ret = cambus_readb(sensor->slv_addr, COM7, &reg);
+        int ret = cambus_readb(&sensor->i2c, sensor->slv_addr, COM7, &reg);
         reg = COM7_SET_RES(reg, COM7_RES_QVGA);
-        ret |= cambus_writeb(sensor->slv_addr, COM7, reg);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, COM7, reg);
 
         // Set QVGA Window Size
-        ret |= cambus_writeb(sensor->slv_addr, HSTART, 0x3F);
-        ret |= cambus_writeb(sensor->slv_addr, HSIZE,  0x50);
-        ret |= cambus_writeb(sensor->slv_addr, VSTART, 0x03);
-        ret |= cambus_writeb(sensor->slv_addr, VSIZE,  0x78);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, HSTART, 0x3F);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, HSIZE,  0x50);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, VSTART, 0x03);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, VSIZE,  0x78);
 
         // Enable auto-scaling/zooming factors
-        ret |= cambus_writeb(sensor->slv_addr, DSPAUTO, 0xFF);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, DSPAUTO, 0xFF);
     } else {
         // Set VGA Resolution
         uint8_t reg;
-        int ret = cambus_readb(sensor->slv_addr, COM7, &reg);
+        int ret = cambus_readb(&sensor->i2c, sensor->slv_addr, COM7, &reg);
         reg = COM7_SET_RES(reg, COM7_RES_VGA);
-        ret |= cambus_writeb(sensor->slv_addr, COM7, reg);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, COM7, reg);
 
         // Set VGA Window Size
-        ret |= cambus_writeb(sensor->slv_addr, HSTART, 0x23);
-        ret |= cambus_writeb(sensor->slv_addr, HSIZE,  0xA0);
-        ret |= cambus_writeb(sensor->slv_addr, VSTART, 0x07);
-        ret |= cambus_writeb(sensor->slv_addr, VSIZE,  0xF0);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, HSTART, 0x23);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, HSIZE,  0xA0);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, VSTART, 0x07);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, VSIZE,  0xF0);
 
         // Disable auto-scaling/zooming factors
-        ret |= cambus_writeb(sensor->slv_addr, DSPAUTO, 0xF3);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, DSPAUTO, 0xF3);
 
         // Clear auto-scaling/zooming factors
-        ret |= cambus_writeb(sensor->slv_addr, SCAL0, 0x00);
-        ret |= cambus_writeb(sensor->slv_addr, SCAL1, 0x40);
-        ret |= cambus_writeb(sensor->slv_addr, SCAL2, 0x40);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, SCAL0, 0x00);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, SCAL1, 0x40);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, SCAL2, 0x40);
     }
 
     return ret;
@@ -282,7 +282,7 @@ static int set_contrast(sensor_t *sensor, int level)
         return -1;
     }
 
-    return cambus_writeb(sensor->slv_addr, CONTRAST, contrast_regs[level][0]);
+    return cambus_writeb(&sensor->i2c, sensor->slv_addr, CONTRAST, contrast_regs[level][0]);
 }
 
 static int set_brightness(sensor_t *sensor, int level)
@@ -293,8 +293,8 @@ static int set_brightness(sensor_t *sensor, int level)
         return -1;
     }
 
-    ret |= cambus_writeb(sensor->slv_addr, BRIGHTNESS, brightness_regs[level][0]);
-    ret |= cambus_writeb(sensor->slv_addr, SIGN_BIT,   brightness_regs[level][1]);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, BRIGHTNESS, brightness_regs[level][0]);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, SIGN_BIT,   brightness_regs[level][1]);
     return ret;
 }
 
@@ -306,41 +306,41 @@ static int set_saturation(sensor_t *sensor, int level)
         return -1;
     }
 
-    ret |= cambus_writeb(sensor->slv_addr, USAT, saturation_regs[level][0]);
-    ret |= cambus_writeb(sensor->slv_addr, VSAT, saturation_regs[level][1]);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, USAT, saturation_regs[level][0]);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, VSAT, saturation_regs[level][1]);
     return ret;
 }
 
 static int set_gainceiling(sensor_t *sensor, gainceiling_t gainceiling)
 {
     uint8_t reg;
-    int ret = cambus_readb(sensor->slv_addr, COM9, &reg);
+    int ret = cambus_readb(&sensor->i2c, sensor->slv_addr, COM9, &reg);
 
     // Set gain ceiling
     reg = COM9_SET_AGC(reg, gainceiling);
-    return cambus_writeb(sensor->slv_addr, COM9, reg) | ret;
+    return cambus_writeb(&sensor->i2c, sensor->slv_addr, COM9, reg) | ret;
 }
 
 static int set_colorbar(sensor_t *sensor, int enable)
 {
     uint8_t reg;
-    int ret = cambus_readb(sensor->slv_addr, COM3, &reg);
+    int ret = cambus_readb(&sensor->i2c, sensor->slv_addr, COM3, &reg);
 
     // Enable colorbar test pattern output
     reg = COM3_SET_CBAR(reg, enable);
-    ret |= cambus_writeb(sensor->slv_addr, COM3, reg);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, COM3, reg);
 
     // Enable DSP colorbar output
-    ret |= cambus_readb(sensor->slv_addr, DSP_CTRL3, &reg);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, DSP_CTRL3, &reg);
     reg = DSP_CTRL3_SET_CBAR(reg, enable);
-    return cambus_writeb(sensor->slv_addr, DSP_CTRL3, reg) | ret;
+    return cambus_writeb(&sensor->i2c, sensor->slv_addr, DSP_CTRL3, reg) | ret;
 }
 
 static int set_auto_gain(sensor_t *sensor, int enable, float gain_db, float gain_db_ceiling)
 {
     uint8_t reg;
-    int ret = cambus_readb(sensor->slv_addr, COM8, &reg);
-    ret |= cambus_writeb(sensor->slv_addr, COM8, COM8_SET_AGC(reg, (enable != 0)));
+    int ret = cambus_readb(&sensor->i2c, sensor->slv_addr, COM8, &reg);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, COM8, COM8_SET_AGC(reg, (enable != 0)));
 
     if ((enable == 0) && (!isnanf(gain_db)) && (!isinff(gain_db))) {
         float gain = IM_MAX(IM_MIN(fast_expf((gain_db / 20.0) * fast_log(10.0)), 32.0), 1.0);
@@ -349,12 +349,12 @@ static int set_auto_gain(sensor_t *sensor, int enable, float gain_db, float gain
         int gain_hi = 0xF >> (4 - gain_temp);
         int gain_lo = IM_MIN(fast_roundf(((gain / (1 << gain_temp)) - 1.0) * 16.0), 15);
 
-        ret |= cambus_writeb(sensor->slv_addr, GAIN, (gain_hi << 4) | (gain_lo << 0));
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, GAIN, (gain_hi << 4) | (gain_lo << 0));
     } else if ((enable != 0) && (!isnanf(gain_db_ceiling)) && (!isinff(gain_db_ceiling))) {
         float gain_ceiling = IM_MAX(IM_MIN(fast_expf((gain_db_ceiling / 20.0) * fast_log(10.0)), 32.0), 2.0);
 
-        ret |= cambus_readb(sensor->slv_addr, COM9, &reg);
-        ret |= cambus_writeb(sensor->slv_addr, COM9, (reg & 0x8F) | ((fast_ceilf(fast_log2(gain_ceiling)) - 1) << 4));
+        ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, COM9, &reg);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, COM9, (reg & 0x8F) | ((fast_ceilf(fast_log2(gain_ceiling)) - 1) << 4));
     }
 
     return ret;
@@ -363,19 +363,19 @@ static int set_auto_gain(sensor_t *sensor, int enable, float gain_db, float gain
 static int get_gain_db(sensor_t *sensor, float *gain_db)
 {
     uint8_t reg, gain;
-    int ret = cambus_readb(sensor->slv_addr, COM8, &reg);
+    int ret = cambus_readb(&sensor->i2c, sensor->slv_addr, COM8, &reg);
 
     // DISABLED
     // if (reg & COM8_AGC_EN) {
-    //     ret |= cambus_writeb(sensor->slv_addr, COM8, COM8_SET_AGC(reg, 0));
+    //     ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, COM8, COM8_SET_AGC(reg, 0));
     // }
     // DISABLED
 
-    ret |= cambus_readb(sensor->slv_addr, GAIN, &gain);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, GAIN, &gain);
 
     // DISABLED
     // if (reg & COM8_AGC_EN) {
-    //     ret |= cambus_writeb(sensor->slv_addr, COM8, COM8_SET_AGC(reg, 1));
+    //     ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, COM8, COM8_SET_AGC(reg, 1));
     // }
     // DISABLED
 
@@ -389,16 +389,16 @@ static int get_gain_db(sensor_t *sensor, float *gain_db)
 static int set_auto_exposure(sensor_t *sensor, int enable, int exposure_us)
 {
     uint8_t reg;
-    int ret = cambus_readb(sensor->slv_addr, COM8, &reg);
-    ret |= cambus_writeb(sensor->slv_addr, COM8, COM8_SET_AEC(reg, (enable != 0)));
+    int ret = cambus_readb(&sensor->i2c, sensor->slv_addr, COM8, &reg);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, COM8, COM8_SET_AEC(reg, (enable != 0)));
 
     if ((enable == 0) && (exposure_us >= 0)) {
-        ret |= cambus_readb(sensor->slv_addr, COM7, &reg);
+        ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, COM7, &reg);
 
         int t_line = (reg & COM7_RES_QVGA) ? (320 + 256) : (640 + 144);
         int t_pclk = (COM7_GET_FMT(reg) == COM7_FMT_P_BAYER) ? 1 : 2;
 
-        ret |= cambus_readb(sensor->slv_addr, COM4, &reg);
+        ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, COM4, &reg);
         int pll_mult = 0;
 
         if (COM4_GET_PLL(reg) == COM4_PLL_BYPASS) pll_mult = 1;
@@ -406,7 +406,7 @@ static int set_auto_exposure(sensor_t *sensor, int enable, int exposure_us)
         if (COM4_GET_PLL(reg) == COM4_PLL_6x) pll_mult = 6;
         if (COM4_GET_PLL(reg) == COM4_PLL_8x) pll_mult = 8;
 
-        ret |= cambus_readb(sensor->slv_addr, CLKRC, &reg);
+        ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, CLKRC, &reg);
         int clk_rc = 0;
 
         if (reg & CLKRC_NO_PRESCALE) {
@@ -417,8 +417,8 @@ static int set_auto_exposure(sensor_t *sensor, int enable, int exposure_us)
 
         int exposure = IM_MAX(IM_MIN(((exposure_us*(((OMV_XCLK_FREQUENCY/clk_rc)*pll_mult)/1000000))/t_pclk)/t_line,0xFFFF),0x0000);
 
-        ret |= cambus_writeb(sensor->slv_addr, AEC, ((exposure >> 0) & 0xFF));
-        ret |= cambus_writeb(sensor->slv_addr, AECH, ((exposure >> 8) & 0xFF));
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, AEC, ((exposure >> 0) & 0xFF));
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, AECH, ((exposure >> 8) & 0xFF));
     }
 
     return ret;
@@ -427,29 +427,29 @@ static int set_auto_exposure(sensor_t *sensor, int enable, int exposure_us)
 static int get_exposure_us(sensor_t *sensor, int *exposure_us)
 {
     uint8_t reg, aec_l, aec_h;
-    int ret = cambus_readb(sensor->slv_addr, COM8, &reg);
+    int ret = cambus_readb(&sensor->i2c, sensor->slv_addr, COM8, &reg);
 
     // DISABLED
     // if (reg & COM8_AEC_EN) {
-    //     ret |= cambus_writeb(sensor->slv_addr, COM8, COM8_SET_AEC(reg, 0));
+    //     ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, COM8, COM8_SET_AEC(reg, 0));
     // }
     // DISABLED
 
-    ret |= cambus_readb(sensor->slv_addr, AEC, &aec_l);
-    ret |= cambus_readb(sensor->slv_addr, AECH, &aec_h);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, AEC, &aec_l);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, AECH, &aec_h);
 
     // DISABLED
     // if (reg & COM8_AEC_EN) {
-    //     ret |= cambus_writeb(sensor->slv_addr, COM8, COM8_SET_AEC(reg, 1));
+    //     ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, COM8, COM8_SET_AEC(reg, 1));
     // }
     // DISABLED
 
-    ret |= cambus_readb(sensor->slv_addr, COM7, &reg);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, COM7, &reg);
 
     int t_line = (reg & COM7_RES_QVGA) ? (320 + 256) : (640 + 144);
     int t_pclk = (COM7_GET_FMT(reg) == COM7_FMT_P_BAYER) ? 1 : 2;
 
-    ret |= cambus_readb(sensor->slv_addr, COM4, &reg);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, COM4, &reg);
     int pll_mult = 0;
 
     if (COM4_GET_PLL(reg) == COM4_PLL_BYPASS) pll_mult = 1;
@@ -457,7 +457,7 @@ static int get_exposure_us(sensor_t *sensor, int *exposure_us)
     if (COM4_GET_PLL(reg) == COM4_PLL_6x) pll_mult = 6;
     if (COM4_GET_PLL(reg) == COM4_PLL_8x) pll_mult = 8;
 
-    ret |= cambus_readb(sensor->slv_addr, CLKRC, &reg);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, CLKRC, &reg);
     int clk_rc = 0;
 
     if (reg & CLKRC_NO_PRESCALE) {
@@ -474,21 +474,21 @@ static int get_exposure_us(sensor_t *sensor, int *exposure_us)
 static int set_auto_whitebal(sensor_t *sensor, int enable, float r_gain_db, float g_gain_db, float b_gain_db)
 {
     uint8_t reg;
-    int ret = cambus_readb(sensor->slv_addr, COM8, &reg);
-    ret |= cambus_writeb(sensor->slv_addr, COM8, COM8_SET_AWB(reg, (enable != 0)));
+    int ret = cambus_readb(&sensor->i2c, sensor->slv_addr, COM8, &reg);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, COM8, COM8_SET_AWB(reg, (enable != 0)));
 
     if ((enable == 0) && (!isnanf(r_gain_db)) && (!isnanf(g_gain_db)) && (!isnanf(b_gain_db))
                       && (!isinff(r_gain_db)) && (!isinff(g_gain_db)) && (!isinff(b_gain_db))) {
-        ret |= cambus_readb(sensor->slv_addr, AWB_CTRL1, &reg);
+        ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, AWB_CTRL1, &reg);
         float gain_div = (reg & 0x2) ? 64.0 : 128.0;
 
         int r_gain = IM_MAX(IM_MIN(fast_roundf(fast_expf((r_gain_db / 20.0) * fast_log(10.0)) * gain_div), 255), 0);
         int g_gain = IM_MAX(IM_MIN(fast_roundf(fast_expf((g_gain_db / 20.0) * fast_log(10.0)) * gain_div), 255), 0);
         int b_gain = IM_MAX(IM_MIN(fast_roundf(fast_expf((b_gain_db / 20.0) * fast_log(10.0)) * gain_div), 255), 0);
 
-        ret |= cambus_writeb(sensor->slv_addr, BLUE, b_gain);
-        ret |= cambus_writeb(sensor->slv_addr, RED, r_gain);
-        ret |= cambus_writeb(sensor->slv_addr, GREEN, g_gain);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, BLUE, b_gain);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, RED, r_gain);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, GREEN, g_gain);
     }
 
     return ret;
@@ -497,25 +497,25 @@ static int set_auto_whitebal(sensor_t *sensor, int enable, float r_gain_db, floa
 static int get_rgb_gain_db(sensor_t *sensor, float *r_gain_db, float *g_gain_db, float *b_gain_db)
 {
     uint8_t reg, blue, red, green;
-    int ret = cambus_readb(sensor->slv_addr, COM8, &reg);
+    int ret = cambus_readb(&sensor->i2c, sensor->slv_addr, COM8, &reg);
 
     // DISABLED
     // if (reg & COM8_AWB_EN) {
-    //     ret |= cambus_writeb(sensor->slv_addr, COM8, COM8_SET_AWB(reg, 0));
+    //     ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, COM8, COM8_SET_AWB(reg, 0));
     // }
     // DISABLED
 
-    ret |= cambus_readb(sensor->slv_addr, BLUE, &blue);
-    ret |= cambus_readb(sensor->slv_addr, RED, &red);
-    ret |= cambus_readb(sensor->slv_addr, GREEN, &green);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, BLUE, &blue);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, RED, &red);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, GREEN, &green);
 
     // DISABLED
     // if (reg & COM8_AWB_EN) {
-    //     ret |= cambus_writeb(sensor->slv_addr, COM8, COM8_SET_AWB(reg, 1));
+    //     ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, COM8, COM8_SET_AWB(reg, 1));
     // }
     // DISABLED
 
-    ret |= cambus_readb(sensor->slv_addr, AWB_CTRL1, &reg);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, AWB_CTRL1, &reg);
     float gain_div = (reg & 0x2) ? 64.0 : 128.0;
 
     *r_gain_db = 20.0 * (fast_log(red / gain_div) / fast_log(10.0));
@@ -528,8 +528,8 @@ static int get_rgb_gain_db(sensor_t *sensor, float *r_gain_db, float *g_gain_db,
 static int set_hmirror(sensor_t *sensor, int enable)
 {
     uint8_t reg;
-    int ret = cambus_readb(sensor->slv_addr, COM3, &reg);
-    ret |= cambus_writeb(sensor->slv_addr, COM3, COM3_SET_MIRROR(reg, enable)) ;
+    int ret = cambus_readb(&sensor->i2c, sensor->slv_addr, COM3, &reg);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, COM3, COM3_SET_MIRROR(reg, enable)) ;
 
     return ret;
 }
@@ -537,8 +537,8 @@ static int set_hmirror(sensor_t *sensor, int enable)
 static int set_vflip(sensor_t *sensor, int enable)
 {
     uint8_t reg;
-    int ret = cambus_readb(sensor->slv_addr, COM3, &reg);
-    ret |= cambus_writeb(sensor->slv_addr, COM3, COM3_SET_FLIP(reg, enable));
+    int ret = cambus_readb(&sensor->i2c, sensor->slv_addr, COM3, &reg);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, COM3, COM3_SET_FLIP(reg, enable));
 
     return ret;
 }
@@ -549,12 +549,12 @@ static int set_special_effect(sensor_t *sensor, sde_t sde)
 
     switch (sde) {
         case SDE_NEGATIVE:
-            ret |= cambus_writeb(sensor->slv_addr, SDE, 0x46);
+            ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, SDE, 0x46);
             break;
         case SDE_NORMAL:
-            ret |= cambus_writeb(sensor->slv_addr, SDE, 0x06);
-            ret |= cambus_writeb(sensor->slv_addr, UFIX, 0x80);
-            ret |= cambus_writeb(sensor->slv_addr, VFIX, 0x80);
+            ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, SDE, 0x06);
+            ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, UFIX, 0x80);
+            ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, VFIX, 0x80);
             break;
         default:
             return -1;
@@ -567,9 +567,9 @@ static int set_lens_correction(sensor_t *sensor, int enable, int radi, int coef)
 {
     int ret=0;
 
-    ret |= cambus_writeb(sensor->slv_addr, LC_CTR, (enable&0x01));
-    ret |= cambus_writeb(sensor->slv_addr, LC_RADI, radi);
-    ret |= cambus_writeb(sensor->slv_addr, LC_COEF, coef);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, LC_CTR, (enable&0x01));
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, LC_RADI, radi);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, LC_COEF, coef);
 
     return ret;
 }

--- a/src/omv/ov9650.c
+++ b/src/omv/ov9650.c
@@ -205,14 +205,14 @@ static int reset(sensor_t *sensor)
     const uint8_t (*regs)[2]=default_regs;
 
     /* Reset all registers */
-    cambus_writeb(sensor->slv_addr, REG_COM7, 0x80);
+    cambus_writeb(&sensor->i2c, sensor->slv_addr, REG_COM7, 0x80);
 
     /* delay n ms */
     systick_sleep(10);
 
     /* Write initial regsiters */
     while (regs[i][0]) {
-        cambus_writeb(sensor->slv_addr, regs[i][0], regs[i][1]);
+        cambus_writeb(&sensor->i2c, sensor->slv_addr, regs[i][0], regs[i][1]);
         i++;
     }
 
@@ -226,7 +226,7 @@ static int set_pixformat(sensor_t *sensor, pixformat_t pixformat)
     uint8_t com7=0; /* framesize/RGB */
 
     /* read pixel format reg */
-    cambus_readb(sensor->slv_addr, REG_COM7, &com7);
+    cambus_readb(&sensor->i2c, sensor->slv_addr, REG_COM7, &com7);
 
     switch (pixformat) {
         case PIXFORMAT_RGB565:
@@ -246,11 +246,11 @@ static int set_pixformat(sensor_t *sensor, pixformat_t pixformat)
     }
 
     /* Set pixel format */
-    cambus_writeb(sensor->slv_addr, REG_COM7, com7);
+    cambus_writeb(&sensor->i2c, sensor->slv_addr, REG_COM7, com7);
 
     /* Write pixel format registers */
     while (regs[i][0]) {
-        cambus_writeb(sensor->slv_addr, regs[i][0], regs[i][1]);
+        cambus_writeb(&sensor->i2c, sensor->slv_addr, regs[i][0], regs[i][1]);
         i++;
     }
 
@@ -263,7 +263,7 @@ static int set_framesize(sensor_t *sensor, framesize_t framesize)
     uint8_t com1=0; /* Skip option */
 
     /* read COM7 RGB bit */
-    cambus_readb(sensor->slv_addr, REG_COM7, &com7);
+    cambus_readb(&sensor->i2c, sensor->slv_addr, REG_COM7, &com7);
     com7 &= REG_COM7_RGB;
 
     switch (framesize) {
@@ -283,8 +283,8 @@ static int set_framesize(sensor_t *sensor, framesize_t framesize)
     }
 
     /* write the frame size registers */
-    cambus_writeb(sensor->slv_addr, REG_COM1, com1);
-    cambus_writeb(sensor->slv_addr, REG_COM7, com7);
+    cambus_writeb(&sensor->i2c, sensor->slv_addr, REG_COM1, com1);
+    cambus_writeb(&sensor->i2c, sensor->slv_addr, REG_COM7, com7);
 
     return 0;
 }
@@ -310,7 +310,7 @@ static int set_brightness(sensor_t *sensor, int level)
     }
 
     for (i=0; i<3; i++) {
-        cambus_writeb(sensor->slv_addr, regs[0][i], regs[level][i]);
+        cambus_writeb(&sensor->i2c, sensor->slv_addr, regs[0][i], regs[level][i]);
     }
 
     return 0;
@@ -319,15 +319,15 @@ static int set_brightness(sensor_t *sensor, int level)
 static int set_gainceiling(sensor_t *sensor, gainceiling_t gainceiling)
 {
     /* Write gain ceiling register */
-    cambus_writeb(sensor->slv_addr, REG_COM9, (gainceiling<<4));
+    cambus_writeb(&sensor->i2c, sensor->slv_addr, REG_COM9, (gainceiling<<4));
     return 0;
 }
 
 static int set_auto_gain(sensor_t *sensor, int enable, float gain_db, float gain_db_ceiling)
 {
     uint8_t reg;
-    int ret = cambus_readb(sensor->slv_addr, REG_COM8, &reg);
-    ret |= cambus_writeb(sensor->slv_addr, REG_COM8, (reg & (~REG_COM8_AGC)) | ((enable != 0) ? REG_COM8_AGC : 0));
+    int ret = cambus_readb(&sensor->i2c, sensor->slv_addr, REG_COM8, &reg);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, REG_COM8, (reg & (~REG_COM8_AGC)) | ((enable != 0) ? REG_COM8_AGC : 0));
 
     if ((enable == 0) && (!isnanf(gain_db)) && (!isinf(gain_db))) {
         float gain = IM_MAX(IM_MIN(fast_expf((gain_db / 20.0) * fast_log(10.0)), 128.0), 1.0);
@@ -336,14 +336,14 @@ static int set_auto_gain(sensor_t *sensor, int enable, float gain_db, float gain
         int gain_hi = 0x3F >> (6 - gain_temp);
         int gain_lo = IM_MIN(fast_roundf(((gain / (1 << gain_temp)) - 1.0) * 16.0), 15);
 
-        ret |= cambus_writeb(sensor->slv_addr, REG_GAIN, ((gain_hi & 0x0F) << 4) | (gain_lo << 0));
-        ret |= cambus_readb(sensor->slv_addr, REG_VREF, &reg);
-        ret |= cambus_writeb(sensor->slv_addr, REG_VREF, ((gain_hi & 0x30) << 2) | (reg & 0x3F));
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, REG_GAIN, ((gain_hi & 0x0F) << 4) | (gain_lo << 0));
+        ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, REG_VREF, &reg);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, REG_VREF, ((gain_hi & 0x30) << 2) | (reg & 0x3F));
     } else if ((enable != 0) && (!isnanf(gain_db_ceiling)) && (!isinf(gain_db_ceiling))) {
         float gain_ceiling = IM_MAX(IM_MIN(fast_expf((gain_db_ceiling / 20.0) * fast_log(10.0)), 128.0), 2.0);
 
-        ret |= cambus_readb(sensor->slv_addr, REG_COM9, &reg);
-        ret |= cambus_writeb(sensor->slv_addr, REG_COM9, (reg & 0x8F) | ((fast_ceilf(fast_log2(gain_ceiling)) - 1) << 4));
+        ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, REG_COM9, &reg);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, REG_COM9, (reg & 0x8F) | ((fast_ceilf(fast_log2(gain_ceiling)) - 1) << 4));
     }
 
     return ret;
@@ -352,20 +352,20 @@ static int set_auto_gain(sensor_t *sensor, int enable, float gain_db, float gain
 static int get_gain_db(sensor_t *sensor, float *gain_db)
 {
     uint8_t reg, gain_lo, gain_hi;
-    int ret = cambus_readb(sensor->slv_addr, REG_COM8, &reg);
+    int ret = cambus_readb(&sensor->i2c, sensor->slv_addr, REG_COM8, &reg);
 
     // DISABLED
     // if (reg & REG_COM8_AGC) {
-    //     ret |= cambus_writeb(sensor->slv_addr, REG_COM8, reg & (~REG_COM8_AGC));
+    //     ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, REG_COM8, reg & (~REG_COM8_AGC));
     // }
     // DISABLED
 
-    ret |= cambus_readb(sensor->slv_addr, REG_GAIN, &gain_lo);
-    ret |= cambus_readb(sensor->slv_addr, REG_VREF, &gain_hi);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, REG_GAIN, &gain_lo);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, REG_VREF, &gain_hi);
 
     // DISABLED
     // if (reg & REG_COM8_AGC) {
-    //     ret |= cambus_writeb(sensor->slv_addr, REG_COM8, reg | REG_COM8_AGC);
+    //     ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, REG_COM8, reg | REG_COM8_AGC);
     // }
     // DISABLED
 
@@ -380,11 +380,11 @@ static int get_gain_db(sensor_t *sensor, float *gain_db)
 static int set_auto_exposure(sensor_t *sensor, int enable, int exposure_us)
 {
     uint8_t reg;
-    int ret = cambus_readb(sensor->slv_addr, REG_COM8, &reg);
-    ret |= cambus_writeb(sensor->slv_addr, REG_COM8, (reg & (~REG_COM8_AEC)) | ((enable != 0) ? REG_COM8_AEC : 0));
+    int ret = cambus_readb(&sensor->i2c, sensor->slv_addr, REG_COM8, &reg);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, REG_COM8, (reg & (~REG_COM8_AEC)) | ((enable != 0) ? REG_COM8_AEC : 0));
 
     if ((enable == 0) && (exposure_us >= 0)) {
-        ret |= cambus_readb(sensor->slv_addr, REG_COM7, &reg);
+        ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, REG_COM7, &reg);
         int t_line = 0, t_pclk = (reg & REG_COM7_RGB) ? 2 : 1;
     
         if (reg & REG_COM7_VGA) t_line = 640 + 160;
@@ -392,20 +392,20 @@ static int set_auto_exposure(sensor_t *sensor, int enable, int exposure_us)
         if (reg & REG_COM7_QVGA) t_line = 320 + 80;
         if (reg & REG_COM7_QCIF) t_line = 176 + 84;
     
-        ret |= cambus_readb(sensor->slv_addr, REG_CLKRC, &reg);
+        ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, REG_CLKRC, &reg);
         int pll_mult = (reg & REG_CLKRC_DOUBLE) ? 2 : 1;
         int clk_rc = ((reg & REG_CLKRC_DIVIDER_MASK) + 1) * 2;
 
         int exposure = IM_MAX(IM_MIN(((exposure_us*(((OMV_XCLK_FREQUENCY/clk_rc)*pll_mult)/1000000))/t_pclk)/t_line,0xFFFF),0x0000);
 
-        ret |= cambus_readb(sensor->slv_addr, REG_COM1, &reg);
-        ret |= cambus_writeb(sensor->slv_addr, REG_COM1, (reg & 0xFC) | ((exposure >> 0) & 0x3));
+        ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, REG_COM1, &reg);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, REG_COM1, (reg & 0xFC) | ((exposure >> 0) & 0x3));
 
-        ret |= cambus_readb(sensor->slv_addr, REG_AECH, &reg);
-        ret |= cambus_writeb(sensor->slv_addr, REG_AECH, (reg & 0x00) | ((exposure >> 2) & 0xFF));
+        ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, REG_AECH, &reg);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, REG_AECH, (reg & 0x00) | ((exposure >> 2) & 0xFF));
 
-        ret |= cambus_readb(sensor->slv_addr, REG_AECHM, &reg);
-        ret |= cambus_writeb(sensor->slv_addr, REG_AECHM, (reg & 0xC0) | ((exposure >> 10) & 0x3F));
+        ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, REG_AECHM, &reg);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, REG_AECHM, (reg & 0xC0) | ((exposure >> 10) & 0x3F));
     }
 
     return ret;
@@ -414,25 +414,25 @@ static int set_auto_exposure(sensor_t *sensor, int enable, int exposure_us)
 static int get_exposure_us(sensor_t *sensor, int *exposure_us)
 {
     uint8_t reg, aec_10, aec_92, aec_1510;
-    int ret = cambus_readb(sensor->slv_addr, REG_COM8, &reg);
+    int ret = cambus_readb(&sensor->i2c, sensor->slv_addr, REG_COM8, &reg);
 
     // DISABLED
     // if (reg & REG_COM8_AEC) {
-    //     ret |= cambus_writeb(sensor->slv_addr, REG_COM8, reg & (~REG_COM8_AEC));
+    //     ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, REG_COM8, reg & (~REG_COM8_AEC));
     // }
     // DISABLED
 
-    ret |= cambus_readb(sensor->slv_addr, REG_COM1, &aec_10);
-    ret |= cambus_readb(sensor->slv_addr, REG_AECH, &aec_92);
-    ret |= cambus_readb(sensor->slv_addr, REG_AECHM, &aec_1510);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, REG_COM1, &aec_10);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, REG_AECH, &aec_92);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, REG_AECHM, &aec_1510);
 
     // DISABLED
     // if (reg & REG_COM8_AEC) {
-    //     ret |= cambus_writeb(sensor->slv_addr, REG_COM8, reg | REG_COM8_AEC);
+    //     ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, REG_COM8, reg | REG_COM8_AEC);
     // }
     // DISABLED
 
-    ret |= cambus_readb(sensor->slv_addr, REG_COM7, &reg);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, REG_COM7, &reg);
     int t_line = 0, t_pclk = (reg & REG_COM7_RGB) ? 2 : 1;
 
     if (reg & REG_COM7_VGA) t_line = 640 + 160;
@@ -440,7 +440,7 @@ static int get_exposure_us(sensor_t *sensor, int *exposure_us)
     if (reg & REG_COM7_QVGA) t_line = 320 + 80;
     if (reg & REG_COM7_QCIF) t_line = 176 + 84;
 
-    ret |= cambus_readb(sensor->slv_addr, REG_CLKRC, &reg);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, REG_CLKRC, &reg);
     int pll_mult = (reg & REG_CLKRC_DOUBLE) ? 2 : 1;
     int clk_rc = ((reg & REG_CLKRC_DIVIDER_MASK) + 1) * 2;
 
@@ -453,16 +453,16 @@ static int get_exposure_us(sensor_t *sensor, int *exposure_us)
 static int set_auto_whitebal(sensor_t *sensor, int enable, float r_gain_db, float g_gain_db, float b_gain_db)
 {
     uint8_t reg;
-    int ret = cambus_readb(sensor->slv_addr, REG_COM8, &reg);
-    ret |= cambus_writeb(sensor->slv_addr, REG_COM8, (reg & (~REG_COM8_AWB)) | ((enable != 0) ? REG_COM8_AWB : 0));
+    int ret = cambus_readb(&sensor->i2c, sensor->slv_addr, REG_COM8, &reg);
+    ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, REG_COM8, (reg & (~REG_COM8_AWB)) | ((enable != 0) ? REG_COM8_AWB : 0));
 
     if ((enable == 0) && (!isnanf(r_gain_db)) && (!isnanf(g_gain_db)) && (!isnanf(b_gain_db))
                       && (!isinff(r_gain_db)) && (!isinff(g_gain_db)) && (!isinff(b_gain_db))) {
         int r_gain = IM_MAX(IM_MIN(fast_roundf(fast_expf((r_gain_db / 20.0) * fast_log(10.0)) * 128.0), 255), 0);
         int b_gain = IM_MAX(IM_MIN(fast_roundf(fast_expf((b_gain_db / 20.0) * fast_log(10.0)) * 128.0), 255), 0);
 
-        ret |= cambus_writeb(sensor->slv_addr, REG_BLUE, b_gain);
-        ret |= cambus_writeb(sensor->slv_addr, REG_RED, r_gain);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, REG_BLUE, b_gain);
+        ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, REG_RED, r_gain);
     }
 
     return ret;
@@ -471,20 +471,20 @@ static int set_auto_whitebal(sensor_t *sensor, int enable, float r_gain_db, floa
 static int get_rgb_gain_db(sensor_t *sensor, float *r_gain_db, float *g_gain_db, float *b_gain_db)
 {
     uint8_t reg, blue, red;
-    int ret = cambus_readb(sensor->slv_addr, REG_COM8, &reg);
+    int ret = cambus_readb(&sensor->i2c, sensor->slv_addr, REG_COM8, &reg);
 
     // DISABLED
     // if (reg & REG_COM8_AWB) {
-    //     ret |= cambus_writeb(sensor->slv_addr, REG_COM8, reg & (~REG_COM8_AWB));
+    //     ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, REG_COM8, reg & (~REG_COM8_AWB));
     // }
     // DISABLED
 
-    ret |= cambus_readb(sensor->slv_addr, REG_BLUE, &blue);
-    ret |= cambus_readb(sensor->slv_addr, REG_RED, &red);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, REG_BLUE, &blue);
+    ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, REG_RED, &red);
 
     // DISABLED
     // if (reg & REG_COM8_AWB) {
-    //     ret |= cambus_writeb(sensor->slv_addr, REG_COM8, reg | REG_COM8_AWB);
+    //     ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, REG_COM8, reg | REG_COM8_AWB);
     // }
     // DISABLED
 
@@ -497,8 +497,8 @@ static int get_rgb_gain_db(sensor_t *sensor, float *r_gain_db, float *g_gain_db,
 static int set_hmirror(sensor_t *sensor, int enable)
 {
    uint8_t val;
-   int ret = cambus_readb(sensor->slv_addr, REG_MVFP, &val);
-   ret |= cambus_writeb(sensor->slv_addr, REG_MVFP, enable ? (val | REG_MVFP_HMIRROR) : (val & (~REG_MVFP_HMIRROR)));
+   int ret = cambus_readb(&sensor->i2c, sensor->slv_addr, REG_MVFP, &val);
+   ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, REG_MVFP, enable ? (val | REG_MVFP_HMIRROR) : (val & (~REG_MVFP_HMIRROR)));
 
    return ret;
 }
@@ -506,8 +506,8 @@ static int set_hmirror(sensor_t *sensor, int enable)
 static int set_vflip(sensor_t *sensor, int enable)
 {
    uint8_t val;
-   int ret = cambus_readb(sensor->slv_addr, REG_MVFP, &val);
-   ret |= cambus_writeb(sensor->slv_addr, REG_MVFP, enable ? (val | REG_MVFP_VFLIP) : (val & (~REG_MVFP_VFLIP)));
+   int ret = cambus_readb(&sensor->i2c, sensor->slv_addr, REG_MVFP, &val);
+   ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, REG_MVFP, enable ? (val | REG_MVFP_VFLIP) : (val & (~REG_MVFP_VFLIP)));
 
    return ret;
 }

--- a/src/omv/sensor.h
+++ b/src/omv/sensor.h
@@ -167,6 +167,8 @@ typedef struct _sensor {
     bool transpose;             // Transpose Image
     bool auto_rotation;         // Rotate Image Automatically
 
+    I2C_HandleTypeDef i2c;      // SCCB/I2C bus.
+
     // Sensor function pointers
     int  (*reset)               (sensor_t *sensor);
     int  (*sleep)               (sensor_t *sensor, int enable);


### PR DESCRIPTION
Tested with the following cams/sensors:
* OPENMV3/OV7725
* OPENMV4 OV2640, OV5640, OV7725, MT9V034 and all FLIR sensors.
* OPENMV4P/OV5640