### PR TITLE
Update JPEG frame buffer after loading/creating images.

### DIFF
--- a/scripts/examples/03-Drawing/copy2fb.py
+++ b/scripts/examples/03-Drawing/copy2fb.py
@@ -17,11 +17,5 @@ sensor.set_pixformat(sensor.GRAYSCALE)
 # Load image
 img = image.Image("/example.bmp", copy_to_fb=True)
 
-# Add drawing code here.
-# img.draw_line(...)
-
-# Flush FB
-sensor.flush()
-
-# Add a small delay to allow the IDE to read the flushed image.
-time.sleep(100)
+# Add a small delay to allow the IDE to read the loaded image.
+time.sleep(500)

--- a/src/omv/py/py_image.c
+++ b/src/omv/py/py_image.c
@@ -7128,10 +7128,6 @@ mp_obj_t py_image_load_image(uint n_args, const mp_obj_t *args, mp_map_t *kw_arg
         }
     }
 
-    if (copy_to_fb) {
-        fb_update_jpeg_buffer();
-    }
-
     image_t image = {0};
 
     if (mode) {
@@ -7188,6 +7184,10 @@ mp_obj_t py_image_load_image(uint n_args, const mp_obj_t *args, mp_map_t *kw_arg
         arg_other->w = image.w;
         arg_other->h = image.h;
         arg_other->bpp = image.bpp;
+    }
+
+    if (copy_to_fb) {
+        fb_update_jpeg_buffer();
     }
 
     return py_image_from_struct(&image);


### PR DESCRIPTION
* With this fix the frame buffer will be updated instantly after loading or creating
new images with the copy_to_fb flag set to true.
* There's no need to flush the framebuffer after loading or creating images anymore,
however the sensor (or image) flush() still needs to be called after drawing to see the updates.