### PR TITLE
Expose fb_alloc_pointer for snapshot

### DIFF
--- a/src/omv/fb_alloc.c
+++ b/src/omv/fb_alloc.c
@@ -12,7 +12,7 @@
 #include "omv_boardconfig.h"
 
 extern char _fballoc;
-static char *pointer = &_fballoc;
+static char *pointer = &_fballoc, *pointer_tmp = &_fballoc;
 static int marks = 0;
 #if defined(FB_ALLOC_STATS)
 static uint32_t alloc_bytes;
@@ -33,7 +33,7 @@ __weak NORETURN void fb_alloc_fail()
 
 void fb_alloc_init0()
 {
-    pointer = &_fballoc;
+    pointer = &_fballoc, pointer_tmp = &_fballoc;
     marks = 0;
     #if defined(OMV_FB_OVERLAY_MEMORY)
     pointer_overlay = &_fballoc_overlay;
@@ -217,4 +217,12 @@ void fb_free_all()
         pointer += size; // Get size and pop.
     }
     marks = 0;
+}
+
+void fb_alloc_test_allocation_changed(void (*callback)(void))
+{
+    if (pointer_tmp != pointer) {
+        callback();
+        pointer_tmp = pointer;
+    }
 }

--- a/src/omv/fb_alloc.h
+++ b/src/omv/fb_alloc.h
@@ -23,4 +23,6 @@ void *fb_alloc_all(uint32_t *size, int hints); // returns pointer and sets size
 void *fb_alloc0_all(uint32_t *size, int hints); // returns pointer and sets size
 void fb_free();
 void fb_free_all();
+// Executes callback if the allocation changed since the last call (excluding init0).
+void fb_alloc_test_allocation_changed(void (*callback)(void));
 #endif /* __FF_ALLOC_H__ */


### PR DESCRIPTION
Renames the pointer used for fb_alloc and exposes it for use with snapshot(). 

fb_alloc_pointer_snapshot is a copy of the pointer which snapshot will update when it's called to adjust how double buffers are setup given user buffer allocation. It's convenient to store here.