### PR TITLE
Fixed buffer size on the 2/3 and reduced the frame buffer to 20M on Plus.

### DIFF
--- a/src/omv/boards/OPENMV2/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV2/omv_boardconfig.h
@@ -77,8 +77,8 @@
 #define OMV_MAIN_MEMORY     CCM     // data, bss, stack and heap
 #define OMV_DMA_MEMORY      SRAM2   // Misc DMA buffers
 
-#define OMV_FB_SIZE         (151K)  // FB memory: header + QVGA/GS image
-#define OMV_FB_ALLOC_SIZE   (12K)   // minimum fb alloc size
+#define OMV_FB_SIZE         (150K)  // FB memory: header + QVGA/GS image
+#define OMV_FB_ALLOC_SIZE   (13K)   // minimum fb alloc size
 #define OMV_STACK_SIZE      (4K)
 #define OMV_HEAP_SIZE       (51K)
 

--- a/src/omv/boards/OPENMV3/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV3/omv_boardconfig.h
@@ -77,8 +77,8 @@
 #define OMV_MAIN_MEMORY     CCM     // data, bss, stack and heap
 #define OMV_DMA_MEMORY      CCM     // Misc DMA buffers
 
-#define OMV_FB_SIZE         (301K)  // FB memory: header + VGA/GS image
-#define OMV_FB_ALLOC_SIZE   (83K)   // minimum fb alloc size
+#define OMV_FB_SIZE         (300K)  // FB memory: header + VGA/GS image
+#define OMV_FB_ALLOC_SIZE   (84K)   // minimum fb alloc size
 #define OMV_STACK_SIZE      (4K)
 #define OMV_HEAP_SIZE       (54K)
 

--- a/src/omv/boards/OPENMV4P/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4P/omv_boardconfig.h
@@ -44,7 +44,7 @@
 #define OMV_BOOTLDR_LED_PORT    (GPIOC)
 
 // RAW buffer size
-#define OMV_RAW_BUF_SIZE        (31457280)
+#define OMV_RAW_BUF_SIZE        (20971520)
 
 // Enable hardware JPEG
 #define OMV_HARDWARE_JPEG       (1)
@@ -121,8 +121,8 @@
 #define OMV_FB_OVERLAY_MEMORY   AXI_SRAM    // _fballoc_overlay memory.
 #define OMV_FB_OVERLAY_MEMORY_OFFSET    (480*1024)  // _fballoc_overlay
 
-#define OMV_FB_SIZE             (30M)       // FB memory: header + VGA/GS image
-#define OMV_FB_ALLOC_SIZE       (1M)        // minimum fb alloc size
+#define OMV_FB_SIZE             (20M)       // FB memory: header + VGA/GS image
+#define OMV_FB_ALLOC_SIZE       (11M)       // minimum fb alloc size
 #define OMV_STACK_SIZE          (15K)
 #define OMV_HEAP_SIZE           (229K)
 #define OMV_SDRAM_SIZE          (32 * 1024 * 1024) // This needs to be here for UVC firmware.


### PR DESCRIPTION
Fixed buffer size on the 2/3 and reduced the frame buffer to 20M on Plus.

OMV_RAW_BUF_SIZE doesn't prevent fb alloc from running into it's area currently. With the coming double buffer commit fb alloc will not easily walk into the frame buffer area anymore and will respect the buffer size except for cases where it known it can (i.e. in single buffer mode - in double buffer mode it will not re-use frame buffer memory).