### PR TITLE
Interpolate pixels for lens correction and rotation_corr

### DIFF
--- a/src/omv/img/apriltag.c
+++ b/src/omv/img/apriltag.c
@@ -12446,13 +12446,14 @@ void imlib_rotation_corr(image_t *img, float x_rotation, float y_rotation, float
 
                     for (int y = 0, yy = h; y < yy; y++) {
                         uint32_t *row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(img, y);
+                        int bw = ((w + UINT32_T_MASK) >> UINT32_T_SHIFT);
                         for (int x = 0, xx = w; x < xx; x++) {
-                            int sourceX = fast_roundf(T4_00*x + T4_01*y + T4_02);
-                            int sourceY = fast_roundf(T4_10*x + T4_11*y + T4_12);
+                            float sourceX = T4_00*x + T4_01*y + T4_02;
+                            float sourceY = T4_10*x + T4_11*y + T4_12;
 
-                            if ((0 <= sourceX) && (sourceX < w) && (0 <= sourceY) && (sourceY < h)) {
-                                uint32_t *ptr = tmp + (((w + UINT32_T_MASK) >> UINT32_T_SHIFT) * sourceY);
-                                int pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, sourceX);
+                            if ((0 <= sourceX) && (sourceX + 1 < w) && (0 <= sourceY) && (sourceY + 1 < h)) {
+                                uint32_t *ptr = tmp + (((w + UINT32_T_MASK) >> UINT32_T_SHIFT) * fast_floorf(sourceY));
+                                int pixel = fast_roundf(IMAGE_GET_BINARY_PIXEL_INTERP(ptr, bw, sourceX, sourceY));
                                 IMAGE_PUT_BINARY_PIXEL_FAST(row_ptr, x, pixel);
                             }
                         }
@@ -12465,12 +12466,12 @@ void imlib_rotation_corr(image_t *img, float x_rotation, float y_rotation, float
                     for (int y = 0, yy = h; y < yy; y++) {
                         uint8_t *row_ptr = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(img, y);
                         for (int x = 0, xx = w; x < xx; x++) {
-                            int sourceX = fast_roundf(T4_00*x + T4_01*y + T4_02);
-                            int sourceY = fast_roundf(T4_10*x + T4_11*y + T4_12);
+                            float sourceX = T4_00*x + T4_01*y + T4_02;
+                            float sourceY = T4_10*x + T4_11*y + T4_12;
 
-                            if ((0 <= sourceX) && (sourceX < w) && (0 <= sourceY) && (sourceY < h)) {
-                                uint8_t *ptr = tmp + (w * sourceY);
-                                int pixel = IMAGE_GET_GRAYSCALE_PIXEL_FAST(ptr, sourceX);
+                            if ((0 <= sourceX) && (sourceX + 1 < w) && (0 <= sourceY) && (sourceY + 1 < h)) {
+                                uint8_t *ptr = tmp + (w * fast_floorf(sourceY));
+                                int pixel = fast_roundf(IMAGE_GET_INTERP_GRAYSCALE_PIXEL(ptr, w, sourceX, sourceY));
                                 IMAGE_PUT_GRAYSCALE_PIXEL_FAST(row_ptr, x, pixel);
                             }
                         }
@@ -12483,12 +12484,12 @@ void imlib_rotation_corr(image_t *img, float x_rotation, float y_rotation, float
                     for (int y = 0, yy = h; y < yy; y++) {
                         uint16_t *row_ptr = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(img, y);
                         for (int x = 0, xx = w; x < xx; x++) {
-                            int sourceX = fast_roundf(T4_00*x + T4_01*y + T4_02);
-                            int sourceY = fast_roundf(T4_10*x + T4_11*y + T4_12);
+                            float sourceX = T4_00*x + T4_01*y + T4_02;
+                            float sourceY = T4_10*x + T4_11*y + T4_12;
 
-                            if ((0 <= sourceX) && (sourceX < w) && (0 <= sourceY) && (sourceY < h)) {
-                                uint16_t *ptr = tmp + (w * sourceY);
-                                int pixel = IMAGE_GET_RGB565_PIXEL_FAST(ptr, sourceX);
+                            if ((0 <= sourceX) && (sourceX + 1 < w) && (0 <= sourceY) && (sourceY + 1 < h)) {
+                                uint16_t *ptr = tmp + (w * fast_floorf(sourceY));
+                                int pixel = fast_roundf(IMAGE_GET_INTERP_RGB565_PIXEL(ptr, w, sourceX, sourceY));
                                 IMAGE_PUT_RGB565_PIXEL_FAST(row_ptr, x, pixel);
                             }
                         }
@@ -12506,16 +12507,17 @@ void imlib_rotation_corr(image_t *img, float x_rotation, float y_rotation, float
 
                     for (int y = 0, yy = h; y < yy; y++) {
                         uint32_t *row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(img, y);
+                        int bw = ((w + UINT32_T_MASK) >> UINT32_T_SHIFT);
                         for (int x = 0, xx = w; x < xx; x++) {
                             float xxx = T4_00*x + T4_01*y + T4_02;
                             float yyy = T4_10*x + T4_11*y + T4_12;
                             float zzz = T4_20*x + T4_21*y + T4_22;
-                            int sourceX = fast_roundf(xxx / zzz);
-                            int sourceY = fast_roundf(yyy / zzz);
+                            float sourceX = xxx / zzz;
+                            float sourceY = yyy / zzz;
 
-                            if ((0 <= sourceX) && (sourceX < w) && (0 <= sourceY) && (sourceY < h)) {
-                                uint32_t *ptr = tmp + (((w + UINT32_T_MASK) >> UINT32_T_SHIFT) * sourceY);
-                                int pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, sourceX);
+                            if ((0 <= sourceX) && (sourceX + 1 < w) && (0 <= sourceY) && (sourceY + 1 < h)) {
+                                uint32_t *ptr = tmp + (((w + UINT32_T_MASK) >> UINT32_T_SHIFT) * fast_floorf(sourceY));
+                                int pixel = fast_roundf(IMAGE_GET_BINARY_PIXEL_INTERP(ptr, bw, sourceX, sourceY));
                                 IMAGE_PUT_BINARY_PIXEL_FAST(row_ptr, x, pixel);
                             }
                         }
@@ -12531,12 +12533,12 @@ void imlib_rotation_corr(image_t *img, float x_rotation, float y_rotation, float
                             float xxx = T4_00*x + T4_01*y + T4_02;
                             float yyy = T4_10*x + T4_11*y + T4_12;
                             float zzz = T4_20*x + T4_21*y + T4_22;
-                            int sourceX = fast_roundf(xxx / zzz);
-                            int sourceY = fast_roundf(yyy / zzz);
+                            float sourceX = xxx / zzz;
+                            float sourceY = yyy / zzz;
 
-                            if ((0 <= sourceX) && (sourceX < w) && (0 <= sourceY) && (sourceY < h)) {
-                                uint8_t *ptr = tmp + (w * sourceY);
-                                int pixel = IMAGE_GET_GRAYSCALE_PIXEL_FAST(ptr, sourceX);
+                            if ((0 <= sourceX) && (sourceX + 1 < w) && (0 <= sourceY) && (sourceY + 1 < h)) {
+                                uint8_t *ptr = tmp + (w * fast_floorf(sourceY));
+                                int pixel = fast_roundf(IMAGE_GET_INTERP_GRAYSCALE_PIXEL(ptr, w, sourceX, sourceY));
                                 IMAGE_PUT_GRAYSCALE_PIXEL_FAST(row_ptr, x, pixel);
                             }
                         }
@@ -12552,12 +12554,12 @@ void imlib_rotation_corr(image_t *img, float x_rotation, float y_rotation, float
                             float xxx = T4_00*x + T4_01*y + T4_02;
                             float yyy = T4_10*x + T4_11*y + T4_12;
                             float zzz = T4_20*x + T4_21*y + T4_22;
-                            int sourceX = fast_roundf(xxx / zzz);
-                            int sourceY = fast_roundf(yyy / zzz);
+                            float sourceX = xxx / zzz;
+                            float sourceY = yyy / zzz;
 
-                            if ((0 <= sourceX) && (sourceX < w) && (0 <= sourceY) && (sourceY < h)) {
-                                uint16_t *ptr = tmp + (w * sourceY);
-                                int pixel = IMAGE_GET_RGB565_PIXEL_FAST(ptr, sourceX);
+                            if ((0 <= sourceX) && (sourceX + 1 < w) && (0 <= sourceY) && (sourceY + 1 < h)) {
+                                uint16_t *ptr = tmp + (w * fast_floorf(sourceY));
+                                int pixel = fast_roundf(IMAGE_GET_INTERP_RGB565_PIXEL(ptr, w, sourceX, sourceY));
                                 IMAGE_PUT_RGB565_PIXEL_FAST(row_ptr, x, pixel);
                             }
                         }

--- a/src/omv/img/imlib.c
+++ b/src/omv/img/imlib.c
@@ -1253,41 +1253,42 @@ void imlib_lens_corr(image_t *img, float strength, float zoom, float x_corr, flo
                     int newX = x - halfWidth;
                     int newX2 = newX * newX;
                     float precalculated = precalculated_table[(int)fast_sqrtf(newX2 + newY2)];
-                    int sourceY = fast_roundf(precalculated * newY); // rounding is necessary
-                    int sourceX = fast_roundf(precalculated * newX); // rounding is necessary
-                    int sourceY_down = down_adj + sourceY;
-                    int sourceY_up = up_adj - sourceY;
-                    int sourceX_right = right_adj + sourceX;
-                    int sourceX_left = left_adj - sourceX;
+                    float sourceY = precalculated * newY + 0.5f;
+                    float sourceX = precalculated * newX + 0.5f;
+                    float sourceY_down = down_adj + sourceY;
+                    float sourceY_up = up_adj - sourceY;
+                    float sourceX_right = right_adj + sourceX - 1;
+                    float sourceX_left = left_adj - sourceX;
+                    int bw = ((w + UINT32_T_MASK) >> UINT32_T_SHIFT);
 
                     // plot the 4 symmetrical pixels
                     // top 2 pixels
-                    if (sourceY_down >= 0 && sourceY_down < h) {
-                        uint32_t *ptr = tmp + (((w + UINT32_T_MASK) >> UINT32_T_SHIFT) * sourceY_down);
+                    if (sourceY_down >= 0 && (sourceY_down + 1) < h) {
+                        uint32_t *ptr = tmp + (bw * (int)fast_floorf(sourceY_down));
 
-                        if (sourceX_right >= 0 && sourceX_right < w) {
-                            uint8_t pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, sourceX_right);
+                        if (sourceX_right >= 0 && (sourceX_right + 1) < w) {
+                            uint8_t pixel = fast_roundf(IMAGE_GET_INTERP_BINARY_PIXEL(ptr, bw, sourceX_right, sourceY_down));
                             IMAGE_PUT_BINARY_PIXEL_FAST(row_ptr, x, pixel);
                         }
-
-                        if (sourceX_left >= 0 && sourceX_left < w) {
-                            uint8_t pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, sourceX_left);
-                            IMAGE_PUT_BINARY_PIXEL_FAST(row_ptr, w - 1 - x, pixel);
+                        
+                        if (sourceX_left >= 0 && (sourceX_left + 1) < w) {
+                            uint8_t pixel = fast_roundf(IMAGE_GET_INTERP_BINARY_PIXEL(ptr, bw, sourceX_left, sourceY_down));
+                            IMAGE_PUT_BINARY_PIXEL_FAST(row_ptr, x2, pixel);
                         }
                     }
 
                     // bottom 2 pixels
-                    if (sourceY_up >= 0 && sourceY_up < h) {
-                        uint32_t *ptr = tmp + (((w + UINT32_T_MASK) >> UINT32_T_SHIFT) * sourceY_up);
+                    if (sourceY_up >= 0 && (sourceY_up + 1) < h && roi->y <= y2 && y2 <= roi_y_max) {
+                        uint32_t *ptr = tmp + (bw * (int)fast_floorf(sourceY_up));
 
-                        if (sourceX_right >= 0 && sourceX_right < w) {
-                            uint8_t pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, sourceX_right);
+                        if (sourceX_right >= 0 && (sourceX_right + 1) < w) {
+                            uint8_t pixel = fast_roundf(IMAGE_GET_INTERP_BINARY_PIXEL(ptr, bw, sourceX_right, sourceY_up));
                             IMAGE_PUT_BINARY_PIXEL_FAST(row_ptr2, x, pixel);
                         }
 
-                        if (sourceX_left >= 0 && sourceX_left < w) {
-                            uint8_t pixel = IMAGE_GET_BINARY_PIXEL_FAST(ptr, sourceX_left);
-                            IMAGE_PUT_BINARY_PIXEL_FAST(row_ptr2, w - 1 - x, pixel);
+                        if (sourceX_left >= 0 && (sourceX_left + 1) < w) {
+                            uint8_t pixel = fast_roundf(IMAGE_GET_INTERP_BINARY_PIXEL(ptr, bw, sourceX_left, sourceY_up));
+                            IMAGE_PUT_BINARY_PIXEL_FAST(row_ptr2, x2, pixel);
                         }
                     }
                 }
@@ -1307,37 +1308,37 @@ void imlib_lens_corr(image_t *img, float strength, float zoom, float x_corr, flo
                     int newX = x - halfWidth;
                     int newX2 = newX * newX;
                     float precalculated = precalculated_table[(int)fast_sqrtf(newX2 + newY2)];
-                    int sourceY = fast_roundf(precalculated * newY); // rounding is necessary
-                    int sourceX = fast_roundf(precalculated * newX); // rounding is necessary
-                    int sourceY_down = down_adj + sourceY;
-                    int sourceY_up = up_adj - sourceY;
-                    int sourceX_right = right_adj + sourceX;
-                    int sourceX_left = left_adj - sourceX;
+                    float sourceY = precalculated * newY + 0.5f;
+                    float sourceX = precalculated * newX + 0.5f;
+                    float sourceY_down = down_adj + sourceY;
+                    float sourceY_up = up_adj - sourceY;
+                    float sourceX_right = right_adj + sourceX - 1;
+                    float sourceX_left = left_adj - sourceX;
 
                     // plot the 4 symmetrical pixels
                     // top 2 pixels
-                    if (sourceY_down >= 0 && sourceY_down < h) {
-                        uint8_t *ptr = tmp + (w * sourceY_down);
+                    if (sourceY_down >= 0 && (sourceY_down + 1) < h) {
+                        uint8_t *ptr = tmp + (w * (int)(fast_floorf(sourceY_down)));
 
-                        if (sourceX_right >= 0 && sourceX_right < w) {
-                            row_ptr[x] = ptr[sourceX_right];
+                        if (sourceX_right >= 0 && (sourceX_right + 1) < w) {
+                            row_ptr[x] = fast_roundf(IMAGE_GET_INTERP_GRAYSCALE_PIXEL(ptr, w, sourceX_right, sourceY_down));
                         }
 
-                        if (sourceX_left >= 0 && sourceX_left < w) {
-                            row_ptr[w - 1 - x] = ptr[sourceX_left];
+                        if (sourceX_left >= 0 && (sourceX_left + 1) < w) {
+                            row_ptr[x2] = fast_roundf(IMAGE_GET_INTERP_GRAYSCALE_PIXEL(ptr, w, sourceX_left, sourceY_down));
                         }
                     }
 
                     // bottom 2 pixels
-                    if (sourceY_up >= 0 && sourceY_up < h) {
-                        uint8_t *ptr = tmp + (w * sourceY_up);
+                    if (sourceY_up >= 0 && (sourceY_up + 1) < h && roi->y <= y2 && y2 <= roi_y_max) {
+                        uint8_t *ptr = tmp + (w * (int)fast_floorf(sourceY_up+1));
 
-                        if (sourceX_right >= 0 && sourceX_right < w) {
-                            row_ptr2[x] = ptr[sourceX_right];
+                        if (sourceX_right >= 0 && (sourceX_right + 1) < w) {
+                            row_ptr2[x] = fast_roundf(IMAGE_GET_INTERP_GRAYSCALE_PIXEL(ptr, w, sourceX_right, sourceY_up));
                         }
 
-                        if (sourceX_left >= 0 && sourceX_left < w) {
-                            row_ptr2[w - 1 - x] = ptr[sourceX_left];
+                        if (sourceX_left >= 0 && (sourceX_left + 1) < w) {
+                            row_ptr2[x2] = fast_roundf(IMAGE_GET_INTERP_GRAYSCALE_PIXEL(ptr, w, sourceX_left, sourceY_up));
                         }
                     }
                 }
@@ -1357,37 +1358,37 @@ void imlib_lens_corr(image_t *img, float strength, float zoom, float x_corr, flo
                     int newX = x - halfWidth;
                     int newX2 = newX * newX;
                     float precalculated = precalculated_table[(int)fast_sqrtf(newX2 + newY2)];
-                    int sourceY = fast_roundf(precalculated * newY); // rounding is necessary
-                    int sourceX = fast_roundf(precalculated * newX); // rounding is necessary
-                    int sourceY_down = down_adj + sourceY;
-                    int sourceY_up = up_adj - sourceY;
-                    int sourceX_right = right_adj + sourceX;
-                    int sourceX_left = left_adj - sourceX;
+                    float sourceY = precalculated * newY + 0.5f;
+                    float sourceX = precalculated * newX + 0.5f;
+                    float sourceY_down = down_adj + sourceY;
+                    float sourceY_up = up_adj - sourceY;
+                    float sourceX_right = right_adj + sourceX - 1;
+                    float sourceX_left = left_adj - sourceX;
 
                     // plot the 4 symmetrical pixels
                     // top 2 pixels
-                    if (sourceY_down >= 0 && sourceY_down < h) {
-                        uint16_t *ptr = tmp + (w * sourceY_down);
+                    if (sourceY_down >= 0 && (sourceY_down + 1) < h) {
+                        uint16_t *ptr = tmp + (w * (int)(fast_floorf(sourceY_down)));
 
-                        if (sourceX_right >= 0 && sourceX_right < w) {
-                            row_ptr[x] = ptr[sourceX_right];
+                        if (sourceX_right >= 0 && (sourceX_right + 1) < w) {
+                            row_ptr[x] = fast_roundf(IMAGE_GET_INTERP_RGB565_PIXEL(ptr, w, sourceX_right, sourceY_down));
                         }
 
-                        if (sourceX_left >= 0 && sourceX_left < w) {
-                            row_ptr[w - 1 - x] = ptr[sourceX_left];
+                        if (sourceX_left >= 0 && (sourceX_left + 1) < w) {
+                            row_ptr[x2] = fast_roundf(IMAGE_GET_INTERP_RGB565_PIXEL(ptr, w, sourceX_left, sourceY_down));
                         }
                     }
 
                     // bottom 2 pixels
-                    if (sourceY_up >= 0 && sourceY_up < h) {
-                        uint16_t *ptr = tmp + (w * sourceY_up);
+                    if (sourceY_up >= 0 && (sourceY_up + 1) < h && roi->y <= y2 && y2 <= roi_y_max) {
+                        uint16_t *ptr = tmp + (w * (int)fast_floorf(sourceY_up+1));
 
-                        if (sourceX_right >= 0 && sourceX_right < w) {
-                            row_ptr2[x] = ptr[sourceX_right];
+                        if (sourceX_right >= 0 && (sourceX_right + 1) < w) {
+                            row_ptr2[x] = fast_roundf(IMAGE_GET_INTERP_RGB565_PIXEL(ptr, w, sourceX_right, sourceY_up));
                         }
 
-                        if (sourceX_left >= 0 && sourceX_left < w) {
-                            row_ptr2[w - 1 - x] = ptr[sourceX_left];
+                        if (sourceX_left >= 0 && (sourceX_left + 1) < w) {
+                            row_ptr2[x2] = fast_roundf(IMAGE_GET_INTERP_RGB565_PIXEL(ptr, w, sourceX_left, sourceY_up));
                         }
                     }
                 }

--- a/src/omv/img/imlib.h
+++ b/src/omv/img/imlib.h
@@ -679,6 +679,57 @@ float IMAGE_Y_RATIO = ((float) _source_rect->s.h) / ((float) _target_rect->s.h);
 
 #define IMAGE_GET_SCALED_RGB565_PIXEL_FAST(row_ptr, x) IMAGE_GET_RGB565_PIXEL_FAST((row_ptr), ((size_t) ((IMAGE_X_RATIO * ((x) - IMAGE_X_TARGET_OFFSET)) + 0.5)) + IMAGE_X_SOURCE_OFFSET)
 
+// Interpolate pixels from float coordinates
+
+#define IMAGE_GET_INTERP_BINARY_PIXEL(row_ptr, row_width, x, y) \
+({ \
+    __typeof__ (row_ptr) __row_ptr = (row_ptr); \
+    __typeof__ (row_ptr) __row_ptr2 = (row_ptr + row_width); \
+    double _xf, _yf; \
+    float _xp = (float)modf((float)x, &_xf); \
+    float _xip = 1.0f - _xp; \
+    float _yp = (float)modf((float)y, &_yf); \
+    float _yip = 1.0f - _yp; \
+    int __x = abs((int)_xf); \
+    ((IMAGE_GET_BINARY_PIXEL_FAST(__row_ptr, __x) * _xip + \
+    IMAGE_GET_BINARY_PIXEL_FAST(__row_ptr, __x + 1) * _xp) * _yip + \
+    (IMAGE_GET_BINARY_PIXEL_FAST(__row_ptr2, __x) * _xip + \
+    IMAGE_GET_BINARY_PIXEL_FAST(__row_ptr2, __x + 1) * _xp) * _yp); \
+})
+
+#define IMAGE_GET_INTERP_GRAYSCALE_PIXEL(row_ptr, row_width, x, y) \
+({ \
+    __typeof__ (row_ptr) __row_ptr = (row_ptr); \
+    __typeof__ (row_ptr) __row_ptr2 = (row_ptr + row_width); \
+    double _xf, _yf; \
+    float _xp = (float)modf((float)x, &_xf); \
+    float _xip = 1.0f - _xp; \
+    float _yp = (float)modf((float)y, &_yf); \
+    float _yip = 1.0f - _yp; \
+    int __x = abs((int)_xf); \
+    ((IMAGE_GET_GRAYSCALE_PIXEL_FAST(__row_ptr, __x) * _xip + \
+    IMAGE_GET_GRAYSCALE_PIXEL_FAST(__row_ptr, __x + 1) * _xp) * _yip + \
+    (IMAGE_GET_GRAYSCALE_PIXEL_FAST(__row_ptr2, __x) * _xip + \
+    IMAGE_GET_GRAYSCALE_PIXEL_FAST(__row_ptr2, __x + 1) * _xp) * _yp); \
+})
+
+#define IMAGE_GET_INTERP_RGB565_PIXEL(row_ptr, row_width, x, y) \
+({ \
+    __typeof__ (row_ptr) __row_ptr = (row_ptr); \
+    __typeof__ (row_ptr) __row_ptr2 = (row_ptr + row_width); \
+    double _xf, _yf; \
+    float _xp = (float)modf((float)x, &_xf); \
+    float _xip = 1.0f - _xp; \
+    float _yp = (float)modf((float)y, &_yf); \
+    float _yip = 1.0f - _yp; \
+    int __x = abs((int)_xf); \
+    ((IMAGE_GET_RGB565_PIXEL_FAST(__row_ptr, __x) * _xip + \
+    IMAGE_GET_RGB565_PIXEL_FAST(__row_ptr, __x + 1) * _xp) * _yip + \
+    (IMAGE_GET_RGB565_PIXEL_FAST(__row_ptr2, __x) * _xip + \
+    IMAGE_GET_RGB565_PIXEL_FAST(__row_ptr2, __x + 1) * _xp) * _yp); \
+})
+
+
 // Old Image Macros - Will be refactor and removed. But, only after making sure through testing new macros work.
 
 #define IM_SWAP16(x) __REV16(x) // Swap bottom two chars in short.


### PR DESCRIPTION
The algorithm for lens correction calculates a table to map source pixels to corrected destination.
The map is calculated in float, but then it rounds each position to an int to select the source pixel to use.

With this change I've instead kept the source coordinates as float and take four neighboring source pixels, using the decimal place to select a percentage of each.

This is done in both x and y axis so the destination pixel is basically a weighed average of 4 source pixels.

eg. if the source coordinate is x=5.2, y=90.7 for dest[3, 80] I use:
```
dest[x=3, y=80] = ((source[x=5, y=90] * 0.8 + source[x=6, y=90] * 0.2) * 0.3) + 
                   (source[x=5, y=91] * 0.8 + source[x=6, y=91] * 0.2) * 0.7))
```

Note: this does incur a significant speed hit, in my initial testing it practically reverses the speed improvement recently made with https://github.com/openmv/openmv/commit/de98dfd3730293f02f6b73d6abccfad3ef56318b 
However, the quality improvement with some stronger curvature lenses is significant, which also improves the reliability of barcode reading dramatically.

Eg. `lens_corr`
![lens_corr](https://user-images.githubusercontent.com/3318786/93831069-395e8f80-fcb5-11ea-91bb-fa7a00d1f752.png)

The `rotation_corr` function works very similarly and benefits significantly from the same change.
![rotation_corr](https://user-images.githubusercontent.com/3318786/93831072-3d8aad00-fcb5-11ea-99a2-61fc9ae08b40.png)
