### PR TITLE
Move all DMA buffers to SRAM3

### DIFF
--- a/src/omv/boards/OPENMV4P/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4P/omv_boardconfig.h
@@ -142,13 +142,12 @@
 #define OMV_FFS_MEMORY          DTCM        // Flash filesystem cache memory
 #define OMV_MAIN_MEMORY         SRAM1       // data, bss and heap
 #define OMV_STACK_MEMORY        ITCM        // stack memory
-#define OMV_DMA_MEMORY          AXI_SRAM    // DMA buffers memory.
+#define OMV_DMA_MEMORY          SRAM3       // DMA buffers memory.
 #define OMV_FB_MEMORY           DRAM        // Framebuffer, fb_alloc
 #define OMV_JPEG_MEMORY         DRAM        // JPEG buffer memory buffer.
 #define OMV_JPEG_MEMORY_OFFSET  (31M)       // JPEG buffer is placed after FB/fballoc memory.
 #define OMV_VOSPI_MEMORY        SRAM4       // VoSPI buffer memory.
 #define OMV_FB_OVERLAY_MEMORY   AXI_SRAM    // _fballoc_overlay memory.
-#define OMV_FB_OVERLAY_MEMORY_OFFSET    (480*1024)  // _fballoc_overlay
 
 #define OMV_FB_SIZE             (20M)       // FB memory: header + VGA/GS image
 #define OMV_FB_ALLOC_SIZE       (11M)       // minimum fb alloc size
@@ -182,7 +181,7 @@
 #define OMV_FB_OVERLAY_MEMORY_ORIGIN    OMV_AXI_SRAM_ORIGIN
 
 // Use the MPU to set an uncacheable memory region.
-#define OMV_DMA_REGION_BASE     (OMV_AXI_SRAM_ORIGIN+OMV_FB_OVERLAY_MEMORY_OFFSET)
+#define OMV_DMA_REGION_BASE     OMV_SRAM3_ORIGIN
 #define OMV_DMA_REGION_SIZE     MPU_REGION_SIZE_32KB
 
 // Image sensor I2C

--- a/src/omv/boards/OPENMVPT/omv_boardconfig.h
+++ b/src/omv/boards/OPENMVPT/omv_boardconfig.h
@@ -139,13 +139,12 @@
 #define OMV_FFS_MEMORY                  DTCM        // Flash filesystem cache memory
 #define OMV_MAIN_MEMORY                 SRAM1       // data, bss and heap
 #define OMV_STACK_MEMORY                ITCM        // stack memory
-#define OMV_DMA_MEMORY                  AXI_SRAM    // DMA buffers memory.
+#define OMV_DMA_MEMORY                  SRAM3       // DMA buffers memory.
 #define OMV_FB_MEMORY                   DRAM        // Framebuffer, fb_alloc
 #define OMV_JPEG_MEMORY                 DRAM        // JPEG buffer memory buffer.
 #define OMV_JPEG_MEMORY_OFFSET          (63M)       // JPEG buffer is placed after FB/fballoc memory.
 #define OMV_VOSPI_MEMORY                SRAM4       // VoSPI buffer memory.
 #define OMV_FB_OVERLAY_MEMORY           AXI_SRAM    // _fballoc_overlay memory.
-#define OMV_FB_OVERLAY_MEMORY_OFFSET    (480*1024)  // _fballoc_overlay
 
 #define OMV_FB_SIZE                     (32M)       // FB memory: header + VGA/GS image
 #define OMV_FB_ALLOC_SIZE               (31M)       // minimum fb alloc size
@@ -179,7 +178,7 @@
 #define OMV_FB_OVERLAY_MEMORY_ORIGIN    OMV_AXI_SRAM_ORIGIN
 
 // Use the MPU to set an uncacheable memory region.
-#define OMV_DMA_REGION_BASE             (OMV_AXI_SRAM_ORIGIN+OMV_FB_OVERLAY_MEMORY_OFFSET)
+#define OMV_DMA_REGION_BASE             OMV_SRAM3_ORIGIN
 #define OMV_DMA_REGION_SIZE             MPU_REGION_SIZE_32KB
 
 // Image sensor I2C

--- a/src/omv/boards/PORTENTA/omv_boardconfig.h
+++ b/src/omv/boards/PORTENTA/omv_boardconfig.h
@@ -140,20 +140,19 @@
 #define OMV_FFS_MEMORY          DTCM        // Flash filesystem cache memory
 #define OMV_MAIN_MEMORY         SRAM1       // data, bss and heap
 #define OMV_STACK_MEMORY        SRAM1       // stack memory
-#define OMV_DMA_MEMORY          AXI_SRAM    // DMA buffers memory.
+#define OMV_DMA_MEMORY          SRAM3       // DMA buffers memory.
 #define OMV_FB_MEMORY           DRAM        // Framebuffer, fb_alloc
 #define OMV_JPEG_MEMORY         DRAM        // JPEG buffer memory buffer.
 #define OMV_JPEG_MEMORY_OFFSET  (7M)        // JPEG buffer is placed after FB/fballoc memory.
 #define OMV_VOSPI_MEMORY        SRAM4       // VoSPI buffer memory.
 #define OMV_FB_OVERLAY_MEMORY   AXI_SRAM    // _fballoc_overlay memory.
-#define OMV_FB_OVERLAY_MEMORY_OFFSET    (480*1024)  // _fballoc_overlay
 #define OMV_CYW43_MEMORY        FLASH_EXT   // CYW43 firmware in external flash mmap'd flash.
 #define OMV_CYW43_MEMORY_OFFSET (0x90F00000)// Last Mbyte.
 
 #define OMV_FB_SIZE             (4M)       // FB memory: header + VGA/GS image
 #define OMV_FB_ALLOC_SIZE       (3M)       // minimum fb alloc size
 #define OMV_STACK_SIZE          (32K)
-#define OMV_HEAP_SIZE           (180K)
+#define OMV_HEAP_SIZE           (148K)
 #define OMV_SDRAM_SIZE          (8 * 1024 * 1024) // This needs to be here for UVC firmware.
 
 #define OMV_LINE_BUF_SIZE       (11 * 1024) // Image line buffer round(2592 * 2BPP * 2 buffers).
@@ -168,7 +167,9 @@
 #define OMV_DTCM_ORIGIN         0x20000000  // Note accessible by CPU and MDMA only.
 #define OMV_DTCM_LENGTH         128K
 #define OMV_SRAM1_ORIGIN        0x30000000
-#define OMV_SRAM1_LENGTH        288K
+#define OMV_SRAM1_LENGTH        256K
+#define OMV_SRAM3_ORIGIN        0x30040000
+#define OMV_SRAM3_LENGTH        32K
 #define OMV_SRAM4_ORIGIN        0x38000000
 #define OMV_SRAM4_LENGTH        64K
 #define OMV_AXI_SRAM_ORIGIN     0x24000000
@@ -180,7 +181,7 @@
 #define OMV_FB_OVERLAY_MEMORY_ORIGIN    OMV_AXI_SRAM_ORIGIN
 
 // Use the MPU to set an uncacheable memory region.
-#define OMV_DMA_REGION_BASE     (OMV_AXI_SRAM_ORIGIN+OMV_FB_OVERLAY_MEMORY_OFFSET)
+#define OMV_DMA_REGION_BASE     OMV_SRAM3_ORIGIN
 #define OMV_DMA_REGION_SIZE     MPU_REGION_SIZE_32KB
 
 // Image sensor I2C

--- a/src/omv/ports/stm32/stm32fxxx.ld.S
+++ b/src/omv/ports/stm32/stm32fxxx.ld.S
@@ -45,6 +45,13 @@ MEMORY
 
 _ram_end    = ORIGIN(OMV_MAIN_MEMORY) + LENGTH(OMV_MAIN_MEMORY);
 
+#if defined(OMV_FB_OVERLAY_MEMORY)
+#if !defined(OMV_FB_OVERLAY_MEMORY_OFFSET)
+#define OMV_FB_OVERLAY_MEMORY_OFFSET    LENGTH(OMV_FB_OVERLAY_MEMORY)
+#endif
+_fballoc_overlay    = ORIGIN(OMV_FB_OVERLAY_MEMORY) + OMV_FB_OVERLAY_MEMORY_OFFSET;
+#endif
+
 #if defined(OMV_FFS_MEMORY)
 #if !defined(OMV_FFS_MEMORY_OFFSET)
 #define OMV_FFS_MEMORY_OFFSET           (0)
@@ -123,11 +130,6 @@ SECTIONS
   /* Misc DMA buffers kept in uncachable region */
   .dma_memory (NOLOAD) :
   {
-    #if defined(OMV_FB_OVERLAY_MEMORY)
-    . = ALIGN(4) + OMV_FB_OVERLAY_MEMORY_OFFSET;
-    _fballoc_overlay = .;
-    #endif
-
     . = ALIGN(4);
     _line_buf = .;      // Image line buffer.
     . = . + OMV_LINE_BUF_SIZE;

--- a/src/uvc/stm32fxxx.ld.S
+++ b/src/uvc/stm32fxxx.ld.S
@@ -42,6 +42,13 @@ MEMORY
 
 _ram_end    = ORIGIN(OMV_MAIN_MEMORY) + LENGTH(OMV_MAIN_MEMORY);
 
+#if defined(OMV_FB_OVERLAY_MEMORY)
+#if !defined(OMV_FB_OVERLAY_MEMORY_OFFSET)
+#define OMV_FB_OVERLAY_MEMORY_OFFSET    LENGTH(OMV_FB_OVERLAY_MEMORY)
+#endif
+_fballoc_overlay    = ORIGIN(OMV_FB_OVERLAY_MEMORY) + OMV_FB_OVERLAY_MEMORY_OFFSET;
+#endif
+
 #if defined(OMV_FFS_MEMORY)
 #if !defined(OMV_FFS_MEMORY_OFFSET)
 #define OMV_FFS_MEMORY_OFFSET           (0)
@@ -104,11 +111,6 @@ SECTIONS
   /* Misc DMA buffers kept in uncachable region */
   .dma_memory (NOLOAD) :
   {
-    #if defined(OMV_FB_OVERLAY_MEMORY)
-    . = ALIGN(4) + OMV_FB_OVERLAY_MEMORY_OFFSET;
-    _fballoc_overlay = .;
-    #endif
-
     . = ALIGN(4);
     _line_buf = .;      // Image line buffer.
     . = . + OMV_LINE_BUF_SIZE;


### PR DESCRIPTION
This PR moves all the DMA buffers for H7 based OpenMV Cam's to SRAM3. This must be done to get the camera DMA off the D2-to-D1 AHB bus which can get busy and bottlenecked when another DMA stream is reading data from SDRAM/AXI_RAM over the D2-to-D1 AHB bus.

![Capture](https://user-images.githubusercontent.com/5694981/110156906-63f06080-7d9c-11eb-8ae8-87dcf15ed69a.PNG)

From this diagram above you can see that if any DMA master in the D2 domain wants to access SDRAM/AXI_RAM there's only one bus to the D1 domain to do so. This means that if the camera DMA needs to write to D1 domain and another DMA master is reading/writing SDRAM/AXI_RAM then the camera DMA has to wait. Note that there's no QoS for the AHB matrix in domain D2. So, there's no priority fix you can do here if multiple DMA masters need to use the same resource.

Because of the shallow depth of the camera DMA fifos you can't really delay that long without the loss of data. So, by moving the DMA buffer much closer to the DMA engine we remove it being blocked for a long time when trying to write data.

...

I tested the changes on the H7 Plus. Using the TV shield with the OV5640 with triple buffering used to crash. It does not anymore.

I tested the changes on the OpenMV Pure Thermal. Using the LCD Output, plus reading the FLIR, plus running the OV5640 used to crash. It does not anymore.

I tested the changes on the Portenta. It continues to work as normal.