### PR TITLE
Allow building the image library and modules without a filesystem.

### DIFF
--- a/src/omv/boards/OPENMV1/imlib_config.h
+++ b/src/omv/boards/OPENMV1/imlib_config.h
@@ -11,6 +11,9 @@
 #ifndef __IMLIB_CONFIG_H__
 #define __IMLIB_CONFIG_H__
 
+// Enable Image I/O
+//#define IMLIB_ENABLE_IMAGE_IO
+
 // Enable LAB LUT
 //#define IMLIB_ENABLE_LAB_LUT
 

--- a/src/omv/boards/OPENMV2/imlib_config.h
+++ b/src/omv/boards/OPENMV2/imlib_config.h
@@ -11,6 +11,9 @@
 #ifndef __IMLIB_CONFIG_H__
 #define __IMLIB_CONFIG_H__
 
+// Enable Image I/O
+#define IMLIB_ENABLE_IMAGE_IO
+
 // Enable LAB LUT
 #define IMLIB_ENABLE_LAB_LUT
 
@@ -121,9 +124,8 @@
 // Enable find_keypoints()
 //#define IMLIB_ENABLE_FIND_KEYPOINTS
 
-#if defined(IMLIB_ENABLE_FIND_LBP) || defined(IMLIB_ENABLE_FIND_KEYPOINTS)
-    #define IMLIB_ENABLE_DESCRIPTOR
-#endif
+// Enable load, save and match descriptor
+//#define IMLIB_ENABLE_DESCRIPTOR
 
 // Enable find_hog()
 //#define IMLIB_ENABLE_HOG

--- a/src/omv/boards/OPENMV3/imlib_config.h
+++ b/src/omv/boards/OPENMV3/imlib_config.h
@@ -11,6 +11,9 @@
 #ifndef __IMLIB_CONFIG_H__
 #define __IMLIB_CONFIG_H__
 
+// Enable Image I/O
+#define IMLIB_ENABLE_IMAGE_IO
+
 // Enable LAB LUT
 #define IMLIB_ENABLE_LAB_LUT
 
@@ -131,9 +134,8 @@
 // Enable find_keypoints()
 #define IMLIB_ENABLE_FIND_KEYPOINTS
 
-#if defined(IMLIB_ENABLE_FIND_LBP) || defined(IMLIB_ENABLE_FIND_KEYPOINTS)
-    #define IMLIB_ENABLE_DESCRIPTOR
-#endif
+// Enable load, save and match descriptor
+#define IMLIB_ENABLE_DESCRIPTOR
 
 // Enable find_hog()
 #define IMLIB_ENABLE_HOG

--- a/src/omv/boards/OPENMV4/imlib_config.h
+++ b/src/omv/boards/OPENMV4/imlib_config.h
@@ -11,6 +11,9 @@
 #ifndef __IMLIB_CONFIG_H__
 #define __IMLIB_CONFIG_H__
 
+// Enable Image I/O
+#define IMLIB_ENABLE_IMAGE_IO
+
 // Enable LAB LUT
 #define IMLIB_ENABLE_LAB_LUT
 
@@ -131,9 +134,8 @@
 // Enable find_keypoints()
 #define IMLIB_ENABLE_FIND_KEYPOINTS
 
-#if defined(IMLIB_ENABLE_FIND_LBP) || defined(IMLIB_ENABLE_FIND_KEYPOINTS)
-    #define IMLIB_ENABLE_DESCRIPTOR
-#endif
+// Enable load, save and match descriptor
+#define IMLIB_ENABLE_DESCRIPTOR
 
 // Enable find_hog()
 #define IMLIB_ENABLE_HOG

--- a/src/omv/boards/OPENMV4P/imlib_config.h
+++ b/src/omv/boards/OPENMV4P/imlib_config.h
@@ -11,6 +11,9 @@
 #ifndef __IMLIB_CONFIG_H__
 #define __IMLIB_CONFIG_H__
 
+// Enable Image I/O
+#define IMLIB_ENABLE_IMAGE_IO
+
 // Enable LAB LUT
 #define IMLIB_ENABLE_LAB_LUT
 
@@ -131,9 +134,8 @@
 // Enable find_keypoints()
 #define IMLIB_ENABLE_FIND_KEYPOINTS
 
-#if defined(IMLIB_ENABLE_FIND_LBP) || defined(IMLIB_ENABLE_FIND_KEYPOINTS)
-    #define IMLIB_ENABLE_DESCRIPTOR
-#endif
+// Enable load, save and match descriptor
+#define IMLIB_ENABLE_DESCRIPTOR
 
 // Enable find_hog()
 #define IMLIB_ENABLE_HOG

--- a/src/omv/boards/OPENMVPT/imlib_config.h
+++ b/src/omv/boards/OPENMVPT/imlib_config.h
@@ -11,6 +11,9 @@
 #ifndef __IMLIB_CONFIG_H__
 #define __IMLIB_CONFIG_H__
 
+// Enable Image I/O
+#define IMLIB_ENABLE_IMAGE_IO
+
 // Enable LAB LUT
 #define IMLIB_ENABLE_LAB_LUT
 
@@ -131,9 +134,8 @@
 // Enable find_keypoints()
 #define IMLIB_ENABLE_FIND_KEYPOINTS
 
-#if defined(IMLIB_ENABLE_FIND_LBP) || defined(IMLIB_ENABLE_FIND_KEYPOINTS)
-    #define IMLIB_ENABLE_DESCRIPTOR
-#endif
+// Enable load, save and match descriptor
+#define IMLIB_ENABLE_DESCRIPTOR
 
 // Enable find_hog()
 #define IMLIB_ENABLE_HOG

--- a/src/omv/boards/PORTENTA/imlib_config.h
+++ b/src/omv/boards/PORTENTA/imlib_config.h
@@ -11,6 +11,9 @@
 #ifndef __IMLIB_CONFIG_H__
 #define __IMLIB_CONFIG_H__
 
+// Enable Image I/O
+#define IMLIB_ENABLE_IMAGE_IO
+
 // Enable LAB LUT
 //#define IMLIB_ENABLE_LAB_LUT
 
@@ -131,9 +134,8 @@
 // Enable find_keypoints()
 #define IMLIB_ENABLE_FIND_KEYPOINTS
 
-#if defined(IMLIB_ENABLE_FIND_LBP) || defined(IMLIB_ENABLE_FIND_KEYPOINTS)
-    #define IMLIB_ENABLE_DESCRIPTOR
-#endif
+// Enable load, save and match descriptor
+#define IMLIB_ENABLE_DESCRIPTOR
 
 // Enable find_hog()
 #define IMLIB_ENABLE_HOG

--- a/src/omv/common/ff_wrapper.c
+++ b/src/omv/common/ff_wrapper.c
@@ -6,10 +6,14 @@
  * File System Helper Functions
  *
  */
+#include "imlib_config.h"
+#if defined(IMLIB_ENABLE_IMAGE_IO)
+
 #include <string.h>
 #include "py/runtime.h"
 #include "extmod/vfs.h"
 #include "extmod/vfs_fat.h"
+
 #include "common.h"
 #include "fb_alloc.h"
 #include "ff_wrapper.h"
@@ -460,3 +464,4 @@ void write_data(FIL *fp, const void *data, UINT size)
         if (bytes != size) ff_write_fail(fp);
     }
 }
+#endif //IMLIB_ENABLE_IMAGE_IO

--- a/src/omv/imlib/bmp.c
+++ b/src/omv/imlib/bmp.c
@@ -8,12 +8,15 @@
  *
  * BMP reader/writer.
  */
-#include <arm_math.h>
-#include <stdlib.h>
-#include <ff.h>
-#include "ff_wrapper.h"
-#include "xalloc.h"
 #include "imlib.h"
+#if defined(IMLIB_ENABLE_IMAGE_IO)
+
+#include <stdlib.h>
+#include "py/obj.h"
+#include "py/nlr.h"
+
+#include "xalloc.h"
+#include "ff_wrapper.h"
 
 // This function inits the geometry values of an image (opens file).
 bool bmp_read_geometry(FIL *fp, image_t *img, const char *path, bmp_read_settings_t *rs)
@@ -216,10 +219,12 @@ void bmp_read(image_t *img, const char *path)
 void bmp_write_subimg(image_t *img, const char *path, rectangle_t *r)
 {
     rectangle_t rect;
-    if (!rectangle_subimg(img, r, &rect)) ff_no_intersection(NULL);
+    if (!rectangle_subimg(img, r, &rect)) {
+        nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "No intersection!"));
+    }
+
     FIL fp;
     file_write_open(&fp, path);
-
     file_buffer_on(&fp);
     if (IM_IS_GS(img)) {
         const int row_bytes = (((rect.w * 8) + 31) / 32) * 4;
@@ -300,3 +305,4 @@ void bmp_write_subimg(image_t *img, const char *path, rectangle_t *r)
 
     file_close(&fp);
 }
+#endif //IMLIB_ENABLE_IMAGE_IO

--- a/src/omv/imlib/fft.c
+++ b/src/omv/imlib/fft.c
@@ -6,6 +6,8 @@
  * FFT LIB - can do 1024 point real FFTs and 512 point complex FFTs
  *
  */
+#include "py/nlr.h"
+#include "py/obj.h"
 #include <arm_math.h>
 #include "fb_alloc.h"
 #include "ff_wrapper.h"
@@ -548,7 +550,9 @@ void fft1d_run_again(fft1d_controller_t *controller)
 void fft2d_alloc(fft2d_controller_t *controller, image_t *img, rectangle_t *r)
 {
     controller->img = img;
-    if (!rectangle_subimg(controller->img, r, &controller->r)) ff_no_intersection(NULL);
+    if (!rectangle_subimg(controller->img, r, &controller->r)) {
+        nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "No intersection!"));
+    }
 
     controller->w_pow2 = int_clog2(controller->r.w);
     controller->h_pow2 = int_clog2(controller->r.h);

--- a/src/omv/imlib/gif.c
+++ b/src/omv/imlib/gif.c
@@ -8,9 +8,11 @@
  *
  * A simple GIF encoder.
  */
+#include "imlib.h"
+#if defined(IMLIB_ENABLE_IMAGE_IO)
+
 #include "fb_alloc.h"
 #include "ff_wrapper.h"
-#include "imlib.h"
 #define BLOCK_SIZE (126) // (2^7) - 2 // (DO NOT CHANGE!)
 
 void gif_open(FIL *fp, int width, int height, bool color, bool loop)
@@ -115,3 +117,4 @@ void gif_close(FIL *fp)
     write_byte(fp, ';');
     file_close(fp);
 }
+#endif //IMLIB_ENABLE_IMAGE_IO

--- a/src/omv/imlib/haar.c
+++ b/src/omv/imlib/haar.c
@@ -10,7 +10,9 @@
  * Based on the work of Francesco Comaschi (f.comaschi@tue.nl)
  */
 #include <stdio.h>
-#include <arm_math.h>
+#include "py/obj.h"
+#include "py/nlr.h"
+
 #include "ff.h"
 #include "ff_wrapper.h"
 #include "xalloc.h"
@@ -163,6 +165,7 @@ array_t *imlib_detect_objects(image_t *image, cascade_t *cascade, rectangle_t *r
     return objects;
 }
 
+#if defined(IMLIB_ENABLE_IMAGE_IO)
 int imlib_load_cascade_from_file(cascade_t *cascade, const char *path)
 {
     int i;
@@ -248,6 +251,7 @@ error:
     file_close(&fp);
     return res;
 }
+#endif //(IMLIB_ENABLE_IMAGE_IO)
 
 int imlib_load_cascade(cascade_t *cascade, const char *path)
 {
@@ -277,8 +281,12 @@ int imlib_load_cascade(cascade_t *cascade, const char *path)
         cascade->weights_array       = (int8_t  *)eye_weights_array;
         cascade->rectangles_array    = (int8_t  *)eye_rectangles_array;
     } else {
+        #if defined(IMLIB_ENABLE_IMAGE_IO)
         // xml cascade
         return imlib_load_cascade_from_file(cascade, path);
+        #else
+        nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "Image I/O is not supported"));
+        #endif
     }
 
     int i;

--- a/src/omv/imlib/jpeg.c
+++ b/src/omv/imlib/jpeg.c
@@ -1290,6 +1290,7 @@ jpeg_overflow:
 }
 #endif //defined OMV_HARDWARE_JPEG
 
+#if defined(IMLIB_ENABLE_IMAGE_IO)
 // This function inits the geometry values of an image.
 void jpeg_read_geometry(FIL *fp, image_t *img, const char *path, jpg_read_settings_t *rs)
 {
@@ -1376,3 +1377,4 @@ void jpeg_write(image_t *img, const char *path, int quality)
     }
     file_close(&fp);
 }
+#endif //IMLIB_ENABLE_IMAGE_IO)

--- a/src/omv/imlib/mjpeg.c
+++ b/src/omv/imlib/mjpeg.c
@@ -8,9 +8,11 @@
  *
  * A simple MJPEG encoder.
  */
+#include "imlib.h"
+#if defined(IMLIB_ENABLE_IMAGE_IO)
+
 #include "fb_alloc.h"
 #include "ff_wrapper.h"
-#include "imlib.h"
 
 #define SIZE_OFFSET             (1*4)
 #define MICROS_OFFSET           (8*4)
@@ -149,3 +151,4 @@ void mjpeg_close(FIL *fp, uint32_t *frames, uint32_t *bytes, float fps)
     write_long(fp, 4 + (*frames * 8) + *bytes);
     file_close(fp);
 }
+#endif //IMLIB_ENABLE_IMAGE_IO

--- a/src/omv/imlib/orb.c
+++ b/src/omv/imlib/orb.c
@@ -704,6 +704,7 @@ int orb_filter_keypoints(array_t *kpts, rectangle_t *r, point_t *c)
     return matches;
 }
 
+#if defined(IMLIB_ENABLE_IMAGE_IO)
 int orb_save_descriptor(FIL *fp, array_t *kpts)
 {
     UINT bytes;
@@ -823,6 +824,7 @@ int orb_load_descriptor(FIL *fp, array_t *kpts)
 error:
     return res;
 }
+#endif  //IMLIB_ENABLE_IMAGE_IO
 
 float orb_cluster_dist(int cx, int cy, void *kp_in)
 {

--- a/src/omv/imlib/ppm.c
+++ b/src/omv/imlib/ppm.c
@@ -8,11 +8,17 @@
  *
  * PPM/PGM reader/writer.
  */
+
+#include "imlib.h"
+#if defined(IMLIB_ENABLE_IMAGE_IO)
+
 #include <stdio.h>
-#include <ff.h>
-#include "ff_wrapper.h"
+#include "py/obj.h"
+#include "py/nlr.h"
+
 #include "xalloc.h"
 #include "imlib.h"
+#include "ff_wrapper.h"
 
 static void read_int_reset(ppm_read_settings_t *rs)
 {
@@ -120,10 +126,12 @@ void ppm_read(image_t *img, const char *path)
 void ppm_write_subimg(image_t *img, const char *path, rectangle_t *r)
 {
     rectangle_t rect;
-    if (!rectangle_subimg(img, r, &rect)) ff_no_intersection(NULL);
+    if (!rectangle_subimg(img, r, &rect)) {
+        nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "No intersection!"));
+    }
+
     FIL fp;
     file_write_open(&fp, path);
-
     file_buffer_on(&fp);
     if (IM_IS_GS(img)) {
         char buffer[20]; // exactly big enough for 5-digit w/h
@@ -157,3 +165,4 @@ void ppm_write_subimg(image_t *img, const char *path, rectangle_t *r)
 
     file_close(&fp);
 }
+#endif //IMLIB_ENABLE_IMAGE_IO

--- a/src/omv/modules/py_gif.c
+++ b/src/omv/modules/py_gif.c
@@ -26,7 +26,9 @@ typedef struct py_gif_obj {
     int height;
     bool color;
     bool loop;
+    #if defined(IMLIB_ENABLE_IMAGE_IO)
     FIL fp;
+    #endif
 } py_gif_obj_t;
 
 static mp_obj_t py_gif_open(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
@@ -38,8 +40,12 @@ static mp_obj_t py_gif_open(uint n_args, const mp_obj_t *args, mp_map_t *kw_args
     gif->loop   = py_helper_keyword_int(n_args, args, 4, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_loop), true);
     gif->base.type = &py_gif_type;
 
+    #if defined(IMLIB_ENABLE_IMAGE_IO)
     file_write_open(&gif->fp, mp_obj_str_get_str(args[0]));
     gif_open(&gif->fp, gif->width, gif->height, gif->color, gif->loop);
+    #else
+    nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "Image I/O is not supported"));
+    #endif
     return gif;
 }
 
@@ -63,8 +69,12 @@ static mp_obj_t py_gif_format(mp_obj_t gif_obj)
 
 static mp_obj_t py_gif_size(mp_obj_t gif_obj)
 {
+    #if defined(IMLIB_ENABLE_IMAGE_IO)
     py_gif_obj_t *arg_gif = gif_obj;
     return mp_obj_new_int(file_size_w_buf(&arg_gif->fp));
+    #else
+    return mp_obj_new_int(0);
+    #endif
 }
 
 static mp_obj_t py_gif_loop(mp_obj_t gif_obj)
@@ -75,6 +85,7 @@ static mp_obj_t py_gif_loop(mp_obj_t gif_obj)
 
 static mp_obj_t py_gif_add_frame(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
 {
+    #if defined(IMLIB_ENABLE_IMAGE_IO)
     py_gif_obj_t *arg_gif = args[0];
     image_t *arg_img = py_image_cobj(args[1]);
     PY_ASSERT_FALSE_MSG(IM_IS_JPEG(arg_img),   "Operation not supported on JPEG images.");
@@ -85,13 +96,18 @@ static mp_obj_t py_gif_add_frame(uint n_args, const mp_obj_t *args, mp_map_t *kw
     int delay = py_helper_keyword_int(n_args, args, 2, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_delay), 10);
 
     gif_add_frame(&arg_gif->fp, arg_img, delay);
+    #else
+    nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "Image I/O is not supported"));
+    #endif
     return mp_const_none;
 }
 
 static mp_obj_t py_gif_close(mp_obj_t gif_obj)
 {
+    #if defined(IMLIB_ENABLE_IMAGE_IO)
     py_gif_obj_t *arg_gif = gif_obj;
     gif_close(&arg_gif->fp);
+    #endif
     return mp_const_none;
 }
 

--- a/src/omv/modules/py_mjpeg.c
+++ b/src/omv/modules/py_mjpeg.c
@@ -24,7 +24,9 @@ typedef struct py_mjpeg_obj {
     int height;
     uint32_t frames;
     uint32_t bytes;
+    #if defined(IMLIB_ENABLE_IMAGE_IO)
     FIL fp;
+    #endif
 } py_mjpeg_obj_t;
 
 static mp_obj_t py_mjpeg_open(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
@@ -36,8 +38,12 @@ static mp_obj_t py_mjpeg_open(uint n_args, const mp_obj_t *args, mp_map_t *kw_ar
     mjpeg->bytes = 0; // private
     mjpeg->base.type = &py_mjpeg_type;
 
+    #if defined(IMLIB_ENABLE_IMAGE_IO)
     file_write_open(&mjpeg->fp, mp_obj_str_get_str(args[0]));
     mjpeg_open(&mjpeg->fp, mjpeg->width, mjpeg->height);
+    #else
+    nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "Image I/O is not supported"));
+    #endif
     return mjpeg;
 }
 
@@ -55,12 +61,17 @@ static mp_obj_t py_mjpeg_height(mp_obj_t mjpeg_obj)
 
 static mp_obj_t py_mjpeg_size(mp_obj_t mjpeg_obj)
 {
+    #if defined(IMLIB_ENABLE_IMAGE_IO)
     py_mjpeg_obj_t *arg_mjpeg = mjpeg_obj;
     return mp_obj_new_int(f_size(&arg_mjpeg->fp));
+    #else
+    return mp_obj_new_int(0);
+    #endif
 }
 
 static mp_obj_t py_mjpeg_add_frame(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
 {
+    #if defined(IMLIB_ENABLE_IMAGE_IO)
     py_mjpeg_obj_t *arg_mjpeg = args[0];
     image_t *arg_img = py_image_cobj(args[1]);
     PY_ASSERT_FALSE_MSG((arg_mjpeg->width != arg_img->w)
@@ -70,13 +81,18 @@ static mp_obj_t py_mjpeg_add_frame(uint n_args, const mp_obj_t *args, mp_map_t *
     int arg_q = py_helper_keyword_int(n_args, args, 2, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_quality), 50);
     arg_q = IM_MIN(IM_MAX(arg_q, 1), 100);
     mjpeg_add_frame(&arg_mjpeg->fp, &arg_mjpeg->frames, &arg_mjpeg->bytes, arg_img, arg_q);
+    #else
+    nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "Image I/O is not supported"));
+    #endif
     return mp_const_none;
 }
 
 static mp_obj_t py_mjpeg_close(mp_obj_t mjpeg_obj, mp_obj_t fps_obj)
 {
+    #if defined(IMLIB_ENABLE_IMAGE_IO)
     py_mjpeg_obj_t *arg_mjpeg = mjpeg_obj;
     mjpeg_close(&arg_mjpeg->fp, &arg_mjpeg->frames, &arg_mjpeg->bytes, mp_obj_get_float(fps_obj));
+    #endif
     return mp_const_none;
 }
 

--- a/src/omv/modules/py_tf.c
+++ b/src/omv/modules/py_tf.c
@@ -140,6 +140,7 @@ STATIC mp_obj_t int_py_tf_load(mp_obj_t path_obj, bool alloc_mode, bool helper_m
         tf_model->model_data = (unsigned char *) g_person_detect_model_data;
         tf_model->model_data_len = g_person_detect_model_data_len;
     } else {
+        #if defined(IMLIB_ENABLE_IMAGE_IO)
         FIL fp;
         file_read_open(&fp, path);
         tf_model->model_data_len = f_size(&fp);
@@ -148,6 +149,9 @@ STATIC mp_obj_t int_py_tf_load(mp_obj_t path_obj, bool alloc_mode, bool helper_m
             : xalloc(tf_model->model_data_len);
         read_data(&fp, tf_model->model_data, tf_model->model_data_len);
         file_close(&fp);
+        #else
+        nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "Image I/O is not supported"));
+        #endif
     }
 
     if (!helper_mode) {

--- a/src/omv/ports/stm32/main.c
+++ b/src/omv/ports/stm32/main.c
@@ -500,7 +500,9 @@ soft_reset:
     uart_init0();
     sensor_init0();
     fb_alloc_init0();
+    #ifdef IMLIB_ENABLE_IMAGE_IO
     file_buffer_init0();
+    #endif
     py_lcd_init0();
     py_fir_init0();
     py_tv_init0();

--- a/src/omv/ports/stm32/usbdbg.c
+++ b/src/omv/ports/stm32/usbdbg.c
@@ -210,6 +210,7 @@ void usbdbg_data_out(void *buffer, int length)
             break;
 
         case USBDBG_TEMPLATE_SAVE: {
+            #if defined(IMLIB_ENABLE_IMAGE_IO)
             image_t image;
             framebuffer_initialize_image(&image);
 
@@ -221,13 +222,16 @@ void usbdbg_data_out(void *buffer, int length)
             char *path = (char*)buffer+sizeof(rectangle_t);
 
             imlib_save_image(&image, path, roi, 50);
+
             // raise a flash IRQ to flush image
             //NVIC->STIR = FLASH_IRQn;
+            #endif  //IMLIB_ENABLE_IMAGE_IO
             break;
         }
 
         case USBDBG_DESCRIPTOR_SAVE: {
-            #ifdef IMLIB_ENABLE_KEYPOINTS
+            #if defined(IMLIB_ENABLE_IMAGE_IO)\
+                && defined(IMLIB_ENABLE_KEYPOINTS)
             image_t image;
             framebuffer_initialize_image(&image);
 
@@ -239,7 +243,7 @@ void usbdbg_data_out(void *buffer, int length)
             char *path = (char*)buffer+sizeof(rectangle_t);
 
             py_image_descriptor_from_roi(&image, path, roi);
-            #endif
+            #endif  //IMLIB_ENABLE_IMAGE_IO && IMLIB_ENABLE_KEYPOINTS
             break;
         }
 


### PR DESCRIPTION
* Images, models and descriptors I/O can be disabled with imlib flag.
* Image creation in memory still works if image I/O is disabled.
* TF and Haar can still load built-in models/cascades if image I/O is disabled.