### PR TITLE
Fix lepton driver on m4 and m7

### DIFF
--- a/src/omv/ports/stm32/modules/py_fir_lepton.c
+++ b/src/omv/ports/stm32/modules/py_fir_lepton.c
@@ -469,17 +469,35 @@ int fir_lepton_init(cambus_t *bus, int *w, int *h, int *refresh, int *resolution
     OMV_FIR_LEPTON_CONTROLLER->spi->hdmatx = NULL;
     OMV_FIR_LEPTON_CONTROLLER->spi->hdmarx = &fir_lepton_spi_rx_dma;
 
+    #if defined(MCU_SERIES_H7)
     fir_lepton_spi_rx_dma.Init.PeriphDataAlignment = DMA_PDATAALIGN_WORD;
+    #else
+    fir_lepton_spi_rx_dma.Init.PeriphDataAlignment = DMA_PDATAALIGN_HALFWORD;
+    #endif
+
+    #if defined(MCU_SERIES_H7)
     fir_lepton_spi_rx_dma.Init.MemDataAlignment = DMA_MDATAALIGN_WORD;
+    #else
+    fir_lepton_spi_rx_dma.Init.MemDataAlignment = DMA_MDATAALIGN_HALFWORD;
+    #endif
+
     fir_lepton_spi_rx_dma.Init.Mode = DMA_CIRCULAR;
 
     ((DMA_Stream_TypeDef *) fir_lepton_spi_rx_dma.Instance)->CR =
         (((DMA_Stream_TypeDef *) fir_lepton_spi_rx_dma.Instance)->CR & ~DMA_SxCR_PSIZE_Msk) |
+        #if defined(MCU_SERIES_H7)
         DMA_PDATAALIGN_WORD;
+        #else
+        DMA_PDATAALIGN_HALFWORD;
+        #endif
 
     ((DMA_Stream_TypeDef *) fir_lepton_spi_rx_dma.Instance)->CR =
         (((DMA_Stream_TypeDef *) fir_lepton_spi_rx_dma.Instance)->CR & ~DMA_SxCR_MSIZE_Msk) |
+        #if defined(MCU_SERIES_H7)
         DMA_MDATAALIGN_WORD;
+        #else
+        DMA_MDATAALIGN_HALFWORD;
+        #endif
 
     ((DMA_Stream_TypeDef *) fir_lepton_spi_rx_dma.Instance)->CR =
         (((DMA_Stream_TypeDef *) fir_lepton_spi_rx_dma.Instance)->CR & ~DMA_SxCR_CIRC_Msk) |

--- a/src/omv/ports/stm32/modules/py_fir_lepton.c
+++ b/src/omv/ports/stm32/modules/py_fir_lepton.c
@@ -55,7 +55,11 @@ static DMA_HandleTypeDef fir_lepton_spi_rx_dma = {};
 #define VOSPI_SEG_SIZE_PIXELS   (VOSPI_PIDS_PER_SEG * VOSPI_PID_SIZE_PIXELS) // 16-bits
 
 #define VOSPI_BUFFER_SIZE       (VOSPI_PACKET_SIZE * 2) // 16-bits
+#if defined(MCU_SERIES_H7)
 #define VOSPI_CLOCK_SPEED       10000000 // hz
+#else
+#define VOSPI_CLOCK_SPEED       20000000 // hz
+#endif
 #define VOSPI_SYNC_MS           200 // ms
 
 static soft_timer_entry_t flir_lepton_spi_rx_timer = {};


### PR DESCRIPTION
Can't do 32-bit transfers to the SPI bus with the M4/M7. The SPI bus for them has only a 16-bit read/write register. So, this switches to 16-bit mode for DMA for them. I have confirmed the FLIR Lepton 1 works on the M4 and M7. The FLIR Lepton 3 didn't work on the M4 because of RAM issues. The Lepton 3 works on the M7.

Regarding the transfer length changing. On the H7 I have the SPI FIFO enabled in 2 data element mode which seems to halve the DMA transaction size. While this doesn't make that much sense on why that happens... I can confirm trying sizes *2 and /2 both don't work and cause issues. This is why the DMA length is unchanged. Only the transfer sizes.

Finally, M4/M7 have a higher target SPI clock speed to ensure they hit a clock divider that can read the image out fast enough (ends up being 11.25 MHz for the M4 and 13.5 MHz on the M7).