### PR TITLE
Add draw_image extent calculator

### DIFF
--- a/src/omv/img/imlib.h
+++ b/src/omv/img/imlib.h
@@ -1154,6 +1154,9 @@ void imlib_draw_row_teardown(imlib_draw_row_data_t *data);
 void *imlib_draw_row_get_row_buffer(imlib_draw_row_data_t *data);
 void imlib_draw_row_put_row_buffer(imlib_draw_row_data_t *data, void *row_buffer);
 void imlib_draw_row(int x_start, int x_end, int y_row, imlib_draw_row_data_t *data);
+bool imlib_draw_image_rectangle(image_t *dst_img, image_t *src_img, int dst_x_start, int dst_y_start, float x_scale, float y_scale, rectangle_t *roi,
+                                int alpha, const uint8_t *alpha_palette, image_hint_t hint,
+                                int *x0, int *x1, int *y0, int *y1);
 void imlib_flood_fill_int(image_t *out, image_t *img, int x, int y,
                           int seed_threshold, int floating_threshold,
                           flood_fill_call_back_t cb, void *data);


### PR DESCRIPTION
Allows code to figure out the area being draw on or not. Useful for optimizing lcd display output.