### PR TITLE
Reduce heap to fit more static driver vars

### DIFF
--- a/src/omv/boards/PORTENTA/omv_boardconfig.h
+++ b/src/omv/boards/PORTENTA/omv_boardconfig.h
@@ -139,7 +139,7 @@
 #define OMV_FB_SIZE             (4M)       // FB memory: header + VGA/GS image
 #define OMV_FB_ALLOC_SIZE       (3M)       // minimum fb alloc size
 #define OMV_STACK_SIZE          (32K)
-#define OMV_HEAP_SIZE           (212K)
+#define OMV_HEAP_SIZE           (210K)
 #define OMV_SDRAM_SIZE          (8 * 1024 * 1024) // This needs to be here for UVC firmware.
 #define OMV_SDRAM_TEST          (0)
 


### PR DESCRIPTION
LCD controller needs more space for static vars.