### PR TITLE
Deinit I2C bus before re-initializing.

### DIFF
--- a/src/omv/cambus.c
+++ b/src/omv/cambus.c
@@ -34,6 +34,7 @@ int cambus_init(I2C_HandleTypeDef *i2c, I2C_TypeDef *instance, uint32_t timing)
     i2c->Init.OwnAddress1     = 0xFE;
     i2c->Init.OwnAddress2     = 0xFE;
 
+    HAL_I2C_DeInit(i2c);
     if (HAL_I2C_Init(i2c) != HAL_OK) {
         /* Initialization Error */
         return -1;


### PR DESCRIPTION
* Fixes occasional failure when sensor I2C is shared with micropython.