### PR TITLE
Add support for the OV5640 to the Arduino Portenta

### DIFF
--- a/src/omv/boards/OPENMV4/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4/omv_boardconfig.h
@@ -39,6 +39,15 @@
 // Sensor Banding Filter Value
 #define OMV_OV7725_BANDING      (0x7F)
 
+// OV5640 Sensor Settings
+#define OMV_OV5640_XCLK_FREQ    (24000000)
+#define OMV_OV5640_PLL_CTRL2    (0x64)
+#define OMV_OV5640_PLL_CTRL3    (0x13)
+#define OMV_OV5640_REV_Y_CHECK  (1)
+#define OMV_OV5640_REV_Y_FREQ   (25000000)
+#define OMV_OV5640_REV_Y_CTRL2  (0x54)
+#define OMV_OV5640_REV_Y_CTRL3  (0x13)
+
 // Bootloader LED GPIO port/pin
 #define OMV_BOOTLDR_LED_PIN     (GPIO_PIN_1)
 #define OMV_BOOTLDR_LED_PORT    (GPIOC)

--- a/src/omv/boards/OPENMV4P/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4P/omv_boardconfig.h
@@ -43,6 +43,15 @@
 // Sensor Banding Filter Value
 #define OMV_OV7725_BANDING      (0x7F)
 
+// OV5640 Sensor Settings
+#define OMV_OV5640_XCLK_FREQ    (24000000)
+#define OMV_OV5640_PLL_CTRL2    (0x64)
+#define OMV_OV5640_PLL_CTRL3    (0x13)
+#define OMV_OV5640_REV_Y_CHECK  (1)
+#define OMV_OV5640_REV_Y_FREQ   (25000000)
+#define OMV_OV5640_REV_Y_CTRL2  (0x54)
+#define OMV_OV5640_REV_Y_CTRL3  (0x13)
+
 // Bootloader LED GPIO port/pin
 #define OMV_BOOTLDR_LED_PIN     (GPIO_PIN_1)
 #define OMV_BOOTLDR_LED_PORT    (GPIOC)

--- a/src/omv/boards/OPENMVPT/omv_boardconfig.h
+++ b/src/omv/boards/OPENMVPT/omv_boardconfig.h
@@ -40,6 +40,15 @@
 // Sensor Banding Filter Value
 #define OMV_OV7725_BANDING              (0x7F)
 
+// OV5640 Sensor Settings
+#define OMV_OV5640_XCLK_FREQ            (24000000)
+#define OMV_OV5640_PLL_CTRL2            (0x64)
+#define OMV_OV5640_PLL_CTRL3            (0x13)
+#define OMV_OV5640_REV_Y_CHECK          (1)
+#define OMV_OV5640_REV_Y_FREQ           (25000000)
+#define OMV_OV5640_REV_Y_CTRL2          (0x54)
+#define OMV_OV5640_REV_Y_CTRL3          (0x13)
+
 // Bootloader LED GPIO port/pin
 #define OMV_BOOTLDR_LED_PIN             (GPIO_PIN_1)
 #define OMV_BOOTLDR_LED_PORT            (GPIOC)

--- a/src/omv/boards/PORTENTA/omv_boardconfig.h
+++ b/src/omv/boards/PORTENTA/omv_boardconfig.h
@@ -37,6 +37,15 @@
 // Sensor Banding Filter Value
 #define OMV_OV7725_BANDING      (0x7F)
 
+// OV5640 Sensor Settings
+#define OMV_OV5640_XCLK_FREQ    (12500000)
+#define OMV_OV5640_PLL_CTRL2    (0x7E)
+#define OMV_OV5640_PLL_CTRL3    (0x13)
+#define OMV_OV5640_REV_Y_CHECK  (0)
+#define OMV_OV5640_REV_Y_FREQ   (12500000)
+#define OMV_OV5640_REV_Y_CTRL2  (0x7E)
+#define OMV_OV5640_REV_Y_CTRL3  (0x13)
+
 // Bootloader LED GPIO port/pin
 #define OMV_BOOTLDR_LED_PIN     (GPIO_PIN_6)
 #define OMV_BOOTLDR_LED_PORT    (GPIOK)
@@ -52,7 +61,7 @@
 
 // Enable sensor drivers
 #define OMV_ENABLE_OV2640       (0)
-#define OMV_ENABLE_OV5640       (0)
+#define OMV_ENABLE_OV5640       (1)
 #define OMV_ENABLE_OV7690       (0)
 #define OMV_ENABLE_OV7725       (1)
 #define OMV_ENABLE_OV9650       (0)
@@ -60,10 +69,10 @@
 #define OMV_ENABLE_MT9V0XX      (1)
 #define OMV_ENABLE_LEPTON       (0)
 #define OMV_ENABLE_HM01B0       (1)
-#define OMV_ENABLE_GC2145       (1)
+#define OMV_ENABLE_GC2145       (0)
 
 // Enable sensor features
-#define OMV_ENABLE_OV5640_AF    (0)
+#define OMV_ENABLE_OV5640_AF    (1)
 
 // Enable WiFi debug
 #define OMV_ENABLE_WIFIDBG      (0)

--- a/src/omv/common/sensor_utils.c
+++ b/src/omv/common/sensor_utils.c
@@ -172,6 +172,8 @@ __weak int sensor_reset()
 int sensor_probe_init(uint32_t bus_id, uint32_t bus_speed)
 {
     int init_ret = 0;
+    int freq;
+    (void) freq;
 
     // Do a power cycle
     DCMI_PWDN_HIGH();
@@ -320,7 +322,13 @@ int sensor_probe_init(uint32_t bus_id, uint32_t bus_speed)
 
         #if (OMV_ENABLE_OV5640 == 1)
         case OV5640_ID:
-            if (sensor_set_xclk_frequency(OV5640_XCLK_FREQ) != 0) {
+            freq = OMV_OV5640_XCLK_FREQ;
+            #if (OMV_OV5640_REV_Y_CHECK == 1)
+            if (HAL_GetREVID() < 0x2003) { // Is this REV Y?
+                freq = OMV_OV5640_REV_Y_FREQ;
+            }
+            #endif
+            if (sensor_set_xclk_frequency(freq) != 0) {
                 return SENSOR_ERROR_TIM_INIT_FAILED;
             }
             init_ret = ov5640_init(&sensor);

--- a/src/omv/sensors/ov5640.h
+++ b/src/omv/sensors/ov5640.h
@@ -10,6 +10,5 @@
  */
 #ifndef __OV5640_H__
 #define __OV5640_H__
-#define OV5640_XCLK_FREQ 24000000
 int ov5640_init(sensor_t *sensor);
 #endif // __OV5640_H__


### PR DESCRIPTION
Sets the PCLK to 70 MHz and gets it working.