### PR TITLE
Kwabena/get openmvpt lepton working

### DIFF
--- a/src/omv/boards/OPENMVPT/omv_boardconfig.h
+++ b/src/omv/boards/OPENMVPT/omv_boardconfig.h
@@ -57,7 +57,7 @@
 #define OMV_ENABLE_OV7725               (0)
 #define OMV_ENABLE_OV9650               (0)
 #define OMV_ENABLE_MT9V034              (0)
-#define OMV_ENABLE_LEPTON               (1)
+#define OMV_ENABLE_LEPTON               (0)
 #define OMV_ENABLE_HM01B0               (0)
 
 // Enable sensor features
@@ -303,57 +303,6 @@
 #define SOFT_I2C_SIOD_WRITE(bit)        HAL_GPIO_WritePin(SOFT_I2C_PORT, SOFT_I2C_SIOD_PIN, bit)
 
 #define SOFT_I2C_SPIN_DELAY             64
-
-#define LEPTON_SPI                      (SPI3)
-// SPI1/2/3 clock source is PLL2 (200MHz/8 == 12.5MHz) - Minimum (164*240*8*27 = 8,501,760Hz)
-#define LEPTON_SPI_PRESCALER            (SPI_BAUDRATEPRESCALER_16)
-
-#define LEPTON_SPI_IRQn                 (SPI3_IRQn)
-#define LEPTON_SPI_IRQHandler           (SPI3_IRQHandler)
-
-#define LEPTON_SPI_DMA_IRQn             (DMA1_Stream0_IRQn)
-#define LEPTON_SPI_DMA_STREAM           (DMA1_Stream0)
-
-#define LEPTON_SPI_DMA_REQUEST          (DMA_REQUEST_SPI3_RX)
-#define LEPTON_SPI_DMA_IRQHandler       (DMA1_Stream0_IRQHandler)
-
-#define LEPTON_SPI_RESET()              __HAL_RCC_SPI3_FORCE_RESET()
-#define LEPTON_SPI_RELEASE()            __HAL_RCC_SPI3_RELEASE_RESET()
-
-#define LEPTON_SPI_CLK_ENABLE()         __HAL_RCC_SPI3_CLK_ENABLE()
-#define LEPTON_SPI_CLK_DISABLE()        __HAL_RCC_SPI3_CLK_DISABLE()
-
-#define LEPTON_SPI_SCLK_AF              (GPIO_AF6_SPI3)
-#define LEPTON_SPI_MISO_AF              (GPIO_AF6_SPI3)
-#define LEPTON_SPI_MOSI_AF              (GPIO_AF7_SPI3)
-#define LEPTON_SPI_SSEL_AF              (GPIO_AF6_SPI3)
-
-#define LEPTON_SPI_SCLK_PIN             (GPIO_PIN_3)
-#define LEPTON_SPI_MISO_PIN             (GPIO_PIN_4)
-#define LEPTON_SPI_MOSI_PIN             (GPIO_PIN_5)
-#define LEPTON_SPI_SSEL_PIN             (GPIO_PIN_15)
-
-#define LEPTON_SPI_SCLK_PORT            (GPIOB)
-#define LEPTON_SPI_MISO_PORT            (GPIOB)
-#define LEPTON_SPI_MOSI_PORT            (GPIOB)
-#define LEPTON_SPI_SSEL_PORT            (GPIOA)
-
-#define LEPTON_RST_PIN                  (GPIO_PIN_5)
-#define LEPTON_RST_PORT                 (GPIOD)
-
-#define LEPTON_PWND_PIN                 (GPIO_PIN_4)
-#define LEPTON_PWDN_PORT                (GPIOD)
-
-#define LEPTON_RST_LOW()                HAL_GPIO_WritePin(LEPTON_RST_PORT, LEPTON_RST_PIN, GPIO_PIN_RESET)
-#define LEPTON_RST_HIGH()               HAL_GPIO_WritePin(LEPTON_RST_PORT, LEPTON_RST_PIN, GPIO_PIN_SET)
-
-#define LEPTON_PWDN_LOW()               HAL_GPIO_WritePin(LEPTON_PWDN_PORT, LEPTON_PWND_PIN, GPIO_PIN_RESET)
-#define LEPTON_PWDN_HIGH()              HAL_GPIO_WritePin(LEPTON_PWDN_PORT, LEPTON_PWND_PIN, GPIO_PIN_SET)
-
-#define LEPTON_CLK_PIN                  (GPIO_PIN_3)
-#define LEPTON_CLK_PORT                 (GPIOA)
-#define LEPTON_CLK_ALT                  (GPIO_AF4_TIM15)
-#define LEPTON_CLK_FREQ                 (25000000)
 
 // QSPI flash configuration for the bootloader.
 #define QSPIF_SIZE_BITS                 (25)        // 2**25 == 32MBytes.

--- a/src/omv/ports/stm32/main.c
+++ b/src/omv/ports/stm32/main.c
@@ -489,6 +489,9 @@ soft_reset:
 
     // Initialise low-level sub-systems. Here we need to do the very basic
     // things like zeroing out memory and resetting any of the sub-systems.
+    py_lcd_init0();
+    py_fir_init0();
+    py_tv_init0();
     readline_init0();
     pin_init0();
     extint_init0();
@@ -505,9 +508,6 @@ soft_reset:
     #ifdef IMLIB_ENABLE_IMAGE_FILE_IO
     file_buffer_init0();
     #endif
-    py_lcd_init0();
-    py_fir_init0();
-    py_tv_init0();
     servo_init();
     usbdbg_init();
     #if MICROPY_HW_ENABLE_SDCARD

--- a/src/omv/ports/stm32/sensor.c
+++ b/src/omv/ports/stm32/sensor.c
@@ -233,8 +233,8 @@ void sensor_init0()
 {
     dcmi_abort();
 
-    #ifdef PORTENTA
-    // The Portenta board uses the same I2C bus for the sensor and
+    #if defined(PORTENTA) || defined(OPENMVPT)
+    // These boards use the same I2C bus for the sensor and
     // user scripts. The I2C bus must be reinitialized on soft-reset.
     cambus_init(&sensor.bus, ISC_I2C_ID, ISC_I2C_SPEED);
     #endif


### PR DESCRIPTION
FLIR Lepton support in our firmware uses SPI2, the same as the LCD module. I choose to build support based off of the PYB SPI module so that DMA would continue to work and to reuse all their handlers.

However, for the OpenMV PT the FLIR Lepton is on SPI3... which is used by the OpenMV4/OpenMV4P for the camera lepton module. I spent quite a bit of time trying to figure out how I could integrate these two things together without having a bunch of code changes. Then I realized that I could just disable OMV_ENABLE_LEPTON to disable the camera module which turns off the custom SPI bus interrupt and DMA handler. This then frees me to simply use SPI3 from the PYB module and have no code changes. SPI3 is enabled here: https://github.com/openmv/micropython/pull/87

Thus the SPI bus resource sharing issue is solved.

...

As for the OpenMV PT, the FIR onboard shares the I2C bus with the main camera sensor. However, the LEPTON module is always in reset on turn on so it won't respond to I2C scanning. However, the I2C bus must be reinited on soft reset. The other code changes handle this.

...

I examined creating a single interrupt handler location in stm32fxxx_hal_msp.c per Ibrahim's request. However, as I wrote more code for this it became clear I was just duplicating things and using more precious .data space without any benefit. Just disabling OMV_ENABLE_LEPTON on the OPENMVPT is the best solution.