### PR TITLE
Fix ep0_mps on the M4.

### DIFF
--- a/src/uvc/src/usbd_conf.c
+++ b/src/uvc/src/usbd_conf.c
@@ -281,7 +281,7 @@ USBD_StatusTypeDef  USBD_LL_Init (USBD_HandleTypeDef *pdev)
   hpcd.Instance = USB_OTG_FS;
   hpcd.Init.dev_endpoints = 3; 
   hpcd.Init.use_dedicated_ep1 = 0;
-  hpcd.Init.ep0_mps = DEP0CTL_MPS_64;  
+  hpcd.Init.ep0_mps = 0x40;
   hpcd.Init.dma_enable = 0;
   hpcd.Init.low_power_enable = 0;
   hpcd.Init.phy_itface = PCD_PHY_EMBEDDED; 


### PR DESCRIPTION
* Note ep0_mps is not used anywhere, but we keep it for now.