### PR TITLE
Make D3/SRAM4 (VOSPI) memory reusable.

### DIFF
--- a/src/omv/boards/OPENMV4/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4/omv_boardconfig.h
@@ -130,7 +130,6 @@
 #define OMV_DMA_MEMORY          AXI_SRAM    // DMA buffers memory.
 #define OMV_FB_MEMORY           AXI_SRAM    // Framebuffer, fb_alloc
 #define OMV_JPEG_MEMORY         SRAM3       // JPEG buffer memory.
-#define OMV_VOSPI_MEMORY        SRAM4       // VoSPI buffer memory.
 
 #define OMV_FB_SIZE             (400K)      // FB memory: header + VGA/GS image
 #define OMV_FB_ALLOC_SIZE       (96K)       // minimum fb alloc size

--- a/src/omv/boards/OPENMV4P/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4P/omv_boardconfig.h
@@ -135,7 +135,6 @@
 #define OMV_FB_MEMORY           DRAM        // Framebuffer, fb_alloc
 #define OMV_JPEG_MEMORY         DRAM        // JPEG buffer memory buffer.
 #define OMV_JPEG_MEMORY_OFFSET  (31M)       // JPEG buffer is placed after FB/fballoc memory.
-#define OMV_VOSPI_MEMORY        SRAM4       // VoSPI buffer memory.
 #define OMV_FB_OVERLAY_MEMORY   AXI_SRAM    // _fballoc_overlay memory.
 #define OMV_FB_OVERLAY_MEMORY_OFFSET    (480*1024)  // _fballoc_overlay
 

--- a/src/omv/boards/OPENMVPURETHERMAL/omv_boardconfig.h
+++ b/src/omv/boards/OPENMVPURETHERMAL/omv_boardconfig.h
@@ -132,7 +132,6 @@
 #define OMV_FB_MEMORY                   DRAM        // Framebuffer, fb_alloc
 #define OMV_JPEG_MEMORY                 DRAM        // JPEG buffer memory buffer.
 #define OMV_JPEG_MEMORY_OFFSET          (63M)       // JPEG buffer is placed after FB/fballoc memory.
-#define OMV_VOSPI_MEMORY                SRAM4       // VoSPI buffer memory.
 #define OMV_FB_OVERLAY_MEMORY           AXI_SRAM    // _fballoc_overlay memory.
 #define OMV_FB_OVERLAY_MEMORY_OFFSET    (480*1024)  // _fballoc_overlay
 

--- a/src/omv/boards/PORTENTA/omv_boardconfig.h
+++ b/src/omv/boards/PORTENTA/omv_boardconfig.h
@@ -130,7 +130,6 @@
 #define OMV_FB_MEMORY           DRAM        // Framebuffer, fb_alloc
 #define OMV_JPEG_MEMORY         DRAM        // JPEG buffer memory buffer.
 #define OMV_JPEG_MEMORY_OFFSET  (7M)        // JPEG buffer is placed after FB/fballoc memory.
-#define OMV_VOSPI_MEMORY        SRAM4       // VoSPI buffer memory.
 #define OMV_FB_OVERLAY_MEMORY   AXI_SRAM    // _fballoc_overlay memory.
 #define OMV_FB_OVERLAY_MEMORY_OFFSET    (480*1024)  // _fballoc_overlay
 #define OMV_CYW43_MEMORY        FLASH_EXT   // CYW43 firmware in external flash mmap'd flash.

--- a/src/omv/lepton.c
+++ b/src/omv/lepton.c
@@ -61,7 +61,7 @@ extern uint8_t _vospi_buf;
 
 static bool vospi_resync = true;
 static uint8_t *vospi_packet = &_line_buf;
-static uint8_t *vospi_buffer = &_vospi_buf;
+static uint8_t vospi_buffer[64*1024] __attribute__((section(".d3_sram_buffer")));
 static volatile uint32_t vospi_pid = 0;
 static volatile uint32_t vospi_seg = 1;
 static uint32_t vospi_packets = 60;

--- a/src/omv/stm32fxxx.ld.S
+++ b/src/omv/stm32fxxx.ld.S
@@ -59,13 +59,6 @@ _ffs_cache          = ORIGIN(OMV_FFS_MEMORY) + OMV_FFS_MEMORY_OFFSET;
 _jpeg_buf           = ORIGIN(OMV_JPEG_MEMORY) + OMV_JPEG_MEMORY_OFFSET;
 #endif
 
-#if defined(OMV_VOSPI_MEMORY)
-#if !defined(OMV_VOSPI_MEMORY_OFFSET)
-#define OMV_VOSPI_MEMORY_OFFSET         (0)
-#endif
-_vospi_buf          = ORIGIN(OMV_VOSPI_MEMORY) + OMV_VOSPI_MEMORY_OFFSET;
-#endif
-
 _heap_size  = OMV_HEAP_SIZE;    /* required amount of heap */
 _stack_size = OMV_STACK_SIZE;   /* minimum amount of stack */
 
@@ -156,6 +149,15 @@ SECTIONS
     *(.dma_buffer)
 
   } >OMV_DMA_MEMORY
+
+  #if defined(OMV_SRAM4_ORIGIN)
+  /* D3 SRAM4 memory */
+  .d3_sram (NOLOAD) :
+  {
+   . = ALIGN(4);
+    *(.d3_sram_buffer)
+  } >SRAM4
+  #endif
 
   /* Initialized data sections */
   .data : AT ( _sidata )

--- a/src/uvc/stm32fxxx.ld.S
+++ b/src/uvc/stm32fxxx.ld.S
@@ -56,13 +56,6 @@ _ffs_cache          = ORIGIN(OMV_FFS_MEMORY) + OMV_FFS_MEMORY_OFFSET;
 _jpeg_buf           = ORIGIN(OMV_JPEG_MEMORY) + OMV_JPEG_MEMORY_OFFSET;
 #endif
 
-#if defined(OMV_VOSPI_MEMORY)
-#if !defined(OMV_VOSPI_MEMORY_OFFSET)
-#define OMV_VOSPI_MEMORY_OFFSET         (0)
-#endif
-_vospi_buf          = ORIGIN(OMV_VOSPI_MEMORY) + OMV_VOSPI_MEMORY_OFFSET;
-#endif
-
 _heap_size  = OMV_HEAP_SIZE;    /* required amount of heap */
 _stack_size = OMV_STACK_SIZE;   /* minimum amount of stack */
 
@@ -137,6 +130,15 @@ SECTIONS
     *(.dma_buffer)
 
   } >OMV_DMA_MEMORY
+
+  #if defined(OMV_SRAM4_ORIGIN)
+  /* D3 SRAM4 memory */
+  .d3_sram (NOLOAD) :
+  {
+   . = ALIGN(4);
+    *(.d3_sram_buffer)
+  } >SRAM4
+  #endif
 
   /* Initialized data sections */
   .data : AT ( _sidata )


### PR DESCRIPTION
* You can reuse the memory if FLIR LEPTON is not enabled.