### PR TITLE
Support boards without image sensors.

### DIFF
--- a/src/omv/cambus.c
+++ b/src/omv/cambus.c
@@ -15,7 +15,7 @@
 #include "omv_boardconfig.h"
 #include "cambus.h"
 #define I2C_FREQUENCY   (100000)
-#define I2C_TIMEOUT     (1000)
+#define I2C_TIMEOUT     (100)
 
 int cambus_init(I2C_HandleTypeDef *i2c, I2C_TypeDef *instance, uint32_t timing)
 {

--- a/src/omv/main.c
+++ b/src/omv/main.c
@@ -409,7 +409,6 @@ int main(void)
     bool sdram_pass = false;
     #endif
     #endif
-    int sensor_init_ret = 0;
     #if MICROPY_HW_ENABLE_SDCARD
     bool sdcard_mounted = false;
     #endif
@@ -502,9 +501,11 @@ soft_reset:
     // Initialize the sensor and check the result after
     // mounting the file-system to log errors (if any).
     if (first_soft_reset) {
-        sensor_init_ret = sensor_init();
+        sensor_init();
         #if MICROPY_PY_IMU
-        if ((!sensor_init_ret) && (sensor_get_id() == OV7690_ID)) py_imu_init();
+        if (sensor_is_detected() && sensor_get_id() == OV7690_ID) {
+            py_imu_init();
+        }
         #endif // MICROPY_PY_IMU
     }
 
@@ -620,13 +621,6 @@ soft_reset:
     }
     #endif
     #endif
-
-    // check sensor init result
-    if (first_soft_reset && sensor_init_ret != 0) {
-        char buf[512];
-        snprintf(buf, sizeof(buf), "Failed to init sensor, error:%d", sensor_init_ret);
-        __fatal_error(buf);
-    }
 
     // Turn boot-up LEDs off
     led_state(LED_RED, 0);

--- a/src/omv/py/py_sensor.c
+++ b/src/omv/py/py_sensor.c
@@ -53,6 +53,18 @@ static void do_auto_rotation(int pitch_deadzone, int roll_activezone) {
 }
 #endif // MICROPY_PY_IMU
 
+static mp_obj_t py_sensor__init__()
+{
+    // This is the module init function, not the sensor init function,
+    // it gets called when the module is imported. This is good
+    // place to check if the sensor was detected or not.
+    if (sensor_is_detected() == false) {
+        nlr_raise(mp_obj_new_exception_msg(&mp_type_RuntimeError,
+                    "The image sensor is detached or failed to initialize!"));
+    }
+    return mp_const_none;
+}
+
 static mp_obj_t py_sensor_reset() {
     PY_ASSERT_FALSE_MSG(sensor_reset() != 0, "Reset Failed");
 #if MICROPY_PY_IMU
@@ -704,6 +716,7 @@ static mp_obj_t py_sensor_read_reg(mp_obj_t addr) {
     return mp_obj_new_int(sensor_read_reg(mp_obj_get_int(addr)));
 }
 
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_sensor__init__obj,              py_sensor__init__);
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_sensor_reset_obj,               py_sensor_reset);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_sensor_sleep_obj,               py_sensor_sleep);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_sensor_shutdown_obj,            py_sensor_shutdown);
@@ -753,6 +766,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_sensor_read_reg_obj,            py_sensor_re
 
 STATIC const mp_map_elem_t globals_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR___name__),            MP_OBJ_NEW_QSTR(MP_QSTR_sensor)},
+
     { MP_OBJ_NEW_QSTR(MP_QSTR_BINARY),              MP_OBJ_NEW_SMALL_INT(PIXFORMAT_BINARY)},   /* 1BPP/BINARY*/
     { MP_OBJ_NEW_QSTR(MP_QSTR_GRAYSCALE),           MP_OBJ_NEW_SMALL_INT(PIXFORMAT_GRAYSCALE)},/* 1BPP/GRAYSCALE*/
     { MP_OBJ_NEW_QSTR(MP_QSTR_RGB565),              MP_OBJ_NEW_SMALL_INT(PIXFORMAT_RGB565)},   /* 2BPP/RGB565*/
@@ -834,6 +848,7 @@ STATIC const mp_map_elem_t globals_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_IOCTL_LEPTON_GET_MEASUREMENT_RANGE),  MP_OBJ_NEW_SMALL_INT(IOCTL_LEPTON_GET_MEASUREMENT_RANGE)},
 
     // Sensor functions
+    { MP_OBJ_NEW_QSTR(MP_QSTR___init__),            (mp_obj_t)&py_sensor__init__obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_reset),               (mp_obj_t)&py_sensor_reset_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_sleep),               (mp_obj_t)&py_sensor_sleep_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_shutdown),            (mp_obj_t)&py_sensor_shutdown_obj },

--- a/src/omv/sensor.c
+++ b/src/omv/sensor.c
@@ -471,6 +471,8 @@ int sensor_init()
     // Set default color palette.
     sensor.color_palette = rainbow_table;
 
+    sensor.detected = true;
+
     /* All good! */
     return 0;
 }
@@ -525,6 +527,11 @@ int sensor_reset()
 int sensor_get_id()
 {
     return sensor.chip_id;
+}
+
+bool sensor_is_detected()
+{
+    return sensor.detected;
 }
 
 int sensor_sleep(int enable)

--- a/src/omv/sensor.h
+++ b/src/omv/sensor.h
@@ -168,6 +168,7 @@ typedef struct _sensor {
     bool vflip;                 // Vertical Flip
     bool transpose;             // Transpose Image
     bool auto_rotation;         // Rotate Image Automatically
+    bool detected;              // Set to true when the sensor is initialized.
 
     I2C_HandleTypeDef i2c;      // SCCB/I2C bus.
 
@@ -212,6 +213,9 @@ int sensor_reset();
 
 // Return sensor PID.
 int sensor_get_id();
+
+// Return true if the sensor was detected and initialized.
+bool sensor_is_detected();
 
 // Sleep mode.
 int sensor_sleep(int enable);

--- a/src/omv/usbdbg.c
+++ b/src/omv/usbdbg.c
@@ -85,7 +85,10 @@ void usbdbg_data_in(void *buffer, int length)
         }
 
         case USBDBG_SENSOR_ID: {
-            int sensor_id = sensor_get_id();
+            int sensor_id = 0xFF;
+            if (sensor_is_detected() == true) {
+                sensor_id = sensor_get_id();
+            }
             memcpy(buffer, &sensor_id, 4);
             cmd = USBDBG_NONE;
             break;


### PR DESCRIPTION
* The firmware will keep running with no image sensor attached.
* The self-tests will still fail to detect production issues.
* If no sensor is detected, usbdbg will return 0xFF for get sensor ID.
* Probably need to disable self-tests for Portenta.