### PR TITLE
Add AXI QOS to make LCD output stable

### DIFF
--- a/src/omv/boards/OPENMVPT/omv_boardconfig.h
+++ b/src/omv/boards/OPENMVPT/omv_boardconfig.h
@@ -192,6 +192,9 @@
 #define OMV_DMA_REGION_D3_BASE  (OMV_SRAM4_ORIGIN+(0*1024))
 #define OMV_DMA_REGION_D3_SIZE  MPU_REGION_SIZE_64KB
 
+// AXI QoS - Low-High (0:15) - default 0
+#define OMV_AXI_QOS_LTDC_R_PRI  15 // Max pri to read out the frame buffer.
+
 // Image sensor I2C
 #define ISC_I2C                        (I2C1)
 #define ISC_I2C_ID                     (1)

--- a/src/omv/boards/PORTENTA/omv_boardconfig.h
+++ b/src/omv/boards/PORTENTA/omv_boardconfig.h
@@ -195,6 +195,9 @@
 #define OMV_DMA_REGION_D3_BASE  (OMV_SRAM4_ORIGIN+(0*1024))
 #define OMV_DMA_REGION_D3_SIZE  MPU_REGION_SIZE_64KB
 
+// AXI QoS - Low-High (0:15) - default 0
+#define OMV_AXI_QOS_LTDC_R_PRI  15 // Max pri to read out the frame buffer.
+
 // Image sensor I2C
 #define ISC_I2C                 (I2C3)
 #define ISC_I2C_ID              (3)

--- a/src/omv/ports/stm32/axiqos.h
+++ b/src/omv/ports/stm32/axiqos.h
@@ -1,0 +1,55 @@
+/*
+ * This file is part of the OpenMV project.
+ *
+ * Copyright (c) 2013-2021 Ibrahim Abdelkader <iabdalkader@openmv.io>
+ * Copyright (c) 2013-2021 Kwabena W. Agyeman <kwagyeman@openmv.io>
+ *
+ * This work is licensed under the MIT license, see the file LICENSE for details.
+ *
+ * AXI QoS Setup
+ */
+#ifndef __AXIQOS_H__
+#define __AXIQOS_H__
+
+#define OMV_AXI_GPV_BASE                0x51000000
+#define OMV_AXI_GPV_QOS_BASE            ((OMV_AXI_GPV_BASE) + 0x41100)
+#define OMV_AXI_GPV_QOS_R_BASE(x)       ((OMV_AXI_GPV_QOS_BASE) + (0x1000 * (x)) + 0x0)
+#define OMV_AXI_GPV_QOS_W_BASE(x)       ((OMV_AXI_GPV_QOS_BASE) + (0x1000 * (x)) + 0x4)
+
+#define OMV_AXI_QOS_D2_AHB_R_ADDRESS    OMV_AXI_GPV_QOS_R_BASE(1)
+#define OMV_AXI_QOS_D2_AHB_R_SET(x)     *((volatile uint32_t *) (OMV_AXI_QOS_D2_AHB_R_ADDRESS)) = (x)
+
+#define OMV_AXI_QOS_D2_AHB_W_ADDRESS    OMV_AXI_GPV_QOS_W_BASE(1)
+#define OMV_AXI_QOS_D2_AHB_W_SET(x)     *((volatile uint32_t *) (OMV_AXI_QOS_D2_AHB_W_ADDRESS)) = (x)
+
+#define OMV_AXI_QOS_C_M7_R_ADDRESS      OMV_AXI_GPV_QOS_R_BASE(2)
+#define OMV_AXI_QOS_C_M7_R_SET(x)       *((volatile uint32_t *) (OMV_AXI_QOS_C_M7_R_ADDRESS)) = (x)
+
+#define OMV_AXI_QOS_C_M7_W_ADDRESS      OMV_AXI_GPV_QOS_W_BASE(2)
+#define OMV_AXI_QOS_C_M7_W_SET(x)       *((volatile uint32_t *) (OMV_AXI_QOS_C_M7_W_ADDRESS)) = (x)
+
+#define OMV_AXI_QOS_SDMMC1_R_ADDRESS    OMV_AXI_GPV_QOS_R_BASE(3)
+#define OMV_AXI_QOS_SDMMC1_R_SET(x)     *((volatile uint32_t *) (OMV_AXI_QOS_SDMMC1_R_ADDRESS)) = (x)
+
+#define OMV_AXI_QOS_SDMMC1_W_ADDRESS    OMV_AXI_GPV_QOS_W_BASE(3)
+#define OMV_AXI_QOS_SDMMC1_W_SET(x)     *((volatile uint32_t *) (OMV_AXI_QOS_SDMMC1_W_ADDRESS)) = (x)
+
+#define OMV_AXI_QOS_MDMA_R_ADDRESS      OMV_AXI_GPV_QOS_R_BASE(4)
+#define OMV_AXI_QOS_MDMA_R_SET(x)       *((volatile uint32_t *) (OMV_AXI_QOS_MDMA_R_ADDRESS)) = (x)
+
+#define OMV_AXI_QOS_MDMA_W_ADDRESS      OMV_AXI_GPV_QOS_W_BASE(4)
+#define OMV_AXI_QOS_MDMA_W_SET(x)       *((volatile uint32_t *) (OMV_AXI_QOS_MDMA_W_ADDRESS)) = (x)
+
+#define OMV_AXI_QOS_DMA2D_R_ADDRESS     OMV_AXI_GPV_QOS_R_BASE(5)
+#define OMV_AXI_QOS_DMA2D_R_SET(x)      *((volatile uint32_t *) (OMV_AXI_QOS_DMA2D_R_ADDRESS)) = (x)
+
+#define OMV_AXI_QOS_DMA2D_W_ADDRESS     OMV_AXI_GPV_QOS_W_BASE(5)
+#define OMV_AXI_QOS_DMA2D_W_SET(x)      *((volatile uint32_t *) (OMV_AXI_QOS_DMA2D_W_ADDRESS)) = (x)
+
+#define OMV_AXI_QOS_LTDC_R_ADDRESS      OMV_AXI_GPV_QOS_R_BASE(6)
+#define OMV_AXI_QOS_LTDC_R_SET(x)      *((volatile uint32_t *) (OMV_AXI_QOS_LTDC_R_ADDRESS)) = (x)
+
+#define OMV_AXI_QOS_LTDC_W_ADDRESS      OMV_AXI_GPV_QOS_W_BASE(6)
+#define OMV_AXI_QOS_LTDC_W_SET(x)      *((volatile uint32_t *) (OMV_AXI_QOS_LTDC_W_ADDRESS)) = (x)
+
+#endif // __AXIQOS_H__

--- a/src/omv/ports/stm32/stm32fxxx_hal_msp.c
+++ b/src/omv/ports/stm32/stm32fxxx_hal_msp.c
@@ -9,6 +9,7 @@
  * HAL MSP.
  */
 #include STM32_HAL_H
+#include "axiqos.h"
 #include "omv_boardconfig.h"
 
 #include "irq.h"
@@ -147,6 +148,44 @@ void HAL_MspInit(void)
     __HAL_RCC_MDMA_CLK_ENABLE();
     NVIC_SetPriority(MDMA_IRQn, IRQ_PRI_MDMA);
     HAL_NVIC_EnableIRQ(MDMA_IRQn);
+    #endif
+
+    /* Setup AXI QoS */
+    #if defined(OMV_AXI_QOS_D2_AHB_R_PRI)
+    OMV_AXI_QOS_D2_AHB_R_SET(OMV_AXI_QOS_D2_AHB_R_PRI);
+    #endif
+    #if defined(OMV_AXI_QOS_D2_AHB_W_PRI)
+    OMV_AXI_QOS_D2_AHB_W_SET(OMV_AXI_QOS_D2_AHB_W_PRI);
+    #endif
+    #if defined(OMV_AXI_QOS_C_M7_R_PRI)
+    OMV_AXI_QOS_C_M7_R_SET(OMV_AXI_QOS_C_M7_R_PRI);
+    #endif
+    #if defined(OMV_AXI_QOS_C_M7_W_PRI)
+    OMV_AXI_QOS_C_M7_W_SET(OMV_AXI_QOS_C_M7_W_PRI);
+    #endif
+    #if defined(OMV_AXI_QOS_SDMMC1_R_PRI)
+    OMV_AXI_QOS_SDMMC1_R_SET(OMV_AXI_QOS_SDMMC1_R_PRI);
+    #endif
+    #if defined(OMV_AXI_QOS_SDMMC1_W_PRI)
+    OMV_AXI_QOS_SDMMC1_W_SET(OMV_AXI_QOS_SDMMC1_W_PRI);
+    #endif
+    #if defined(OMV_AXI_QOS_MDMA_R_PRI)
+    OMV_AXI_QOS_MDMA_R_SET(OMV_AXI_QOS_MDMA_R_PRI);
+    #endif
+    #if defined(OMV_AXI_QOS_MDMA_W_PRI)
+    OMV_AXI_QOS_MDMA_W_SET(OMV_AXI_QOS_MDMA_W_PRI);
+    #endif
+    #if defined(OMV_AXI_QOS_DMA2D_R_PRI)
+    OMV_AXI_QOS_DMA2D_R_SET(OMV_AXI_QOS_DMA2D_R_PRI);
+    #endif
+    #if defined(OMV_AXI_QOS_DMA2D_W_PRI)
+    OMV_AXI_QOS_DMA2D_W_SET(OMV_AXI_QOS_DMA2D_W_PRI);
+    #endif
+    #if defined(OMV_AXI_QOS_LTDC_R_PRI)
+    OMV_AXI_QOS_LTDC_R_SET(OMV_AXI_QOS_LTDC_R_PRI);
+    #endif
+    #if defined(OMV_AXI_QOS_LTDC_W_PRI)
+    OMV_AXI_QOS_LTDC_W_SET(OMV_AXI_QOS_LTDC_W_PRI);
     #endif
 
     #if defined(DCMI_RESET_PIN) || defined(DCMI_PWDN_PIN) || defined(DCMI_FSYNC_PIN)


### PR DESCRIPTION
This PR lets you set the AXI priority on the H7 per read/write channel.

For the OpenMV Pure Thermal and Portenta which have the ability to drive external displays this PR gives the LTDC the maximum priority ensuring that the display stays stable even when other masters are using it.

MDMA is give the next highest priority for future continuous camera image data capture reading from DMA2's line buffer and write back to the main frame buffer.

...

Note, while this PR helps with giving the LTDC controller better SDRAM bandwidth when other masters are using the bus it does not prevent other masters from switching SDRAM banks between LTDC access which lowers the SDRAM performance. So, you still can't actually display image data from the camera and have the processor manipulate it at 1080p@60Hz or UXGA@60Hz. However, SDRAM has enough bandwidth for everything at 1280x720@60Hz - this resolution looks crisp and clean.