### PR TITLE
Use MP HAL delay/ticks instead of systick.

### DIFF
--- a/src/omv/imlib/jpeg.c
+++ b/src/omv/imlib/jpeg.c
@@ -11,7 +11,6 @@
  * DCT implementation is based on Arai, Agui, and Nakajima's algorithm for scaled DCT.
  */
 #include <stdio.h>
-#include STM32_HAL_H
 #include <arm_math.h>
 
 #include "xalloc.h"
@@ -21,6 +20,9 @@
 #include "omv_boardconfig.h"
 
 #define TIME_JPEG   (0)
+#if (TIME_JPEG == 1)
+#include "py/mphal.h"
+#endif
 
 // Expand 4 bits to 32 for binary to grayscale; process 4 pixels at a time
 const uint32_t u32Expand[16] = {0x0, 0xff, 0xff00, 0xffff, 0xff0000,
@@ -152,6 +154,7 @@ static void bayer_to_ycbcr(image_t *img, int x_offset, int y_offset, uint8_t *Y0
 } /* bayer_to_ycbcr() */
 
 #if (OMV_HARDWARE_JPEG == 1)
+#include STM32_HAL_H
 
 #define MCU_W                       (8)
 #define MCU_H                       (8)
@@ -309,7 +312,7 @@ void HAL_JPEG_ErrorCallback(JPEG_HandleTypeDef *hjpeg)
 bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc)
 {
 #if (TIME_JPEG==1)
-    uint32_t start = HAL_GetTick();
+    mp_uint_t start = mp_hal_ticks_ms();
 #endif
 
     // Init the HAL JPEG driver
@@ -369,7 +372,7 @@ bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc)
     dst->bpp = jpeg_enc.out_size;
 
 #if (TIME_JPEG==1)
-    printf("time: %lums\n", HAL_GetTick() - start);
+    printf("time: %u ms\n", mp_hal_ticks_ms() - start);
 #endif
 
     HAL_JPEG_DeInit(&JPEG_Handle);
@@ -959,7 +962,7 @@ bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc)
     int DCY=0, DCU=0, DCV=0;
 
     #if (TIME_JPEG==1)
-    uint32_t start = HAL_GetTick();
+    uint32_t start = mp_hal_ticks_ms();
     #endif
 
     // JPEG buffer
@@ -1279,7 +1282,7 @@ bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc)
     dst->data = jpeg_buf.buf;
 
     #if (TIME_JPEG==1)
-    printf("time: %lums\n", HAL_GetTick() - start);
+    printf("time: %lums\n", mp_hal_ticks_ms() - start);
     #endif
 
 jpeg_overflow:

--- a/src/omv/modules/py_clock.c
+++ b/src/omv/modules/py_clock.c
@@ -9,7 +9,7 @@
  * Clock Python module.
  */
 #include "py/obj.h"
-#include "systick.h"
+#include "py/mphal.h"
 #include "py_clock.h"
 
 /* Clock Type */
@@ -23,7 +23,7 @@ typedef struct _py_clock_obj_t {
 mp_obj_t py_clock_tick(mp_obj_t clock_obj)
 {
     py_clock_obj_t *clock = (py_clock_obj_t*) clock_obj;
-    clock->t_start = systick_current_millis();
+    clock->t_start = mp_hal_ticks_ms();
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_clock_tick_obj,  py_clock_tick);
@@ -32,7 +32,7 @@ mp_obj_t py_clock_fps(mp_obj_t clock_obj)
 {
     py_clock_obj_t *clock = (py_clock_obj_t*) clock_obj;
     clock->t_frame++;
-    clock->t_ticks += (systick_current_millis()-clock->t_start);
+    clock->t_ticks += (mp_hal_ticks_ms() - clock->t_start);
     float fps = 1000.0f / (clock->t_ticks/(float)clock->t_frame);
     return mp_obj_new_float(fps);
 }
@@ -42,7 +42,7 @@ mp_obj_t py_clock_avg(mp_obj_t clock_obj)
 {
     py_clock_obj_t *clock = (py_clock_obj_t*) clock_obj;
     clock->t_frame++;
-    clock->t_ticks += (systick_current_millis()-clock->t_start);
+    clock->t_ticks += (mp_hal_ticks_ms() - clock->t_start);
     return mp_obj_new_float(clock->t_ticks/(float)clock->t_frame);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_clock_avg_obj,   py_clock_avg);

--- a/src/omv/modules/py_image.c
+++ b/src/omv/modules/py_image.c
@@ -13,13 +13,13 @@
 #include <stdbool.h>
 #include <arm_math.h>
 #include "py/nlr.h"
-#include "systick.h"
 #include "py/obj.h"
 #include "py/objlist.h"
 #include "py/objstr.h"
 #include "py/objtuple.h"
 #include "py/objtype.h"
 #include "py/runtime.h"
+#include "py/mphal.h"
 
 #include "imlib.h"
 #include "array.h"
@@ -6667,7 +6667,7 @@ mp_obj_t py_imagewriter_add_frame(mp_obj_t self_in, mp_obj_t img_obj)
     PY_ASSERT_TYPE(img_obj, &py_image_type);
     image_t *arg_img = &((py_image_obj_t *) img_obj)->_cobj;
 
-    uint32_t ms = systick_current_millis(); // Write out elapsed ms.
+    uint32_t ms = mp_hal_ticks_ms(); // Write out elapsed ms.
     write_long(fp, ms - ((py_imagewriter_obj_t *) self_in)->ms);
     ((py_imagewriter_obj_t *) self_in)->ms = ms;
 
@@ -6718,7 +6718,7 @@ mp_obj_t py_image_imagewriter(mp_obj_t path)
     write_long(&obj->fp, *((uint32_t *) "STR ")); // Stream
     write_long(&obj->fp, *((uint32_t *) "V1.0")); // v1.0
 
-    obj->ms = systick_current_millis();
+    obj->ms = mp_hal_ticks_ms();
     return obj;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_image_imagewriter_obj, py_image_imagewriter);
@@ -6781,9 +6781,9 @@ mp_obj_t py_imagereader_next_frame(uint n_args, const mp_obj_t *args, mp_map_t *
     uint32_t ms; // Wait for elapsed ms.
     ms = 0;
     if (!py_helper_keyword_int(n_args, args, 3, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_pause), true)) {
-        for (ms = systick_current_millis();
+        for (ms = mp_hal_ticks_ms();
             ((ms - ((py_imagewriter_obj_t *) args[0])->ms) < ms_tmp);
-            ms = systick_current_millis()) {
+            ms = mp_hal_ticks_ms()) {
             __WFI();
         }
     }
@@ -6856,7 +6856,7 @@ mp_obj_t py_image_imagereader(mp_obj_t path)
     read_long_expect(&obj->fp, *((uint32_t *) "STR ")); // Stream
     read_long_expect(&obj->fp, *((uint32_t *) "V1.0")); // v1.0
 
-    obj->ms = systick_current_millis();
+    obj->ms = mp_hal_ticks_ms();
     return obj;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_image_imagereader_obj, py_image_imagereader);

--- a/src/omv/modules/py_sensor.c
+++ b/src/omv/modules/py_sensor.c
@@ -21,7 +21,6 @@
 #include "omv_boardconfig.h"
 #include "py_helper.h"
 #include "framebuffer.h"
-#include "systick.h"
 
 extern sensor_t sensor;
 
@@ -123,15 +122,15 @@ static mp_obj_t py_sensor_skip_frames(uint n_args, const mp_obj_t *args, mp_map_
         time = mp_obj_get_int(kw_arg->value);
     }
 
-    uint32_t millis = systick_current_millis();
+    uint32_t millis = mp_hal_ticks_ms();
 
     if (!n_args) {
-        while ((systick_current_millis() - millis) < time) { // 32-bit math handles wrap around...
+        while ((mp_hal_ticks_ms() - millis) < time) { // 32-bit math handles wrap around...
             py_sensor_snapshot(0, NULL, NULL);
         }
     } else {
         for (int i = 0, j = mp_obj_get_int(args[0]); i < j; i++) {
-            if ((kw_arg != NULL) && ((systick_current_millis() - millis) >= time)) {
+            if ((kw_arg != NULL) && ((mp_hal_ticks_ms() - millis) >= time)) {
                 break;
             }
 

--- a/src/omv/sensors/hm01b0.c
+++ b/src/omv/sensors/hm01b0.c
@@ -18,7 +18,7 @@
 #include "sensor.h"
 #include "hm01b0.h"
 #include "hm01b0_regs.h"
-#include "systick.h"
+#include "py/mphal.h"
 
 #define HIMAX_BOOT_RETRY        (10)
 #define HIMAX_LINE_LEN_PCK      0x172
@@ -127,7 +127,7 @@ static int reset(sensor_t *sensor)
             return -1;
         }
         // Delay for 1ms.
-        systick_sleep(1);
+        mp_hal_delay_ms(1);
         if (cambus_readb2(&sensor->i2c, sensor->slv_addr, MODE_SELECT, &reg) != 0) {
             return -1;
         }

--- a/src/omv/sensors/mt9v034.c
+++ b/src/omv/sensors/mt9v034.c
@@ -14,7 +14,7 @@
 #include "cambus.h"
 #include "sensor.h"
 #include "mt9v034.h"
-#include "systick.h"
+#include "py/mphal.h"
 #include "framebuffer.h"
 
 #define MT9V034_MAX_HEIGHT                      (480)
@@ -112,16 +112,16 @@
 static int reset(sensor_t *sensor)
 {
     DCMI_PWDN_HIGH();
-    systick_sleep(1);
+    mp_hal_delay_ms(1);
 
     DCMI_PWDN_LOW();
-    systick_sleep(1);
+    mp_hal_delay_ms(1);
 
     DCMI_RESET_LOW();
-    systick_sleep(1);
+    mp_hal_delay_ms(1);
 
     DCMI_RESET_HIGH();
-    systick_sleep(1);
+    mp_hal_delay_ms(1);
 
     int ret = 0;
 
@@ -140,10 +140,10 @@ static int sleep(sensor_t *sensor, int enable)
 {
     if (enable) {
         DCMI_PWDN_HIGH();
-        systick_sleep(1);
+        mp_hal_delay_ms(1);
     } else {
         DCMI_PWDN_LOW();
-        systick_sleep(1);
+        mp_hal_delay_ms(1);
     }
 
     return 0;

--- a/src/omv/sensors/ov2640.c
+++ b/src/omv/sensors/ov2640.c
@@ -19,7 +19,7 @@
 #include "sensor.h"
 #include "ov2640.h"
 #include "ov2640_regs.h"
-#include "systick.h"
+#include "py/mphal.h"
 
 #define CIF_WIDTH       (400)
 #define CIF_HEIGHT      (296)
@@ -352,7 +352,7 @@ static int reset(sensor_t *sensor)
     ret |= cambus_writeb(&sensor->i2c, sensor->slv_addr, COM7, COM7_SRST);
 
     // Delay 5 ms
-    systick_sleep(5);
+    mp_hal_delay_ms(5);
 
     // Write default regsiters
     for (int i = 0; default_regs[i][0]; i++) {
@@ -360,7 +360,7 @@ static int reset(sensor_t *sensor)
     }
 
     // Delay 300 ms
-    systick_sleep(300);
+    mp_hal_delay_ms(300);
 
     return ret;
 }

--- a/src/omv/sensors/ov5640.c
+++ b/src/omv/sensors/ov5640.c
@@ -19,7 +19,7 @@
 #include "sensor.h"
 #include "ov5640.h"
 #include "ov5640_regs.h"
-#include "systick.h"
+#include "py/mphal.h"
 
 #define BLANK_LINES             8
 #define DUMMY_LINES             6
@@ -657,7 +657,7 @@ static int reset(sensor_t *sensor)
     ret |= cambus_writeb2(&sensor->i2c, sensor->slv_addr, SYSTEM_CTROL0, 0x82);
 
     // Delay 5 ms
-    systick_sleep(5);
+    mp_hal_delay_ms(5);
 
     // Write default regsiters
     for (int i = 0; default_regs[i][0]; i++) {
@@ -686,7 +686,7 @@ static int reset(sensor_t *sensor)
     #endif
 
     // Delay 300 ms
-    systick_sleep(300);
+    mp_hal_delay_ms(300);
 
     return ret;
 }
@@ -1297,13 +1297,13 @@ static int ioctl(sensor_t *sensor, int request, va_list ap)
             break;
         }
         case IOCTL_WAIT_ON_AUTO_FOCUS: {
-            uint32_t start_tick = HAL_GetTick(), delay_ms = va_arg(ap, uint32_t);
+            mp_uint_t start_tick = mp_hal_ticks_ms(), delay_ms = va_arg(ap, uint32_t);
             for (;;) {
                 uint8_t reg;
                 ret = cambus_readb2(&sensor->i2c, sensor->slv_addr, AF_CMD_ACK, &reg);
                 if ((ret < 0) || (!reg)) break;
-                if ((HAL_GetTick() - start_tick) >= delay_ms) return -1;
-                systick_sleep(1);
+                if ((mp_hal_ticks_ms() - start_tick) >= delay_ms) return -1;
+                mp_hal_delay_ms(1);
             }
             break;
         }

--- a/src/omv/sensors/ov7690.c
+++ b/src/omv/sensors/ov7690.c
@@ -19,7 +19,7 @@
 #include "sensor.h"
 #include "ov7690.h"
 #include "ov7690_regs.h"
-#include "systick.h"
+#include "py/mphal.h"
 
 static const uint8_t default_regs[][2] = {
 
@@ -189,7 +189,7 @@ static int reset(sensor_t *sensor)
     int ret = cambus_writeb(&sensor->i2c, sensor->slv_addr, REG12, 0x80);
 
     // Delay 2 ms
-    systick_sleep(2);
+    mp_hal_delay_ms(2);
 
     // Write default regsiters
     for (int i = 0; default_regs[i][0]; i++) {
@@ -197,7 +197,7 @@ static int reset(sensor_t *sensor)
     }
 
     // Delay 300 ms
-    systick_sleep(300);
+    mp_hal_delay_ms(300);
 
     return ret;
 }

--- a/src/omv/sensors/ov7725.c
+++ b/src/omv/sensors/ov7725.c
@@ -19,7 +19,7 @@
 #include "sensor.h"
 #include "ov7725.h"
 #include "ov7725_regs.h"
-#include "systick.h"
+#include "py/mphal.h"
 
 static const uint8_t default_regs[][2] = {
 
@@ -156,7 +156,7 @@ static int reset(sensor_t *sensor)
     int ret = cambus_writeb(&sensor->i2c, sensor->slv_addr, COM7, COM7_RESET);
 
     // Delay 2 ms
-    systick_sleep(2);
+    mp_hal_delay_ms(2);
 
     // Write default regsiters
     for (int i = 0; default_regs[i][0]; i++) {
@@ -164,7 +164,7 @@ static int reset(sensor_t *sensor)
     }
 
     // Delay 300 ms
-    systick_sleep(300);
+    mp_hal_delay_ms(300);
 
     return ret;
 }

--- a/src/omv/sensors/ov9650.c
+++ b/src/omv/sensors/ov9650.c
@@ -18,7 +18,7 @@
 #include "cambus.h"
 #include "sensor.h"
 #include "ov9650.h"
-#include "systick.h"
+#include "py/mphal.h"
 #include "ov9650_regs.h"
 
 #define NUM_BR_LEVELS       7
@@ -211,7 +211,7 @@ static int reset(sensor_t *sensor)
     cambus_writeb(&sensor->i2c, sensor->slv_addr, REG_COM7, 0x80);
 
     /* delay n ms */
-    systick_sleep(10);
+    mp_hal_delay_ms(10);
 
     /* Write initial regsiters */
     while (regs[i][0]) {

--- a/src/uvc/src/main.c
+++ b/src/uvc/src/main.c
@@ -24,6 +24,16 @@ USBD_HandleTypeDef hUsbDeviceFS;
 extern volatile uint8_t g_uvc_stream_status;
 extern struct uvc_streaming_control videoCommitControl;
 
+void mp_hal_delay_ms(uint32_t Delay)
+{
+    HAL_Delay(Delay);
+}
+
+mp_uint_t mp_hal_ticks_ms(void)
+{
+    return HAL_GetTick();
+}
+
 void __attribute__((noreturn)) __fatal_error()
 {
     while (1) {


### PR DESCRIPTION
* Allow building sensor drivers with different ports.