### PR TITLE
Add accessor functions to framebuffer.

### DIFF
--- a/src/omv/framebuffer.c
+++ b/src/omv/framebuffer.c
@@ -155,3 +155,16 @@ void fb_update_jpeg_buffer()
         }
     }
 }
+
+
+uint8_t *framebuffer_get_buffer()
+{
+    return fb_framebuffer->pixels;
+}
+
+void framebuffer_set(int32_t w, int32_t h, int32_t bpp)
+{
+    fb_framebuffer->w = w;
+    fb_framebuffer->h = h;
+    fb_framebuffer->bpp = bpp;
+}

--- a/src/omv/framebuffer.h
+++ b/src/omv/framebuffer.h
@@ -60,4 +60,11 @@ uint32_t fb_buffer_size();
 
 // Transfers the frame buffer to the jpeg frame buffer if not locked.
 void fb_update_jpeg_buffer();
+
+// Return the current buffer address.
+uint8_t *framebuffer_get_buffer();
+
+// Set the framebuffer w, h and bpp.
+void framebuffer_set(int32_t w, int32_t h, int32_t bpp);
+
 #endif /* __FRAMEBUFFER_H__ */


### PR DESCRIPTION
Add functions to access the main framebuffer pointer and set w, h and bpp. I didn't make the function accept an image to decouple it from imlib.