### PR TITLE
Modernize the FIR module to support optimized smooth scaling.

### DIFF
--- a/scripts/examples/OpenMV/12-Thermopile-Shield/AMG8833_camera.py
+++ b/scripts/examples/OpenMV/12-Thermopile-Shield/AMG8833_camera.py
@@ -3,10 +3,14 @@
 # This example shows off how to overlay a heatmap onto your OpenMV Cam's
 # live video output from the main camera.
 
-import image, time, fir
+import sensor, image, time, fir
+
+drawing_hint = image.BICUBIC # or image.BILINEAR or 0 (nearest neighbor)
 
 # Initialize the thermal sensor
 fir.init(type=fir.FIR_AMG8833)
+w = fir.width() * 20
+h = fir.height() * 20
 
 # FPS clock
 clock = time.clock()
@@ -15,7 +19,9 @@ while (True):
     clock.tick()
 
     try:
-        img = fir.snapshot(copy_to_fb=True)
+        img = fir.snapshot(x_size=w, y_size=h,
+                           color_palette=sensor.PALETTE_IRONBOW, hint=drawing_hint,
+                           copy_to_fb=True)
     except OSError:
         continue
 

--- a/scripts/examples/OpenMV/12-Thermopile-Shield/AMG8833_camera.py
+++ b/scripts/examples/OpenMV/12-Thermopile-Shield/AMG8833_camera.py
@@ -3,7 +3,7 @@
 # This example shows off how to overlay a heatmap onto your OpenMV Cam's
 # live video output from the main camera.
 
-import sensor, image, time, fir
+import image, time, fir
 
 drawing_hint = image.BICUBIC # or image.BILINEAR or 0 (nearest neighbor)
 
@@ -20,7 +20,7 @@ while (True):
 
     try:
         img = fir.snapshot(x_size=w, y_size=h,
-                           color_palette=sensor.PALETTE_IRONBOW, hint=drawing_hint,
+                           color_palette=fir.PALETTE_IRONBOW, hint=drawing_hint,
                            copy_to_fb=True)
     except OSError:
         continue

--- a/scripts/examples/OpenMV/12-Thermopile-Shield/MLX90621_camera.py
+++ b/scripts/examples/OpenMV/12-Thermopile-Shield/MLX90621_camera.py
@@ -3,10 +3,14 @@
 # This example shows off how to overlay a heatmap onto your OpenMV Cam's
 # live video output from the main camera.
 
-import image, time, fir
+import sensor, image, time, fir
+
+drawing_hint = image.BICUBIC # or image.BILINEAR or 0 (nearest neighbor)
 
 # Initialize the thermal sensor
 fir.init(type=fir.FIR_MLX90621)
+w = fir.width() * 20
+h = fir.height() * 20
 
 # FPS clock
 clock = time.clock()
@@ -15,7 +19,9 @@ while (True):
     clock.tick()
 
     try:
-        img = fir.snapshot(copy_to_fb=True)
+        img = fir.snapshot(x_size=w, y_size=h,
+                           color_palette=sensor.PALETTE_IRONBOW, hint=drawing_hint,
+                           copy_to_fb=True)
     except OSError:
         continue
 

--- a/scripts/examples/OpenMV/12-Thermopile-Shield/MLX90621_camera.py
+++ b/scripts/examples/OpenMV/12-Thermopile-Shield/MLX90621_camera.py
@@ -3,7 +3,7 @@
 # This example shows off how to overlay a heatmap onto your OpenMV Cam's
 # live video output from the main camera.
 
-import sensor, image, time, fir
+import image, time, fir
 
 drawing_hint = image.BICUBIC # or image.BILINEAR or 0 (nearest neighbor)
 
@@ -20,7 +20,7 @@ while (True):
 
     try:
         img = fir.snapshot(x_size=w, y_size=h,
-                           color_palette=sensor.PALETTE_IRONBOW, hint=drawing_hint,
+                           color_palette=fir.PALETTE_IRONBOW, hint=drawing_hint,
                            copy_to_fb=True)
     except OSError:
         continue

--- a/scripts/examples/OpenMV/12-Thermopile-Shield/MLX90640_camera.py
+++ b/scripts/examples/OpenMV/12-Thermopile-Shield/MLX90640_camera.py
@@ -3,7 +3,7 @@
 # This example shows off how to overlay a heatmap onto your OpenMV Cam's
 # live video output from the main camera.
 
-import sensor, image, time, fir
+import image, time, fir
 
 drawing_hint = image.BICUBIC # or image.BILINEAR or 0 (nearest neighbor)
 
@@ -20,7 +20,7 @@ while (True):
 
     try:
         img = fir.snapshot(x_size=w, y_size=h,
-                           color_palette=sensor.PALETTE_IRONBOW, hint=drawing_hint,
+                           color_palette=fir.PALETTE_IRONBOW, hint=drawing_hint,
                            copy_to_fb=True)
     except OSError:
         continue

--- a/scripts/examples/OpenMV/12-Thermopile-Shield/MLX90640_camera.py
+++ b/scripts/examples/OpenMV/12-Thermopile-Shield/MLX90640_camera.py
@@ -3,10 +3,14 @@
 # This example shows off how to overlay a heatmap onto your OpenMV Cam's
 # live video output from the main camera.
 
-import image, time, fir
+import sensor, image, time, fir
+
+drawing_hint = image.BICUBIC # or image.BILINEAR or 0 (nearest neighbor)
 
 # Initialize the thermal sensor
-fir.init(type=fir.FIR_MLX90640, refresh=32) # 16Hz, 32Hz or 64Hz.
+fir.init(type=fir.FIR_MLX90640)
+w = fir.width() * 10
+h = fir.height() * 10
 
 # FPS clock
 clock = time.clock()
@@ -15,7 +19,9 @@ while (True):
     clock.tick()
 
     try:
-        img = fir.snapshot(copy_to_fb=True)
+        img = fir.snapshot(x_size=w, y_size=h,
+                           color_palette=sensor.PALETTE_IRONBOW, hint=drawing_hint,
+                           copy_to_fb=True)
     except OSError:
         continue
 

--- a/src/omv/imlib/fmath.c
+++ b/src/omv/imlib/fmath.c
@@ -85,7 +85,7 @@ float fast_expf(float x)
 }
 #pragma GCC diagnostic pop
 
-/* 
+/*
  * From Hackers Delight:
  * This is a very approximate but very fast version of acbrt. It is just eight
  * integer instructions (shift rights and adds), plus instructions to load the constant.
@@ -175,7 +175,6 @@ float fast_atan2f(float y, float x)
   return (y == 0) ? 0 : ((y > 0) ? M_PI : -M_PI);
 }
 
-
 float fast_log2(float x)
 {
   union { float f; uint32_t i; } vx = { x };
@@ -197,4 +196,24 @@ float fast_powf(float a, float b)
     union { float d; int x; } u = { a };
     u.x = (int)((b * (u.x - 1064866805)) + 1064866805);
     return u.d;
+}
+
+void fast_get_min_max(float *data, size_t data_len, float *p_min, float *p_max)
+{
+    float min = FLT_MAX, max = FLT_MIN;
+
+    for (size_t i = 0; i < data_len; i++) {
+        float temp = data[i];
+
+        if (temp < min) {
+            min = temp;
+        }
+
+        if (temp > max) {
+            max = temp;
+        }
+    }
+
+    *p_min = min;
+    *p_max = max;
 }

--- a/src/omv/imlib/fmath.h
+++ b/src/omv/imlib/fmath.h
@@ -10,7 +10,9 @@
  */
 #ifndef __FMATH_H__
 #define __FMATH_H__
+#include <stdlib.h>
 #include <stdint.h>
+#include <float.h>
 float fast_sqrtf(float x);
 int fast_floorf(float x);
 int fast_ceilf(float x);
@@ -23,6 +25,7 @@ float fast_fabsf(float d);
 float fast_log(float x);
 float fast_log2(float x);
 float fast_powf(float a, float b);
+void fast_get_min_max(float *data, size_t data_len, float *p_min, float *p_max);
 extern const float cos_table[360];
 extern const float sin_table[360];
 #endif // __FMATH_H__

--- a/src/omv/imlib/imlib.h
+++ b/src/omv/imlib/imlib.h
@@ -1031,6 +1031,10 @@ typedef struct imlib_draw_row_data {
 
 typedef void (*imlib_draw_row_callback_t)(int x_start, int x_end, int y_row, imlib_draw_row_data_t *data);
 
+// Generic Helper Functions
+void imlib_fill_image_from_float(image_t *img, int w, int h, float *data, float min, float max,
+                                 bool mirror, bool flip, bool dst_transpose, bool src_transpose);
+
 /* Color space functions */
 int8_t imlib_rgb565_to_l(uint16_t pixel);
 int8_t imlib_rgb565_to_a(uint16_t pixel);

--- a/src/omv/modules/py_fir.c
+++ b/src/omv/modules/py_fir.c
@@ -860,23 +860,27 @@ mp_obj_t py_fir_snapshot(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_fir_snapshot_obj, 0, py_fir_snapshot);
 
 STATIC const mp_rom_map_elem_t globals_dict_table[] = {
-    { MP_ROM_QSTR(MP_QSTR___name__),        MP_OBJ_NEW_QSTR(MP_QSTR_fir) },
-    { MP_ROM_QSTR(MP_QSTR_FIR_NONE),        MP_ROM_INT(FIR_NONE) },
-    { MP_ROM_QSTR(MP_QSTR_FIR_SHIELD),      MP_ROM_INT(FIR_MLX90621) },
-    { MP_ROM_QSTR(MP_QSTR_FIR_MLX90621),    MP_ROM_INT(FIR_MLX90621) },
-    { MP_ROM_QSTR(MP_QSTR_FIR_MLX90640),    MP_ROM_INT(FIR_MLX90640) },
-    { MP_ROM_QSTR(MP_QSTR_FIR_AMG8833),     MP_ROM_INT(FIR_AMG8833) },
-    { MP_ROM_QSTR(MP_QSTR_init),            MP_ROM_PTR(&py_fir_init_obj) },
-    { MP_ROM_QSTR(MP_QSTR_deinit),          MP_ROM_PTR(&py_fir_deinit_obj) },
-    { MP_ROM_QSTR(MP_QSTR_type),            MP_ROM_PTR(&py_fir_type_obj) },
-    { MP_ROM_QSTR(MP_QSTR_width),           MP_ROM_PTR(&py_fir_width_obj) },
-    { MP_ROM_QSTR(MP_QSTR_height),          MP_ROM_PTR(&py_fir_height_obj) },
-    { MP_ROM_QSTR(MP_QSTR_refresh),         MP_ROM_PTR(&py_fir_refresh_obj) },
-    { MP_ROM_QSTR(MP_QSTR_resolution),      MP_ROM_PTR(&py_fir_resolution_obj) },
-    { MP_ROM_QSTR(MP_QSTR_read_ta),         MP_ROM_PTR(&py_fir_read_ta_obj) },
-    { MP_ROM_QSTR(MP_QSTR_read_ir),         MP_ROM_PTR(&py_fir_read_ir_obj) },
-    { MP_ROM_QSTR(MP_QSTR_draw_ir),         MP_ROM_PTR(&py_fir_draw_ir_obj) },
-    { MP_ROM_QSTR(MP_QSTR_snapshot),        MP_ROM_PTR(&py_fir_snapshot_obj) }
+    { MP_ROM_QSTR(MP_QSTR___name__),        MP_ROM_QSTR(MP_QSTR_fir)            },
+    { MP_ROM_QSTR(MP_QSTR_FIR_NONE),        MP_ROM_INT(FIR_NONE)                },
+    { MP_ROM_QSTR(MP_QSTR_FIR_SHIELD),      MP_ROM_INT(FIR_MLX90621)            },
+    { MP_ROM_QSTR(MP_QSTR_FIR_MLX90621),    MP_ROM_INT(FIR_MLX90621)            },
+    { MP_ROM_QSTR(MP_QSTR_FIR_MLX90640),    MP_ROM_INT(FIR_MLX90640)            },
+    { MP_ROM_QSTR(MP_QSTR_FIR_AMG8833),     MP_ROM_INT(FIR_AMG8833)             },
+    { MP_ROM_QSTR(MP_QSTR_PALETTE_RAINBOW), MP_ROM_INT(COLOR_PALETTE_RAINBOW)   },
+    { MP_ROM_QSTR(MP_QSTR_PALETTE_IRONBOW), MP_ROM_INT(COLOR_PALETTE_IRONBOW)   },
+    { MP_ROM_QSTR(MP_QSTR_GRAYSCALE),       MP_ROM_INT(PIXFORMAT_GRAYSCALE)     },
+    { MP_ROM_QSTR(MP_QSTR_RGB565),          MP_ROM_INT(PIXFORMAT_RGB565)        },
+    { MP_ROM_QSTR(MP_QSTR_init),            MP_ROM_PTR(&py_fir_init_obj)        },
+    { MP_ROM_QSTR(MP_QSTR_deinit),          MP_ROM_PTR(&py_fir_deinit_obj)      },
+    { MP_ROM_QSTR(MP_QSTR_type),            MP_ROM_PTR(&py_fir_type_obj)        },
+    { MP_ROM_QSTR(MP_QSTR_width),           MP_ROM_PTR(&py_fir_width_obj)       },
+    { MP_ROM_QSTR(MP_QSTR_height),          MP_ROM_PTR(&py_fir_height_obj)      },
+    { MP_ROM_QSTR(MP_QSTR_refresh),         MP_ROM_PTR(&py_fir_refresh_obj)     },
+    { MP_ROM_QSTR(MP_QSTR_resolution),      MP_ROM_PTR(&py_fir_resolution_obj)  },
+    { MP_ROM_QSTR(MP_QSTR_read_ta),         MP_ROM_PTR(&py_fir_read_ta_obj)     },
+    { MP_ROM_QSTR(MP_QSTR_read_ir),         MP_ROM_PTR(&py_fir_read_ir_obj)     },
+    { MP_ROM_QSTR(MP_QSTR_draw_ir),         MP_ROM_PTR(&py_fir_draw_ir_obj)     },
+    { MP_ROM_QSTR(MP_QSTR_snapshot),        MP_ROM_PTR(&py_fir_snapshot_obj)    }
 };
 
 STATIC MP_DEFINE_CONST_DICT(globals_dict, globals_dict_table);

--- a/src/omv/modules/py_fir.c
+++ b/src/omv/modules/py_fir.c
@@ -59,20 +59,6 @@ static int fir_ir_fresh_rate = 0;
 static int fir_adc_resolution = 0;
 static bool fir_transposed = false;
 
-static void fir_get_minmax(float *data, size_t len, float *p_min, float *p_max)
-{
-    float min = FLT_MAX, max = FLT_MIN;
-
-    for (int i = 0; i < len; i++) {
-        float temp = data[i];
-        if (temp < min) min = temp;
-        if (temp > max) max = temp;
-    }
-
-    *p_min = min;
-    *p_max = max;
-}
-
 // img->w == data_w && img->h == data_h && img->bpp == IMAGE_BPP_GRAYSCALE
 static void fir_fill_image_float(image_t *img, int w, int h, float *data, float min, float max,
                                  bool mirror, bool flip, bool dst_transpose, bool src_transpose)
@@ -821,7 +807,11 @@ mp_obj_t py_fir_snapshot(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
         case FIR_MLX90621: {
             float Ta, *To = fb_alloc(MLX90621_WIDTH * MLX90621_HEIGHT * sizeof(float), FB_ALLOC_NO_HINT);
             fir_MLX90621_get_frame(&Ta, To);
-            if (!scale_obj) fir_get_minmax(To, MLX90621_WIDTH * MLX90621_HEIGHT, &min, &max);
+
+            if (!scale_obj) {
+                fast_get_min_max(To, MLX90621_WIDTH * MLX90621_HEIGHT, &min, &max);
+            }
+
             fir_fill_image_float(&src_img, MLX90621_WIDTH, MLX90621_HEIGHT, To, min, max,
                     arg_hmirror ^ true, arg_vflip, arg_transpose, true);
             fb_free();
@@ -830,7 +820,11 @@ mp_obj_t py_fir_snapshot(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
         case FIR_MLX90640: {
             float Ta, *To = fb_alloc(MLX90640_WIDTH * MLX90640_HEIGHT * sizeof(float), FB_ALLOC_NO_HINT);
             fir_MLX90640_get_frame(&Ta, To);
-            if (!scale_obj) fir_get_minmax(To, MLX90640_WIDTH * MLX90640_HEIGHT, &min, &max);
+
+            if (!scale_obj) {
+                fast_get_min_max(To, MLX90640_WIDTH * MLX90640_HEIGHT, &min, &max);
+            }
+
             fir_fill_image_float(&src_img, MLX90640_WIDTH, MLX90640_HEIGHT, To, min, max,
                     arg_hmirror ^ true, arg_vflip, arg_transpose, false);
             fb_free();
@@ -839,7 +833,11 @@ mp_obj_t py_fir_snapshot(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
         case FIR_AMG8833: {
             float Ta, *To = fb_alloc(AMG8833_WIDTH * AMG8833_HEIGHT * sizeof(float), FB_ALLOC_NO_HINT);
             fir_AMG8833_get_frame(&Ta, To);
-            if (!scale_obj) fir_get_minmax(To, AMG8833_WIDTH * AMG8833_HEIGHT, &min, &max);
+
+            if (!scale_obj) {
+                fast_get_min_max(To, AMG8833_WIDTH * AMG8833_HEIGHT, &min, &max);
+            }
+
             fir_fill_image_float(&src_img, AMG8833_WIDTH, AMG8833_HEIGHT, To, min, max,
                     arg_hmirror ^ true, arg_vflip, arg_transpose, true);
             fb_free();

--- a/src/omv/modules/py_fir.c
+++ b/src/omv/modules/py_fir.c
@@ -285,6 +285,7 @@ mp_obj_t py_fir_init(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
                     cambus_pulse_scl(&fir_bus);
                     goto FIR_MLX90621_RETRY;
                 } else {
+                    py_fir_deinit();
                     nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Failed to init the MLX90621!"));
                 }
             }
@@ -328,6 +329,7 @@ mp_obj_t py_fir_init(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
                     cambus_pulse_scl(&fir_bus);
                     goto FIR_MLX90640_RETRY;
                 } else {
+                    py_fir_deinit();
                     nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Failed to init the MLX90640!"));
                 }
             }
@@ -346,7 +348,8 @@ mp_obj_t py_fir_init(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
             FIR_AMG8833_RETRY:
             cambus_init(&fir_bus, FIR_I2C_ID, CAMBUS_SPEED_STANDARD);
 
-            int error = cambus_write_bytes(&fir_bus, AMG8833_ADDR, AMG8833_RESET_REGISTER, (uint8_t [1]){AMG8833_INITIAL_RESET_VALUE}, 1);
+            int error = cambus_write_bytes(&fir_bus, AMG8833_ADDR, AMG8833_RESET_REGISTER,
+                                           (uint8_t [1]){AMG8833_INITIAL_RESET_VALUE}, 1);
 
             if (error != 0) {
                 if (first_init) {
@@ -354,6 +357,7 @@ mp_obj_t py_fir_init(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
                     cambus_pulse_scl(&fir_bus);
                     goto FIR_AMG8833_RETRY;
                 } else {
+                    py_fir_deinit();
                     nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "Failed to init the AMG8833!"));
                 }
             }


### PR DESCRIPTION
* Adds hmirror, vflip, and transpose to read_ir.
* Improves memory allocation of read_ir such that it's not trashing the heap anymore.
* Peak memory usage reduced.
* Refactored code to improve things.
* Made snapshot() support all the same args as read_ir/draw_ir with the ability to set custom output resolutions.

This PR significantly improves the performance of the FIR module by using tight'ish loops for all operations and it avoids copying IR arrays into the heap to MP land and then back into C land again.

All sensors are tested and working.