### PR TITLE
Frame buffer respects fb alloc now

### DIFF
--- a/src/omv/fb_alloc.c
+++ b/src/omv/fb_alloc.c
@@ -31,6 +31,11 @@ static char *fb_alloc_min_address()
     return (char *) (framebuffer_get_buffer() + framebuffer_get_frame_size());
 }
 
+char *fb_alloc_stack_pointer()
+{
+    return pointer;
+}
+
 __weak NORETURN void fb_alloc_fail()
 {
     nlr_raise(mp_obj_new_exception_msg(&mp_type_MemoryError,

--- a/src/omv/fb_alloc.h
+++ b/src/omv/fb_alloc.h
@@ -12,6 +12,7 @@
 #define FB_ALLOC_NO_HINT 0
 #define FB_ALLOC_PREFER_SPEED 1
 #define FB_ALLOC_PREFER_SIZE 2
+char *fb_alloc_stack_pointer();
 void fb_alloc_fail();
 void fb_alloc_init0();
 uint32_t fb_avail();

--- a/src/omv/framebuffer.h
+++ b/src/omv/framebuffer.h
@@ -64,7 +64,8 @@ int32_t framebuffer_get_depth();
 // otherwise return 0 if the framebuffer is unintialized or invalid (e.g. first frame).
 uint32_t framebuffer_get_frame_size();
 
-// Return the max frame size that fits the framebuffer (i.e OMV_RAW_BUF_SIZE - sizeof(framebuffer_t))
+// Return the max frame size that fits the framebuffer
+// (i.e OMV_RAW_BUF_SIZE - sizeof(framebuffer_t))
 uint32_t framebuffer_get_buffer_size();
 
 // Return the current buffer address.

--- a/src/omv/lepton.c
+++ b/src/omv/lepton.c
@@ -475,7 +475,7 @@ static int sensor_check_buffsize(sensor_t *sensor)
             break;
     }
 
-    if ((MAIN_FB()->w * MAIN_FB()->h * bpp) > OMV_RAW_BUF_SIZE) {
+    if ((MAIN_FB()->w * MAIN_FB()->h * bpp) > framebuffer_get_buffer_size()) {
         return -1;
     }
 


### PR DESCRIPTION
This commit makes sure that when trying to figure out how much space to give a frame in the frame buffer the amount already on the fb_alloc stack is respected versus being overrun.

As an optimization, the amount of bytes allocated for the frame buffer is capped to not be too big.