### PR TITLE
Keep JPEG core on during script execution

### DIFF
--- a/src/omv/imlib/imlib.c
+++ b/src/omv/imlib/imlib.c
@@ -21,13 +21,18 @@
 
 void imlib_init_all()
 {
-    // Nothing for now.
+    #if (OMV_HARDWARE_JPEG == 1)
+    imlib_jpeg_compress_init();
+    #endif
 }
 
 void imlib_deinit_all()
 {
     #ifdef IMLIB_ENABLE_DMA2D
     imlib_draw_row_deinit_all();
+    #endif
+    #if (OMV_HARDWARE_JPEG == 1)
+    imlib_jpeg_compress_deinit();
     #endif
 }
 

--- a/src/omv/imlib/imlib.h
+++ b/src/omv/imlib/imlib.h
@@ -27,6 +27,7 @@
 #include "fmath.h"
 #include "collections.h"
 #include "imlib_config.h"
+#include "omv_boardconfig.h"
 
 #define IM_LOG2_2(x)    (((x) &                0x2ULL) ? ( 2                        ) :             1) // NO ({ ... }) !
 #define IM_LOG2_4(x)    (((x) &                0xCULL) ? ( 2 +  IM_LOG2_2((x) >>  2)) :  IM_LOG2_2(x)) // NO ({ ... }) !
@@ -1070,6 +1071,10 @@ bool bmp_read_geometry(FIL *fp, image_t *img, const char *path, bmp_read_setting
 void bmp_read_pixels(FIL *fp, image_t *img, int n_lines, bmp_read_settings_t *rs);
 void bmp_read(image_t *img, const char *path);
 void bmp_write_subimg(image_t *img, const char *path, rectangle_t *r);
+#if (OMV_HARDWARE_JPEG == 1)
+void imlib_jpeg_compress_init();
+void imlib_jpeg_compress_deinit();
+#endif
 bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc);
 int jpeg_clean_trailing_bytes(int bpp, uint8_t *data);
 void jpeg_read_geometry(FIL *fp, image_t *img, const char *path, jpg_read_settings_t *rs);

--- a/src/omv/ports/stm32/stm32fxxx_hal_msp.c
+++ b/src/omv/ports/stm32/stm32fxxx_hal_msp.c
@@ -117,11 +117,6 @@ void HAL_MspInit(void)
     __GPIOK_CLK_ENABLE();
     #endif
 
-    #if defined (OMV_HARDWARE_JPEG)
-    /* Enable JPEG clock */
-    __HAL_RCC_JPEG_CLK_ENABLE();
-    #endif
-
     /* Enable DMA clocks */
     __DMA1_CLK_ENABLE();
     __DMA2_CLK_ENABLE();
@@ -129,11 +124,6 @@ void HAL_MspInit(void)
     #if defined(MCU_SERIES_H7)
     // MDMA clock
     __HAL_RCC_MDMA_CLK_ENABLE();
-    #endif
-
-    #if defined(OMV_HARDWARE_JPEG)
-    // Enable JPEG clock
-    __HAL_RCC_JPGDECEN_CLK_ENABLE();
     #endif
 
     #if defined(DCMI_RESET_PIN) || defined(DCMI_PWDN_PIN) || defined(DCMI_FSYNC_PIN)
@@ -399,6 +389,20 @@ void HAL_DMA2D_MspDeInit(DMA2D_HandleTypeDef *hdma2d)
     __HAL_RCC_DMA2D_RELEASE_RESET();
     __HAL_RCC_DMA2D_CLK_DISABLE();
 }
+
+#if (OMV_HARDWARE_JPEG == 1)
+void HAL_JPEG_MspInit(JPEG_HandleTypeDef *hjpeg)
+{
+    __HAL_RCC_JPEG_CLK_ENABLE();
+}
+
+void HAL_JPEG_MspDeInit(JPEG_HandleTypeDef *hjpeg)
+{
+    __HAL_RCC_JPEG_FORCE_RESET();
+    __HAL_RCC_JPEG_RELEASE_RESET();
+    __HAL_RCC_JPEG_CLK_DISABLE();
+}
+#endif
 
 #if defined(OMV_LCD_CONTROLLER) && (!defined(OMV_DSI_CONTROLLER))
 typedef struct {


### PR DESCRIPTION
Speeds up JPEG in a minor way by keeping the core on between compresses.