### PR TITLE
Filled out PWM TIMER init for FLIR/LCD

### DIFF
--- a/src/omv/ports/stm32/modules/py_fir_lepton.c
+++ b/src/omv/ports/stm32/modules/py_fir_lepton.c
@@ -320,17 +320,21 @@ int fir_lepton_init(cambus_t *bus, int *w, int *h, int *refresh, int *resolution
     HAL_GPIO_Init(OMV_FIR_LEPTON_MCLK_PORT, &GPIO_InitStructure);
 
     fir_lepton_mclk_tim_handle.Instance = OMV_FIR_LEPTON_MCLK_TIM;
-    fir_lepton_mclk_tim_handle.Init.Period = period;
-    fir_lepton_mclk_tim_handle.Init.Prescaler = TIM_ETRPRESCALER_DIV1;
+    fir_lepton_mclk_tim_handle.Init.Prescaler = 0;
     fir_lepton_mclk_tim_handle.Init.CounterMode = TIM_COUNTERMODE_UP;
+    fir_lepton_mclk_tim_handle.Init.Period = period;
     fir_lepton_mclk_tim_handle.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+    fir_lepton_mclk_tim_handle.Init.RepetitionCounter = 0;
+    fir_lepton_mclk_tim_handle.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
 
     TIM_OC_InitTypeDef fir_lepton_mclk_tim_oc_handle;
     fir_lepton_mclk_tim_oc_handle.Pulse = period / 2;
     fir_lepton_mclk_tim_oc_handle.OCMode = TIM_OCMODE_PWM1;
     fir_lepton_mclk_tim_oc_handle.OCPolarity = TIM_OCPOLARITY_HIGH;
+    fir_lepton_mclk_tim_oc_handle.OCNPolarity = TIM_OCNPOLARITY_HIGH;
     fir_lepton_mclk_tim_oc_handle.OCFastMode = TIM_OCFAST_DISABLE;
     fir_lepton_mclk_tim_oc_handle.OCIdleState = TIM_OCIDLESTATE_RESET;
+    fir_lepton_mclk_tim_oc_handle.OCNIdleState = TIM_OCNIDLESTATE_RESET;
 
     OMV_FIR_LEPTON_MCLK_TIM_CLK_ENABLE();
     HAL_TIM_PWM_Init(&fir_lepton_mclk_tim_handle);

--- a/src/omv/ports/stm32/modules/py_lcd.c
+++ b/src/omv/ports/stm32/modules/py_lcd.c
@@ -1095,17 +1095,21 @@ static void ltdc_set_backlight(int intensity)
         HAL_GPIO_Init(OMV_LCD_BL_PORT, &GPIO_InitStructure);
 
         lcd_tim_handle.Instance = OMV_LCD_BL_TIM;
-        lcd_tim_handle.Init.Period = period;
-        lcd_tim_handle.Init.Prescaler = TIM_ETRPRESCALER_DIV1;
+        lcd_tim_handle.Init.Prescaler = 0;
         lcd_tim_handle.Init.CounterMode = TIM_COUNTERMODE_UP;
+        lcd_tim_handle.Init.Period = period;
         lcd_tim_handle.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+        lcd_tim_handle.Init.RepetitionCounter = 0;
+        lcd_tim_handle.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
 
         TIM_OC_InitTypeDef lcd_tim_oc_handle;
         lcd_tim_oc_handle.Pulse = (period * intensity) / 255;
         lcd_tim_oc_handle.OCMode = TIM_OCMODE_PWM1;
         lcd_tim_oc_handle.OCPolarity = TIM_OCPOLARITY_HIGH;
+        lcd_tim_oc_handle.OCNPolarity = TIM_OCNPOLARITY_HIGH;
         lcd_tim_oc_handle.OCFastMode = TIM_OCFAST_DISABLE;
         lcd_tim_oc_handle.OCIdleState = TIM_OCIDLESTATE_RESET;
+        lcd_tim_oc_handle.OCNIdleState = TIM_OCNIDLESTATE_RESET;
 
         HAL_TIM_PWM_Init(&lcd_tim_handle);
         HAL_TIM_PWM_ConfigChannel(&lcd_tim_handle, &lcd_tim_oc_handle, OMV_LCD_BL_TIM_CHANNEL);


### PR DESCRIPTION
TIM_ETRPRESCALER_DIV1 is not a valid prescaler value. It happens to be 0 which is what we want but it's not the right define.

Also, filled in other fields with defaults.