### PR TITLE
Call gc_sweep_all on soft-reset.

### DIFF
--- a/src/omv/ports/stm32/main.c
+++ b/src/omv/ports/stm32/main.c
@@ -745,6 +745,9 @@ soft_reset:
     #ifdef IMLIB_ENABLE_DMA2D
     imlib_draw_row_deinit_all();
     #endif
+    #if MICROPY_PY_LWIP
+    gc_sweep_all();
+    #endif
     first_soft_reset = false;
     goto soft_reset;
 }


### PR DESCRIPTION
* Make sure to collect open lwip sockets otherwise it runs out of memory.
* This should be okay to add in general but will only enable for LWIP for now.