### PR TITLE
Make lepton driver take cambus_t

### DIFF
--- a/src/drivers/lepton/include/LEPTON_I2C_Protocol.h
+++ b/src/drivers/lepton/include/LEPTON_I2C_Protocol.h
@@ -111,7 +111,7 @@ extern "C"
     extern LEP_RESULT LEP_I2C_SelectDevice(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
                                            LEP_PROTOCOL_DEVICE_E device);
 
-    extern LEP_RESULT LEP_I2C_OpenPort(LEP_UINT16 portID,
+    extern LEP_RESULT LEP_I2C_OpenPort(cambus_t *bus,
                                        LEP_UINT16 *baudRateInkHz,
                                        LEP_UINT8 *deviceAddress);
 
@@ -157,4 +157,3 @@ extern "C"
     #endif
 
 #endif  /* _LEPTON_I2C_PROTOCOL_H_ */
-

--- a/src/drivers/lepton/include/LEPTON_I2C_Service.h
+++ b/src/drivers/lepton/include/LEPTON_I2C_Service.h
@@ -72,7 +72,6 @@ extern "C"
 /******************************************************************************/
 #include "LEPTON_Types.h"
 #include "LEPTON_ErrorCodes.h"
-#include "cambus.h"
 
 /******************************************************************************/
 /** EXPORTED DEFINES                                                         **/
@@ -89,42 +88,41 @@ extern "C"
 /******************************************************************************/
 /** EXPORTED PUBLIC FUNCTIONS                                                **/
 /******************************************************************************/
-    void LEP_I2C_Init(cambus_t *bus);
 
     extern LEP_RESULT LEP_I2C_MasterSelectDevice(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
                                                  LEP_PROTOCOL_DEVICE_E device);
 
-    extern LEP_RESULT LEP_I2C_MasterOpen(LEP_UINT16 portID,
+    extern LEP_RESULT LEP_I2C_MasterOpen(cambus_t *bus,
                                          LEP_UINT16 *portBaudRate);
 
     extern LEP_RESULT LEP_I2C_MasterClose(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr);
 
     extern LEP_RESULT LEP_I2C_MasterReset(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr);
 
-    extern LEP_RESULT LEP_I2C_MasterReadData(LEP_UINT16 portID,
+    extern LEP_RESULT LEP_I2C_MasterReadData(cambus_t *bus,
                                              LEP_UINT8  deviceAddress,
                                              LEP_UINT16 subAddress,
                                              LEP_UINT16 *dataPtr,
                                              LEP_UINT16 dataLength);
 
-    extern LEP_RESULT LEP_I2C_MasterWriteData(LEP_UINT16 portID,
+    extern LEP_RESULT LEP_I2C_MasterWriteData(cambus_t *bus,
                                               LEP_UINT8  deviceAddress,
                                               LEP_UINT16 subAddress,
                                               LEP_UINT16 *dataPtr,
                                               LEP_UINT16 dataLength);
 
-    extern LEP_RESULT LEP_I2C_MasterReadRegister(LEP_UINT16 portID,
+    extern LEP_RESULT LEP_I2C_MasterReadRegister(cambus_t *bus,
                                                  LEP_UINT8  deviceAddress,
                                                  LEP_UINT16 regAddress,
                                                  LEP_UINT16 *regValue);
 
 
-    extern LEP_RESULT LEP_I2C_MasterWriteRegister(LEP_UINT16 portID,
+    extern LEP_RESULT LEP_I2C_MasterWriteRegister(cambus_t *bus,
                                                   LEP_UINT8  deviceAddress,
                                                   LEP_UINT16 regAddress,
                                                   LEP_UINT16 regValue);
 
-    extern LEP_RESULT LEP_I2C_MasterStatus(LEP_UINT16 portID,
+    extern LEP_RESULT LEP_I2C_MasterStatus(cambus_t *bus,
                                            LEP_UINT16 *portStatus);
 
 /******************************************************************************/

--- a/src/drivers/lepton/include/LEPTON_SDK.h
+++ b/src/drivers/lepton/include/LEPTON_SDK.h
@@ -130,7 +130,7 @@ extern "C"
     extern LEP_RESULT LEP_SelectDevice(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
                                        LEP_PROTOCOL_DEVICE_E device);
 
-    extern LEP_RESULT LEP_OpenPort(LEP_UINT16 portID,
+    extern LEP_RESULT LEP_OpenPort(cambus_t *bus,
                                    LEP_CAMERA_PORT_E portType,
                                    LEP_UINT16   portBaudRate,
                                    LEP_CAMERA_PORT_DESC_T_PTR portDescPtr);

--- a/src/drivers/lepton/include/LEPTON_Types.h
+++ b/src/drivers/lepton/include/LEPTON_Types.h
@@ -84,6 +84,8 @@ extern "C"
        #include <stdbool.h>
     #endif
 
+    #include "cambus.h"
+
 /******************************************************************************/
 /** EXPORTED DEFINES                                                         **/
 /******************************************************************************/
@@ -211,7 +213,7 @@ extern "C"
         LEP_CCI_TWI=0,
         LEP_CCI_SPI,
         LEP_END_CCI_PORTS,
-        
+
         LEP_CCI_PORTS_MAKE_32_BIT_ENUM = 0x7FFFFFFF
     }LEP_CAMERA_PORT_E, *LEP_CAMERA_PORT_E_PTR;
 
@@ -228,7 +230,7 @@ extern "C"
         /* SPI Devices */
 
         LEP_END_PROTOCOL_DEVICE,
-        
+
         LEP_PROTOCOL_DEVICE_MAKE_32_BIT_ENUM = 0x7FFFFFFF
     } LEP_PROTOCOL_DEVICE_E, *LEP_PROTOCOL_DEVICE_E_PTR;
 
@@ -260,7 +262,7 @@ extern "C"
     */
     typedef struct  LEP_CAMERA_PORT_DESC_T_TAG
     {
-        LEP_UINT16  portID;
+        cambus_t *bus;
         LEP_CAMERA_PORT_E   portType;
         LEP_UINT16  portBaudRate;
         LEP_UINT8 deviceAddress;
@@ -281,5 +283,3 @@ extern "C"
 }
     #endif
 #endif   // _FLIR_TYPES_H_
-
-

--- a/src/drivers/lepton/src/LEPTON_I2C_Protocol.c
+++ b/src/drivers/lepton/src/LEPTON_I2C_Protocol.c
@@ -104,25 +104,25 @@ LEP_RESULT LEP_I2C_SelectDevice(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
     return(result);
 }
 
-LEP_RESULT LEP_I2C_OpenPort(LEP_UINT16 portID,
+LEP_RESULT LEP_I2C_OpenPort(cambus_t *bus,
                             LEP_UINT16 *baudRateInkHz,
                             LEP_UINT8* deviceAddress)
 {
    LEP_RESULT result;
    LEP_UINT16 statusReg;
 
-   result = LEP_I2C_MasterOpen( portID, baudRateInkHz );
+   result = LEP_I2C_MasterOpen( bus, baudRateInkHz );
    if(result != LEP_OK)
    {
       return(LEP_COMM_INVALID_PORT_ERROR);
    }
 
    *deviceAddress = 0x2a;
-   result = LEP_I2C_MasterReadData( portID,
-                                *deviceAddress,
-                                LEP_I2C_STATUS_REG,
-                                &statusReg,
-                                1 );
+   result = LEP_I2C_MasterReadData( bus,
+                                    *deviceAddress,
+                                    LEP_I2C_STATUS_REG,
+                                    &statusReg,
+                                    1 );
 
    if(result != LEP_OK)
    {
@@ -131,11 +131,11 @@ LEP_RESULT LEP_I2C_OpenPort(LEP_UINT16 portID,
        *
        */
       *deviceAddress = 0x00;
-      result = LEP_I2C_MasterReadData( portID,
-                                   *deviceAddress,
-                                   LEP_I2C_STATUS_REG,
-                                   &statusReg,
-                                   1 );
+      result = LEP_I2C_MasterReadData( bus,
+                                       *deviceAddress,
+                                       LEP_I2C_STATUS_REG,
+                                       &statusReg,
+                                       1 );
       if(result != LEP_OK)
       {
          return(LEP_COMM_NO_DEV);
@@ -188,7 +188,7 @@ LEP_RESULT LEP_I2C_GetAttribute(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
     {
         /* Read the Status REGISTER and peek at the BUSY Bit
         */
-        result = LEP_I2C_MasterReadData( portDescPtr->portID,
+        result = LEP_I2C_MasterReadData( portDescPtr->bus,
                                          portDescPtr->deviceAddress,
                                          LEP_I2C_STATUS_REG,
                                          &statusReg,
@@ -204,7 +204,7 @@ LEP_RESULT LEP_I2C_GetAttribute(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
     /* Set the Lepton's DATA LENGTH REGISTER first to inform the
     ** Lepton Camera how many 16-bit DATA words we want to read.
     */
-    result = LEP_I2C_MasterWriteData( portDescPtr->portID,
+    result = LEP_I2C_MasterWriteData( portDescPtr->bus,
                                       portDescPtr->deviceAddress,
                                       LEP_I2C_DATA_LENGTH_REG,
                                       &attributeWordLength,
@@ -215,7 +215,7 @@ LEP_RESULT LEP_I2C_GetAttribute(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
     }
     /* Now issue the GET Attribute Command
     */
-    result = LEP_I2C_MasterWriteData( portDescPtr->portID,
+    result = LEP_I2C_MasterWriteData( portDescPtr->bus,
                                       portDescPtr->deviceAddress,
                                       LEP_I2C_COMMAND_REG,
                                       &commandID,
@@ -234,7 +234,7 @@ LEP_RESULT LEP_I2C_GetAttribute(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
     {
         /* Read the statusReg REGISTER and peek at the BUSY Bit
         */
-        result = LEP_I2C_MasterReadData( portDescPtr->portID,
+        result = LEP_I2C_MasterReadData( portDescPtr->bus,
                                          portDescPtr->deviceAddress,
                                          LEP_I2C_STATUS_REG,
                                          &statusReg,
@@ -264,7 +264,7 @@ LEP_RESULT LEP_I2C_GetAttribute(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
         /* Read from the DATA Registers - always start from DATA 0
         ** Little Endean
         */
-        result = LEP_I2C_MasterReadData(portDescPtr->portID,
+        result = LEP_I2C_MasterReadData(portDescPtr->bus,
                                         portDescPtr->deviceAddress,
                                         LEP_I2C_DATA_0_REG,
                                         attributePtr,
@@ -274,7 +274,7 @@ LEP_RESULT LEP_I2C_GetAttribute(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
     {
         /* Read from the DATA Block Buffer
         */
-      result = LEP_I2C_MasterReadData(portDescPtr->portID,
+      result = LEP_I2C_MasterReadData(portDescPtr->bus,
                                       portDescPtr->deviceAddress,
                                       LEP_I2C_DATA_BUFFER_0,
                                       attributePtr,
@@ -283,7 +283,7 @@ LEP_RESULT LEP_I2C_GetAttribute(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
     if(result == LEP_OK && attributeWordLength > 0)
     {
        /* Check CRC */
-       result = LEP_I2C_MasterReadData( portDescPtr->portID,
+       result = LEP_I2C_MasterReadData( portDescPtr->bus,
                                         portDescPtr->deviceAddress,
                                         LEP_I2C_DATA_CRC_REG,
                                         &crcExpected,
@@ -325,7 +325,7 @@ LEP_RESULT LEP_I2C_SetAttribute(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
     {
         /* Read the Status REGISTER and peek at the BUSY Bit
         */
-        result = LEP_I2C_MasterReadData( portDescPtr->portID,
+        result = LEP_I2C_MasterReadData( portDescPtr->bus,
                                          portDescPtr->deviceAddress,
                                          LEP_I2C_STATUS_REG,
                                          &statusReg,
@@ -353,7 +353,7 @@ LEP_RESULT LEP_I2C_SetAttribute(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
         {
             /* WRITE to the DATA Registers - always start from DATA 0
             */
-            result = LEP_I2C_MasterWriteData(portDescPtr->portID,
+            result = LEP_I2C_MasterWriteData(portDescPtr->bus,
                                              portDescPtr->deviceAddress,
                                              LEP_I2C_DATA_0_REG,
                                              attributePtr,
@@ -363,7 +363,7 @@ LEP_RESULT LEP_I2C_SetAttribute(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
         {
             /* WRITE to the DATA Block Buffer
             */
-            result = LEP_I2C_MasterWriteData(portDescPtr->portID,
+            result = LEP_I2C_MasterWriteData(portDescPtr->bus,
                                              portDescPtr->deviceAddress,
                                              LEP_I2C_DATA_BUFFER_0,
                                              attributePtr,
@@ -379,7 +379,7 @@ LEP_RESULT LEP_I2C_SetAttribute(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
         /* Set the Lepton's DATA LENGTH REGISTER first to inform the
         ** Lepton Camera how many 16-bit DATA words we want to read.
         */
-        result = LEP_I2C_MasterWriteData( portDescPtr->portID,
+        result = LEP_I2C_MasterWriteData( portDescPtr->bus,
                                           portDescPtr->deviceAddress,
                                           LEP_I2C_DATA_LENGTH_REG,
                                           &attributeWordLength,
@@ -389,7 +389,7 @@ LEP_RESULT LEP_I2C_SetAttribute(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
         {
             /* Now issue the SET Attribute Command
             */
-            result = LEP_I2C_MasterWriteData( portDescPtr->portID,
+            result = LEP_I2C_MasterWriteData( portDescPtr->bus,
                                               portDescPtr->deviceAddress,
                                               LEP_I2C_COMMAND_REG,
                                               &commandID,
@@ -405,7 +405,7 @@ LEP_RESULT LEP_I2C_SetAttribute(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
                 {
                     /* Read the statusReg REGISTER and peek at the BUSY Bit
                     */
-                    result = LEP_I2C_MasterReadData( portDescPtr->portID,
+                    result = LEP_I2C_MasterReadData( portDescPtr->bus,
                                                      portDescPtr->deviceAddress,
                                                      LEP_I2C_STATUS_REG,
                                                      &statusReg,
@@ -456,7 +456,7 @@ LEP_RESULT LEP_I2C_RunCommand(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
     {
         /* Read the Status REGISTER and peek at the BUSY Bit
         */
-        result = LEP_I2C_MasterReadRegister( portDescPtr->portID,
+        result = LEP_I2C_MasterReadRegister( portDescPtr->bus,
                                              portDescPtr->deviceAddress,
                                              LEP_I2C_STATUS_REG,
                                              &statusReg);
@@ -479,7 +479,7 @@ LEP_RESULT LEP_I2C_RunCommand(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
         /* Set the Lepton's DATA LENGTH REGISTER first to inform the
         ** Lepton Camera no 16-bit DATA words being transferred.
         */
-        result = LEP_I2C_MasterWriteRegister( portDescPtr->portID,
+        result = LEP_I2C_MasterWriteRegister( portDescPtr->bus,
                                               portDescPtr->deviceAddress,
                                               LEP_I2C_DATA_LENGTH_REG,
                                               (LEP_UINT16)0);
@@ -488,7 +488,7 @@ LEP_RESULT LEP_I2C_RunCommand(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
         {
             /* Now issue the Run Command
             */
-            result = LEP_I2C_MasterWriteRegister( portDescPtr->portID,
+            result = LEP_I2C_MasterWriteRegister( portDescPtr->bus,
                                                   portDescPtr->deviceAddress,
                                                   LEP_I2C_COMMAND_REG,
                                                   commandID);
@@ -502,7 +502,7 @@ LEP_RESULT LEP_I2C_RunCommand(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
                 {
                     /* Read the statusReg REGISTER and peek at the BUSY Bit
                     */
-                    result = LEP_I2C_MasterReadRegister( portDescPtr->portID,
+                    result = LEP_I2C_MasterReadRegister( portDescPtr->bus,
                                                          portDescPtr->deviceAddress,
                                                          LEP_I2C_STATUS_REG,
                                                          &statusReg);
@@ -537,7 +537,7 @@ LEP_RESULT LEP_I2C_DirectReadRegister(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
 {
    LEP_RESULT result = LEP_OK;
 
-   result = LEP_I2C_MasterReadRegister( portDescPtr->portID,
+   result = LEP_I2C_MasterReadRegister( portDescPtr->bus,
                                         portDescPtr->deviceAddress,
                                         regAddress,
                                         regValue);
@@ -575,7 +575,7 @@ LEP_RESULT LEP_I2C_DirectWriteBuffer(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
 
    /* WRITE to the DATA Block Buffer
    */
-   result = LEP_I2C_MasterWriteData(portDescPtr->portID,
+   result = LEP_I2C_MasterWriteData(portDescPtr->bus,
                                     portDescPtr->deviceAddress,
                                     LEP_I2C_DATA_BUFFER_0,
                                     attributePtr,
@@ -592,7 +592,7 @@ LEP_RESULT LEP_I2C_DirectWriteRegister(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
 {
    LEP_RESULT result = LEP_OK;
 
-   result = LEP_I2C_MasterWriteRegister(portDescPtr->portID,
+   result = LEP_I2C_MasterWriteRegister(portDescPtr->bus,
                                         portDescPtr->deviceAddress,
                                         regAddress,
                                         regValue);
@@ -602,5 +602,3 @@ LEP_RESULT LEP_I2C_DirectWriteRegister(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
 /******************************************************************************/
 /** PRIVATE MODULE FUNCTIONS                                                 **/
 /******************************************************************************/
-
-

--- a/src/drivers/lepton/src/LEPTON_I2C_Service.c
+++ b/src/drivers/lepton/src/LEPTON_I2C_Service.c
@@ -73,14 +73,6 @@
 #include "LEPTON_Types.h"
 #include "LEPTON_ErrorCodes.h"
 #include "LEPTON_I2C_Service.h"
-#include "cambus.h"
-
-static cambus_t *bus;
-
-void LEP_I2C_Init(cambus_t *hbus)
-{
-    bus = hbus;
-}
 
 /******************************************************************************/
 /** LOCAL DEFINES                                                            **/
@@ -116,7 +108,7 @@ LEP_RESULT LEP_I2C_MasterSelectDevice(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
 
 /* Driver Open
 */
-LEP_RESULT LEP_I2C_MasterOpen(LEP_UINT16 portID,
+LEP_RESULT LEP_I2C_MasterOpen(cambus_t *bus,
                               LEP_UINT16 *portBaudRate)
 {
     LEP_RESULT result = LEP_OK;
@@ -147,8 +139,6 @@ LEP_RESULT LEP_I2C_MasterReset(LEP_CAMERA_PORT_DESC_T_PTR portDescriptorPtr )
  *    Use Lepton I2C protocol for READ starting from current
  *      location
  *
- * @param portID        User-defined parameter to identify one of multiple ports
- *
  * @param deviceAddress This is the Lepton TWI/CCI (I2C) device address.
  *
  * @param subAddress    Specifies the Lepton Register Address to write to
@@ -159,7 +149,7 @@ LEP_RESULT LEP_I2C_MasterReset(LEP_CAMERA_PORT_DESC_T_PTR portDescriptorPtr )
  *
  * @return
  */
-LEP_RESULT LEP_I2C_MasterReadData(LEP_UINT16 portID,
+LEP_RESULT LEP_I2C_MasterReadData(cambus_t *bus,
                                   LEP_UINT8  deviceAddress,
                                   LEP_UINT16 subAddress,
                                   LEP_UINT16 *dataPtr,
@@ -179,8 +169,6 @@ LEP_RESULT LEP_I2C_MasterReadData(LEP_UINT16 portID,
 /**
  * Driver Write
  *
- * @param portID     User-defined parameter to identify one of multiple ports
- *
  * @param subAddress Specifies the Lepton Register Address to write to
  *
  * @param dataPtr    Pointer to a DATA buffer to source the transfers
@@ -189,7 +177,7 @@ LEP_RESULT LEP_I2C_MasterReadData(LEP_UINT16 portID,
  *
  * @return LEP_RESULT   LEP_OK if all goes well; otherwise a Lepton error code.
  */
-LEP_RESULT LEP_I2C_MasterWriteData(LEP_UINT16 portID,
+LEP_RESULT LEP_I2C_MasterWriteData(cambus_t *bus,
                                    LEP_UINT8  deviceAddress,
                                    LEP_UINT16 subAddress,
                                    LEP_UINT16 *dataPtr,
@@ -206,7 +194,7 @@ LEP_RESULT LEP_I2C_MasterWriteData(LEP_UINT16 portID,
     return(result);
 }
 
-LEP_RESULT LEP_I2C_MasterReadRegister(LEP_UINT16 portID,
+LEP_RESULT LEP_I2C_MasterReadRegister(cambus_t *bus,
                                       LEP_UINT8  deviceAddress,
                                       LEP_UINT16 regAddress,
                                       LEP_UINT16 *regValue)
@@ -220,7 +208,7 @@ LEP_RESULT LEP_I2C_MasterReadRegister(LEP_UINT16 portID,
     return(result);
 }
 
-LEP_RESULT LEP_I2C_MasterWriteRegister(LEP_UINT16 portID,
+LEP_RESULT LEP_I2C_MasterWriteRegister(cambus_t *bus,
                                        LEP_UINT8  deviceAddress,
                                        LEP_UINT16 regAddress,
                                        LEP_UINT16 regValue)
@@ -236,7 +224,7 @@ LEP_RESULT LEP_I2C_MasterWriteRegister(LEP_UINT16 portID,
 
 /* Driver Status
 */
-LEP_RESULT LEP_I2C_MasterStatus(LEP_UINT16 portID,
+LEP_RESULT LEP_I2C_MasterStatus(cambus_t *bus,
                                 LEP_UINT16 *portStatus)
 {
     LEP_RESULT result = LEP_OK;

--- a/src/drivers/lepton/src/LEPTON_SDK.c
+++ b/src/drivers/lepton/src/LEPTON_SDK.c
@@ -268,11 +268,6 @@ LEP_RESULT LEP_SelectDevice(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
  * This function dynamically allocates a new descriptor from the
  * system heap.
  *
- * @param portID      LEP_UINT 16  User defined port ID.  This
- *                    value is not used by the Lepton SDK but
- *                    provides the ability for
- *                    application-specific use.
- *
  * @param portType    LEP_CAMERA_PORT_E  Specifies the Lepton
  *                    Communications Port type.
  *
@@ -283,7 +278,7 @@ LEP_RESULT LEP_SelectDevice(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
  * @return LEP_RESULT  Lepton Error Code.  LEP_OK if all goes well,
  *         otherise and Lepton error code is retunred.
  */
-LEP_RESULT LEP_OpenPort(LEP_UINT16 portID,
+LEP_RESULT LEP_OpenPort(cambus_t *bus,
                         LEP_CAMERA_PORT_E portType,
                         LEP_UINT16   portBaudRate,
                         LEP_CAMERA_PORT_DESC_T_PTR portDescPtr)
@@ -313,11 +308,11 @@ LEP_RESULT LEP_OpenPort(LEP_UINT16 portID,
         switch( portType )
         {
             case LEP_CCI_TWI:
-                result = LEP_I2C_OpenPort(portID, &portBaudRate, &deviceAddress);
+                result = LEP_I2C_OpenPort(bus, &portBaudRate, &deviceAddress);
                 if( result == LEP_OK )
                 {
                     portDescPtr->portBaudRate = portBaudRate;
-                    portDescPtr->portID = portID;
+                    portDescPtr->bus = bus;
                     portDescPtr->portType = portType;
                     portDescPtr->deviceAddress = deviceAddress;
                 }
@@ -570,5 +565,3 @@ LEP_RESULT LEP_GetCameraBootStatus(LEP_CAMERA_PORT_DESC_T_PTR portDescPtr,
 //    }
 //    return(LEP_OK);
 //}
-
-

--- a/src/omv/ports/stm32/modules/py_fir_lepton.c
+++ b/src/omv/ports/stm32/modules/py_fir_lepton.c
@@ -361,10 +361,8 @@ int fir_lepton_init()
     LEP_RAD_ENABLE_E rad;
     LEP_AGC_ROI_T roi;
 
-    LEP_I2C_Init(&fir_bus);
-
     for (uint32_t start = systick_current_millis();; systick_sleep(1)) {
-        if (LEP_OpenPort(0, LEP_CCI_TWI, 0, &fir_lepton_handle) == LEP_OK) {
+        if (LEP_OpenPort(&fir_bus, LEP_CCI_TWI, 0, &fir_lepton_handle) == LEP_OK) {
             break;
         }
 

--- a/src/omv/sensors/lepton.c
+++ b/src/omv/sensors/lepton.c
@@ -345,7 +345,7 @@ static int lepton_reset(sensor_t *sensor, bool measurement_mode)
     memset(&LEPHandle, 0, sizeof(LEP_CAMERA_PORT_DESC_T));
 
     for (mp_uint_t start = mp_hal_ticks_ms(); ;mp_hal_delay_ms(1)) {
-        if (LEP_OpenPort(0, LEP_CCI_TWI, 0, &LEPHandle) == LEP_OK) {
+        if (LEP_OpenPort(&sensor->bus, LEP_CCI_TWI, 0, &LEPHandle) == LEP_OK) {
             break;
         }
         if ((mp_hal_ticks_ms() - start) >= LEPTON_TIMEOUT) {
@@ -671,8 +671,6 @@ int lepton_init(sensor_t *sensor)
     SENSOR_HW_FLAGS_SET(sensor, SENSOR_HW_FLAGS_PIXCK, 0);
     SENSOR_HW_FLAGS_SET(sensor, SENSOR_HW_FLAGS_FSYNC, 0);
     SENSOR_HW_FLAGS_SET(sensor, SENSOR_HW_FLAGS_JPEGE, 0);
-
-    LEP_I2C_Init(&sensor->bus);
 
     // Configure the DMA handler for Transmission process
     DMAHandle.Instance                 = LEPTON_SPI_DMA_STREAM;


### PR DESCRIPTION
Tested on an OpenMV Cam H7 with both a Lepton on the camera bus and another on the external pins. Both work at the same time.

The previous code could not support both at the same time. This code can do that and saves a var.