### PR TITLE
Fix buffer overflow issues

### DIFF
--- a/src/omv/boards/OPENMV2/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV2/omv_boardconfig.h
@@ -82,7 +82,7 @@
 #define OMV_STACK_SIZE      (4K)
 #define OMV_HEAP_SIZE       (51K)
 
-#define OMV_LINE_BUF_SIZE   (2K)    // Image line buffer round(320 * 2BPP * 2 buffers).
+#define OMV_LINE_BUF_SIZE   (2 * 1024)  // Image line buffer round(320 * 2BPP * 2 buffers).
 #define OMV_MSC_BUF_SIZE    (2K)    // USB MSC bot data
 #define OMV_VFS_BUF_SIZE    (1K)    // VFS sturct + FATFS file buffer (624 bytes)
 #define OMV_FFS_BUF_SIZE    (16K)   // Flash filesystem cache

--- a/src/omv/boards/OPENMV3/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV3/omv_boardconfig.h
@@ -82,7 +82,7 @@
 #define OMV_STACK_SIZE      (4K)
 #define OMV_HEAP_SIZE       (54K)
 
-#define OMV_LINE_BUF_SIZE   (3K)    // Image line buffer round(640 * 2BPP * 2 buffers).
+#define OMV_LINE_BUF_SIZE   (3 * 1024)  // Image line buffer round(640 * 2BPP * 2 buffers).
 #define OMV_MSC_BUF_SIZE    (2K)    // USB MSC bot data
 #define OMV_VFS_BUF_SIZE    (1K)    // VFS sturct + FATFS file buffer (624 bytes)
 #define OMV_FFS_BUF_SIZE    (32K)   // Flash filesystem cache

--- a/src/omv/boards/OPENMV4/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4/omv_boardconfig.h
@@ -122,7 +122,7 @@
 #define OMV_STACK_SIZE          (15K)
 #define OMV_HEAP_SIZE           (229K)
 
-#define OMV_LINE_BUF_SIZE       (3K)        // Image line buffer round(640 * 2BPP * 2 buffers).
+#define OMV_LINE_BUF_SIZE       (3 * 1024)  // Image line buffer round(640 * 2BPP * 2 buffers).
 #define OMV_MSC_BUF_SIZE        (12K)       // USB MSC bot data
 #define OMV_VFS_BUF_SIZE        (1K)        // VFS sturct + FATFS file buffer (624 bytes)
 #define OMV_JPEG_BUF_SIZE       (32 * 1024) // IDE JPEG buffer (header + data).

--- a/src/omv/boards/OPENMV4P/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4P/omv_boardconfig.h
@@ -128,7 +128,7 @@
 #define OMV_SDRAM_SIZE          (32 * 1024 * 1024) // This needs to be here for UVC firmware.
 #define OMV_SDRAM_TEST          (0)
 
-#define OMV_LINE_BUF_SIZE       (11K)       // Image line buffer round(2592 * 2BPP * 2 buffers).
+#define OMV_LINE_BUF_SIZE       (11 * 1024) // Image line buffer round(2592 * 2BPP * 2 buffers).
 #define OMV_MSC_BUF_SIZE        (12K)       // USB MSC bot data
 #define OMV_VFS_BUF_SIZE        (1K)        // VFS sturct + FATFS file buffer (624 bytes)
 #define OMV_JPEG_BUF_SIZE       (1024*1024) // IDE JPEG buffer (header + data).

--- a/src/omv/boards/PORTENTA/omv_boardconfig.h
+++ b/src/omv/boards/PORTENTA/omv_boardconfig.h
@@ -119,7 +119,7 @@
 #define OMV_STACK_SIZE          (12K)
 #define OMV_HEAP_SIZE           (230K)
 
-#define OMV_LINE_BUF_SIZE       (3K)        // Image line buffer round(640 * 2BPP * 2 buffers).
+#define OMV_LINE_BUF_SIZE       (3 * 1024)  // Image line buffer round(640 * 2BPP * 2 buffers).
 #define OMV_MSC_BUF_SIZE        (12K)       // USB MSC bot data
 #define OMV_VFS_BUF_SIZE        (1K)        // VFS sturct + FATFS file buffer (624 bytes)
 #define OMV_JPEG_BUF_SIZE       (32 * 1024) // IDE JPEG buffer (header + data).

--- a/src/omv/ov2640.c
+++ b/src/omv/ov2640.c
@@ -419,9 +419,6 @@ static int set_pixformat(sensor_t *sensor, pixformat_t pixformat)
         ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, regs[i][0], regs[i][1]);
     }
 
-    // Delay 300 ms
-    systick_sleep(300);
-
     return ret;
 }
 
@@ -434,7 +431,7 @@ static int set_framesize(sensor_t *sensor, framesize_t framesize)
     uint16_t w = resolution[framesize][0];
     uint16_t h = resolution[framesize][1];
 
-    if ((w % 4) || (h % 4)) { // w/h must be divisble by 4
+    if ((w % 4) || (h % 4) || (w > UXGA_WIDTH) || (h > UXGA_HEIGHT)) { // w/h must be divisble by 4
         return -1;
     }
 
@@ -478,9 +475,6 @@ static int set_framesize(sensor_t *sensor, framesize_t framesize)
     ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, ZMHH, ZMHH_OUTW_SET(w) | ZMHH_OUTH_SET(h));
     ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, R_DVP_SP, div);
     ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, RESET, 0x00);
-
-    // Delay 300 ms
-    systick_sleep(300);
 
     return ret;
 }

--- a/src/omv/ov7725.c
+++ b/src/omv/ov7725.c
@@ -228,6 +228,10 @@ static int set_framesize(sensor_t *sensor, framesize_t framesize)
     uint16_t w = resolution[framesize][0];
     uint16_t h = resolution[framesize][1];
 
+    if ((w > 640) || (h > 480)) {
+        return -1;
+    }
+
     // Write MSBs
     ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, HOUTSIZE, w>>2);
     ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, VOUTSIZE, h>>1);

--- a/src/omv/ov9650.c
+++ b/src/omv/ov9650.c
@@ -386,12 +386,12 @@ static int set_auto_exposure(sensor_t *sensor, int enable, int exposure_us)
     if ((enable == 0) && (exposure_us >= 0)) {
         ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, REG_COM7, &reg);
         int t_line = 0, t_pclk = (reg & REG_COM7_RGB) ? 2 : 1;
-    
+
         if (reg & REG_COM7_VGA) t_line = 640 + 160;
         if (reg & REG_COM7_CIF) t_line = 352 + 168;
         if (reg & REG_COM7_QVGA) t_line = 320 + 80;
         if (reg & REG_COM7_QCIF) t_line = 176 + 84;
-    
+
         ret |= cambus_readb(&sensor->i2c, sensor->slv_addr, REG_CLKRC, &reg);
         int pll_mult = (reg & REG_CLKRC_DOUBLE) ? 2 : 1;
         int clk_rc = ((reg & REG_CLKRC_DIVIDER_MASK) + 1) * 2;

--- a/src/omv/py/py_sensor.c
+++ b/src/omv/py/py_sensor.c
@@ -77,7 +77,7 @@ static mp_obj_t py_sensor_snapshot(uint n_args, const mp_obj_t *args, mp_map_t *
     mp_obj_t image = py_image(0, 0, 0, 0);
 
     if (sensor.snapshot(&sensor, (image_t *) py_image_cobj(image), NULL) == -1) {
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_RuntimeError, "Sensor Timeout"));
+        nlr_raise(mp_obj_new_exception_msg(&mp_type_RuntimeError, "Capture Failed"));
     }
 
     return image;

--- a/src/omv/py/py_sensor.c
+++ b/src/omv/py/py_sensor.c
@@ -75,9 +75,11 @@ static mp_obj_t py_sensor_snapshot(uint n_args, const mp_obj_t *args, mp_map_t *
 #endif // MICROPY_PY_IMU
 
     mp_obj_t image = py_image(0, 0, 0, 0);
+    // Note: OV2640 JPEG mode can __fatal_error().
+    int ret = sensor.snapshot(&sensor, (image_t *) py_image_cobj(image), NULL);
 
-    if (sensor.snapshot(&sensor, (image_t *) py_image_cobj(image), NULL) == -1) {
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_RuntimeError, "Capture Failed"));
+    if (ret < 0) {
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_RuntimeError, "Capture Failed: %d", ret));
     }
 
     return image;
@@ -95,7 +97,7 @@ static mp_obj_t py_sensor_skip_frames(uint n_args, const mp_obj_t *args, mp_map_
     uint32_t millis = systick_current_millis();
 
     if (!n_args) {
-        while ((systick_current_millis() - millis) < time) { // 32-bit math handles wrap arrounds...
+        while ((systick_current_millis() - millis) < time) { // 32-bit math handles wrap around...
             py_sensor_snapshot(0, NULL, NULL);
         }
     } else {


### PR DESCRIPTION
This commit fixes most of the frame buffer overflow issues that can cause memory corruption. In particular, this commit is needed so that when you use a camera sensor on a board not designed for it you do not get memory corruption because of various buffers being too small. The error checks will now trigger to prevent issues before hand. This is what is fixed:

* Made OMV_LINE_BUF_SIZE an int so it can be used in code.
* Removed sleeps on the OV2640.
* Protect max resolution on the OV2640/OV7725.
* Renamed the sensor timeout error to something more generic now that sensor.snapshot throws more errors.
* Added mode error checks to set_pixformat/set_framesize/set_windowing.
* Made it policy for the same offsets to be used for BAYER/GRAYSCALE/RGB565 so that when switching between pixformats the frame doesn't jiggle around.
* Redid sensor_check_buffsize() so that it scales down the frame buffer to fit within the frame we have available for the frame buffer in a very nice way.
* Catch uninitialized framesize/pixformat for snapshot.
* Catch issues if the line buffer is too small to handle the DCMI data input.
* Catch OV5640 JPEG buffer overflow.
* Catch OV2640 JPEG buffer overflow.
* Added missing deassert of the frame trigger pin on snapshot error.
