### PR TITLE
Add correction to imlib lens corr + optimise

### DIFF
--- a/src/omv/img/imlib.c
+++ b/src/omv/img/imlib.c
@@ -1244,40 +1244,41 @@ void imlib_lens_corr(image_t *img, float strength, float zoom, float x_corr, flo
                 for (int x = 0; x < halfWidth; x++) {
                     int newX = x - halfWidth;
                     int newX2 = newX * newX;
-
                     float precalculated = precalculated_table[(int)fast_sqrtf(newX2 + newY2)];
-                    int sourceX = fast_roundf(precalculated * newX); // rounding is necessary
                     int sourceY = fast_roundf(precalculated * newY); // rounding is necessary
-
-                    // plot the 4 symmetrical pixels
-                    uint32_t *ptr, pixel;
+                    int sourceX = fast_roundf(precalculated * newX); // rounding is necessary
                     int sourceY_down = down_adj + sourceY;
                     int sourceY_up = up_adj - sourceY;
                     int sourceX_right = right_adj + sourceX;
                     int sourceX_left = left_adj - sourceX;
 
+                    // plot the 4 symmetrical pixels
+                    // top 2 pixels
                     if (sourceY_down >= 0 && sourceY_down < h) {
-                        ptr = tmp + (((w + UINT32_T_MASK) >> UINT32_T_SHIFT) * sourceY_down);
+                        uint32_t *ptr = tmp + (((w + UINT32_T_MASK) >> UINT32_T_SHIFT) * sourceY_down);
+
                         if (sourceX_right >= 0 && sourceX_right < w) {
-                            pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, sourceX_right);
+                            uint8_t pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, sourceX_right);
                             IMAGE_PUT_BINARY_PIXEL_FAST(row_ptr, x, pixel);
                         }
                         
                         if (sourceX_left >= 0 && sourceX_left < w) {
-                            pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, sourceX_left);
+                            uint8_t pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, sourceX_left);
                             IMAGE_PUT_BINARY_PIXEL_FAST(row_ptr, w - 1 - x, pixel);
                         }
                     }
 
+                    // bottom 2 pixels
                     if (sourceY_up >= 0 && sourceY_up < h) {
-                        ptr = tmp + (((w + UINT32_T_MASK) >> UINT32_T_SHIFT) * sourceY_up);
+                        uint32_t *ptr = tmp + (((w + UINT32_T_MASK) >> UINT32_T_SHIFT) * sourceY_up);
+
                         if (sourceX_right >= 0 && sourceX_right < w) {
-                            pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, sourceX_right);
+                            uint8_t pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, sourceX_right);
                             IMAGE_PUT_BINARY_PIXEL_FAST(row_ptr2, x, pixel);
                         }
 
                         if (sourceX_left >= 0 && sourceX_left < w) {
-                            pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, sourceX_left);
+                            uint8_t pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, sourceX_left);
                             IMAGE_PUT_BINARY_PIXEL_FAST(row_ptr2, w - 1 - x, pixel);
                         }
                     }
@@ -1297,21 +1298,19 @@ void imlib_lens_corr(image_t *img, float strength, float zoom, float x_corr, flo
                 for (int x = 0; x < halfWidth; x++) {
                     int newX = x - halfWidth;
                     int newX2 = newX * newX;
-
                     float precalculated = precalculated_table[(int)fast_sqrtf(newX2 + newY2)];
-                    int sourceX = fast_roundf(precalculated * newX); // rounding is necessary
                     int sourceY = fast_roundf(precalculated * newY); // rounding is necessary
-
-                    // plot the 4 symmetrical pixels
-                    uint8_t *ptr;
+                    int sourceX = fast_roundf(precalculated * newX); // rounding is necessary
                     int sourceY_down = down_adj + sourceY;
                     int sourceY_up = up_adj - sourceY;
                     int sourceX_right = right_adj + sourceX;
                     int sourceX_left = left_adj - sourceX;
 
+                    // plot the 4 symmetrical pixels
                     // top 2 pixels
                     if (sourceY_down >= 0 && sourceY_down < h) {
-                        ptr = tmp + (w * sourceY_down);
+                        uint8_t *ptr = tmp + (w * sourceY_down);
+
                         if (sourceX_right >= 0 && sourceX_right < w) {
                             row_ptr[x] = ptr[sourceX_right];
                         }
@@ -1323,7 +1322,8 @@ void imlib_lens_corr(image_t *img, float strength, float zoom, float x_corr, flo
 
                     // bottom 2 pixels
                     if (sourceY_up >= 0 && sourceY_up < h) {
-                        ptr = tmp + (w * sourceY_up);
+                        uint8_t *ptr = tmp + (w * sourceY_up);
+
                         if (sourceX_right >= 0 && sourceX_right < w) {
                             row_ptr2[x] = ptr[sourceX_right];
                         }
@@ -1348,21 +1348,19 @@ void imlib_lens_corr(image_t *img, float strength, float zoom, float x_corr, flo
                 for (int x = 0; x < halfWidth; x++) {
                     int newX = x - halfWidth;
                     int newX2 = newX * newX;
-
                     float precalculated = precalculated_table[(int)fast_sqrtf(newX2 + newY2)];
-                    int sourceX = fast_roundf(precalculated * newX); // rounding is necessary
                     int sourceY = fast_roundf(precalculated * newY); // rounding is necessary
-
-                    // plot the 4 symmetrical pixels
-                    uint16_t *ptr;
+                    int sourceX = fast_roundf(precalculated * newX); // rounding is necessary
                     int sourceY_down = down_adj + sourceY;
                     int sourceY_up = up_adj - sourceY;
                     int sourceX_right = right_adj + sourceX;
                     int sourceX_left = left_adj - sourceX;
 
+                    // plot the 4 symmetrical pixels
                     // top 2 pixels
                     if (sourceY_down >= 0 && sourceY_down < h) {
-                        ptr = tmp + (w * sourceY_down);
+                        uint16_t *ptr = tmp + (w * sourceY_down);
+
                         if (sourceX_right >= 0 && sourceX_right < w) {
                             row_ptr[x] = ptr[sourceX_right];
                         }
@@ -1374,7 +1372,8 @@ void imlib_lens_corr(image_t *img, float strength, float zoom, float x_corr, flo
 
                     // bottom 2 pixels
                     if (sourceY_up >= 0 && sourceY_up < h) {
-                        ptr = tmp + (w * sourceY_up);
+                        uint16_t *ptr = tmp + (w * sourceY_up);
+
                         if (sourceX_right >= 0 && sourceX_right < w) {
                             row_ptr2[x] = ptr[sourceX_right];
                         }

--- a/src/omv/img/imlib.c
+++ b/src/omv/img/imlib.c
@@ -1220,7 +1220,7 @@ void imlib_lens_corr(image_t *img, float strength, float zoom, float x_corr, flo
     memcpy(data, img->data, size);
     memset(img->data, 0, size);
 
-    int maximum_radius = fast_ceilf(maximum_diameter / 2);
+    int maximum_radius = fast_ceilf(maximum_diameter / 2) + 1; // +1 inclusive of final value
     float *precalculated_table = fb_alloc(maximum_radius * sizeof(float), FB_ALLOC_NO_HINT);
     
     for(int i=0; i < maximum_radius; i++) {

--- a/src/omv/img/imlib.c
+++ b/src/omv/img/imlib.c
@@ -1237,39 +1237,38 @@ void imlib_lens_corr(image_t *img, float strength, float zoom, float x_corr, flo
 
                     float r = lens_corr_radius * fast_sqrtf(newX2 + newY2);
                     float theta = fast_atanf(r) / r; // r is never 0
-                    int sourceX = halfWidth + fast_roundf(theta * zoomedX); // rounding is necessary
-                    int sourceY = halfHeight + fast_roundf(theta * zoomedY); // rounding is necessary
+                    int sourceX = halfWidth + x_off +  fast_roundf(theta * zoomedX); // rounding is necessary
+                    int sourceY = halfHeight + y_off + fast_roundf(theta * zoomedY); // rounding is necessary
 
-                    if ((0 <= sourceX) && (0 <= sourceY)) { // plot the 4 symmetrical pixels
-                        uint32_t *ptr, pixel;
-                        int sourceY_adj = sourceY + y_off;
-                        if (sourceY_adj >= 0 && sourceY_adj < h) {
-                            ptr = tmp + (((w + UINT32_T_MASK) >> UINT32_T_SHIFT) * sourceY_adj);
-                            int sourceX_adj = sourceX + x_off;
-                            if (sourceX_adj >= 0 && sourceX_adj < w) {
-                                pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, sourceX_adj);
-                                IMAGE_PUT_BINARY_PIXEL_FAST(row_ptr, x, pixel);
-                            }
-                            sourceX_adj = w - 1 - sourceX + x_off;
-                            if (sourceX_adj >= 0 && sourceX_adj < w) {
-                                pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, sourceX_adj);
-                                IMAGE_PUT_BINARY_PIXEL_FAST(row_ptr, w - 1 - x, pixel);
-                            }
+                    // plot the 4 symmetrical pixels
+                    uint32_t *ptr, pixel;
+                    int sourceX_adj = w - 1 - sourceX;
+
+                    if (sourceY >= 0 && sourceY < h) {
+                        ptr = tmp + (((w + UINT32_T_MASK) >> UINT32_T_SHIFT) * sourceY);
+                        if (sourceX >= 0 && sourceX < w) {
+                            pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, sourceX);
+                            IMAGE_PUT_BINARY_PIXEL_FAST(row_ptr, x, pixel);
+                        }
+                        
+                        if (sourceX_adj >= 0 && sourceX_adj < w) {
+                            pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, sourceX_adj);
+                            IMAGE_PUT_BINARY_PIXEL_FAST(row_ptr, w - 1 - x, pixel);
+                        }
+                    }
+
+                    int sourceY_adj = h - 1 - sourceY;
+
+                    if (sourceY_adj >= 0 && sourceY_adj < h) {
+                        ptr = tmp + (((w + UINT32_T_MASK) >> UINT32_T_SHIFT) * sourceY_adj);
+                        if (sourceX >= 0 && sourceX < w) {
+                            pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, sourceX);
+                            IMAGE_PUT_BINARY_PIXEL_FAST(row_ptr2, x, pixel);
                         }
 
-                        sourceY_adj = h - 1 - sourceY + y_off;
-                        if (sourceY_adj >= 0 && sourceY_adj < h) {
-                            ptr = tmp + (((w + UINT32_T_MASK) >> UINT32_T_SHIFT) * sourceY_adj);
-                            int sourceX_adj = sourceX + x_off;
-                            if (sourceX_adj >= 0 && sourceX_adj < w) {
-                                pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, sourceX_adj);
-                                IMAGE_PUT_BINARY_PIXEL_FAST(row_ptr2, x, pixel);
-                            }
-                            sourceX_adj = w - 1 - sourceX + x_off;
-                            if (sourceX_adj >= 0 && sourceX_adj < w) {
-                                pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, w - 1 - sourceX_adj);
-                                IMAGE_PUT_BINARY_PIXEL_FAST(row_ptr2, w - 1 - x, pixel);
-                            }
+                        if (sourceX_adj >= 0 && sourceX_adj < w) {
+                            pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, w - 1 - sourceX_adj);
+                            IMAGE_PUT_BINARY_PIXEL_FAST(row_ptr2, w - 1 - x, pixel);
                         }
                     }
                 }
@@ -1293,39 +1292,38 @@ void imlib_lens_corr(image_t *img, float strength, float zoom, float x_corr, flo
 
                     float r = lens_corr_radius * fast_sqrtf(newX2 + newY2);
                     float theta = fast_atanf(r) / r;
-                    int sourceX = halfWidth + fast_roundf(theta * zoomedX); // rounding is necessary
-                    int sourceY = halfHeight + fast_roundf(theta * zoomedY); // rounding is necessary
+                    int sourceX = halfWidth + x_off + fast_roundf(theta * zoomedX); // rounding is necessary
+                    int sourceY = halfHeight + y_off + fast_roundf(theta * zoomedY); // rounding is necessary
 
-                    if ((0 <= sourceX) && (0 <= sourceY)) { // plot the 4 symmetrical pixels
-                        uint8_t *ptr, pixel;
-                        int sourceY_adj = sourceY + y_off;
-                        if (sourceY_adj >= 0 && sourceY_adj < h) {
-                            ptr = tmp + (w * sourceY_adj); // top 2 pixels
-                            int sourceX_adj = sourceX + x_off;
-                            if (sourceX_adj >= 0 && sourceX_adj < w) {
-                                pixel = ptr[sourceX_adj];
-                                row_ptr[x] = pixel;
-                            }
-                            sourceX_adj = w - 1 - sourceX + x_off;
-                            if (sourceX_adj >= 0 && sourceX_adj < w) {
-                                pixel = ptr[sourceX_adj];
-                                row_ptr[w - 1 - x] = pixel;
-                            }
+                    // plot the 4 symmetrical pixels
+                    uint8_t *ptr, pixel;
+                    int sourceX_adj = w - 1 - sourceX;
+
+                    if (sourceY >= 0 && sourceY < h) {
+                        ptr = tmp + (w * sourceY); // top 2 pixels
+                        if (sourceX >= 0 && sourceX < w) {
+                            pixel = ptr[sourceX];
+                            row_ptr[x] = pixel;
                         }
 
-                        sourceY_adj = h - 1 - sourceY + y_off;
-                        if (sourceY_adj >= 0 && sourceY_adj < h) {
-                            ptr = tmp + (w * sourceY_adj); // bottom 2 pixels
-                            int sourceX_adj = sourceX + x_off;
-                            if (sourceX_adj >= 0 && sourceX_adj < w) {
-                                pixel = ptr[sourceX_adj];
-                                row_ptr2[x] = pixel;
-                            }
-                            sourceX_adj = w - 1 - sourceX + x_off;
-                            if (sourceX_adj >= 0 && sourceX_adj < w) {
-                                pixel = ptr[sourceX_adj];
-                                row_ptr2[w - 1 - x] = pixel;
-                            }
+                        if (sourceX_adj >= 0 && sourceX_adj < w) {
+                            pixel = ptr[sourceX_adj];
+                            row_ptr[w - 1 - x] = pixel;
+                        }
+                    }
+
+                    int sourceY_adj = h - 1 - sourceY;
+
+                    if (sourceY_adj >= 0 && sourceY_adj < h) {
+                        ptr = tmp + (w * sourceY_adj); // bottom 2 pixels
+                        if (sourceX >= 0 && sourceX < w) {
+                            pixel = ptr[sourceX];
+                            row_ptr2[x] = pixel;
+                        }
+
+                        if (sourceX_adj >= 0 && sourceX_adj < w) {
+                            pixel = ptr[sourceX_adj];
+                            row_ptr2[w - 1 - x] = pixel;
                         }
                     }
                 }
@@ -1349,39 +1347,38 @@ void imlib_lens_corr(image_t *img, float strength, float zoom, float x_corr, flo
 
                     float r = lens_corr_radius * fast_sqrtf(newX2 + newY2);
                     float theta = fast_atanf(r) / r; // r is never 0
-                    int sourceX = halfWidth + fast_roundf(theta * zoomedX); // rounding is necessary
-                    int sourceY = halfHeight + fast_roundf(theta * zoomedY); // rounding is necessary
+                    int sourceX = halfWidth + x_off + fast_roundf(theta * zoomedX); // rounding is necessary
+                    int sourceY = halfHeight + y_off + fast_roundf(theta * zoomedY); // rounding is necessary
 
-                    if ((0 <= sourceX) && (0 <= sourceY)) { // plot the 4 symmetrical pixels
-                        uint16_t *ptr, pixel;
+                    // plot the 4 symmetrical pixels
+                    uint16_t *ptr, pixel;
+                    int sourceX_adj = w - 1 - sourceX;
 
-                        int sourceY_adj = sourceY + y_off;
-                        if (sourceY_adj >= 0 && sourceY_adj < h) {
-                            ptr = tmp + (w * sourceY_adj); // top 2 pixels
-                            int sourceX_adj = sourceX + x_off;
-                            if (sourceX_adj >= 0 && x < w) {
-                                pixel = ptr[sourceX_adj];
-                                row_ptr[x] = pixel;
-                            }
-                            sourceX_adj = w - 1 - sourceX + x_off;
-                            if (sourceX_adj >= 0 && sourceX_adj < w) {
-                                pixel = ptr[sourceX_adj];
-                                row_ptr[sourceX_adj] = pixel;
-                            }
+                    if (sourceY >= 0 && sourceY < h) {
+                        ptr = tmp + (w * sourceY); // top 2 pixels
+                        if (sourceX >= 0 && x < w) {
+                            pixel = ptr[sourceX];
+                            row_ptr[x] = pixel;
                         }
-                        sourceY_adj = h - 1 - sourceY + y_off;
-                        if (sourceY_adj >= 0 && sourceY_adj < h) {
-                            ptr = tmp + (w * sourceY_adj); // bottom 2 pixels
-                            int sourceX_adj = sourceX + x_off;
-                            if (sourceX_adj >= 0 && sourceX_adj < w) {
-                                pixel = ptr[sourceX_adj];
-                                row_ptr2[x] = pixel;
-                            }
-                            sourceX_adj = w - 1 - sourceX + x_off;
-                            if (sourceX_adj >= 0 && sourceX_adj < w) {
-                                pixel = ptr[sourceX_adj];
-                                row_ptr2[w - 1 - x] = pixel;
-                            }
+
+                        if (sourceX_adj >= 0 && sourceX_adj < w) {
+                            pixel = ptr[sourceX_adj];
+                            row_ptr[sourceX_adj] = pixel;
+                        }
+                    }
+                    
+                    int sourceY_adj = h - 1 - sourceY;
+
+                    if (sourceY_adj >= 0 && sourceY_adj < h) {
+                        ptr = tmp + (w * sourceY_adj); // bottom 2 pixels
+                        if (sourceX >= 0 && sourceX < w) {
+                            pixel = ptr[sourceX];
+                            row_ptr2[x] = pixel;
+                        }
+
+                        if (sourceX_adj >= 0 && sourceX_adj < w) {
+                            pixel = ptr[sourceX_adj];
+                            row_ptr2[w - 1 - x] = pixel;
                         }
                     }
                 }

--- a/src/omv/img/imlib.c
+++ b/src/omv/img/imlib.c
@@ -1220,10 +1220,10 @@ void imlib_lens_corr(image_t *img, float strength, float zoom, float x_corr, flo
     memcpy(data, img->data, size);
     memset(img->data, 0, size);
 
-    float *precalculated = fb_alloc((int)maximum_radius * sizeof(float), FB_ALLOC_NO_HINT);
+    float *precalculated_table = fb_alloc((int)maximum_radius * sizeof(float), FB_ALLOC_NO_HINT);
     for(int i=0; i < (int)maximum_radius; i++) {
         float r = lens_corr_radius * i;
-        precalculated[i] = (fast_atanf(r) / r) * zoom;
+        precalculated_table[i] = (fast_atanf(r) / r) * zoom;
     }
 
     switch(img->bpp) {
@@ -1240,9 +1240,9 @@ void imlib_lens_corr(image_t *img, float strength, float zoom, float x_corr, flo
                     int newX = x - halfWidth;
                     int newX2 = newX * newX;
 
-                    float theta = precalculated[(int)fast_sqrtf(newX2 + newY2)];
-                    int sourceX = x_off + fast_roundf(theta * newX); // rounding is necessary
-                    int sourceY = y_off + fast_roundf(theta * newY); // rounding is necessary
+                    float precalculated = precalculated_table[(int)fast_sqrtf(newX2 + newY2)];
+                    int sourceX = x_off + fast_roundf(precalculated * newX); // rounding is necessary
+                    int sourceY = y_off + fast_roundf(precalculated * newY); // rounding is necessary
 
                     // plot the 4 symmetrical pixels
                     uint32_t *ptr, pixel;
@@ -1292,9 +1292,9 @@ void imlib_lens_corr(image_t *img, float strength, float zoom, float x_corr, flo
                     int newX = x - halfWidth;
                     int newX2 = newX * newX;
 
-                    float theta = precalculated[(int)fast_sqrtf(newX2 + newY2)];
-                    int sourceX = x_off + fast_roundf(theta * newX); // rounding is necessary
-                    int sourceY = y_off + fast_roundf(theta * newY); // rounding is necessary
+                    float precalculated = precalculated_table[(int)fast_sqrtf(newX2 + newY2)];
+                    int sourceX = x_off + fast_roundf(precalculated * newX); // rounding is necessary
+                    int sourceY = y_off + fast_roundf(precalculated * newY); // rounding is necessary
 
                     // plot the 4 symmetrical pixels
                     uint8_t *ptr, pixel;
@@ -1344,9 +1344,9 @@ void imlib_lens_corr(image_t *img, float strength, float zoom, float x_corr, flo
                     int newX = x - halfWidth;
                     int newX2 = newX * newX;
 
-                    float theta = precalculated[(int)fast_sqrtf(newX2 + newY2)];
-                    int sourceX = x_off + fast_roundf(theta * newX); // rounding is necessary
-                    int sourceY = y_off + fast_roundf(theta * newY); // rounding is necessary
+                    float precalculated = precalculated_table[(int)fast_sqrtf(newX2 + newY2)];
+                    int sourceX = x_off + fast_roundf(precalculated * newX); // rounding is necessary
+                    int sourceY = y_off + fast_roundf(precalculated * newY); // rounding is necessary
 
                     // plot the 4 symmetrical pixels
                     uint16_t *ptr, pixel;
@@ -1388,7 +1388,7 @@ void imlib_lens_corr(image_t *img, float strength, float zoom, float x_corr, flo
         }
     }
     
-    fb_free(precalculated);
+    fb_free(precalculated_table);
     fb_free();
 }
 #endif //IMLIB_ENABLE_LENS_CORR

--- a/src/omv/img/imlib.c
+++ b/src/omv/img/imlib.c
@@ -1388,8 +1388,8 @@ void imlib_lens_corr(image_t *img, float strength, float zoom, float x_corr, flo
         }
     }
     
-    fb_free(precalculated_table);
-    fb_free();
+    fb_free(); // precalculated_table
+    fb_free(); // data
 }
 #endif //IMLIB_ENABLE_LENS_CORR
 

--- a/src/omv/img/imlib.c
+++ b/src/omv/img/imlib.c
@@ -1282,17 +1282,17 @@ void imlib_lens_corr(image_t *img, float strength, float zoom, float x_corr, flo
             for (int y = 0; y < halfHeight; y++) {
                 uint8_t *row_ptr = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(img, y);
                 uint8_t *row_ptr2 = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(img, h-1-y);
-                int newY = y - halfHeight; // from big to small value
-                int newY2 = newY * newY; // 
+                int newY = y - halfHeight;
+                int newY2 = newY * newY;
                 float zoomedY = newY * zoom;
 
                 for (int x = 0; x < halfWidth; x++) {
-                    int newX = x - halfWidth; // from big to small value
+                    int newX = x - halfWidth;
                     int newX2 = newX * newX;
                     float zoomedX = newX * zoom;
 
-                    float r = lens_corr_radius * fast_sqrtf(newX2 + newY2); // length of ray
-                    float theta = fast_atanf(r) / r; // r is never 
+                    float r = lens_corr_radius * fast_sqrtf(newX2 + newY2);
+                    float theta = fast_atanf(r) / r;
                     int sourceX = halfWidth + fast_roundf(theta * zoomedX); // rounding is necessary
                     int sourceY = halfHeight + fast_roundf(theta * zoomedY); // rounding is necessary
 

--- a/src/omv/img/imlib.c
+++ b/src/omv/img/imlib.c
@@ -1200,7 +1200,7 @@ void imlib_zero(image_t *img, image_t *mask, bool invert)
 #ifdef IMLIB_ENABLE_LENS_CORR
 // A simple algorithm for correcting lens distortion.
 // See http://www.tannerhelland.com/4743/simple-algorithm-correcting-lens-distortion/
-void imlib_lens_corr(image_t *img, float strength, float zoom)
+void imlib_lens_corr(image_t *img, float strength, float zoom, float x_corr, float y_corr)
 {
     int w = img->w;
     int h = img->h;
@@ -1208,6 +1208,10 @@ void imlib_lens_corr(image_t *img, float strength, float zoom)
     int halfHeight = h / 2;
     float lens_corr_radius = strength / fast_sqrtf((w * w) + (h * h));
     zoom = 1 / zoom;
+
+    // Convert percentage offset to pixels
+    int x_off = w * x_corr;
+    int y_off = h * y_corr;
 
     // Create a tmp copy of the image to pull pixels from.
     size_t size = image_size(img);
@@ -1219,14 +1223,14 @@ void imlib_lens_corr(image_t *img, float strength, float zoom)
         case IMAGE_BPP_BINARY: {
             uint32_t *tmp = (uint32_t *) data;
 
-            for (int y = 0, yy = halfHeight; y < yy; y++) {
+            for (int y = 0; y < halfHeight; y++) {
                 uint32_t *row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(img, y);
                 uint32_t *row_ptr2 = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(img, h-1-y);
                 int newY = y - halfHeight;
                 int newY2 = newY * newY;
                 float zoomedY = newY * zoom;
 
-                for (int x = 0, xx = halfWidth; x < xx; x++) {
+                for (int x = 0; x < halfWidth; x++) {
                     int newX = x - halfWidth;
                     int newX2 = newX * newX;
                     float zoomedX = newX * zoom;
@@ -1238,16 +1242,35 @@ void imlib_lens_corr(image_t *img, float strength, float zoom)
 
                     if ((0 <= sourceX) && (0 <= sourceY)) { // plot the 4 symmetrical pixels
                         uint32_t *ptr, pixel;
-                        ptr = tmp + (((w + UINT32_T_MASK) >> UINT32_T_SHIFT) * sourceY);
-                        pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, sourceX);
-                        IMAGE_PUT_BINARY_PIXEL_FAST(row_ptr, x, pixel);
-                        pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, w-1-sourceX);
-                        IMAGE_PUT_BINARY_PIXEL_FAST(row_ptr, w-1-x, pixel);
-                        ptr = tmp + (((w + UINT32_T_MASK) >> UINT32_T_SHIFT) * (h-1-sourceY));
-                        pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, sourceX);
-                        IMAGE_PUT_BINARY_PIXEL_FAST(row_ptr2, x, pixel);
-                        pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, w-1-sourceX);
-                        IMAGE_PUT_BINARY_PIXEL_FAST(row_ptr2, w-1-x, pixel);
+                        int sourceY_adj = sourceY + y_off;
+                        if (sourceY_adj >= 0 && sourceY_adj < h) {
+                            ptr = tmp + (((w + UINT32_T_MASK) >> UINT32_T_SHIFT) * sourceY_adj);
+                            int sourceX_adj = sourceX + x_off;
+                            if (sourceX_adj >= 0 && sourceX_adj < w) {
+                                pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, sourceX_adj);
+                                IMAGE_PUT_BINARY_PIXEL_FAST(row_ptr, x, pixel);
+                            }
+                            sourceX_adj = w - 1 - sourceX + x_off;
+                            if (sourceX_adj >= 0 && sourceX_adj < w) {
+                                pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, sourceX_adj);
+                                IMAGE_PUT_BINARY_PIXEL_FAST(row_ptr, w - 1 - x, pixel);
+                            }
+                        }
+
+                        sourceY_adj = h - 1 - sourceY + y_off;
+                        if (sourceY_adj >= 0 && sourceY_adj < h) {
+                            ptr = tmp + (((w + UINT32_T_MASK) >> UINT32_T_SHIFT) * sourceY_adj);
+                            int sourceX_adj = sourceX + x_off;
+                            if (sourceX_adj >= 0 && sourceX_adj < w) {
+                                pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, sourceX_adj);
+                                IMAGE_PUT_BINARY_PIXEL_FAST(row_ptr2, x, pixel);
+                            }
+                            sourceX_adj = w - 1 - sourceX + x_off;
+                            if (sourceX_adj >= 0 && sourceX_adj < w) {
+                                pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, w - 1 - sourceX_adj);
+                                IMAGE_PUT_BINARY_PIXEL_FAST(row_ptr2, w - 1 - x, pixel);
+                            }
+                        }
                     }
                 }
             }
@@ -1256,35 +1279,54 @@ void imlib_lens_corr(image_t *img, float strength, float zoom)
         case IMAGE_BPP_GRAYSCALE: {
             uint8_t *tmp = (uint8_t *) data;
 
-            for (int y = 0, yy = halfHeight; y < yy; y++) {
+            for (int y = 0; y < halfHeight; y++) {
                 uint8_t *row_ptr = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(img, y);
                 uint8_t *row_ptr2 = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(img, h-1-y);
-                int newY = y - halfHeight;
-                int newY2 = newY * newY;
+                int newY = y - halfHeight; // from big to small value
+                int newY2 = newY * newY; // 
                 float zoomedY = newY * zoom;
 
-                for (int x = 0, xx = halfWidth; x < xx; x++) {
-                    int newX = x - halfWidth;
+                for (int x = 0; x < halfWidth; x++) {
+                    int newX = x - halfWidth; // from big to small value
                     int newX2 = newX * newX;
                     float zoomedX = newX * zoom;
 
-                    float r = lens_corr_radius * fast_sqrtf(newX2 + newY2);
-                    float theta = fast_atanf(r) / r; // r is never 0
+                    float r = lens_corr_radius * fast_sqrtf(newX2 + newY2); // length of ray
+                    float theta = fast_atanf(r) / r; // r is never 
                     int sourceX = halfWidth + fast_roundf(theta * zoomedX); // rounding is necessary
                     int sourceY = halfHeight + fast_roundf(theta * zoomedY); // rounding is necessary
 
                     if ((0 <= sourceX) && (0 <= sourceY)) { // plot the 4 symmetrical pixels
                         uint8_t *ptr, pixel;
-                        ptr = tmp + (w * sourceY); // top 2 pixels
-                        pixel = ptr[sourceX];
-                        row_ptr[x] = pixel;
-                        pixel = ptr[w - 1 - sourceX];
-                        row_ptr[w - 1 - x] = pixel;
-                        ptr = tmp + (w * (h - 1 - sourceY)); // bottom 2 pixels
-                        pixel = ptr[sourceX];
-                        row_ptr2[x] = pixel;
-                        pixel = ptr[w - 1 - sourceX];
-                        row_ptr2[w - 1 - x] = pixel;
+                        int sourceY_adj = sourceY + y_off;
+                        if (sourceY_adj >= 0 && sourceY_adj < h) {
+                            ptr = tmp + (w * sourceY_adj); // top 2 pixels
+                            int sourceX_adj = sourceX + x_off;
+                            if (sourceX_adj >= 0 && sourceX_adj < w) {
+                                pixel = ptr[sourceX_adj];
+                                row_ptr[x] = pixel;
+                            }
+                            sourceX_adj = w - 1 - sourceX + x_off;
+                            if (sourceX_adj >= 0 && sourceX_adj < w) {
+                                pixel = ptr[sourceX_adj];
+                                row_ptr[w - 1 - x] = pixel;
+                            }
+                        }
+
+                        sourceY_adj = h - 1 - sourceY + y_off;
+                        if (sourceY_adj >= 0 && sourceY_adj < h) {
+                            ptr = tmp + (w * sourceY_adj); // bottom 2 pixels
+                            int sourceX_adj = sourceX + x_off;
+                            if (sourceX_adj >= 0 && sourceX_adj < w) {
+                                pixel = ptr[sourceX_adj];
+                                row_ptr2[x] = pixel;
+                            }
+                            sourceX_adj = w - 1 - sourceX + x_off;
+                            if (sourceX_adj >= 0 && sourceX_adj < w) {
+                                pixel = ptr[sourceX_adj];
+                                row_ptr2[w - 1 - x] = pixel;
+                            }
+                        }
                     }
                 }
             }
@@ -1293,14 +1335,14 @@ void imlib_lens_corr(image_t *img, float strength, float zoom)
         case IMAGE_BPP_RGB565: {
             uint16_t *tmp = (uint16_t *) data;
 
-            for (int y = 0, yy = halfHeight; y < yy; y++) {
+            for (int y = 0; y < halfHeight; y++) {
                 uint16_t *row_ptr = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(img, y);
                 uint16_t *row_ptr2 = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(img, h-1-y);
                 int newY = y - halfHeight;
                 int newY2 = newY * newY;
                 float zoomedY = newY * zoom;
 
-                for (int x = 0, xx = halfWidth; x < xx; x++) {
+                for (int x = 0; x < halfWidth; x++) {
                     int newX = x - halfWidth;
                     int newX2 = newX * newX;
                     float zoomedX = newX * zoom;
@@ -1312,16 +1354,35 @@ void imlib_lens_corr(image_t *img, float strength, float zoom)
 
                     if ((0 <= sourceX) && (0 <= sourceY)) { // plot the 4 symmetrical pixels
                         uint16_t *ptr, pixel;
-                        ptr = tmp + (w * sourceY); // top 2 pixels
-                        pixel = ptr[sourceX];
-                        row_ptr[x] = pixel;
-                        pixel = ptr[w - 1 - sourceX];
-                        row_ptr[w - 1 - x] = pixel;
-                        ptr = tmp + (w * (h - 1 - sourceY)); // bottom 2 pixels
-                        pixel = ptr[sourceX];
-                        row_ptr2[x] = pixel;
-                        pixel = ptr[w - 1 - sourceX];
-                        row_ptr2[w - 1 - x] = pixel; 
+
+                        int sourceY_adj = sourceY + y_off;
+                        if (sourceY_adj >= 0 && sourceY_adj < h) {
+                            ptr = tmp + (w * sourceY_adj); // top 2 pixels
+                            int sourceX_adj = sourceX + x_off;
+                            if (sourceX_adj >= 0 && x < w) {
+                                pixel = ptr[sourceX_adj];
+                                row_ptr[x] = pixel;
+                            }
+                            sourceX_adj = w - 1 - sourceX + x_off;
+                            if (sourceX_adj >= 0 && sourceX_adj < w) {
+                                pixel = ptr[sourceX_adj];
+                                row_ptr[sourceX_adj] = pixel;
+                            }
+                        }
+                        sourceY_adj = h - 1 - sourceY + y_off;
+                        if (sourceY_adj >= 0 && sourceY_adj < h) {
+                            ptr = tmp + (w * sourceY_adj); // bottom 2 pixels
+                            int sourceX_adj = sourceX + x_off;
+                            if (sourceX_adj >= 0 && sourceX_adj < w) {
+                                pixel = ptr[sourceX_adj];
+                                row_ptr2[x] = pixel;
+                            }
+                            sourceX_adj = w - 1 - sourceX + x_off;
+                            if (sourceX_adj >= 0 && sourceX_adj < w) {
+                                pixel = ptr[sourceX_adj];
+                                row_ptr2[w - 1 - x] = pixel;
+                            }
+                        }
                     }
                 }
             }

--- a/src/omv/img/imlib.c
+++ b/src/omv/img/imlib.c
@@ -1206,8 +1206,8 @@ void imlib_lens_corr(image_t *img, float strength, float zoom, float x_corr, flo
     int h = img->h;
     int halfWidth = w / 2;
     int halfHeight = h / 2;
-    float maximum_radius = fast_sqrtf((w * w) + (h * h));
-    float lens_corr_radius = strength / maximum_radius;
+    float maximum_diameter = fast_sqrtf((w * w) + (h * h));
+    float lens_corr_diameter = strength / maximum_diameter;
     zoom = 1 / zoom;
 
     // Convert percentage offset to pixels from center of image
@@ -1220,9 +1220,11 @@ void imlib_lens_corr(image_t *img, float strength, float zoom, float x_corr, flo
     memcpy(data, img->data, size);
     memset(img->data, 0, size);
 
-    float *precalculated_table = fb_alloc((int)maximum_radius * sizeof(float), FB_ALLOC_NO_HINT);
-    for(int i=0; i < (int)maximum_radius; i++) {
-        float r = lens_corr_radius * i;
+    int maximum_radius = fast_ceilf(maximum_diameter / 2);
+    float *precalculated_table = fb_alloc(maximum_radius * sizeof(float), FB_ALLOC_NO_HINT);
+    
+    for(int i=0; i < maximum_radius; i++) {
+        float r = lens_corr_diameter * i;
         precalculated_table[i] = (fast_atanf(r) / r) * zoom;
     }
 

--- a/src/omv/img/imlib.c
+++ b/src/omv/img/imlib.c
@@ -1226,6 +1226,11 @@ void imlib_lens_corr(image_t *img, float strength, float zoom, float x_corr, flo
         precalculated_table[i] = (fast_atanf(r) / r) * zoom;
     }
 
+    int down_adj = halfHeight + y_off;
+    int up_adj = h - 1 - halfHeight + y_off;
+    int right_adj = halfWidth + x_off;
+    int left_adj = w - 1 - halfWidth + x_off;
+
     switch(img->bpp) {
         case IMAGE_BPP_BINARY: {
             uint32_t *tmp = (uint32_t *) data;
@@ -1241,15 +1246,15 @@ void imlib_lens_corr(image_t *img, float strength, float zoom, float x_corr, flo
                     int newX2 = newX * newX;
 
                     float precalculated = precalculated_table[(int)fast_sqrtf(newX2 + newY2)];
-                    int sourceX = halfWidth + fast_roundf(precalculated * newX); // rounding is necessary
-                    int sourceY = halfHeight + fast_roundf(precalculated * newY); // rounding is necessary
+                    int sourceX = fast_roundf(precalculated * newX); // rounding is necessary
+                    int sourceY = fast_roundf(precalculated * newY); // rounding is necessary
 
                     // plot the 4 symmetrical pixels
                     uint32_t *ptr, pixel;
-                    int sourceY_down = sourceY + y_off;
-                    int sourceY_up = h - 1 - sourceY + y_off;
-                    int sourceX_right = sourceX + x_off;
-                    int sourceX_left = w - 1 - sourceX + x_off;
+                    int sourceY_down = down_adj + sourceY;
+                    int sourceY_up = up_adj - sourceY;
+                    int sourceX_right = right_adj + sourceX;
+                    int sourceX_left = left_adj - sourceX;
 
                     if (sourceY_down >= 0 && sourceY_down < h) {
                         ptr = tmp + (((w + UINT32_T_MASK) >> UINT32_T_SHIFT) * sourceY_down);
@@ -1294,18 +1299,19 @@ void imlib_lens_corr(image_t *img, float strength, float zoom, float x_corr, flo
                     int newX2 = newX * newX;
 
                     float precalculated = precalculated_table[(int)fast_sqrtf(newX2 + newY2)];
-                    int sourceX = halfWidth + fast_roundf(precalculated * newX); // rounding is necessary
-                    int sourceY = halfHeight + fast_roundf(precalculated * newY); // rounding is necessary
+                    int sourceX = fast_roundf(precalculated * newX); // rounding is necessary
+                    int sourceY = fast_roundf(precalculated * newY); // rounding is necessary
 
                     // plot the 4 symmetrical pixels
                     uint8_t *ptr;
-                    int sourceY_down = sourceY + y_off;
-                    int sourceY_up = h - 1 - sourceY + y_off;
-                    int sourceX_right = sourceX + x_off;
-                    int sourceX_left = w - 1 - sourceX + x_off;
+                    int sourceY_down = down_adj + sourceY;
+                    int sourceY_up = up_adj - sourceY;
+                    int sourceX_right = right_adj + sourceX;
+                    int sourceX_left = left_adj - sourceX;
 
+                    // top 2 pixels
                     if (sourceY_down >= 0 && sourceY_down < h) {
-                        ptr = tmp + (w * sourceY_down); // top 2 pixels
+                        ptr = tmp + (w * sourceY_down);
                         if (sourceX_right >= 0 && sourceX_right < w) {
                             row_ptr[x] = ptr[sourceX_right];
                         }
@@ -1315,8 +1321,9 @@ void imlib_lens_corr(image_t *img, float strength, float zoom, float x_corr, flo
                         }
                     }
 
+                    // bottom 2 pixels
                     if (sourceY_up >= 0 && sourceY_up < h) {
-                        ptr = tmp + (w * sourceY_up); // bottom 2 pixels
+                        ptr = tmp + (w * sourceY_up);
                         if (sourceX_right >= 0 && sourceX_right < w) {
                             row_ptr2[x] = ptr[sourceX_right];
                         }
@@ -1343,18 +1350,19 @@ void imlib_lens_corr(image_t *img, float strength, float zoom, float x_corr, flo
                     int newX2 = newX * newX;
 
                     float precalculated = precalculated_table[(int)fast_sqrtf(newX2 + newY2)];
-                    int sourceX = halfWidth + fast_roundf(precalculated * newX); // rounding is necessary
-                    int sourceY = halfHeight + fast_roundf(precalculated * newY); // rounding is necessary
+                    int sourceX = fast_roundf(precalculated * newX); // rounding is necessary
+                    int sourceY = fast_roundf(precalculated * newY); // rounding is necessary
 
                     // plot the 4 symmetrical pixels
                     uint16_t *ptr;
-                    int sourceY_down = sourceY + y_off;
-                    int sourceY_up = h - 1 - sourceY + y_off;
-                    int sourceX_right = sourceX + x_off;
-                    int sourceX_left = w - 1 - sourceX + x_off;
+                    int sourceY_down = down_adj + sourceY;
+                    int sourceY_up = up_adj - sourceY;
+                    int sourceX_right = right_adj + sourceX;
+                    int sourceX_left = left_adj - sourceX;
 
+                    // top 2 pixels
                     if (sourceY_down >= 0 && sourceY_down < h) {
-                        ptr = tmp + (w * sourceY_down); // top 2 pixels
+                        ptr = tmp + (w * sourceY_down);
                         if (sourceX_right >= 0 && sourceX_right < w) {
                             row_ptr[x] = ptr[sourceX_right];
                         }
@@ -1364,8 +1372,9 @@ void imlib_lens_corr(image_t *img, float strength, float zoom, float x_corr, flo
                         }
                     }
 
+                    // bottom 2 pixels
                     if (sourceY_up >= 0 && sourceY_up < h) {
-                        ptr = tmp + (w * sourceY_up); // bottom 2 pixels
+                        ptr = tmp + (w * sourceY_up);
                         if (sourceX_right >= 0 && sourceX_right < w) {
                             row_ptr2[x] = ptr[sourceX_right];
                         }

--- a/src/omv/img/imlib.h
+++ b/src/omv/img/imlib.h
@@ -1331,7 +1331,7 @@ void imlib_remove_shadows(image_t *img, const char *path, image_t *other, int sc
 void imlib_chrominvar(image_t *img);
 void imlib_illuminvar(image_t *img);
 // Lens/Rotation Correction
-void imlib_lens_corr(image_t *img, float strength, float zoom);
+void imlib_lens_corr(image_t *img, float strength, float zoom, float x_corr, float y_corr);
 void imlib_rotation_corr(image_t *img, float x_rotation, float y_rotation,
                          float z_rotation, float x_translation, float y_translation,
                          float zoom, float fov, float *corners);

--- a/src/omv/py/py_image.c
+++ b/src/omv/py/py_image.c
@@ -3237,8 +3237,13 @@ STATIC mp_obj_t py_image_lens_corr(uint n_args, const mp_obj_t *args, mp_map_t *
         py_helper_keyword_float(n_args, args, 2, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_zoom), 1.0f);
     PY_ASSERT_TRUE_MSG(arg_zoom > 0.0f, "Zoom must be > 0!");
 
+    float arg_x_corr =
+        py_helper_keyword_float(n_args, args, 3, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_x_corr), 0.0f);
+    float arg_y_corr =
+        py_helper_keyword_float(n_args, args, 4, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_y_corr), 0.0f);
+
     fb_alloc_mark();
-    imlib_lens_corr(arg_img, arg_strength, arg_zoom);
+    imlib_lens_corr(arg_img, arg_strength, arg_zoom, arg_x_corr, arg_y_corr);
     fb_alloc_free_till_mark();
     return args[0];
 }

--- a/src/omv/py/qstrdefsomv.h
+++ b/src/omv/py/qstrdefsomv.h
@@ -806,6 +806,8 @@ Q(logpolar)
 Q(lens_corr)
 Q(strength)
 Q(zoom)
+Q(x_corr)
+Q(y_corr)
 
 // Rotation Correction
 Q(rotation_corr)


### PR DESCRIPTION
Most cheap lenses are not aligned to their sensors, this creates issues when overlaying two images as they don't quite align correctly.  We can fix this using a rotation_corr with a translate, or creating a new image and drawing it with offset, but this is slow.
I've added x_corr and y_corr to imlib_lens_corr.
The values represent a percentage/100 (0->1) x/y offset to apply before performing the lens correction.
As of example my H7's camera offset is over 5%.