### PR TITLE
Move DMA buffers around to fix bus contention and save RAM

### DIFF
--- a/src/omv/boards/BORMIO/omv_boardconfig.h
+++ b/src/omv/boards/BORMIO/omv_boardconfig.h
@@ -12,7 +12,7 @@
 #define __OMV_BOARDCONFIG_H__
 
 // Architecture info
-#define OMV_ARCH_STR            "BORMIO H7 8192 SDRAM" // 33 chars max
+#define OMV_ARCH_STR            "BORMIO H7 1024" // 33 chars max
 #define OMV_BOARD_TYPE          "BORMIO"
 #define OMV_UNIQUE_ID_ADDR      0x1FF1E800
 #define OMV_UNIQUE_ID_SIZE      3 // 3 words
@@ -130,7 +130,7 @@
 #define OMV_FFS_MEMORY          DTCM        // Flash filesystem cache memory
 #define OMV_MAIN_MEMORY         SRAM1       // data, bss and heap
 #define OMV_STACK_MEMORY        SRAM1       // stack memory
-#define OMV_DMA_MEMORY          AXI_SRAM    // DMA buffers memory.
+#define OMV_DMA_MEMORY          SRAM2       // DMA buffers memory.
 #define OMV_FB_MEMORY           AXI_SRAM    // Framebuffer, fb_alloc
 #define OMV_JPEG_MEMORY         SRAM3       // JPEG buffer memory buffer.
 #define OMV_VOSPI_MEMORY        SRAM4       // VoSPI buffer memory.
@@ -138,9 +138,9 @@
 #define OMV_CYW43_MEMORY_OFFSET (0x90F00000)// Last Mbyte.
 
 #define OMV_FB_SIZE             (400K)      // FB memory: header + VGA/GS image
-#define OMV_FB_ALLOC_SIZE       (96K)       // minimum fb alloc size
+#define OMV_FB_ALLOC_SIZE       (108K)      // minimum fb alloc size
 #define OMV_STACK_SIZE          (32K)
-#define OMV_HEAP_SIZE           (180K)
+#define OMV_HEAP_SIZE           (172K)
 
 #define OMV_LINE_BUF_SIZE       (3 * 1024)  // Image line buffer round(640 * 2BPP * 2 buffers).
 #define OMV_MSC_BUF_SIZE        (2K)        // USB MSC bot data
@@ -156,7 +156,9 @@
 #define OMV_ITCM_ORIGIN         0x00000000
 #define OMV_ITCM_LENGTH         64K
 #define OMV_SRAM1_ORIGIN        0x30000000
-#define OMV_SRAM1_LENGTH        256K
+#define OMV_SRAM1_LENGTH        248K
+#define OMV_SRAM2_ORIGIN        0x3003E000  // 8KB of SRAM1
+#define OMV_SRAM2_LENGTH        8K
 #define OMV_SRAM3_ORIGIN        0x30040000
 #define OMV_SRAM3_LENGTH        32K
 #define OMV_SRAM4_ORIGIN        0x38000000
@@ -168,13 +170,13 @@
 
 // Domain 1 DMA buffers region.
 #define OMV_DMA_MEMORY_D1       AXI_SRAM
-#define OMV_DMA_REGION_D1_BASE  (OMV_AXI_SRAM_ORIGIN+(496*1024))
-#define OMV_DMA_REGION_D1_SIZE  MPU_REGION_SIZE_16KB
+#define OMV_DMA_REGION_D1_BASE  (OMV_AXI_SRAM_ORIGIN+(508*1024))
+#define OMV_DMA_REGION_D1_SIZE  MPU_REGION_SIZE_4KB
 
 // Domain 2 DMA buffers region.
-//#define OMV_DMA_MEMORY_D2       SRAM3
-//#define OMV_DMA_REGION_D2_BASE  (OMV_SRAM3_ORIGIN+(0*1024))
-//#define OMV_DMA_REGION_D2_SIZE  MPU_REGION_SIZE_32KB
+#define OMV_DMA_MEMORY_D2       SRAM2
+#define OMV_DMA_REGION_D2_BASE  (OMV_SRAM2_ORIGIN+(0*1024))
+#define OMV_DMA_REGION_D2_SIZE  MPU_REGION_SIZE_8KB
 
 // Domain 3 DMA buffers region.
 //#define OMV_DMA_MEMORY_D3       SRAM4

--- a/src/omv/boards/OPENMV4/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4/omv_boardconfig.h
@@ -138,15 +138,15 @@
 #define OMV_FFS_MEMORY          DTCM        // Flash filesystem cache memory
 #define OMV_MAIN_MEMORY         SRAM1       // data, bss and heap memory
 #define OMV_STACK_MEMORY        ITCM        // stack memory
-#define OMV_DMA_MEMORY          AXI_SRAM    // DMA buffers memory.
+#define OMV_DMA_MEMORY          SRAM2       // DMA buffers memory.
 #define OMV_FB_MEMORY           AXI_SRAM    // Framebuffer, fb_alloc
 #define OMV_JPEG_MEMORY         SRAM3       // JPEG buffer memory.
 #define OMV_VOSPI_MEMORY        SRAM4       // VoSPI buffer memory.
 
 #define OMV_FB_SIZE             (400K)      // FB memory: header + VGA/GS image
-#define OMV_FB_ALLOC_SIZE       (96K)       // minimum fb alloc size
+#define OMV_FB_ALLOC_SIZE       (108K)      // minimum fb alloc size
 #define OMV_STACK_SIZE          (64K)
-#define OMV_HEAP_SIZE           (244K)
+#define OMV_HEAP_SIZE           (236K)
 
 #define OMV_LINE_BUF_SIZE       (3 * 1024)  // Image line buffer round(640 * 2BPP * 2 buffers).
 #define OMV_MSC_BUF_SIZE        (2K)        // USB MSC bot data
@@ -162,7 +162,9 @@
 #define OMV_ITCM_ORIGIN         0x00000000
 #define OMV_ITCM_LENGTH         64K
 #define OMV_SRAM1_ORIGIN        0x30000000
-#define OMV_SRAM1_LENGTH        256K
+#define OMV_SRAM1_LENGTH        248K
+#define OMV_SRAM2_ORIGIN        0x3003E000  // 8KB of SRAM1
+#define OMV_SRAM2_LENGTH        8K
 #define OMV_SRAM3_ORIGIN        0x30040000
 #define OMV_SRAM3_LENGTH        32K
 #define OMV_SRAM4_ORIGIN        0x38000000
@@ -172,13 +174,13 @@
 
 // Domain 1 DMA buffers region.
 #define OMV_DMA_MEMORY_D1       AXI_SRAM
-#define OMV_DMA_REGION_D1_BASE  (OMV_AXI_SRAM_ORIGIN+(496*1024))
-#define OMV_DMA_REGION_D1_SIZE  MPU_REGION_SIZE_16KB
+#define OMV_DMA_REGION_D1_BASE  (OMV_AXI_SRAM_ORIGIN+(508*1024))
+#define OMV_DMA_REGION_D1_SIZE  MPU_REGION_SIZE_4KB
 
 // Domain 2 DMA buffers region.
-//#define OMV_DMA_MEMORY_D2       SRAM3
-//#define OMV_DMA_REGION_D2_BASE  (OMV_SRAM3_ORIGIN+(0*1024))
-//#define OMV_DMA_REGION_D2_SIZE  MPU_REGION_SIZE_32KB
+#define OMV_DMA_MEMORY_D2       SRAM2
+#define OMV_DMA_REGION_D2_BASE  (OMV_SRAM2_ORIGIN+(0*1024))
+#define OMV_DMA_REGION_D2_SIZE  MPU_REGION_SIZE_8KB
 
 // Domain 3 DMA buffers region.
 //#define OMV_DMA_MEMORY_D3       SRAM4

--- a/src/omv/boards/OPENMV4P/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4P/omv_boardconfig.h
@@ -142,18 +142,18 @@
 #define OMV_FFS_MEMORY          DTCM        // Flash filesystem cache memory
 #define OMV_MAIN_MEMORY         SRAM1       // data, bss and heap
 #define OMV_STACK_MEMORY        ITCM        // stack memory
-#define OMV_DMA_MEMORY          AXI_SRAM    // Misc DMA buffers memory.
+#define OMV_DMA_MEMORY          SRAM3       // Misc DMA buffers memory.
 #define OMV_FB_MEMORY           DRAM        // Framebuffer, fb_alloc
 #define OMV_JPEG_MEMORY         DRAM        // JPEG buffer memory buffer.
 #define OMV_JPEG_MEMORY_OFFSET  (31M)       // JPEG buffer is placed after FB/fballoc memory.
 #define OMV_VOSPI_MEMORY        SRAM4       // VoSPI buffer memory.
 #define OMV_FB_OVERLAY_MEMORY   AXI_SRAM    // Fast fb_alloc memory.
-#define OMV_FB_OVERLAY_MEMORY_OFFSET    (496*1024) // Fast fb_alloc memory size.
+#define OMV_FB_OVERLAY_MEMORY_OFFSET    (508*1024) // Fast fb_alloc memory size.
 
 #define OMV_FB_SIZE             (20M)       // FB memory: header + VGA/GS image
 #define OMV_FB_ALLOC_SIZE       (11M)       // minimum fb alloc size
 #define OMV_STACK_SIZE          (64K)
-#define OMV_HEAP_SIZE           (244K)
+#define OMV_HEAP_SIZE           (256K)
 #define OMV_SDRAM_SIZE          (32 * 1024 * 1024) // This needs to be here for UVC firmware.
 
 #define OMV_LINE_BUF_SIZE       (11 * 1024) // Image line buffer round(2592 * 2BPP * 2 buffers).
@@ -170,9 +170,9 @@
 #define OMV_ITCM_ORIGIN         0x00000000
 #define OMV_ITCM_LENGTH         64K
 #define OMV_SRAM1_ORIGIN        0x30000000
-#define OMV_SRAM1_LENGTH        256K
-#define OMV_SRAM3_ORIGIN        0x30040000
-#define OMV_SRAM3_LENGTH        32K
+#define OMV_SRAM1_LENGTH        272K        // SRAM1 + SRAM2 + 1/2 SRAM3
+#define OMV_SRAM3_ORIGIN        0x30044000
+#define OMV_SRAM3_LENGTH        16K
 #define OMV_SRAM4_ORIGIN        0x38000000
 #define OMV_SRAM4_LENGTH        64K
 #define OMV_AXI_SRAM_ORIGIN     0x24000000
@@ -183,13 +183,13 @@
 
 // Domain 1 DMA buffers region.
 #define OMV_DMA_MEMORY_D1       AXI_SRAM
-#define OMV_DMA_REGION_D1_BASE  (OMV_AXI_SRAM_ORIGIN+(496*1024))
-#define OMV_DMA_REGION_D1_SIZE  MPU_REGION_SIZE_16KB
+#define OMV_DMA_REGION_D1_BASE  (OMV_AXI_SRAM_ORIGIN+OMV_FB_OVERLAY_MEMORY_OFFSET)
+#define OMV_DMA_REGION_D1_SIZE  MPU_REGION_SIZE_4KB
 
 // Domain 2 DMA buffers region.
 #define OMV_DMA_MEMORY_D2       SRAM3
 #define OMV_DMA_REGION_D2_BASE  (OMV_SRAM3_ORIGIN+(0*1024))
-#define OMV_DMA_REGION_D2_SIZE  MPU_REGION_SIZE_32KB
+#define OMV_DMA_REGION_D2_SIZE  MPU_REGION_SIZE_16KB
 
 // Domain 3 DMA buffers region.
 #define OMV_DMA_MEMORY_D3       SRAM4

--- a/src/omv/boards/OPENMVPT/omv_boardconfig.h
+++ b/src/omv/boards/OPENMVPT/omv_boardconfig.h
@@ -139,18 +139,18 @@
 #define OMV_FFS_MEMORY                  DTCM        // Flash filesystem cache memory
 #define OMV_MAIN_MEMORY                 SRAM1       // data, bss and heap
 #define OMV_STACK_MEMORY                ITCM        // stack memory
-#define OMV_DMA_MEMORY                  AXI_SRAM    // DMA buffers memory.
+#define OMV_DMA_MEMORY                  SRAM3       // DMA buffers memory.
 #define OMV_FB_MEMORY                   DRAM        // Framebuffer, fb_alloc
 #define OMV_JPEG_MEMORY                 DRAM        // JPEG buffer memory buffer.
 #define OMV_JPEG_MEMORY_OFFSET          (63M)       // JPEG buffer is placed after FB/fballoc memory.
 #define OMV_VOSPI_MEMORY                SRAM4       // VoSPI buffer memory.
 #define OMV_FB_OVERLAY_MEMORY           AXI_SRAM    // Fast fb_alloc memory.
-#define OMV_FB_OVERLAY_MEMORY_OFFSET    (496*1024)  // Fast fb_alloc memory size.
+#define OMV_FB_OVERLAY_MEMORY_OFFSET    (508*1024)  // Fast fb_alloc memory size.
 
 #define OMV_FB_SIZE                     (32M)       // FB memory: header + VGA/GS image
 #define OMV_FB_ALLOC_SIZE               (31M)       // minimum fb alloc size
 #define OMV_STACK_SIZE                  (64K)
-#define OMV_HEAP_SIZE                   (240K)
+#define OMV_HEAP_SIZE                   (256K)
 #define OMV_SDRAM_SIZE                  (64 * 1024 * 1024) // This needs to be here for UVC firmware.
 
 #define OMV_LINE_BUF_SIZE               (11 * 1024) // Image line buffer round(2592 * 2BPP * 2 buffers).
@@ -167,9 +167,9 @@
 #define OMV_ITCM_ORIGIN                 0x00000000
 #define OMV_ITCM_LENGTH                 64K
 #define OMV_SRAM1_ORIGIN                0x30000000
-#define OMV_SRAM1_LENGTH                256K
-#define OMV_SRAM3_ORIGIN                0x30040000
-#define OMV_SRAM3_LENGTH                32K
+#define OMV_SRAM1_LENGTH                272K        // SRAM1 + SRAM2 + 1/2 SRAM3
+#define OMV_SRAM3_ORIGIN                0x30044000
+#define OMV_SRAM3_LENGTH                16K
 #define OMV_SRAM4_ORIGIN                0x38000000
 #define OMV_SRAM4_LENGTH                64K
 #define OMV_AXI_SRAM_ORIGIN             0x24000000
@@ -180,13 +180,13 @@
 
 // Domain 1 DMA buffers region.
 #define OMV_DMA_MEMORY_D1       AXI_SRAM
-#define OMV_DMA_REGION_D1_BASE  (OMV_AXI_SRAM_ORIGIN+(496*1024))
-#define OMV_DMA_REGION_D1_SIZE  MPU_REGION_SIZE_16KB
+#define OMV_DMA_REGION_D1_BASE  (OMV_AXI_SRAM_ORIGIN+OMV_FB_OVERLAY_MEMORY_OFFSET)
+#define OMV_DMA_REGION_D1_SIZE  MPU_REGION_SIZE_4KB
 
 // Domain 2 DMA buffers region.
 #define OMV_DMA_MEMORY_D2       SRAM3
 #define OMV_DMA_REGION_D2_BASE  (OMV_SRAM3_ORIGIN+(0*1024))
-#define OMV_DMA_REGION_D2_SIZE  MPU_REGION_SIZE_32KB
+#define OMV_DMA_REGION_D2_SIZE  MPU_REGION_SIZE_16KB
 
 // Domain 3 DMA buffers region.
 #define OMV_DMA_MEMORY_D3       SRAM4

--- a/src/omv/boards/PORTENTA/omv_boardconfig.h
+++ b/src/omv/boards/PORTENTA/omv_boardconfig.h
@@ -140,7 +140,7 @@
 #define OMV_FFS_MEMORY          DTCM        // Flash filesystem cache memory
 #define OMV_MAIN_MEMORY         SRAM1       // data, bss and heap
 #define OMV_STACK_MEMORY        SRAM1       // stack memory
-#define OMV_DMA_MEMORY          AXI_SRAM    // DMA buffers memory.
+#define OMV_DMA_MEMORY          SRAM3       // DMA buffers memory.
 #define OMV_FB_MEMORY           DRAM        // Framebuffer, fb_alloc
 #define OMV_JPEG_MEMORY         DRAM        // JPEG buffer memory buffer.
 #define OMV_JPEG_MEMORY_OFFSET  (7M)        // JPEG buffer is placed after FB/fballoc memory.
@@ -183,7 +183,7 @@
 
 // Domain 1 DMA buffers region.
 #define OMV_DMA_MEMORY_D1       AXI_SRAM
-#define OMV_DMA_REGION_D1_BASE  (OMV_AXI_SRAM_ORIGIN+(480*1024))
+#define OMV_DMA_REGION_D1_BASE  (OMV_AXI_SRAM_ORIGIN+OMV_FB_OVERLAY_MEMORY_OFFSET)
 #define OMV_DMA_REGION_D1_SIZE  MPU_REGION_SIZE_32KB
 
 // Domain 2 DMA buffers region.


### PR DESCRIPTION
This PR moves all the DMA buffers for H7 based OpenMV Cam's to SRAM3. This must be done to get the camera DMA off the D2-to-D1 AHB bus which can get busy and bottlenecked when another DMA stream is reading data from SDRAM/AXI_RAM over the D2-to-D1 AHB bus.

![Capture](https://user-images.githubusercontent.com/5694981/110259045-7f08cf00-7f5a-11eb-99f5-ae0f75a3a607.PNG)

From this diagram above you can see that if any DMA master in the D2 domain wants to access SDRAM/AXI_RAM there's only one bus to the D1 domain to do so. This means that if the camera DMA needs to write to D1 domain and another DMA master is reading/writing SDRAM/AXI_RAM then the camera DMA has to wait. Note that there's no QoS for the AHB matrix in domain D2. So, there's no priority fix you can do here if multiple DMA masters need to use the same resource.

Because of the shallow depth of the camera DMA fifos you can't really delay that long without the loss of data. So, by moving the DMA buffer much closer to the DMA engine we remove it being blocked for a long time when trying to write data.

...

I tested the changes on the H7 Plus. Using the TV shield with the OV5640 with triple buffering used to crash. It does not anymore.

I tested the changes on the OpenMV Pure Thermal. Using the LCD Output, plus reading the FLIR, plus running the OV5640 used to crash. It does not anymore.

I tested the changes on the Portenta. It continues to work as normal. WIFI was tested and works.

I also tested on the H7 regular and that works fine too.

...

Future todos. The SD card DMA buffer is placed in D1. Both SDMMC masters can access it there. However, it should be split into 2 buffers in both DMA regions per SDMMC channel.

Additionally, other DMA masters should have their buffers placed in the right domains.