### PR TITLE
Speed up clearing trailing jpeg data

### DIFF
--- a/src/omv/imlib/imlib.h
+++ b/src/omv/imlib/imlib.h
@@ -1068,6 +1068,7 @@ void bmp_read_pixels(FIL *fp, image_t *img, int n_lines, bmp_read_settings_t *rs
 void bmp_read(image_t *img, const char *path);
 void bmp_write_subimg(image_t *img, const char *path, rectangle_t *r);
 bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc);
+int jpeg_clean_trailing_bytes(int bpp, uint8_t *data);
 void jpeg_read_geometry(FIL *fp, image_t *img, const char *path, jpg_read_settings_t *rs);
 void jpeg_read_pixels(FIL *fp, image_t *img);
 void jpeg_read(image_t *img, const char *path);

--- a/src/omv/ports/stm32/sensor.c
+++ b/src/omv/ports/stm32/sensor.c
@@ -1533,12 +1533,8 @@ int sensor_snapshot(sensor_t *sensor, image_t *image, streaming_cb_t streaming_c
                     SCB_InvalidateDCache_by_Addr((uint32_t*)MAIN_FB()->pixels, size);
                     #endif
                 }
-                // Clean trailing data.
-                while ((MAIN_FB()->bpp >= 2)
-                   && ((MAIN_FB()->pixels[MAIN_FB()->bpp-2] != 0xFF)
-                    || (MAIN_FB()->pixels[MAIN_FB()->bpp-1] != 0xD9))) {
-                    MAIN_FB()->bpp -= 1;
-                }
+                // Clean trailing data after 0xFFD9 at the end of the jpeg byte stream.
+                MAIN_FB()->bpp = jpeg_clean_trailing_bytes(MAIN_FB()->bpp, MAIN_FB()->pixels);
                 break;
             default:
                 break;


### PR DESCRIPTION
Puts bpp in a register versus a Read/Write/Modify per byte.