### PR TITLE
Allow stack to be placed in a separate memory.

### DIFF
--- a/src/omv/boards/OPENMV2/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV2/omv_boardconfig.h
@@ -74,7 +74,8 @@
 // The maximum available fb_alloc memory = FB_ALLOC_SIZE + FB_SIZE - (w*h*bpp).
 // Note: fb_alloc overwrites the line buffer which is only used during readout.
 #define OMV_FB_MEMORY       SRAM1   // Framebuffer, fb_alloc
-#define OMV_MAIN_MEMORY     CCM     // data, bss, stack and heap
+#define OMV_MAIN_MEMORY     CCM     // data, bss and heap memory
+#define OMV_STACK_MEMORY    CCM     // stack memory
 #define OMV_DMA_MEMORY      SRAM2   // Misc DMA buffers
 
 #define OMV_FB_SIZE         (150K)  // FB memory: header + QVGA/GS image

--- a/src/omv/boards/OPENMV3/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV3/omv_boardconfig.h
@@ -74,7 +74,8 @@
 // Note: fb_alloc is a stack-based, dynamically allocated memory on FB.
 // The maximum available fb_alloc memory = FB_ALLOC_SIZE + FB_SIZE - (w*h*bpp).
 #define OMV_FB_MEMORY       SRAM1   // Framebuffer, fb_alloc
-#define OMV_MAIN_MEMORY     CCM     // data, bss, stack and heap
+#define OMV_MAIN_MEMORY     CCM     // data, bss and heap
+#define OMV_STACK_MEMORY    CCM     // stack memory
 #define OMV_DMA_MEMORY      CCM     // Misc DMA buffers
 
 #define OMV_FB_SIZE         (300K)  // FB memory: header + VGA/GS image

--- a/src/omv/boards/OPENMV4/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4/omv_boardconfig.h
@@ -111,7 +111,8 @@
 // Note: fb_alloc is a stack-based, dynamically allocated memory on FB.
 // The maximum available fb_alloc memory = FB_ALLOC_SIZE + FB_SIZE - (w*h*bpp).
 #define OMV_FFS_MEMORY          CCM         // Flash filesystem cache memory
-#define OMV_MAIN_MEMORY         SRAM1       // data, bss, stack and heap
+#define OMV_MAIN_MEMORY         SRAM1       // data, bss and heap memory
+#define OMV_STACK_MEMORY        SRAM1       // stack memory
 #define OMV_DMA_MEMORY          AXI_SRAM    // DMA buffers memory.
 #define OMV_FB_MEMORY           AXI_SRAM    // Framebuffer, fb_alloc
 #define OMV_JPEG_MEMORY         SRAM3       // JPEG buffer memory.

--- a/src/omv/boards/OPENMV4P/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4P/omv_boardconfig.h
@@ -112,7 +112,8 @@
 // Note: fb_alloc is a stack-based, dynamically allocated memory on FB.
 // The maximum available fb_alloc memory = FB_ALLOC_SIZE + FB_SIZE - (w*h*bpp).
 #define OMV_FFS_MEMORY          CCM         // Flash filesystem cache memory
-#define OMV_MAIN_MEMORY         SRAM1       // data, bss, stack and heap
+#define OMV_MAIN_MEMORY         SRAM1       // data, bss and heap
+#define OMV_STACK_MEMORY        SRAM1       // stack memory
 #define OMV_DMA_MEMORY          AXI_SRAM    // DMA buffers memory.
 #define OMV_FB_MEMORY           DRAM        // Framebuffer, fb_alloc
 #define OMV_JPEG_MEMORY         DRAM        // JPEG buffer memory buffer.

--- a/src/omv/boards/PORTENTA/omv_boardconfig.h
+++ b/src/omv/boards/PORTENTA/omv_boardconfig.h
@@ -108,7 +108,8 @@
 // Note: fb_alloc is a stack-based, dynamically allocated memory on FB.
 // The maximum available fb_alloc memory = FB_ALLOC_SIZE + FB_SIZE - (w*h*bpp).
 #define OMV_FFS_MEMORY          CCM         // Flash filesystem cache memory
-#define OMV_MAIN_MEMORY         SRAM1       // data, bss, stack and heap
+#define OMV_MAIN_MEMORY         SRAM1       // data, bss and heap
+#define OMV_STACK_MEMORY        SRAM1       // stack memory
 #define OMV_DMA_MEMORY          AXI_SRAM    // DMA buffers memory.
 #define OMV_FB_MEMORY           DRAM        // Framebuffer, fb_alloc
 #define OMV_JPEG_MEMORY         DRAM        // JPEG buffer memory buffer.

--- a/src/omv/main.c
+++ b/src/omv/main.c
@@ -460,8 +460,8 @@ soft_reset:
 
     // Stack limit should be less than real stack size, so we have a
     // chance to recover from limit hit. (Limit is measured in bytes)
-    mp_stack_set_top(&_ram_end);
-    mp_stack_set_limit((char*)&_ram_end - (char*)&_heap_end - 1024);
+    mp_stack_set_top(&_estack);
+    mp_stack_set_limit((char*)&_estack - (char*)&_sstack - 1024);
 
     // GC init
     gc_init(&_heap_start, &_heap_end);

--- a/src/omv/stm32fxxx.ld.S
+++ b/src/omv/stm32fxxx.ld.S
@@ -6,7 +6,7 @@
  *
  * This work is licensed under the MIT license, see the file LICENSE for details.
  *
- * Linker script for STM32F Devices.
+ * Linker script for STM32 Devices.
  */
 
 /* Entry Point */
@@ -37,7 +37,6 @@ MEMORY
   FLASH_TEXT (rx)   : ORIGIN = OMV_TEXT_ORIGIN,     LENGTH = OMV_TEXT_LENGTH
 }
 
-_estack     = ORIGIN(OMV_MAIN_MEMORY) + LENGTH(OMV_MAIN_MEMORY);
 _ram_end    = ORIGIN(OMV_MAIN_MEMORY) + LENGTH(OMV_MAIN_MEMORY);
 
 #if defined(OMV_FFS_MEMORY)
@@ -194,6 +193,9 @@ SECTIONS
     . = ALIGN(4);
     _sstack  = .;
     . = . + _stack_size;
+
+    . = ALIGN(4);
+    _estack  = .;
   } >OMV_MAIN_MEMORY
 
   .ARM.attributes 0 : { *(.ARM.attributes) }

--- a/src/omv/stm32fxxx.ld.S
+++ b/src/omv/stm32fxxx.ld.S
@@ -196,7 +196,7 @@ SECTIONS
 
     . = ALIGN(4);
     _estack  = .;
-  } >OMV_MAIN_MEMORY
+  } >OMV_STACK_MEMORY
 
   .ARM.attributes 0 : { *(.ARM.attributes) }
 }

--- a/src/uvc/stm32fxxx.ld.S
+++ b/src/uvc/stm32fxxx.ld.S
@@ -191,7 +191,7 @@ SECTIONS
 
     . = ALIGN(4);
     _estack  = .;
-  } >OMV_MAIN_MEMORY
+  } >OMV_STACK_MEMORY
 
   .ARM.attributes 0 : { *(.ARM.attributes) }
 }

--- a/src/uvc/stm32fxxx.ld.S
+++ b/src/uvc/stm32fxxx.ld.S
@@ -6,7 +6,7 @@
  *
  * This work is licensed under the MIT license, see the file LICENSE for details.
  *
- * Linker script for STM32F4xx Devices.
+ * Linker script for STM32 Devices.
  */
 
 /* Entry Point */
@@ -37,7 +37,6 @@ MEMORY
   FLASH_TEXT (rx)   : ORIGIN = OMV_TEXT_ORIGIN,     LENGTH = OMV_TEXT_LENGTH
 }
 
-_estack     = ORIGIN(OMV_MAIN_MEMORY) + LENGTH(OMV_MAIN_MEMORY);
 _ram_end    = ORIGIN(OMV_MAIN_MEMORY) + LENGTH(OMV_MAIN_MEMORY);
 
 #if defined(OMV_FFS_MEMORY)
@@ -100,7 +99,6 @@ SECTIONS
   } >OMV_FB_MEMORY
 
   /* Misc DMA buffers kept in uncachable region */
-  /* NOTE: on H7 DMA buffers are kept in cached AXI RAM and cache maintenance is performed */
   .dma_memory (NOLOAD) :
   {
     #if defined(OMV_FB_OVERLAY_MEMORY)
@@ -188,7 +186,11 @@ SECTIONS
   ._stack (NOLOAD) :
   {
     . = ALIGN(4);
+    _sstack  = .;
     . = . + _stack_size;
+
+    . = ALIGN(4);
+    _estack  = .;
   } >OMV_MAIN_MEMORY
 
   .ARM.attributes 0 : { *(.ARM.attributes) }


### PR DESCRIPTION
* Set estack to the end of the stack region, instead of the end of the whole memory.
* Use sstack and estack variables to set stack top and calculate the stack size in main.
* Allow stack memory to be configured in board files.
