### PR TITLE
Fix fballoc for complex allocations

### DIFF
--- a/src/omv/img/blob.c
+++ b/src/omv/img/blob.c
@@ -406,7 +406,17 @@ void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int 
                                     bin_up(y_hist_bins, ptr->h, y_hist_bins_max, &lnk_blob.y_hist_bins, &lnk_blob.y_hist_bins_count);
                                 }
 
-                                if (((threshold_cb_arg == NULL) || threshold_cb(threshold_cb_arg, &lnk_blob))) {
+                                bool add_to_list = threshold_cb_arg == NULL;
+                                if (!add_to_list) {
+                                    // Protect ourselves from caught exceptions in the callback
+                                    // code from freeing our fb_alloc() stack.
+                                    fb_alloc_mark();
+                                    fb_alloc_mark_permanent();
+                                    add_to_list = threshold_cb(threshold_cb_arg, &lnk_blob);
+                                    fb_alloc_free_till_mark_past_mark_permanent();
+                                }
+
+                                if (add_to_list) {
                                     list_push_back(out, &lnk_blob);
                                 } else {
                                     if (lnk_blob.x_hist_bins) xfree(lnk_blob.x_hist_bins);
@@ -666,7 +676,17 @@ void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int 
                                     bin_up(y_hist_bins, ptr->h, y_hist_bins_max, &lnk_blob.y_hist_bins, &lnk_blob.y_hist_bins_count);
                                 }
 
-                                if (((threshold_cb_arg == NULL) || threshold_cb(threshold_cb_arg, &lnk_blob))) {
+                                bool add_to_list = threshold_cb_arg == NULL;
+                                if (!add_to_list) {
+                                    // Protect ourselves from caught exceptions in the callback
+                                    // code from freeing our fb_alloc() stack.
+                                    fb_alloc_mark();
+                                    fb_alloc_mark_permanent();
+                                    add_to_list = threshold_cb(threshold_cb_arg, &lnk_blob);
+                                    fb_alloc_free_till_mark_past_mark_permanent();
+                                }
+
+                                if (add_to_list) {
                                     list_push_back(out, &lnk_blob);
                                 } else {
                                     if (lnk_blob.x_hist_bins) xfree(lnk_blob.x_hist_bins);
@@ -926,7 +946,17 @@ void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int 
                                     bin_up(y_hist_bins, ptr->h, y_hist_bins_max, &lnk_blob.y_hist_bins, &lnk_blob.y_hist_bins_count);
                                 }
 
-                                if (((threshold_cb_arg == NULL) || threshold_cb(threshold_cb_arg, &lnk_blob))) {
+                                bool add_to_list = threshold_cb_arg == NULL;
+                                if (!add_to_list) {
+                                    // Protect ourselves from caught exceptions in the callback
+                                    // code from freeing our fb_alloc() stack.
+                                    fb_alloc_mark();
+                                    fb_alloc_mark_permanent();
+                                    add_to_list = threshold_cb(threshold_cb_arg, &lnk_blob);
+                                    fb_alloc_free_till_mark_past_mark_permanent();
+                                }
+
+                                if (add_to_list) {
                                     list_push_back(out, &lnk_blob);
                                 } else {
                                     if (lnk_blob.x_hist_bins) xfree(lnk_blob.x_hist_bins);

--- a/src/omv/py/py_sensor.c
+++ b/src/omv/py/py_sensor.c
@@ -206,12 +206,13 @@ static mp_obj_t py_sensor_alloc_extra_fb(mp_obj_t w_obj, mp_obj_t h_obj, mp_obj_
 
     fb_alloc_mark();
     ((image_t *) py_image_cobj(r))->pixels = fb_alloc0(image_size(&img), FB_ALLOC_NO_HINT);
+    fb_alloc_mark_permanent(); // pixels will not be popped on exception
     return r;
 }
 
 static mp_obj_t py_sensor_dealloc_extra_fb()
 {
-    fb_alloc_free_till_mark();
+    fb_alloc_free_till_mark_past_mark_permanent();
     return mp_const_none;
 }
 

--- a/src/omv/py/py_tf.c
+++ b/src/omv/py/py_tf.c
@@ -184,6 +184,8 @@ STATIC mp_obj_t int_py_tf_load(mp_obj_t path_obj, bool alloc_mode, bool helper_m
 
     if ((!helper_mode) && (!alloc_mode)) {
         fb_alloc_free_till_mark();
+    } else if ((!helper_mode) && alloc_mode) {
+        fb_alloc_mark_permanent(); // tf_model->model_data will not be popped on exception.
     }
 
     return tf_model;
@@ -197,7 +199,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_tf_load_obj, 1, py_tf_load);
 
 STATIC mp_obj_t py_tf_free_from_fb()
 {
-    fb_alloc_free_till_mark();
+    fb_alloc_free_till_mark_past_mark_permanent();
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_tf_free_from_fb_obj, py_tf_free_from_fb);


### PR DESCRIPTION
I noticed a bug with load_to_fb=True for tesnorflow where exceptions not in our code path caused the allocated buffers to be popped. This commit fixes that issue. The previous marks semaphore was not strong enough to handle how I'd like to allocate buffers in different situations. This new method is superior.

Other ways this is helpful... imagine if you want to allocate 3 buffers for triple buffering the LCD output. Each is a huge fb_alloc(). One may fail in the alloc loop. If a failure happens you want all previous ones freed. Sure, our code does that now. After all succeed you want to lock them all to prevent them from being popped by any exceptions. This code makes that happen now.

But, in particular, TensorFlow has a rather complex multi-alloc and then pop usage case before it wants to lock a buffer. This method helps for it too.

The semaphore method was only helpful for the extra_fb method where I was just allocing an fb not inside of a mark region.