### PR TITLE
Update ImageIO version

### DIFF
--- a/src/omv/modules/py_imageio.c
+++ b/src/omv/modules/py_imageio.c
@@ -45,6 +45,7 @@ typedef struct _py_imageio_obj {
             FIL fp;
             uint32_t ms;
             uint32_t mode;
+            int version;
         };
         #endif
         struct {
@@ -56,7 +57,7 @@ typedef struct _py_imageio_obj {
             uint32_t offset;
             uint8_t *buffer;
         };
-    }; 
+    };
     image_io_stream_type_t type;
 } py_imageio_obj_t;
 
@@ -203,10 +204,26 @@ mp_obj_t py_imageio_read(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
 
         char ignore[15];
         read_data(fp, image.data, size);
+
+        // Check if original byte reversed data.
+        if ((image.bpp == IMAGE_BPP_RGB565) && (stream->version == 10)) {
+            uint32_t *data_ptr = (uint32_t *) image.data;
+            size_t data_len = image.w * image.h;
+
+            for (; data_len >= 2; data_len -= 2, data_ptr += 1) {
+                *data_ptr = __REV16(*data_ptr); // long aligned
+            }
+
+            if (data_len) {
+                *((uint16_t *) data_ptr) = __REV16(*((uint16_t *) data_ptr)); // word aligned
+            }
+        }
+
         if (size % 16) {
             // Read in to multiple of 16 bytes.
             read_data(fp, ignore, 16 - (size % 16));
         }
+
         py_helper_update_framebuffer(&image);
 
         if (arg_other) {
@@ -301,17 +318,26 @@ mp_obj_t py_imageio_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_
         stream->type = IMAGE_IO_FILE_STREAM;
         stream->mode = mp_obj_str_get_str(args[1])[0];
         if (stream->mode == IMAGE_IO_FILE_READ) {
+            uint8_t version_hi, version_lo;
             file_read_open(&stream->fp, mp_obj_str_get_str(args[0]));
             read_long_expect(&stream->fp, *((uint32_t *) "OMV ")); // OpenMV
             read_long_expect(&stream->fp, *((uint32_t *) "IMG ")); // Image
             read_long_expect(&stream->fp, *((uint32_t *) "STR ")); // Stream
-            read_long_expect(&stream->fp, *((uint32_t *) "V1.0")); // v1.0
+            read_byte_expect(&stream->fp, 'V');
+            read_byte(&stream->fp, &version_hi);
+            read_byte_expect(&stream->fp, '.');
+            read_byte(&stream->fp, &version_lo);
+            if ((version_hi != '1') || ((version_lo != '0') && (version_lo != '1'))) {
+                mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("Expected version V1.0 or V1.1"));
+            }
+            stream->version = ((version_hi - '0') * 10) + (version_lo - '0');
         } else if (stream->mode == IMAGE_IO_FILE_WRITE) {
             file_write_open(&stream->fp, mp_obj_str_get_str(args[0]));
             write_long(&stream->fp, *((uint32_t *) "OMV ")); // OpenMV
             write_long(&stream->fp, *((uint32_t *) "IMG ")); // Image
             write_long(&stream->fp, *((uint32_t *) "STR ")); // Stream
-            write_long(&stream->fp, *((uint32_t *) "V1.0")); // v1.0
+            write_long(&stream->fp, *((uint32_t *) "V1.1")); // v1.1
+            stream->version = 11;
         } else {
             mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("Invalid stream mode, expected 'r' or 'w'"));
         }


### PR DESCRIPTION
New files created don't have rgb565 byte reversal. Can read old files with this issue.