### PR TITLE
Use SPI Callbacks

### DIFF
--- a/src/hal/stm32/f4/include/stm32f4xx_hal_conf.h
+++ b/src/hal/stm32/f4/include/stm32f4xx_hal_conf.h
@@ -182,7 +182,7 @@
 #define  USE_HAL_SRAM_REGISTER_CALLBACKS        0U /* SRAM register callback disabled      */
 #define  USE_HAL_SPDIFRX_REGISTER_CALLBACKS     0U /* SPDIFRX register callback disabled   */
 #define  USE_HAL_SMBUS_REGISTER_CALLBACKS       0U /* SMBUS register callback disabled     */
-#define  USE_HAL_SPI_REGISTER_CALLBACKS         0U /* SPI register callback disabled       */
+#define  USE_HAL_SPI_REGISTER_CALLBACKS         1U /* SPI register callback disabled       */
 #define  USE_HAL_TIM_REGISTER_CALLBACKS         0U /* TIM register callback disabled       */
 #define  USE_HAL_UART_REGISTER_CALLBACKS        0U /* UART register callback disabled      */
 #define  USE_HAL_USART_REGISTER_CALLBACKS       0U /* USART register callback disabled     */

--- a/src/hal/stm32/f7/include/stm32f7xx_hal_conf.h
+++ b/src/hal/stm32/f7/include/stm32f7xx_hal_conf.h
@@ -182,7 +182,7 @@
 #define  USE_HAL_SRAM_REGISTER_CALLBACKS        0U /* SRAM register callback disabled      */
 #define  USE_HAL_SPDIFRX_REGISTER_CALLBACKS     0U /* SPDIFRX register callback disabled   */
 #define  USE_HAL_SMBUS_REGISTER_CALLBACKS       0U /* SMBUS register callback disabled     */
-#define  USE_HAL_SPI_REGISTER_CALLBACKS         0U /* SPI register callback disabled       */
+#define  USE_HAL_SPI_REGISTER_CALLBACKS         1U /* SPI register callback disabled       */
 #define  USE_HAL_TIM_REGISTER_CALLBACKS         0U /* TIM register callback disabled       */
 #define  USE_HAL_UART_REGISTER_CALLBACKS        0U /* UART register callback disabled      */
 #define  USE_HAL_USART_REGISTER_CALLBACKS       0U /* USART register callback disabled     */

--- a/src/hal/stm32/h7/include/stm32h7xx_hal_conf.h
+++ b/src/hal/stm32/h7/include/stm32h7xx_hal_conf.h
@@ -211,7 +211,7 @@
 #define  USE_HAL_SMARTCARD_REGISTER_CALLBACKS  0U /* SMARTCARD register callback disabled */
 #define  USE_HAL_SPDIFRX_REGISTER_CALLBACKS 0U /* SPDIFRX register callback disabled */
 #define  USE_HAL_SMBUS_REGISTER_CALLBACKS   0U /* SMBUS register callback disabled   */
-#define  USE_HAL_SPI_REGISTER_CALLBACKS     0U /* SPI register callback disabled     */
+#define  USE_HAL_SPI_REGISTER_CALLBACKS     1U /* SPI register callback disabled     */
 #define  USE_HAL_SWPMI_REGISTER_CALLBACKS   0U /* SWPMI register callback disabled   */
 #define  USE_HAL_TIM_REGISTER_CALLBACKS     0U /* TIM register callback disabled     */
 #define  USE_HAL_UART_REGISTER_CALLBACKS    0U /* UART register callback disabled    */

--- a/src/omv/ports/stm32/modules/py_lcd.c
+++ b/src/omv/ports/stm32/modules/py_lcd.c
@@ -99,6 +99,8 @@ static void spi_config_deinit()
     ///////////////////////////////////////////////////////////////////////
 }
 
+void spi_lcd_callback(SPI_HandleTypeDef *hspi);
+
 static void spi_config_init(int w, int h, int refresh_rate, bool triple_buffer, bool bgr)
 {
     OMV_SPI_LCD_CONTROLLER->spi->Init.Mode = SPI_MODE_MASTER;
@@ -108,6 +110,7 @@ static void spi_config_init(int w, int h, int refresh_rate, bool triple_buffer, 
     OMV_SPI_LCD_CONTROLLER->spi->Init.CRCCalculation = SPI_CRCCALCULATION_DISABLE;
     spi_set_params(OMV_SPI_LCD_CONTROLLER, 0xffffffff, w * h * refresh_rate * 16, 0, 0, 8, 0);
     spi_init(OMV_SPI_LCD_CONTROLLER, true);
+    HAL_SPI_RegisterCallback(OMV_SPI_LCD_CONTROLLER->spi, HAL_SPI_TX_COMPLETE_CB_ID, spi_lcd_callback);
 
     // Do not put in HAL_SPI_MspInit as other modules share the SPI2 bus.
 
@@ -195,7 +198,7 @@ static void spi_config_init(int w, int h, int refresh_rate, bool triple_buffer, 
 
 static bool spi_tx_cb_state_on[FRAMEBUFFER_COUNT] = {};
 
-void spi_lcd_callback()
+void spi_lcd_callback(SPI_HandleTypeDef *hspi)
 {
     if (lcd_type == LCD_SHIELD) {
         static uint16_t *spi_tx_cb_state_memory_write_addr = NULL;
@@ -295,7 +298,7 @@ static void spi_lcd_kick()
         }
 
         spi_tx_cb_state = SPI_TX_CB_MEMORY_WRITE_CMD;
-        spi_lcd_callback();
+        spi_lcd_callback(OMV_SPI_LCD_CONTROLLER->spi);
     }
 }
 

--- a/src/omv/ports/stm32/stm32fxxx_hal_msp.c
+++ b/src/omv/ports/stm32/stm32fxxx_hal_msp.c
@@ -520,21 +520,3 @@ void HAL_MspDeInit(void)
 {
 
 }
-
-#if defined(OMV_SPI_LCD_CONTROLLER)
-extern void spi_lcd_callback();
-#endif
-
-__attribute__((weak)) void spi_lcd_callback()
-{
-    // Necessary for UVC compile...
-}
-
-void HAL_SPI_TxCpltCallback(SPI_HandleTypeDef *hspi)
-{
-    #if defined(OMV_SPI_LCD_CONTROLLER)
-    if (hspi->Instance == OMV_SPI_LCD_CONTROLLER_INSTANCE) {
-        spi_lcd_callback();
-    }
-    #endif
-}


### PR DESCRIPTION
* Enabled USE_HAL_SPI_REGISTER_CALLBACKS for the F4/F7/H7.
* Switch to using callbacks with the LCD module.
* Remove stm32xx code for the callback.