### PR TITLE
Fix linker script stack alignment for boards with SRAM stack.

### DIFF
--- a/src/omv/ports/stm32/stm32fxxx.ld.S
+++ b/src/omv/ports/stm32/stm32fxxx.ld.S
@@ -208,11 +208,11 @@ SECTIONS
   /* Make sure there is enough ram for the stack */
   ._stack (NOLOAD) :
   {
-    . = ALIGN(4);
+    . = ALIGN(8);
     _sstack  = .;
     . = . + _stack_size;
 
-    . = ALIGN(4);
+    . = ALIGN(8);
     _estack  = .;
   } >OMV_STACK_MEMORY
 


### PR DESCRIPTION
* The stack pointer needs to be aligned to 8 bytes to conform with EABI, most of the boards are configured
to use ITCM for stack, which starts at 0 and are Not affected by the linker script alignment. This patch
fixes the issue with boards that use SRAM for stack which can get misaligned.