### PR TITLE
ov5640 pclk calculation now uses current register values

### DIFF
--- a/src/omv/sensors/ov5640_regs.h
+++ b/src/omv/sensors/ov5640_regs.h
@@ -28,6 +28,7 @@
 #define SC_PLL_CONTRL3      0x3037
 
 #define SCCB_SYSTEM_CTRL_1  0x3103
+#define SYSTEM_ROOT_DIVIDER 0x3108
 
 #define AWB_R_GAIN_H        0x3400
 #define AWB_R_GAIN_L        0x3401

--- a/src/omv/sensors/ov5640_regs.h
+++ b/src/omv/sensors/ov5640_regs.h
@@ -23,6 +23,7 @@
 #define AF_CMD_ACK          0x3023
 #define AF_FW_STATUS        0x3029
 
+#define SC_PLL_CONTRL0      0x3034
 #define SC_PLL_CONTRL1      0x3035
 #define SC_PLL_CONTRL2      0x3036
 #define SC_PLL_CONTRL3      0x3037


### PR DESCRIPTION
I realized why setting long exposure settings was only sort-of working, and had weird timings, and also failed frequently.

The PCLK calculations were simply not taking into account the changes I wrote into all the PLL registers via the hack you've suggested.

I added some additional register retrievals and calculated PCLK properly and now it's working soooo much better