### PR TITLE
Specify address per board of swd frame buffer test address

### DIFF
--- a/src/omv/boards/OPENMV2/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV2/omv_boardconfig.h
@@ -16,6 +16,9 @@
 #define OMV_BOARD_TYPE          "M4"
 #define OMV_UNIQUE_ID_ADDR      0x1FFF7A10
 
+// Needed by the SWD JTAG testrig - located at the bottom of the frame buffer stack.
+#define OMV_SELF_TEST_SWD_ADDR  MAIN_FB()->bpp
+
 // Flash sectors for the bootloader.
 // Flash FS sector, main FW sector, max sector.
 #define OMV_FLASH_LAYOUT        {1, 4, 11}

--- a/src/omv/boards/OPENMV3/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV3/omv_boardconfig.h
@@ -16,6 +16,9 @@
 #define OMV_BOARD_TYPE          "M7"
 #define OMV_UNIQUE_ID_ADDR      0x1FF0F420
 
+// Needed by the SWD JTAG testrig - located at the bottom of the frame buffer stack.
+#define OMV_SELF_TEST_SWD_ADDR  MAIN_FB()->bpp
+
 // Flash sectors for the bootloader.
 // Flash FS sector, main FW sector, max sector.
 #define OMV_FLASH_LAYOUT        {1, 4, 11}

--- a/src/omv/boards/OPENMV4/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4/omv_boardconfig.h
@@ -16,6 +16,9 @@
 #define OMV_BOARD_TYPE          "H7"
 #define OMV_UNIQUE_ID_ADDR      0x1FF1E800
 
+// Needed by the SWD JTAG testrig - located at the bottom of the frame buffer stack.
+#define OMV_SELF_TEST_SWD_ADDR  MAIN_FB()->bpp
+
 // Flash sectors for the bootloader.
 // Flash FS sector, main FW sector, max sector.
 #define OMV_FLASH_LAYOUT        {1, 2, 15}

--- a/src/omv/boards/OPENMV4P/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4P/omv_boardconfig.h
@@ -16,6 +16,9 @@
 #define OMV_BOARD_TYPE          "H7"
 #define OMV_UNIQUE_ID_ADDR      0x1FF1E800
 
+// Needed by the SWD JTAG testrig - located at the bottom of the frame buffer overlay stack.
+#define OMV_SELF_TEST_SWD_ADDR  *((uint32_t *) 0x24000018)
+
 // Flash sectors for the bootloader.
 // Flash FS sector, main FW sector, max sector.
 #define OMV_FLASH_LAYOUT        {1, 2, 15}

--- a/src/omv/main.c
+++ b/src/omv/main.c
@@ -393,9 +393,11 @@ FRESULT exec_boot_script(const char *path, bool selftest, bool interruptible)
         f_unlink(&vfs_fat->fatfs, path);
         storage_flush();
 
+        #ifdef OMV_SELF_TEST_SWD_ADDR
         // Set flag for SWD debugger.
         // Note: main.py does not use the frame buffer.
-        MAIN_FB()->bpp = 0xDEADBEEF;
+        OMV_SELF_TEST_SWD_ADDR = 0xDEADBEEF;
+        #endif
     }
 
     return f_res;


### PR DESCRIPTION
Note, there's no check for the PORTENTA or OPENMVPURETHERMAL. These don't hit our factory, so, they don't need the check.