### PR TITLE
Enable the lepton bus to be used on external pins

### DIFF
--- a/src/drivers/lepton/include/LEPTON_I2C_Service.h
+++ b/src/drivers/lepton/include/LEPTON_I2C_Service.h
@@ -60,7 +60,7 @@
 **
 *******************************************************************************/
 #ifndef _LEPTON_I2C_SERVICE_H_
-    #define _LEPTON_I2C_SERVICE_H_
+#define _LEPTON_I2C_SERVICE_H_
 
     #ifdef __cplusplus
 extern "C"
@@ -70,9 +70,9 @@ extern "C"
 /******************************************************************************/
 /** INCLUDE FILES                                                            **/
 /******************************************************************************/
-    #include "LEPTON_Types.h"
-    #include "LEPTON_ErrorCodes.h"
-
+#include "LEPTON_Types.h"
+#include "LEPTON_ErrorCodes.h"
+#include "cambus.h"
 
 /******************************************************************************/
 /** EXPORTED DEFINES                                                         **/
@@ -89,6 +89,7 @@ extern "C"
 /******************************************************************************/
 /** EXPORTED PUBLIC FUNCTIONS                                                **/
 /******************************************************************************/
+    void LEP_I2C_Init(cambus_t *bus);
 
     extern LEP_RESULT LEP_I2C_MasterSelectDevice(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
                                                  LEP_PROTOCOL_DEVICE_E device);
@@ -96,9 +97,9 @@ extern "C"
     extern LEP_RESULT LEP_I2C_MasterOpen(LEP_UINT16 portID,
                                          LEP_UINT16 *portBaudRate);
 
-    extern LEP_RESULT LEP_I2C_MasterClose(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr );
+    extern LEP_RESULT LEP_I2C_MasterClose(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr);
 
-    extern LEP_RESULT LEP_I2C_MasterReset(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr );
+    extern LEP_RESULT LEP_I2C_MasterReset(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr);
 
     extern LEP_RESULT LEP_I2C_MasterReadData(LEP_UINT16 portID,
                                              LEP_UINT8  deviceAddress,
@@ -124,7 +125,7 @@ extern "C"
                                                   LEP_UINT16 regValue);
 
     extern LEP_RESULT LEP_I2C_MasterStatus(LEP_UINT16 portID,
-                                           LEP_UINT16 *portStatus );
+                                           LEP_UINT16 *portStatus);
 
 /******************************************************************************/
     #ifdef __cplusplus

--- a/src/drivers/lepton/src/LEPTON_I2C_Service.c
+++ b/src/drivers/lepton/src/LEPTON_I2C_Service.c
@@ -74,19 +74,21 @@
 #include "LEPTON_ErrorCodes.h"
 #include "LEPTON_I2C_Service.h"
 #include "cambus.h"
-#include "sensor.h"
-extern sensor_t sensor;
+
+static cambus_t *bus;
+
+void LEP_I2C_Init(cambus_t *hbus)
+{
+    bus = hbus;
+}
 
 /******************************************************************************/
 /** LOCAL DEFINES                                                            **/
 /******************************************************************************/
 
-#define LEP_I2C_BUSY_BIT_MASK                   0x0001   /* Bit 0 is the Busy Bit */
-
 /******************************************************************************/
 /** LOCAL TYPE DEFINITIONS                                                   **/
 /******************************************************************************/
-
 
 /******************************************************************************/
 /** PRIVATE DATA DECLARATIONS                                                **/
@@ -95,7 +97,6 @@ extern sensor_t sensor;
 /******************************************************************************/
 /** PRIVATE FUNCTION DECLARATIONS                                            **/
 /******************************************************************************/
-
 
 /******************************************************************************/
 /** EXPORTED PUBLIC DATA                                                     **/
@@ -167,7 +168,9 @@ LEP_RESULT LEP_I2C_MasterReadData(LEP_UINT16 portID,
     LEP_RESULT result = LEP_OK;
 
     for (int i = 0; i < dataLength; i++) {
-        if (cambus_readw2(&sensor.bus, deviceAddress << 1, subAddress + (i * 2), &dataPtr[i])) return LEP_ERROR;
+        if (cambus_readw2(bus, deviceAddress << 1, subAddress + (i * 2), &dataPtr[i])) {
+            return LEP_ERROR;
+        }
     }
 
     return(result);
@@ -195,12 +198,13 @@ LEP_RESULT LEP_I2C_MasterWriteData(LEP_UINT16 portID,
     LEP_RESULT result = LEP_OK;
 
     for (int i = 0; i < dataLength; i++) {
-        if (cambus_writew2(&sensor.bus, deviceAddress << 1, subAddress + (i * 2), dataPtr[i])) return LEP_ERROR;
+        if (cambus_writew2(bus, deviceAddress << 1, subAddress + (i * 2), dataPtr[i])) {
+            return LEP_ERROR;
+        }
     }
 
     return(result);
 }
-
 
 LEP_RESULT LEP_I2C_MasterReadRegister(LEP_UINT16 portID,
                                       LEP_UINT8  deviceAddress,
@@ -209,11 +213,12 @@ LEP_RESULT LEP_I2C_MasterReadRegister(LEP_UINT16 portID,
 {
     LEP_RESULT result = LEP_OK;
 
-    if (cambus_readw2(&sensor.bus, deviceAddress << 1, regAddress, regValue)) return LEP_ERROR;
+    if (cambus_readw2(bus, deviceAddress << 1, regAddress, regValue)) {
+        return LEP_ERROR;
+    }
 
     return(result);
 }
-
 
 LEP_RESULT LEP_I2C_MasterWriteRegister(LEP_UINT16 portID,
                                        LEP_UINT8  deviceAddress,
@@ -222,16 +227,17 @@ LEP_RESULT LEP_I2C_MasterWriteRegister(LEP_UINT16 portID,
 {
     LEP_RESULT result = LEP_OK;
 
-    if (cambus_writew2(&sensor.bus, deviceAddress << 1, regAddress, regValue)) return LEP_ERROR;
+    if (cambus_writew2(bus, deviceAddress << 1, regAddress, regValue)) {
+        return LEP_ERROR;
+    }
 
     return(result);
 }
 
-
 /* Driver Status
 */
 LEP_RESULT LEP_I2C_MasterStatus(LEP_UINT16 portID,
-                                LEP_UINT16 *portStatus )
+                                LEP_UINT16 *portStatus)
 {
     LEP_RESULT result = LEP_OK;
 

--- a/src/omv/sensors/lepton.c
+++ b/src/omv/sensors/lepton.c
@@ -672,6 +672,8 @@ int lepton_init(sensor_t *sensor)
     SENSOR_HW_FLAGS_SET(sensor, SENSOR_HW_FLAGS_FSYNC, 0);
     SENSOR_HW_FLAGS_SET(sensor, SENSOR_HW_FLAGS_JPEGE, 0);
 
+    LEP_I2C_Init(&sensor->bus);
+
     // Configure the DMA handler for Transmission process
     DMAHandle.Instance                 = LEPTON_SPI_DMA_STREAM;
     DMAHandle.Init.Request             = LEPTON_SPI_DMA_REQUEST;


### PR DESCRIPTION
For support of this module per user requests.

https://learn.sparkfun.com/tutorials/flir-lepton-hookup-guide/all

Tested and works with the FLIR Lepton.