### PR TITLE
FIR I2C Improvements

### DIFF
--- a/src/omv/cambus.c
+++ b/src/omv/cambus.c
@@ -39,6 +39,26 @@ int cambus_init(I2C_HandleTypeDef *i2c, I2C_TypeDef *instance, uint32_t timing)
         return -1;
     }
 
+    if (timing == I2C_TIMING_FAST) {
+        // Enable FAST mode plus.
+        if (instance == I2C1) {
+            #if defined(I2C_FASTMODEPLUS_I2C1)
+            HAL_I2CEx_EnableFastModePlus(I2C_FASTMODEPLUS_I2C1);
+            #endif
+        } else if (instance == I2C2) {
+            #if defined(I2C_FASTMODEPLUS_I2C2)
+            HAL_I2CEx_EnableFastModePlus(I2C_FASTMODEPLUS_I2C2);
+            #endif
+        } else if (instance == I2C3) {
+            #if defined(I2C_FASTMODEPLUS_I2C3)
+            HAL_I2CEx_EnableFastModePlus(I2C_FASTMODEPLUS_I2C3);
+            #endif
+        } else {
+            #if defined(I2C_FASTMODEPLUS_I2C4)
+            HAL_I2CEx_EnableFastModePlus(I2C_FASTMODEPLUS_I2C4);
+            #endif
+        }
+    }
     return 0;
 }
 

--- a/src/omv/cambus.c
+++ b/src/omv/cambus.c
@@ -177,48 +177,36 @@ int cambus_writew2(I2C_HandleTypeDef *i2c, uint8_t slv_addr, uint16_t reg_addr, 
 
 int cambus_read_bytes(I2C_HandleTypeDef *i2c, uint8_t slv_addr, uint8_t reg_addr, uint8_t *buf, int len)
 {
-    int ret=0;
-    __disable_irq();
     if (HAL_I2C_Mem_Read(i2c, slv_addr, reg_addr,
                 I2C_MEMADD_SIZE_8BIT, buf, len, I2C_TIMEOUT) != HAL_OK) {
-        ret = -1;
+        return -1;
     }
-    __enable_irq();
-    return ret;
+    return 0;
 }
 
 int cambus_write_bytes(I2C_HandleTypeDef *i2c, uint8_t slv_addr, uint8_t reg_addr, uint8_t *buf, int len)
 {
-    int ret=0;
-    __disable_irq();
     if (HAL_I2C_Mem_Write(i2c, slv_addr, reg_addr,
                 I2C_MEMADD_SIZE_8BIT, buf, len, I2C_TIMEOUT) != HAL_OK) {
-        ret = -1;
+        return -1;
     }
-    __enable_irq();
-    return ret;
+    return 0;
 }
 
 int cambus_readw_bytes(I2C_HandleTypeDef *i2c, uint8_t slv_addr, uint16_t reg_addr, uint8_t *buf, int len)
 {
-    int ret=0;
-    __disable_irq();
     if (HAL_I2C_Mem_Read(i2c, slv_addr, reg_addr,
                 I2C_MEMADD_SIZE_16BIT, buf, len, I2C_TIMEOUT) != HAL_OK) {
-        ret = -1;
+        return -1;
     }
-    __enable_irq();
-    return ret;
+    return 0;
 }
 
 int cambus_writew_bytes(I2C_HandleTypeDef *i2c, uint8_t slv_addr, uint16_t reg_addr, uint8_t *buf, int len)
 {
-    int ret=0;
-    __disable_irq();
     if (HAL_I2C_Mem_Write(i2c, slv_addr, reg_addr,
                 I2C_MEMADD_SIZE_16BIT, buf, len, I2C_TIMEOUT) != HAL_OK) {
-        ret = -1;
+        return -1;
     }
-    __enable_irq();
-    return ret;
+    return 0;
 }

--- a/src/omv/cambus.c
+++ b/src/omv/cambus.c
@@ -65,6 +65,14 @@ int cambus_scan(I2C_HandleTypeDef *i2c)
     return 0;
 }
 
+int cambus_gencall(I2C_HandleTypeDef *i2c, uint8_t cmd)
+{
+    if (HAL_I2C_Master_Transmit(i2c, 0x00, &cmd, 1, I2C_TIMEOUT) != HAL_OK) {
+        return -1;
+    }
+    return 0;
+}
+
 int cambus_readb(I2C_HandleTypeDef *i2c, uint8_t slv_addr, uint8_t reg_addr, uint8_t *reg_data)
 {
     int ret = 0;

--- a/src/omv/cambus.h
+++ b/src/omv/cambus.h
@@ -33,6 +33,7 @@
 int cambus_init(I2C_HandleTypeDef *i2c, I2C_TypeDef *instance, uint32_t timing);
 int cambus_deinit(I2C_HandleTypeDef *i2c);
 int cambus_scan(I2C_HandleTypeDef *i2c);
+int cambus_gencall(I2C_HandleTypeDef *i2c, uint8_t cmd);
 int cambus_readb(I2C_HandleTypeDef *i2c, uint8_t slv_addr, uint8_t reg_addr,  uint8_t *reg_data);
 int cambus_writeb(I2C_HandleTypeDef *i2c, uint8_t slv_addr, uint8_t reg_addr, uint8_t reg_data);
 int cambus_readb2(I2C_HandleTypeDef *i2c, uint8_t slv_addr, uint16_t reg_addr,  uint8_t *reg_data);

--- a/src/omv/stm32fxxx_hal_msp.c
+++ b/src/omv/stm32fxxx_hal_msp.c
@@ -179,7 +179,7 @@ void HAL_I2C_MspInit(I2C_HandleTypeDef *hi2c)
         /* Configure FIR I2C GPIOs */
         GPIO_InitTypeDef GPIO_InitStructure;
         GPIO_InitStructure.Pull      = GPIO_NOPULL;
-        GPIO_InitStructure.Speed     = GPIO_SPEED_LOW;
+        GPIO_InitStructure.Speed     = GPIO_SPEED_FREQ_VERY_HIGH;
         GPIO_InitStructure.Mode      = GPIO_MODE_AF_OD;
         GPIO_InitStructure.Alternate = FIR_I2C_AF;
 


### PR DESCRIPTION
* Add general call support to cambus.
* Enable IRQs in cambus read/write_bytes
* Increase FIR I2C GPIO speed.
* Enable I2C FMP on cams that support it.