### PR TITLE
Kwabena/cache alignment

### DIFF
--- a/src/omv/alloc/fb_alloc.c
+++ b/src/omv/alloc/fb_alloc.c
@@ -137,7 +137,7 @@ void *fb_alloc(uint32_t size, int hints)
     #if __DCACHE_PRESENT
     if (hints & FB_ALLOC_CACHE_ALIGN) {
         size = ((size + __SCB_DCACHE_LINE_SIZE - 1) / __SCB_DCACHE_LINE_SIZE) * __SCB_DCACHE_LINE_SIZE;
-        size += __SCB_DCACHE_LINE_SIZE;
+        size += __SCB_DCACHE_LINE_SIZE - sizeof(uint32_t);
     }
     #endif
 

--- a/src/omv/alloc/fb_alloc.c
+++ b/src/omv/alloc/fb_alloc.c
@@ -209,13 +209,6 @@ void *fb_alloc_all(uint32_t *size, int hints)
 
     *size = (temp / sizeof(uint32_t)) * sizeof(uint32_t); // Round Down
 
-    #if __DCACHE_PRESENT
-    if (hints & FB_ALLOC_CACHE_ALIGN) {
-        *size = ((*size + __SCB_DCACHE_LINE_SIZE - 1) / __SCB_DCACHE_LINE_SIZE) * __SCB_DCACHE_LINE_SIZE;
-        *size += __SCB_DCACHE_LINE_SIZE;
-    }
-    #endif
-
     char *result = pointer - *size;
     char *new_pointer = result - sizeof(uint32_t);
 
@@ -244,8 +237,11 @@ void *fb_alloc_all(uint32_t *size, int hints)
     if (hints & FB_ALLOC_CACHE_ALIGN) {
         int offset = ((uint32_t) result) % __SCB_DCACHE_LINE_SIZE;
         if (offset) {
-            result += __SCB_DCACHE_LINE_SIZE - offset;
+            int inc = __SCB_DCACHE_LINE_SIZE - offset;
+            result += inc;
+            *size -= inc;
         }
+        *size = (*size / __SCB_DCACHE_LINE_SIZE) * __SCB_DCACHE_LINE_SIZE;
     }
     #endif
 

--- a/src/omv/alloc/fb_alloc.h
+++ b/src/omv/alloc/fb_alloc.h
@@ -35,6 +35,19 @@
  * mark.
  *
  * Note that fb_free() and fb_free_all() do not respect any marks and permanent regions.
+ *
+ * Regardings the flags below:
+ * - FB_ALLOC_NO_HINT - fb_alloc doesn't do anything special.
+ * - FB_ALLOC_PREFER_SPEED - fb_alloc will make sure the allocated region is in the fatest possible
+ *                           memory. E.g. allocs will be in SRAM versus SDRAM if SDRAM is available.
+ *                           Setting this flag affects where fb_alloc_all() gets RAM from. If this
+ *                           flag is set then fb_alloc_all() will not use the SDRAM.
+ * - FB_ALLOC_PREFER_SIZE - fb_alloc will make sure the allocated region is the largest possible
+ *                          memory. E.g. allocs will be in SDRAM versus SRAM if SDRAM is available.
+ *                          Setting this flag affects where fb_alloc_all() gets RAM from. If this
+ *                          flag is set then fb_alloc_all() will use the SDRAM (default).
+ * - FB_ALLOC_CACHE_ALIGN - Aligns the starting address returned to a cache line and makes sure
+ *                          the amount of memory allocated is padded to the end of a cache line.
  */
 #ifndef __FB_ALLOC_H__
 #define __FB_ALLOC_H__
@@ -42,6 +55,7 @@
 #define FB_ALLOC_NO_HINT 0
 #define FB_ALLOC_PREFER_SPEED 1
 #define FB_ALLOC_PREFER_SIZE 2
+#define FB_ALLOC_CACHE_ALIGN 4
 char *fb_alloc_stack_pointer();
 void fb_alloc_fail();
 void fb_alloc_init0();

--- a/src/omv/imlib/framebuffer.h
+++ b/src/omv/imlib/framebuffer.h
@@ -21,8 +21,8 @@ typedef struct framebuffer {
     int32_t u,v;
     int32_t bpp;
     int32_t streaming_enabled;
-    // NOTE: This buffer must be aligned on a 16 byte boundary
-    OMV_ATTR_ALIGNED(uint8_t pixels[], 16);
+    // NOTE: This buffer must be aligned on a 32 byte boundary
+    OMV_ATTR_ALIGNED(uint8_t pixels[], 32);
 } framebuffer_t;
 
 extern framebuffer_t *framebuffer;
@@ -33,7 +33,9 @@ typedef struct jpegbuffer {
     int32_t enabled;
     int32_t quality;
     mutex_t lock;
-    uint8_t pixels[];
+    int64_t __padding;
+    // NOTE: This buffer must be aligned on a 32 byte boundary
+    OMV_ATTR_ALIGNED(uint8_t pixels[], 32);
 } jpegbuffer_t;
 
 extern jpegbuffer_t *jpeg_framebuffer;

--- a/src/omv/imlib/framebuffer.h
+++ b/src/omv/imlib/framebuffer.h
@@ -33,7 +33,6 @@ typedef struct jpegbuffer {
     int32_t enabled;
     int32_t quality;
     mutex_t lock;
-    int64_t __padding;
     // NOTE: This buffer must be aligned on a 32 byte boundary
     OMV_ATTR_ALIGNED(uint8_t pixels[], 32);
 } jpegbuffer_t;

--- a/src/omv/ports/stm32/modules/py_fir_lepton.c
+++ b/src/omv/ports/stm32/modules/py_fir_lepton.c
@@ -455,22 +455,8 @@ int fir_lepton_init(cambus_t *bus, int *w, int *h, int *refresh, int *resolution
                                                  FB_ALLOC_NO_HINT);
     }
 
-    size_t size = VOSPI_BUFFER_SIZE * sizeof(uint16_t);
-
-    // The DMA buffer must not start/end partially on a cache line.
-    #if defined(MCU_SERIES_F7) || defined(MCU_SERIES_H7)
-    size = ((size + __SCB_DCACHE_LINE_SIZE - 1) / __SCB_DCACHE_LINE_SIZE) * __SCB_DCACHE_LINE_SIZE;
-    size += __SCB_DCACHE_LINE_SIZE;
-    #endif
-
-    fir_lepton_spi_rx_cb_dma_buffer = (uint16_t *) fb_alloc(size, FB_ALLOC_PREFER_SPEED);
-
-    #if defined(MCU_SERIES_F7) || defined(MCU_SERIES_H7)
-    int offset = ((uint32_t) fir_lepton_spi_rx_cb_dma_buffer) % __SCB_DCACHE_LINE_SIZE;
-    if (offset) {
-        fir_lepton_spi_rx_cb_dma_buffer += __SCB_DCACHE_LINE_SIZE - offset;
-    }
-    #endif
+    fir_lepton_spi_rx_cb_dma_buffer = (uint16_t *) fb_alloc(VOSPI_BUFFER_SIZE * sizeof(uint16_t),
+                                                            FB_ALLOC_PREFER_SPEED | FB_ALLOC_CACHE_ALIGN);
 
     dma_init(&fir_lepton_spi_rx_dma,
              OMV_FIR_LEPTON_CONTROLLER->rx_dma_descr,


### PR DESCRIPTION
Add cache alignment support for fb_alloc(). This will let us use fb_alloc for DMA buffers without issues. Also fixed the alignment of the frame buffer and jpeg buffer to be aligned to 32-byte cache lines.