### PR TITLE
Use DMA buffer for FIR Lepton

### DIFF
--- a/src/omv/boards/BORMIO/omv_boardconfig.h
+++ b/src/omv/boards/BORMIO/omv_boardconfig.h
@@ -144,6 +144,7 @@
 #define OMV_LINE_BUF_SIZE       (3 * 1024)  // Image line buffer round(640 * 2BPP * 2 buffers).
 #define OMV_MSC_BUF_SIZE        (2K)        // USB MSC bot data
 #define OMV_VFS_BUF_SIZE        (1K)        // VFS sturct + FATFS file buffer (624 bytes)
+#define OMV_FIR_LEPTON_BUF_SIZE (1K)        // FIR Lepton Packet Double Buffer (328 bytes)
 #define OMV_JPEG_BUF_SIZE       (32 * 1024) // IDE JPEG buffer (header + data).
 
 #define OMV_BOOT_ORIGIN         0x08000000

--- a/src/omv/boards/OPENMV2/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV2/omv_boardconfig.h
@@ -104,13 +104,14 @@
 #define OMV_DMA_MEMORY      SRAM2   // Misc DMA buffers
 
 #define OMV_FB_SIZE         (150K)  // FB memory: header + QVGA/GS image
-#define OMV_FB_ALLOC_SIZE   (13K)   // minimum fb alloc size
+#define OMV_FB_ALLOC_SIZE   (12K)   // minimum fb alloc size
 #define OMV_STACK_SIZE      (4K)
 #define OMV_HEAP_SIZE       (51K)
 
 #define OMV_LINE_BUF_SIZE   (2 * 1024)  // Image line buffer round(320 * 2BPP * 2 buffers).
 #define OMV_MSC_BUF_SIZE    (2K)    // USB MSC bot data
 #define OMV_VFS_BUF_SIZE    (1K)    // VFS sturct + FATFS file buffer (624 bytes)
+#define OMV_FIR_LEPTON_BUF_SIZE (1K) // FIR Lepton Packet Double Buffer (328 bytes)
 #define OMV_FFS_BUF_SIZE    (16K)   // Flash filesystem cache
 #define OMV_JPEG_BUF_SIZE   (8 * 1024)  // IDE JPEG buffer size (header + data).
 
@@ -121,9 +122,9 @@
 #define OMV_DTCM_ORIGIN     0x10000000
 #define OMV_DTCM_LENGTH     64K
 #define OMV_SRAM1_ORIGIN    0x20000000
-#define OMV_SRAM1_LENGTH    163K
-#define OMV_SRAM2_ORIGIN    0x20028C00
-#define OMV_SRAM2_LENGTH    29K
+#define OMV_SRAM1_LENGTH    162K
+#define OMV_SRAM2_ORIGIN    0x20028800
+#define OMV_SRAM2_LENGTH    30K
 
 // Image sensor I2C
 #define ISC_I2C                 (I2C1)

--- a/src/omv/boards/OPENMV3/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV3/omv_boardconfig.h
@@ -106,11 +106,12 @@
 #define OMV_FB_SIZE         (300K)  // FB memory: header + VGA/GS image
 #define OMV_FB_ALLOC_SIZE   (84K)   // minimum fb alloc size
 #define OMV_STACK_SIZE      (16K)
-#define OMV_HEAP_SIZE       (56K)
+#define OMV_HEAP_SIZE       (55K)
 
 #define OMV_LINE_BUF_SIZE   (3 * 1024)  // Image line buffer round(640 * 2BPP * 2 buffers).
 #define OMV_MSC_BUF_SIZE    (2K)    // USB MSC bot data
 #define OMV_VFS_BUF_SIZE    (1K)    // VFS sturct + FATFS file buffer (624 bytes)
+#define OMV_FIR_LEPTON_BUF_SIZE (1K) // FIR Lepton Packet Double Buffer (328 bytes)
 #define OMV_FFS_BUF_SIZE    (32K)   // Flash filesystem cache
 #define OMV_JPEG_BUF_SIZE   (22 * 1024) // IDE JPEG buffer (header + data).
 

--- a/src/omv/boards/OPENMV4/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4/omv_boardconfig.h
@@ -151,6 +151,7 @@
 #define OMV_LINE_BUF_SIZE       (3 * 1024)  // Image line buffer round(640 * 2BPP * 2 buffers).
 #define OMV_MSC_BUF_SIZE        (2K)        // USB MSC bot data
 #define OMV_VFS_BUF_SIZE        (1K)        // VFS sturct + FATFS file buffer (624 bytes)
+#define OMV_FIR_LEPTON_BUF_SIZE (1K)        // FIR Lepton Packet Double Buffer (328 bytes)
 #define OMV_JPEG_BUF_SIZE       (32 * 1024) // IDE JPEG buffer (header + data).
 
 #define OMV_BOOT_ORIGIN         0x08000000

--- a/src/omv/boards/OPENMV4P/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4P/omv_boardconfig.h
@@ -158,6 +158,7 @@
 #define OMV_LINE_BUF_SIZE       (11 * 1024) // Image line buffer round(2592 * 2BPP * 2 buffers).
 #define OMV_MSC_BUF_SIZE        (2K)        // USB MSC bot data
 #define OMV_VFS_BUF_SIZE        (1K)        // VFS sturct + FATFS file buffer (624 bytes)
+#define OMV_FIR_LEPTON_BUF_SIZE (1K)        // FIR Lepton Packet Double Buffer (328 bytes)
 #define OMV_JPEG_BUF_SIZE       (1024*1024) // IDE JPEG buffer (header + data).
 
 #define OMV_BOOT_ORIGIN         0x08000000

--- a/src/omv/boards/OPENMVPT/omv_boardconfig.h
+++ b/src/omv/boards/OPENMVPT/omv_boardconfig.h
@@ -155,6 +155,7 @@
 #define OMV_LINE_BUF_SIZE               (11 * 1024) // Image line buffer round(2592 * 2BPP * 2 buffers).
 #define OMV_MSC_BUF_SIZE                (2K)        // USB MSC bot data
 #define OMV_VFS_BUF_SIZE                (1K)        // VFS sturct + FATFS file buffer (624 bytes)
+#define OMV_FIR_LEPTON_BUF_SIZE         (1K)        // FIR Lepton Packet Double Buffer (328 bytes)
 #define OMV_JPEG_BUF_SIZE               (1024*1024) // IDE JPEG buffer (header + data).
 
 #define OMV_BOOT_ORIGIN                 0x08000000

--- a/src/omv/boards/PORTENTA/omv_boardconfig.h
+++ b/src/omv/boards/PORTENTA/omv_boardconfig.h
@@ -158,6 +158,7 @@
 #define OMV_LINE_BUF_SIZE       (11 * 1024) // Image line buffer round(2592 * 2BPP * 2 buffers).
 #define OMV_MSC_BUF_SIZE        (2K)        // USB MSC bot data
 #define OMV_VFS_BUF_SIZE        (1K)        // VFS sturct + FATFS file buffer (624 bytes)
+#define OMV_FIR_LEPTON_BUF_SIZE (1K)        // FIR Lepton Packet Double Buffer (328 bytes)
 #define OMV_JPEG_BUF_SIZE       (1024*1024) // IDE JPEG buffer (header + data).
 
 #define OMV_BOOT_ORIGIN         0x08000000

--- a/src/omv/ports/stm32/stm32fxxx.ld.S
+++ b/src/omv/ports/stm32/stm32fxxx.ld.S
@@ -145,6 +145,10 @@ SECTIONS
     _vfs_buf  = .;      // VFS sturct + FATFS file buffer  (around 624 bytes)
     . = . + OMV_VFS_BUF_SIZE;
 
+    . = ALIGN(16);
+    _fir_lepton_buf = .; // FIR Lepton Packet Double Buffer (328 bytes)
+    . = . + OMV_FIR_LEPTON_BUF_SIZE;
+
     #if !defined(OMV_FFS_MEMORY) && defined(OMV_FFS_BUF_SIZE)
     . = ALIGN(16);
     _ffs_cache = .;     // Flash filesystem cache

--- a/src/uvc/stm32fxxx.ld.S
+++ b/src/uvc/stm32fxxx.ld.S
@@ -126,6 +126,10 @@ SECTIONS
     _vfs_buf  = .;      // VFS sturct + FATFS file buffer  (around 624 bytes)
     . = . + OMV_VFS_BUF_SIZE;
 
+    . = ALIGN(16);
+    _fir_lepton_buf = .; // FIR Lepton Packet Double Buffer (328 bytes)
+    . = . + OMV_FIR_LEPTON_BUF_SIZE;
+
     #if !defined(OMV_FFS_MEMORY) && defined(OMV_FFS_BUF_SIZE)
     . = ALIGN(16);
     _ffs_cache = .;     // Flash filesystem cache


### PR DESCRIPTION
Moves the FIR Lepton DMA buffer from fb_alloc to the DMA buffer area.

...

On the STM32H7 this moves the DMA buffer into region D2 getting bus traffic off of the D2->D1 AHB bus.

...

We should change the DMA buffer defines to the necessary byte size. It will save RAM. Right now they are bigger than needed.