### PR TITLE
Move software jpeg encoder front end to new SIMD MCU code

### DIFF
--- a/src/hal/cmsis/include/cmsis_gcc.h
+++ b/src/hal/cmsis/include/cmsis_gcc.h
@@ -2174,9 +2174,25 @@ __STATIC_FORCEINLINE int32_t __SMMLA (int32_t op1, int32_t op2, int32_t op3)
  return(result);
 }
 
+#else
+
+__STATIC_FORCEINLINE uint32_t __UXTB(uint32_t op1)
+{
+  return op1 & 0xFF;
+}
+
+__STATIC_FORCEINLINE uint32_t __UXTB_RORn(uint32_t op1, uint32_t rotate)
+{
+  return (op1 >> rotate) & 0xFF;
+}
+
+__STATIC_FORCEINLINE uint32_t __SSUB16(uint32_t op1, uint32_t op2)
+{
+  return ((op1 & 0xFFFF0000) - (op2 & 0xFFFF0000)) | ((op1 - op2) & 0xFFFF);
+}
+
 #endif /* (__ARM_FEATURE_DSP == 1) */
 /*@} end of group CMSIS_SIMD_intrinsics */
-
 
 #pragma GCC diagnostic pop
 


### PR DESCRIPTION
This PR updates the JPEG code to use the new and tested get MCU front end developed for the H7 hardware JPEG compressor. The code is now shared between both software and hardware JPEG.

To ensure speed... I have ifdefs that switch things around in the output generated depending on if we are in software versus hardware mode.

I have tested this code on the H7/H7P/M7/M4.

I tested the hardware code for BINARY/GRAYSCALE/RGB565/BAYER.

I tested the software code for BINRARY/GRAYSCALE/RGB565/BAYER with 1x1, 2x1, and 2x2 sampling for each.

To support the NANO33 (Cortex-M3) I also added in intrinsics for non-m4/m7 processors. The code was tested and continued to work when using these. 

Additionally, I spent time trying to optimize the DCT methods in the software JPEG code. However, this did not yield any good results. It's not possible to improve the speed of the column-wise DCT with cortex-simd instructions. I could only get the inner loop down to 51 instructions from 59. As for the row wise DCT I was able to get that down to 40 instructions from 59. However, neither of these will produce much speedup. For example, debayering is noticeably faster because I reduced the instruction count to like 24 from 50.

I also tried to optimize the software UV 2x1/2x2 averaging. However, the cortex-m4/m7 SIMD instruction set can't help easily in this case given the layout of MCUs in RAM. The U/V MCUs would need to be interleaved to enable the use the __SHADD8() instruction. __USAD8 is not usable given the absolute value op it does.