### PR TITLE
Optimized Sensor Driver for Double FPS

### DIFF
--- a/src/omv/ov5640.c
+++ b/src/omv/ov5640.c
@@ -332,7 +332,7 @@ static const uint8_t default_regs[][3] = {
     { 0x3a, 0x14, 0x07 },
     { 0x3a, 0x15, 0xae },
     { 0x44, 0x01, 0x0d }, // | Read SRAM enable when blanking | Read SRAM at first blanking
-    { 0x47, 0x23, 0x01 }, // DVP JPEG Mode456 Skip Line Number
+    { 0x47, 0x23, 0x03 }, // DVP JPEG Mode456 Skip Line Number
 
 // End.
 

--- a/src/sthal/f7/src/stm32f7xx_hal_dcmi.c
+++ b/src/sthal/f7/src/stm32f7xx_hal_dcmi.c
@@ -331,8 +331,8 @@ HAL_StatusTypeDef HAL_DCMI_Start_DMA(DCMI_HandleTypeDef* hdcmi, uint32_t DCMI_Mo
   hdcmi->DMA_Handle->XferAbortCallback = NULL;
 
   /* Reset transfer counters value */
-  hdcmi->XferCount = 0;
-  hdcmi->XferTransferNumber = 0;
+  hdcmi->XferCount = 1U;
+  hdcmi->XferTransferNumber = 1U;
 
   if(Length <= 0xFFFF)
   {
@@ -345,7 +345,7 @@ HAL_StatusTypeDef HAL_DCMI_Start_DMA(DCMI_HandleTypeDef* hdcmi, uint32_t DCMI_Mo
     hdcmi->DMA_Handle->XferM1CpltCallback = DCMI_DMAXferCplt;
 
     /* Initialize transfer parameters */
-    hdcmi->XferCount = 1;
+    hdcmi->XferCount = 1U;
     hdcmi->XferSize = Length;
     hdcmi->pBuffPtr = pData;
 
@@ -357,7 +357,6 @@ HAL_StatusTypeDef HAL_DCMI_Start_DMA(DCMI_HandleTypeDef* hdcmi, uint32_t DCMI_Mo
     }
 
     /* Update DCMI counter  and transfer number*/
-    hdcmi->XferCount = (hdcmi->XferCount - 2);
     hdcmi->XferTransferNumber = hdcmi->XferCount;
 
     /* Update second memory address */
@@ -378,7 +377,7 @@ HAL_StatusTypeDef HAL_DCMI_Start_DMA(DCMI_HandleTypeDef* hdcmi, uint32_t DCMI_Mo
 }
 
 HAL_StatusTypeDef HAL_DCMI_Start_DMA_MB(DCMI_HandleTypeDef* hdcmi, uint32_t DCMI_Mode, uint32_t pData, uint32_t Length, uint32_t Count)
-{  
+{
   /* Initialise the second memory address */
   uint32_t SecondMemAddress = 0;
 
@@ -412,10 +411,11 @@ HAL_StatusTypeDef HAL_DCMI_Start_DMA_MB(DCMI_HandleTypeDef* hdcmi, uint32_t DCMI
   hdcmi->DMA_Handle->XferM1CpltCallback = DCMI_DMAXferCplt;
 
   /* Initialise transfer parameters */
-  hdcmi->XferCount = Count-2;
+  hdcmi->XferCount = Count;
   hdcmi->XferSize = Length/Count;
   hdcmi->pBuffPtr = pData;
-    
+  hdcmi->XferTransferNumber = Count;
+
   /* Update second memory address */
   SecondMemAddress = (uint32_t)(pData + (4*hdcmi->XferSize));
 
@@ -875,7 +875,6 @@ static void DCMI_DMAXferCplt(DMA_HandleTypeDef *hdma)
 {
   DCMI_HandleTypeDef* hdcmi;
   hdcmi = (DCMI_HandleTypeDef*) ((DMA_HandleTypeDef*)hdma)->Parent;
-  //hdcmi->State= HAL_DCMI_STATE_READY;
 
   // Note: we don't need to adjust memory addresses because they stay the same.
   if (hdcmi->XferCount != 0) {
@@ -890,10 +889,17 @@ static void DCMI_DMAXferCplt(DMA_HandleTypeDef *hdma)
     DCMI_DMAConvCpltUser(hdcmi->DMA_Handle->Instance->M0AR);
   }
 
-  if (__HAL_DCMI_GET_FLAG(hdcmi, DCMI_FLAG_FRAMERI) != RESET) {
-    /* Re-enable frame interrupt */
+  /* Check if the frame is transferred */
+  if(hdcmi->XferCount == 0) {
+    /* Reload XferCount */
+    hdcmi->XferCount = hdcmi->XferTransferNumber;
+    /* Enable the Frame interrupt */
     __HAL_DCMI_ENABLE_IT(hdcmi, DCMI_IT_FRAME);
-    hdcmi->State= HAL_DCMI_STATE_READY;
+
+    /* When snapshot mode, set dcmi state to ready */
+    if((hdcmi->Instance->CR & DCMI_CR_CM) == DCMI_MODE_SNAPSHOT) {
+      hdcmi->State= HAL_DCMI_STATE_READY;
+    }
   }
 }
 /**


### PR DESCRIPTION
This PR maxes out the speed of the sensor driver and gives us the max FPS each sensor module is able to run at. In particular, the H7 with the OV7725 out of the box in daylight will hit 150 FPS at QVGA. Readout control on the OV5640 allows you to hit 170 FPS.

It's been tested on:

OpenMV Cam H7+ => OV7725 => GRAYSCALE/RGB565/BAYER all supported resolutions work
OpenMV Cam H7+ => MT9V034 => GRAYSCALE all supported resolutions work
OpenMV Cam H7+ => LEPTON => GRAYSCALE/RGB565 all supported resolutions work
OpenMV Cam H7+ => OV5640 => GRAYSCALE/RGB565/BAYER/JPEG all supported resolutions work
OpenMV Cam H7+ => OV2640 => GRAYSCALE/RGB565/BAYER/JPEG all supported resolutions work

OpenMV Cam H7 => OV7725 => GRAYSCALE/RGB565/BAYER all supported resolutions work
OpenMV Cam H7 => MT9V034 => GRAYSCALE all supported resolutions work
OpenMV Cam H7 => LEPTON => GRAYSCALE/RGB565 all supported resolutions work
OpenMV Cam H7 => OV5640 => GRAYSCALE/RGB565/BAYER/JPEG all supported resolutions work
OpenMV Cam H7 => OV2640 => GRAYSCALE/RGB565/BAYER/JPEG all supported resolutions work

OpenMV Cam H7 Micro => OV7690 => GRAYSCALE/RGB565/BAYER all supported resolutions work

OpenMV Cam M7 => OV7725 => GRAYSCALE/RGB565/BAYER all supported resolutions work

OpenMV Cam M4 => OV7725 => GRAYSCALE/RGB565/BAYER all supported resolutions work
OpenMV Cam M4 => OV2640 => GRAYSCALE/RGB565/BAYER/JPEG all supported resolutions work

IOCTLS:

MT9V034 Trigger mode has been tested.
OV5640 Read Out Control has been tested.

Changes:

For the M4/F7/H7 HAL the DCMI driver has been modified so that the callback correctly track how many lines have been processed and then only enable the end of frame interrupt after the last line has been transferred. This had to be fixed so that the end of frame interrupt would actually mean that all data has been transferred. Without this fix the end of frame interrupt could happen before or after the last line of the image had been transferred causing sync issues.

Second, the HAL has also been modified such that if the DMA is not aborted, it will be able to continue going and receive the next frame and generate the same end of frame interrupt at the right time again.

In the sensor driver itself the method I'm using to speed things up works by starting the DMCI bus and then leaving it running after a frame has been received. Hardware will then not miss the VSYNC start of the next frame that it needs to see in-order to read data. That said, most cameras generate VSYNC and then expose the image for a very long period of time before sending image pixels. So, data will not start immediately after VSYNC. Moving on, once data starts coming in since we have the line buffer with interrupts I can disable the DMA transfer if snapshot has not been called already and was waiting for data. However, it snapshot was called again and is waiting for data we can just receive the data.

By operating this way above we are able to receive every frame from the camera and if we can process the frame in less than the exposure time we will achieve the max FPS. If processing takes longer than the exposure time then the frame rate will default to 1/2 the max FPS and go down from there. So, for lower resolution images this change significantly increases your FPS.