### PR TITLE
Modify draw row for LCD screen use

### DIFF
--- a/src/omv/boards/OPENMV4P/imlib_config.h
+++ b/src/omv/boards/OPENMV4P/imlib_config.h
@@ -18,10 +18,10 @@
 //#define IMLIB_ENABLE_YUV_LUT
 
 // Enable mean pooling
-#define IMLIB_ENABLE_MEAN_POOLING
+// #define IMLIB_ENABLE_MEAN_POOLING
 
 // Enable midpoint pooling
-#define IMLIB_ENABLE_MIDPOINT_POOLING
+// #define IMLIB_ENABLE_MIDPOINT_POOLING
 
 // Enable binary ops
 #define IMLIB_ENABLE_BINARY_OPS
@@ -30,7 +30,7 @@
 #define IMLIB_ENABLE_MATH_OPS
 
 // Enable flood_fill()
-#define IMLIB_ENABLE_FLOOD_FILL
+// #define IMLIB_ENABLE_FLOOD_FILL
 
 // Enable mean()
 #define IMLIB_ENABLE_MEAN
@@ -161,6 +161,6 @@
 #define IMLIB_ENABLE_HOG
 
 // Enable selective_search()
-#define IMLIB_ENABLE_SELECTIVE_SEARCH
+// #define IMLIB_ENABLE_SELECTIVE_SEARCH
 
 #endif //__IMLIB_CONFIG_H__

--- a/src/omv/boards/OPENMVPURETHERMAL/imlib_config.h
+++ b/src/omv/boards/OPENMVPURETHERMAL/imlib_config.h
@@ -18,10 +18,10 @@
 //#define IMLIB_ENABLE_YUV_LUT
 
 // Enable mean pooling
-#define IMLIB_ENABLE_MEAN_POOLING
+// #define IMLIB_ENABLE_MEAN_POOLING
 
 // Enable midpoint pooling
-#define IMLIB_ENABLE_MIDPOINT_POOLING
+// #define IMLIB_ENABLE_MIDPOINT_POOLING
 
 // Enable binary ops
 #define IMLIB_ENABLE_BINARY_OPS
@@ -30,7 +30,7 @@
 #define IMLIB_ENABLE_MATH_OPS
 
 // Enable flood_fill()
-#define IMLIB_ENABLE_FLOOD_FILL
+// #define IMLIB_ENABLE_FLOOD_FILL
 
 // Enable mean()
 #define IMLIB_ENABLE_MEAN
@@ -161,6 +161,6 @@
 #define IMLIB_ENABLE_HOG
 
 // Enable selective_search()
-#define IMLIB_ENABLE_SELECTIVE_SEARCH
+// #define IMLIB_ENABLE_SELECTIVE_SEARCH
 
 #endif //__IMLIB_CONFIG_H__

--- a/src/omv/img/apriltag.c
+++ b/src/omv/img/apriltag.c
@@ -12115,7 +12115,7 @@ void imlib_find_rects(list_t *out, image_t *ptr, rectangle_t *roi, uint32_t thre
     img.h = roi->h;
     img.bpp = IMAGE_BPP_GRAYSCALE;
     img.data = fb_alloc(image_size(&img), FB_ALLOC_NO_HINT);
-    imlib_draw_image(&img, ptr, 0, 0, 1.f, 1.f, roi, -1, 256, NULL, NULL, 0);
+    imlib_draw_image(&img, ptr, 0, 0, 1.f, 1.f, roi, -1, 256, NULL, NULL, 0, NULL, NULL);
 
     image_u8_t im;
     im.width = roi->w;

--- a/src/omv/img/imlib.h
+++ b/src/omv/img/imlib.h
@@ -991,12 +991,13 @@ typedef struct find_barcodes_list_lnk_data {
 } find_barcodes_list_lnk_data_t;
 
 typedef enum image_hint {
-    IMAGE_HINT_AREA = 1,
-    IMAGE_HINT_BILINEAR = 2,
-    IMAGE_HINT_BICUBIC = 4,
-    IMAGE_HINT_CENTER = 128,
-    IMAGE_HINT_EXTRACT_RGB_CHANNEL_FIRST = 256,
-    IMAGE_HINT_APPLY_COLOR_PALETTE_FIRST = 512
+    IMAGE_HINT_AREA = 1 << 0,
+    IMAGE_HINT_BILINEAR = 1 << 1,
+    IMAGE_HINT_BICUBIC = 1 << 2,
+    IMAGE_HINT_CENTER = 1 << 7,
+    IMAGE_HINT_EXTRACT_RGB_CHANNEL_FIRST = 1 << 8,
+    IMAGE_HINT_APPLY_COLOR_PALETTE_FIRST = 1 << 9,
+    IMAGE_HINT_BLACK_BACKGROUND = 1 << 31
 } image_hint_t;
 
 typedef struct imlib_draw_row_data {
@@ -1006,11 +1007,16 @@ typedef struct imlib_draw_row_data {
     int alpha; // user
     const uint16_t *color_palette; // user
     const uint8_t *alpha_palette; // user
+    bool black_background; // user
+    void *callback; // user
+    void *dst_row_override; // user
     int toggle; // private
     void *row_buffer[2]; // private
     long smuad_alpha; // private
     uint32_t *smuad_alpha_palette; // private
 } imlib_draw_row_data_t;
+
+typedef void (*imlib_draw_row_callback_t)(int x_start, int x_end, int y_row, imlib_draw_row_data_t *data);
 
 /* Color space functions */
 int8_t imlib_rgb565_to_l(uint16_t pixel);
@@ -1162,7 +1168,8 @@ void imlib_draw_ellipse(image_t *img, int cx, int cy, int rx, int ry, int rotati
 void imlib_draw_string(image_t *img, int x_off, int y_off, const char *str, int c, float scale, int x_spacing, int y_spacing, bool mono_space,
                        int char_rotation, bool char_hmirror, bool char_vflip, int string_rotation, bool string_hmirror, bool string_hflip);
 void imlib_draw_image(image_t *dst_img, image_t *src_img, int dst_x_start, int dst_y_start, float x_scale, float y_scale, rectangle_t *roi,
-                      int rgb_channel, int alpha, const uint16_t *color_palette, const uint8_t *alpha_palette, image_hint_t hint);
+                      int rgb_channel, int alpha, const uint16_t *color_palette, const uint8_t *alpha_palette, image_hint_t hint,
+                      imlib_draw_row_callback_t callback, void *dst_row_override);
 void imlib_flood_fill(image_t *img, int x, int y,
                       float seed_threshold, float floating_threshold,
                       int c, bool invert, bool clear_background, image_t *mask);

--- a/src/omv/py/py_image.c
+++ b/src/omv/py/py_image.c
@@ -1918,7 +1918,7 @@ STATIC mp_obj_t py_image_draw_image(uint n_args, const mp_obj_t *args, mp_map_t 
 
     fb_alloc_mark();
     imlib_draw_image(arg_img, arg_other, arg_x_off, arg_y_off, arg_x_scale, arg_y_scale, &arg_roi,
-                     arg_rgb_channel, arg_alpha, color_palette, alpha_palette, hint);
+                     arg_rgb_channel, arg_alpha, color_palette, alpha_palette, hint, NULL, NULL);
     fb_alloc_free_till_mark();
     return args[0];
 }


### PR DESCRIPTION
In an effort to make sure new code is as fast as possible I am not taking any shortcuts anymore and wasting processor time...

As such, I've added a new mode to draw_row for drawing on a canvas with a black background. If the black_background flag is set draw row switches to faster versions of it's drawing methods that have alpha blending support which will assume the background pixels are black by default.

This saves having to do a memset per frame buffer update before drawing an image on the frame buffer. Additionally, for the LCD interface it's possible to tell the display driver which areas were actually drawn causing anything outside that area to be black. This means you can draw on a 1080p canvas without having to suffer the cost of a memset on 4MB of pixels per frame draw.

Second, this commit also adds a callback parameter to draw row and replacing the destination pointer with a custom pointer. This allows you to draw on a virtual image that has no data buffer allocated and have the row draws sent to a private row buffer which you can then flush to a screen. This is useful for SPI LCD output without having to have a buffer for the whole LCD image.

...

Had to disable things to make this fit. Will re-enable later. Need to get the OpenMV Pure Thermal working quickly.