### PR TITLE
Fix CUBE-AI build

### DIFF
--- a/src/omv/boards/OPENMV1/imlib_config.h
+++ b/src/omv/boards/OPENMV1/imlib_config.h
@@ -83,9 +83,6 @@
 // Enable find_barcodes() (42 KB)
 //#define IMLIB_ENABLE_BARCODES
 
-// Enable LENET (200+ KB).
-//#define IMLIB_ENABLE_LENET
-
 // Enable Tensor Flow
 //#define IMLIB_ENABLE_TF
 

--- a/src/omv/boards/OPENMV2/imlib_config.h
+++ b/src/omv/boards/OPENMV2/imlib_config.h
@@ -128,9 +128,6 @@
 // Enable find_barcodes() (42 KB)
 //#define IMLIB_ENABLE_BARCODES
 
-// Enable LENET (200+ KB).
-//#define IMLIB_ENABLE_LENET
-
 // Enable Tensor Flow
 //#define IMLIB_ENABLE_TF
 

--- a/src/omv/boards/OPENMV3/imlib_config.h
+++ b/src/omv/boards/OPENMV3/imlib_config.h
@@ -132,10 +132,14 @@
 #define IMLIB_ENABLE_BARCODES
 
 // Enable CMSIS NN
+#if !defined(CUBEAI)
 #define IMLIB_ENABLE_CNN
+#endif
 
 // Enable Tensor Flow
+#if !defined(CUBEAI)
 #define IMLIB_ENABLE_TF
+#endif
 
 // Enable FAST (20+ KBs).
 #define IMLIB_ENABLE_FAST

--- a/src/omv/boards/OPENMV3/imlib_config.h
+++ b/src/omv/boards/OPENMV3/imlib_config.h
@@ -131,9 +131,6 @@
 // Enable find_barcodes() (42 KB)
 #define IMLIB_ENABLE_BARCODES
 
-// Enable LENET (200+ KB).
-#define IMLIB_ENABLE_LENET
-
 // Enable CMSIS NN
 #define IMLIB_ENABLE_CNN
 

--- a/src/omv/boards/OPENMV4/imlib_config.h
+++ b/src/omv/boards/OPENMV4/imlib_config.h
@@ -132,10 +132,14 @@
 #define IMLIB_ENABLE_BARCODES
 
 // Enable CMSIS NN
+#if !defined(CUBEAI)
 #define IMLIB_ENABLE_CNN
+#endif
 
 // Enable Tensor Flow
+#if !defined(CUBEAI)
 #define IMLIB_ENABLE_TF
+#endif
 
 // Enable FAST (20+ KBs).
 #define IMLIB_ENABLE_FAST

--- a/src/omv/boards/OPENMV4/imlib_config.h
+++ b/src/omv/boards/OPENMV4/imlib_config.h
@@ -131,9 +131,6 @@
 // Enable find_barcodes() (42 KB)
 #define IMLIB_ENABLE_BARCODES
 
-// Enable LENET (200+ KB).
-#define IMLIB_ENABLE_LENET
-
 // Enable CMSIS NN
 #define IMLIB_ENABLE_CNN
 

--- a/src/omv/boards/OPENMV4/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4/omv_boardconfig.h
@@ -120,7 +120,7 @@
 #define OMV_FB_SIZE             (400K)      // FB memory: header + VGA/GS image
 #define OMV_FB_ALLOC_SIZE       (96K)       // minimum fb alloc size
 #define OMV_STACK_SIZE          (15K)
-#define OMV_HEAP_SIZE           (229K)
+#define OMV_HEAP_SIZE           (228K)
 
 #define OMV_LINE_BUF_SIZE       (3 * 1024)  // Image line buffer round(640 * 2BPP * 2 buffers).
 #define OMV_MSC_BUF_SIZE        (12K)       // USB MSC bot data

--- a/src/omv/boards/OPENMV4P/imlib_config.h
+++ b/src/omv/boards/OPENMV4P/imlib_config.h
@@ -132,10 +132,14 @@
 #define IMLIB_ENABLE_BARCODES
 
 // Enable CMSIS NN
+#if !defined(CUBEAI)
 #define IMLIB_ENABLE_CNN
+#endif
 
 // Enable Tensor Flow
+#if !defined(CUBEAI)
 #define IMLIB_ENABLE_TF
+#endif
 
 // Enable FAST (20+ KBs).
 #define IMLIB_ENABLE_FAST

--- a/src/omv/boards/OPENMV4P/imlib_config.h
+++ b/src/omv/boards/OPENMV4P/imlib_config.h
@@ -131,9 +131,6 @@
 // Enable find_barcodes() (42 KB)
 #define IMLIB_ENABLE_BARCODES
 
-// Enable LENET (200+ KB).
-#define IMLIB_ENABLE_LENET
-
 // Enable CMSIS NN
 #define IMLIB_ENABLE_CNN
 

--- a/src/omv/boards/OPENMV4P/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4P/omv_boardconfig.h
@@ -124,7 +124,7 @@
 #define OMV_FB_SIZE             (20M)       // FB memory: header + VGA/GS image
 #define OMV_FB_ALLOC_SIZE       (11M)       // minimum fb alloc size
 #define OMV_STACK_SIZE          (15K)
-#define OMV_HEAP_SIZE           (229K)
+#define OMV_HEAP_SIZE           (228K)
 #define OMV_SDRAM_SIZE          (32 * 1024 * 1024) // This needs to be here for UVC firmware.
 #define OMV_SDRAM_TEST          (0)
 

--- a/src/omv/boards/PORTENTA/imlib_config.h
+++ b/src/omv/boards/PORTENTA/imlib_config.h
@@ -132,10 +132,14 @@
 #define IMLIB_ENABLE_BARCODES
 
 // Enable CMSIS NN
+#if !defined(CUBEAI)
 #define IMLIB_ENABLE_CNN
+#endif
 
 // Enable Tensor Flow
+#if !defined(CUBEAI)
 #define IMLIB_ENABLE_TF
+#endif
 
 // Enable FAST (20+ KBs).
 #define IMLIB_ENABLE_FAST

--- a/src/omv/boards/PORTENTA/imlib_config.h
+++ b/src/omv/boards/PORTENTA/imlib_config.h
@@ -131,9 +131,6 @@
 // Enable find_barcodes() (42 KB)
 #define IMLIB_ENABLE_BARCODES
 
-// Enable LENET (200+ KB).
-#define IMLIB_ENABLE_LENET
-
 // Enable CMSIS NN
 #define IMLIB_ENABLE_CNN
 

--- a/src/sthal/f7/Makefile
+++ b/src/sthal/f7/Makefile
@@ -13,6 +13,8 @@ stm32f7xx_hal_dac.c\
 stm32f7xx_hal_dac_ex.c\
 stm32f7xx_hal.c\
 stm32f7xx_hal_cortex.c\
+stm32f7xx_hal_crc.c\
+stm32f7xx_hal_crc_ex.c\
 stm32f7xx_hal_dcmi.c\
 stm32f7xx_hal_dma.c\
 stm32f7xx_hal_dma_ex.c\

--- a/src/sthal/f7/src/stm32f7xx_hal_crc.c
+++ b/src/sthal/f7/src/stm32f7xx_hal_crc.c
@@ -418,6 +418,8 @@ uint32_t HAL_CRC_Calculate(CRC_HandleTypeDef *hcrc, uint32_t pBuffer[], uint32_t
 static uint32_t CRC_Handle_8(CRC_HandleTypeDef *hcrc, uint8_t pBuffer[], uint32_t BufferLength)
 {
   uint32_t i = 0; /* input data buffer index */
+  uint16_t data;
+  __IO uint16_t *pReg;
 
    /* Processing time optimization: 4 bytes are entered in a row with a single word write,
     * last bytes must be carefully fed to the CRC calculator to ensure a correct type
@@ -435,11 +437,16 @@ static uint32_t CRC_Handle_8(CRC_HandleTypeDef *hcrc, uint8_t pBuffer[], uint32_
      }
      if(BufferLength%4 == 2)
      {
-       *(__IO uint16_t*) (&hcrc->Instance->DR) = (uint16_t)((uint16_t)((uint16_t)(pBuffer[4*i])<<8) | (uint16_t)(pBuffer[4*i+1]));
+       data = (uint16_t)((uint16_t)((uint16_t)(pBuffer[4*i])<<8) | (uint16_t)(pBuffer[4*i+1]));
+       pReg = (__IO uint16_t*) (&hcrc->Instance->DR);
+       *pReg = data;
      }
      if(BufferLength%4 == 3)
      {
-       *(__IO uint16_t*) (&hcrc->Instance->DR) = (uint16_t)((uint16_t)((uint16_t)(pBuffer[4*i])<<8) | (uint16_t)(pBuffer[4*i+1]));
+       data = (uint16_t)((uint16_t)((uint16_t)(pBuffer[4*i])<<8) | (uint16_t)(pBuffer[4*i+1]));
+       pReg = (__IO uint16_t*) (&hcrc->Instance->DR);
+       *pReg = data;
+
        *(__IO uint8_t*) (&hcrc->Instance->DR) = pBuffer[4*i+2];
      }
    }
@@ -459,6 +466,8 @@ static uint32_t CRC_Handle_8(CRC_HandleTypeDef *hcrc, uint8_t pBuffer[], uint32_
 static uint32_t CRC_Handle_16(CRC_HandleTypeDef *hcrc, uint16_t pBuffer[], uint32_t BufferLength)
 {
   uint32_t i = 0;  /* input data buffer index */
+  __IO uint16_t *pReg;
+
 
   /* Processing time optimization: 2 HalfWords are entered in a row with a single word write,
    * in case of odd length, last HalfWord must be carefully fed to the CRC calculator to ensure
@@ -469,7 +478,8 @@ static uint32_t CRC_Handle_16(CRC_HandleTypeDef *hcrc, uint16_t pBuffer[], uint3
   }
   if((BufferLength%2) != 0)
   {
-     *(__IO uint16_t*) (&hcrc->Instance->DR) = pBuffer[2*i];
+     pReg = (__IO uint16_t*) (&hcrc->Instance->DR);
+     *pReg = pBuffer[2*i];
   }
 
   /* Return the CRC computed value */

--- a/src/sthal/h7/Makefile
+++ b/src/sthal/h7/Makefile
@@ -13,6 +13,8 @@ stm32h7xx_hal_dac.c\
 stm32h7xx_hal_dac_ex.c\
 stm32h7xx_hal.c\
 stm32h7xx_hal_cortex.c\
+stm32h7xx_hal_crc.c\
+stm32h7xx_hal_crc_ex.c\
 stm32h7xx_hal_dcmi.c\
 stm32h7xx_hal_dma.c\
 stm32h7xx_hal_dma_ex.c\

--- a/src/stm32cubeai/Makefile
+++ b/src/stm32cubeai/Makefile
@@ -39,12 +39,6 @@ SRCS += $(addprefix data/,\
 	network.c             \
    )
 
-# CRC is needed for cubeai to work
-SRCS += $(addprefix ../sthal/h7/src/,\
-	stm32h7xx_hal_crc.c              \
-	stm32h7xx_hal_crc_ex.c           \
-   )
-
 OBJS = $(addprefix $(BUILD)/, $(SRCS:.c=.o))
 OBJ_DIRS = $(sort $(dir $(OBJS)))
 


### PR DESCRIPTION
* Disable built-in AI libraries if CUBE-AI is defined.
* Remove the hard-coded crc drivers from cubeai Makefile.
* Reduce the heap of all H7 targets to fix the build.
* Fixes #814 