### PR TITLE
Made code that uses the framebuffer more readable

### DIFF
--- a/src/omv/framebuffer.c
+++ b/src/omv/framebuffer.c
@@ -8,24 +8,27 @@
  *
  * Framebuffer functions.
  */
+#include <stdio.h>
 #include "mpprint.h"
 #include "framebuffer.h"
 #include "omv_boardconfig.h"
 
+#define CONSERVATIVE_JPEG_BUF_SIZE  (OMV_JPEG_BUF_SIZE-64)
+
 extern char _fb_base;
-framebuffer_t *fb_framebuffer = (framebuffer_t *) &_fb_base;
+framebuffer_t *framebuffer = (framebuffer_t *) &_fb_base;
 
 extern char _jpeg_buf;
-jpegbuffer_t *jpeg_fb_framebuffer = (jpegbuffer_t *) &_jpeg_buf;
+jpegbuffer_t *jpeg_framebuffer = (jpegbuffer_t *) &_jpeg_buf;
 
 void fb_set_streaming_enabled(bool enable)
 {
-    MAIN_FB()->streaming_enabled = enable;
+    framebuffer->streaming_enabled = enable;
 }
 
 bool fb_get_streaming_enabled()
 {
-    return MAIN_FB()->streaming_enabled;
+    return framebuffer->streaming_enabled;
 }
 
 int fb_encode_for_ide_new_size(image_t *img)
@@ -67,24 +70,24 @@ void fb_encode_for_ide(uint8_t *ptr, image_t *img)
     *ptr++ = 0xFE;
 }
 
-uint32_t fb_buffer_size()
+void framebuffer_initialize_image(image_t *img)
 {
-    switch (MAIN_FB()->bpp) {
-        case IMAGE_BPP_BINARY: {
-            return ((MAIN_FB()->w + UINT32_T_MASK) >> UINT32_T_SHIFT) * MAIN_FB()->h;
-        }
-        case IMAGE_BPP_GRAYSCALE: {
-            return (MAIN_FB()->w * MAIN_FB()->h) * sizeof(uint8_t);
-        }
-        case IMAGE_BPP_RGB565: {
-            return (MAIN_FB()->w * MAIN_FB()->h) * sizeof(uint16_t);
-        }
-        case IMAGE_BPP_BAYER: {
-            return MAIN_FB()->w * MAIN_FB()->h;
-        }
-        default: { // JPEG
-            return MAIN_FB()->bpp;
-        }
+    img->w = framebuffer->w;
+    img->h = framebuffer->h;
+    img->bpp = framebuffer->bpp;
+    img->data = framebuffer->pixels;
+}
+
+static void initialize_jpeg_buf_from_image(image_t *img)
+{
+    if (!img) {
+        jpeg_framebuffer->w = 0;
+        jpeg_framebuffer->h = 0;
+        jpeg_framebuffer->size = 0;
+    } else {
+        jpeg_framebuffer->w = img->w;
+        jpeg_framebuffer->h = img->h;
+        jpeg_framebuffer->size = img->bpp;
     }
 }
 
@@ -92,65 +95,68 @@ void fb_update_jpeg_buffer()
 {
     static int overflow_count = 0;
 
-    if (MAIN_FB()->streaming_enabled && JPEG_FB()->enabled) {
-        if (MAIN_FB()->bpp > 3) {
+    image_t src;
+    framebuffer_initialize_image(&src);
+
+    if (framebuffer->streaming_enabled && jpeg_framebuffer->enabled) {
+        if (src.bpp > 3) {
             bool does_not_fit = false;
-            // Lock FB
-            if (mutex_try_lock(&JPEG_FB()->lock, MUTEX_TID_OMV)) {
-                if((OMV_JPEG_BUF_SIZE-64) < MAIN_FB()->bpp) {
-                    // image won't fit. so don't copy.
-                    JPEG_FB()->w = 0; JPEG_FB()->h = 0; JPEG_FB()->size = 0;
+
+            if (mutex_try_lock(&jpeg_framebuffer->lock, MUTEX_TID_OMV)) {
+                if(CONSERVATIVE_JPEG_BUF_SIZE < src.bpp) {
+                    initialize_jpeg_buf_from_image(NULL);
                     does_not_fit = true;
                 } else {
-                    memcpy(JPEG_FB()->pixels, MAIN_FB()->pixels, MAIN_FB()->bpp);
-                    JPEG_FB()->w = MAIN_FB()->w; JPEG_FB()->h = MAIN_FB()->h; JPEG_FB()->size = MAIN_FB()->bpp;
+                    initialize_jpeg_buf_from_image(&src);
+                    memcpy(jpeg_framebuffer->pixels, src.pixels, src.bpp);
                 }
 
-                // Unlock the framebuffer mutex
-                mutex_unlock(&JPEG_FB()->lock, MUTEX_TID_OMV);
+                mutex_unlock(&jpeg_framebuffer->lock, MUTEX_TID_OMV);
             }
+
             if (does_not_fit) {
-                image_t out = { .w=MAIN_FB()->w, .h=MAIN_FB()->h, .bpp=MAIN_FB()->bpp, .data=MAIN_FB()->pixels };
-                int new_size = fb_encode_for_ide_new_size(&out);
+                printf("Warning: JPEG too big! Trying framebuffer transfer using fallback method!\n");
+                int new_size = fb_encode_for_ide_new_size(&src);
                 fb_alloc_mark();
                 uint8_t *temp = fb_alloc(new_size, FB_ALLOC_NO_HINT);
-                fb_encode_for_ide(temp, &out);
+                fb_encode_for_ide(temp, &src);
                 (MP_PYTHON_PRINTER)->print_strn((MP_PYTHON_PRINTER)->data, (const char *) temp, new_size);
                 fb_alloc_free_till_mark();
             }
-        } else if (MAIN_FB()->bpp >= 0) {
-            // Lock FB
-            if (mutex_try_lock(&JPEG_FB()->lock, MUTEX_TID_OMV)) {
-                // Set JPEG src and dst images.
-                image_t src = {.w=MAIN_FB()->w, .h=MAIN_FB()->h, .bpp=MAIN_FB()->bpp,     .pixels=MAIN_FB()->pixels};
-                image_t dst = {.w=MAIN_FB()->w, .h=MAIN_FB()->h, .bpp=(OMV_JPEG_BUF_SIZE-64),  .pixels=JPEG_FB()->pixels};
-
+        } else if (src.bpp >= 0) {
+            if (mutex_try_lock(&jpeg_framebuffer->lock, MUTEX_TID_OMV)) {
+                image_t dst = {.w=src.w, .h=src.h, .bpp=CONSERVATIVE_JPEG_BUF_SIZE, .pixels=jpeg_framebuffer->pixels};
                 // Note: lower quality saves USB bandwidth and results in a faster IDE FPS.
-                bool overflow = jpeg_compress(&src, &dst, JPEG_FB()->quality, false);
-                if (overflow == true) {
+                bool overflow = jpeg_compress(&src, &dst, jpeg_framebuffer->quality, false);
+
+                if (overflow) {
                     // JPEG buffer overflowed, reduce JPEG quality for the next frame
                     // and skip the current frame. The IDE doesn't receive this frame.
-                    if (JPEG_FB()->quality > 1) {
+                    if (jpeg_framebuffer->quality > 1) {
                         // Keep this quality for the next n frames
                         overflow_count = 60;
-                        JPEG_FB()->quality = IM_MAX(1, (JPEG_FB()->quality/2));
+                        jpeg_framebuffer->quality = IM_MAX(1, (jpeg_framebuffer->quality/2));
                     }
-                    JPEG_FB()->w = 0; JPEG_FB()->h = 0; JPEG_FB()->size = 0;
+
+                    initialize_jpeg_buf_from_image(NULL);
                 } else {
                     if (overflow_count) {
                         overflow_count--;
                     }
-                    // No buffer overflow, increase quality up to max quality based on frame size
-                    if (overflow_count == 0 && JPEG_FB()->quality
-                           < ((fb_buffer_size() > JPEG_QUALITY_THRESH) ? JPEG_QUALITY_LOW:JPEG_QUALITY_HIGH)) {
-                        JPEG_FB()->quality++;
+
+                    // Dynamically adjust our quality if the image is huge.
+                    bool big_frame_buffer = image_size(&src) > JPEG_QUALITY_THRESH;
+                    int jpeg_quality_max = big_frame_buffer ? JPEG_QUALITY_LOW : JPEG_QUALITY_HIGH;
+
+                    // No buffer overflow, increase quality up to max quality based on frame size...
+                    if ((!overflow_count) && (jpeg_framebuffer->quality < jpeg_quality_max)) {
+                        jpeg_framebuffer->quality++;
                     }
-                    // Set FB from JPEG image
-                    JPEG_FB()->w = dst.w; JPEG_FB()->h = dst.h; JPEG_FB()->size = dst.bpp;
+
+                    initialize_jpeg_buf_from_image(&dst);
                 }
 
-                // Unlock the framebuffer mutex
-                mutex_unlock(&JPEG_FB()->lock, MUTEX_TID_OMV);
+                mutex_unlock(&jpeg_framebuffer->lock, MUTEX_TID_OMV);
             }
         }
     }
@@ -158,37 +164,37 @@ void fb_update_jpeg_buffer()
 
 int32_t framebuffer_get_x()
 {
-    return fb_framebuffer->x;
+    return framebuffer->x;
 }
 
 int32_t framebuffer_get_y()
 {
-    return fb_framebuffer->y;
+    return framebuffer->y;
 }
 
 int32_t framebuffer_get_u()
 {
-    return fb_framebuffer->u;
+    return framebuffer->u;
 }
 
 int32_t framebuffer_get_v()
 {
-    return fb_framebuffer->v;
+    return framebuffer->v;
 }
 
 int32_t framebuffer_get_width()
 {
-    return fb_framebuffer->w;
+    return framebuffer->w;
 }
 
 int32_t framebuffer_get_height()
 {
-    return fb_framebuffer->h;
+    return framebuffer->h;
 }
 
 int32_t framebuffer_get_depth()
 {
-    return fb_framebuffer->bpp;
+    return framebuffer->bpp;
 }
 
 uint32_t framebuffer_get_size()
@@ -198,12 +204,12 @@ uint32_t framebuffer_get_size()
 
 uint8_t *framebuffer_get_buffer()
 {
-    return fb_framebuffer->pixels;
+    return framebuffer->pixels;
 }
 
 void framebuffer_set(int32_t w, int32_t h, int32_t bpp)
 {
-    fb_framebuffer->w = w;
-    fb_framebuffer->h = h;
-    fb_framebuffer->bpp = bpp;
+    framebuffer->w = w;
+    framebuffer->h = h;
+    framebuffer->bpp = bpp;
 }

--- a/src/omv/framebuffer.h
+++ b/src/omv/framebuffer.h
@@ -24,7 +24,7 @@ typedef struct framebuffer {
     uint8_t pixels[];
 } framebuffer_t;
 
-extern framebuffer_t *fb_framebuffer;
+extern framebuffer_t *framebuffer;
 
 typedef struct jpegbuffer {
     int32_t w,h;
@@ -35,17 +35,7 @@ typedef struct jpegbuffer {
     uint8_t pixels[];
 } jpegbuffer_t;
 
-extern jpegbuffer_t *jpeg_fb_framebuffer;
-
-// Use these macros to get a pointer to main or JPEG framebuffer.
-#define MAIN_FB()           (fb_framebuffer)
-#define JPEG_FB()           (jpeg_fb_framebuffer)
-
-// Use this macro to get a pointer to the free SRAM area located after the framebuffer.
-#define MAIN_FB_PIXELS()    (MAIN_FB()->pixels + fb_buffer_size())
-
-// Use this macro to get a pointer to the free SRAM area located after the framebuffer.
-#define JPEG_FB_PIXELS()    (JPEG_FB()->pixels + JPEG_FB()->size)
+extern jpegbuffer_t *jpeg_framebuffer;
 
 // Force fb streaming to the IDE off.
 void fb_set_streaming_enabled(bool enable);
@@ -55,8 +45,8 @@ bool fb_get_streaming_enabled();
 int fb_encode_for_ide_new_size(image_t *img);
 void fb_encode_for_ide(uint8_t *ptr, image_t *img);
 
-// Returns the main frame buffer size, factoring in pixel formats.
-uint32_t fb_buffer_size();
+// Initializes an image_t struct with the frame buffer.
+void framebuffer_initialize_image(image_t *img);
 
 // Transfers the frame buffer to the jpeg frame buffer if not locked.
 void fb_update_jpeg_buffer();
@@ -77,5 +67,9 @@ uint8_t *framebuffer_get_buffer();
 
 // Set the framebuffer w, h and bpp.
 void framebuffer_set(int32_t w, int32_t h, int32_t bpp);
+
+// Use these macros to get a pointer to main or JPEG framebuffer.
+#define MAIN_FB()           (framebuffer)
+#define JPEG_FB()           (jpeg_framebuffer)
 
 #endif /* __FRAMEBUFFER_H__ */

--- a/src/omv/py/py_fir.c
+++ b/src/omv/py/py_fir.c
@@ -603,7 +603,7 @@ mp_obj_t py_fir_draw_ta(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
     int alpha = py_helper_keyword_int(n_args, args, 2, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_alpha), 128);
     PY_ASSERT_TRUE_MSG((0 <= alpha) && (alpha <= 256), "Error: 0 <= alpha <= 256!");
 
-    mp_obj_t scale_obj = py_helper_keyword_object(n_args, args, 3, kw_args, 
+    mp_obj_t scale_obj = py_helper_keyword_object(n_args, args, 3, kw_args,
                                                   MP_OBJ_NEW_QSTR(MP_QSTR_scale));
     if (scale_obj) {
         mp_obj_t *arg_scale;
@@ -788,7 +788,7 @@ mp_obj_t py_fir_snapshot(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
         arg_other->h = image.h;
         arg_other->bpp = image.bpp;
     }
- 
+
     mp_obj_t snapshot = py_image_from_struct(&image);
 
     mp_obj_t *new_args = xalloc((2 + n_args) * sizeof(mp_obj_t));

--- a/src/omv/py/py_sensor.c
+++ b/src/omv/py/py_sensor.c
@@ -141,17 +141,12 @@ static mp_obj_t py_sensor_height()
 
 static mp_obj_t py_sensor_get_fb()
 {
-    if (framebuffer_get_depth() == 0) {
+    if (framebuffer_get_depth() < 0) {
         return mp_const_none;
     }
 
-    image_t image = {
-        .w      = framebuffer_get_width(),
-        .h      = framebuffer_get_height(),
-        .bpp    = framebuffer_get_depth(),
-        .pixels = framebuffer_get_buffer()
-    };
-
+    image_t image;
+    framebuffer_initialize_image(&image);
     return py_image_from_struct(&image);
 }
 

--- a/src/omv/usbdbg.c
+++ b/src/omv/usbdbg.c
@@ -197,12 +197,8 @@ void usbdbg_data_out(void *buffer, int length)
             break;
 
         case USBDBG_TEMPLATE_SAVE: {
-            image_t image ={
-                .w = MAIN_FB()->w,
-                .h = MAIN_FB()->h,
-                .bpp = MAIN_FB()->bpp,
-                .pixels = MAIN_FB()->pixels
-            };
+            image_t image;
+            framebuffer_initialize_image(&image);
 
             // null terminate the path
             length = (length == 64) ? 63:length;
@@ -218,12 +214,8 @@ void usbdbg_data_out(void *buffer, int length)
         }
 
         case USBDBG_DESCRIPTOR_SAVE: {
-            image_t image ={
-                .w = MAIN_FB()->w,
-                .h = MAIN_FB()->h,
-                .bpp = MAIN_FB()->bpp,
-                .pixels = MAIN_FB()->pixels
-            };
+            image_t image;
+            framebuffer_initialize_image(&image);
 
             // null terminate the path
             length = (length == 64) ? 63:length;
@@ -358,5 +350,3 @@ void usbdbg_control(void *buffer, uint8_t request, uint32_t length)
             break;
     }
 }
-
-


### PR DESCRIPTION
Trying to remove MAIN_FB() stuff from being everywhere. Instead, it's inside of access functions.