### PR TITLE
Double buffer mode working for all imaging modes

### DIFF
--- a/src/omv/alloc/fb_alloc.c
+++ b/src/omv/alloc/fb_alloc.c
@@ -36,11 +36,6 @@ static char *pointer_overlay = &_fballoc_overlay_end;
 // Use fb_alloc_free_till_mark_permanent() instead.
 #define FB_PERMANENT_FLAG 0x2
 
-static char *fb_alloc_min_address()
-{
-    return (char *) (framebuffer_get_buffer() + framebuffer_get_frame_size());
-}
-
 char *fb_alloc_stack_pointer()
 {
     return pointer;
@@ -63,7 +58,7 @@ void fb_alloc_init0()
 
 uint32_t fb_avail()
 {
-    uint32_t temp = pointer - fb_alloc_min_address() - sizeof(uint32_t);
+    uint32_t temp = pointer - framebuffer_get_buffers_end() - sizeof(uint32_t);
     return (temp < sizeof(uint32_t)) ? 0 : temp;
 }
 
@@ -72,7 +67,7 @@ void fb_alloc_mark()
     char *new_pointer = pointer - sizeof(uint32_t);
 
     // Check if allocation overwrites the framebuffer pixels
-    if (new_pointer < fb_alloc_min_address()) {
+    if (new_pointer < framebuffer_get_buffers_end()) {
         nlr_raise_for_fb_alloc_mark(mp_obj_new_exception_msg(&mp_type_MemoryError,
             MP_ERROR_TEXT("Out of fast Frame Buffer Stack Memory!"
             " Please reduce the resolution of the image you are running this algorithm on to bypass this issue!")));
@@ -149,7 +144,7 @@ void *fb_alloc(uint32_t size, int hints)
     char *new_pointer = result - sizeof(uint32_t);
 
     // Check if allocation overwrites the framebuffer pixels
-    if (new_pointer < fb_alloc_min_address()) {
+    if (new_pointer < framebuffer_get_buffers_end()) {
         fb_alloc_fail();
     }
 
@@ -195,7 +190,7 @@ void *fb_alloc0(uint32_t size, int hints)
 
 void *fb_alloc_all(uint32_t *size, int hints)
 {
-    uint32_t temp = pointer - fb_alloc_min_address() - sizeof(uint32_t);
+    uint32_t temp = pointer - framebuffer_get_buffers_end() - sizeof(uint32_t);
 
     if (temp < sizeof(uint32_t)) {
         *size = 0;

--- a/src/omv/common/sensor.h
+++ b/src/omv/common/sensor.h
@@ -11,6 +11,7 @@
 #ifndef __SENSOR_H__
 #define __SENSOR_H__
 #include <stdarg.h>
+#include "cambus.h"
 #include "imlib.h"
 
 #define OV2640_SLV_ADDR     (0x60)
@@ -309,6 +310,9 @@ int sensor_set_auto_rotation(bool enable);
 // Get transpose mode state.
 bool sensor_get_auto_rotation();
 
+// Set the number of virtual frame buffers.
+int sensor_set_framebuffers(int count);
+
 // Set special digital effects (SDE).
 int sensor_set_special_effect(sde_t sde);
 
@@ -329,4 +333,5 @@ const uint16_t *sensor_get_color_palette();
 
 // Default snapshot function.
 int sensor_snapshot(sensor_t *sensor, image_t *image, uint32_t flags);
+
 #endif /* __SENSOR_H__ */

--- a/src/omv/imlib/framebuffer.h
+++ b/src/omv/imlib/framebuffer.h
@@ -15,17 +15,45 @@
 #include "mutex.h"
 #include "common.h"
 
+// DMA Buffers need to be aligned by cache lines or 16 bytes.
+#ifndef __DCACHE_PRESENT
+#define FRAMEBUFFER_ALIGNMENT 16
+#else
+#define FRAMEBUFFER_ALIGNMENT __SCB_DCACHE_LINE_SIZE
+#endif
+
 typedef struct framebuffer {
     int32_t x,y;
     int32_t w,h;
     int32_t u,v;
     int32_t bpp;
     int32_t streaming_enabled;
-    // NOTE: This buffer must be aligned on a 32 byte boundary
-    OMV_ATTR_ALIGNED(uint8_t pixels[], 32);
+    uint32_t raw_buffer_size;
+    int32_t n_buffers;
+    int32_t head;
+    volatile int32_t tail;
+    bool check_head;
+    int32_t sampled_head;
+    OMV_ATTR_ALIGNED(uint8_t data[], FRAMEBUFFER_ALIGNMENT);
 } framebuffer_t;
 
 extern framebuffer_t *framebuffer;
+
+typedef enum {
+    FB_NO_FLAGS =   (0 << 0),
+    FB_PEEK     =   (1 << 0),   // If set, will not move the head/tail.
+} framebuffer_flags_t;
+
+typedef struct vbuffer {
+    // Used by snapshot code to figure out the jpeg size (bpp).
+    int32_t offset;
+    bool jpeg_buffer_overflow;
+    // Used internally by frame buffer code.
+    volatile bool waiting_for_data;
+    bool reset_state;
+    // Image data array.
+    OMV_ATTR_ALIGNED(uint8_t data[], FRAMEBUFFER_ALIGNMENT);
+} vbuffer_t;
 
 typedef struct jpegbuffer {
     int32_t w,h;
@@ -33,8 +61,7 @@ typedef struct jpegbuffer {
     int32_t enabled;
     int32_t quality;
     mutex_t lock;
-    // NOTE: This buffer must be aligned on a 32 byte boundary
-    OMV_ATTR_ALIGNED(uint8_t pixels[], 32);
+    OMV_ATTR_ALIGNED(uint8_t pixels[], FRAMEBUFFER_ALIGNMENT);
 } jpegbuffer_t;
 
 extern jpegbuffer_t *jpeg_framebuffer;
@@ -58,16 +85,11 @@ int32_t framebuffer_get_width();
 int32_t framebuffer_get_height();
 int32_t framebuffer_get_depth();
 
-// Return the size of the current frame (w * h * bpp) if the framebuffer is initialized,
-// otherwise return 0 if the framebuffer is unintialized or invalid (e.g. first frame).
-uint32_t framebuffer_get_frame_size();
-
-// Return the max frame size that fits the framebuffer
-// (i.e OMV_RAW_BUF_SIZE - sizeof(framebuffer_t))
+// Return the number of bytes in the current buffer.
 uint32_t framebuffer_get_buffer_size();
 
-// Return the current buffer address.
-uint8_t *framebuffer_get_buffer();
+// Return the state of a buffer.
+vbuffer_t *framebuffer_get_buffer(int32_t index);
 
 // Initializes an image_t struct with the frame buffer.
 void framebuffer_initialize_image(image_t *img);
@@ -78,6 +100,33 @@ void framebuffer_update_jpeg_buffer();
 
 // Set the framebuffer w, h and bpp.
 void framebuffer_set(int32_t w, int32_t h, int32_t bpp);
+
+// Clears out all old captures frames in the framebuffer.
+void framebuffer_flush_buffers();
+
+// Resets all buffers (for use after aborting)
+void framebuffer_reset_buffers();
+
+// Controls the number of virtual buffers in the frame buffer.
+int framebuffer_set_buffers(int32_t n_buffers);
+
+// Automatically finds the best buffering size given RAM.
+void framebuffer_auto_adjust_buffers();
+
+// Call when done with the current vbuffer to mark it as free.
+void framebuffer_free_current_buffer();
+
+// Sets the current frame buffer to the latest virtual frame buffer.
+// Returns the buffer if it is ready or NULL if not...
+// Pass FB_PEEK to get the next buffer but not take it.
+vbuffer_t *framebuffer_get_head(framebuffer_flags_t flags);
+
+// Return the next vbuffer to store image data to or NULL if none.
+// Pass FB_PEEK to get the next buffer but not commit it.
+vbuffer_t *framebuffer_get_tail(framebuffer_flags_t flags);
+
+// Returns a pointer to the end of the framebuffer(s).
+char *framebuffer_get_buffers_end();
 
 // Use these macros to get a pointer to main or JPEG framebuffer.
 #define MAIN_FB()           (framebuffer)

--- a/src/omv/modules/py_helper.c
+++ b/src/omv/modules/py_helper.c
@@ -11,6 +11,7 @@
 #include "py/obj.h"
 #include "py/runtime.h"
 #include "framebuffer.h"
+#include "sensor.h"
 #include "py_helper.h"
 #include "py_assert.h"
 
@@ -483,7 +484,7 @@ const uint8_t *py_helper_keyword_alpha_palette(uint n_args, const mp_obj_t *args
 
 bool py_helper_is_equal_to_framebuffer(image_t *img)
 {
-    return framebuffer_get_buffer() == img->data;
+    return framebuffer_get_buffer(framebuffer->head)->data == img->data;
 }
 
 void py_helper_update_framebuffer(image_t *img)
@@ -495,8 +496,14 @@ void py_helper_update_framebuffer(image_t *img)
 
 void py_helper_set_to_framebuffer(image_t *img)
 {
+    #if MICROPY_PY_SENSOR
+    sensor_set_framebuffers(1);
+    #else
+    framebuffer_set_buffers(1);
+    #endif
+
     PY_ASSERT_TRUE_MSG((image_size(img) <= framebuffer_get_buffer_size()),
             "The image doesn't fit in the frame buffer!");
     framebuffer_set(img->w, img->h, img->bpp);
-    img->data = framebuffer_get_buffer();
+    img->data = framebuffer_get_buffer(framebuffer->head)->data;
 }

--- a/src/omv/modules/py_sensor.c
+++ b/src/omv/modules/py_sensor.c
@@ -179,6 +179,11 @@ static mp_obj_t py_sensor_get_id()
     return mp_obj_new_int(sensor_get_id());
 }
 
+static mp_obj_t py_sensor_get_frame_available()
+{
+    return mp_obj_new_bool(framebuffer->tail != framebuffer->head);
+}
+
 static mp_obj_t py_sensor_alloc_extra_fb(mp_obj_t w_obj, mp_obj_t h_obj, mp_obj_t type_obj)
 {
     int w = mp_obj_get_int(w_obj);
@@ -516,6 +521,26 @@ static mp_obj_t py_sensor_set_auto_rotation(mp_obj_t enable)
 static mp_obj_t py_sensor_get_auto_rotation()
 {
     return mp_obj_new_bool(sensor_get_auto_rotation());
+}
+
+static mp_obj_t py_sensor_set_framebuffers(mp_obj_t count)
+{
+    mp_int_t c = mp_obj_get_int(count);
+
+    if (framebuffer->n_buffers == c) {
+        return mp_const_none;
+    }
+
+    if ((c < 1) || (sensor_set_framebuffers(c) != 0)) {
+        mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("Invalid framebuffer count!"));
+    }
+
+    return mp_const_none;
+}
+
+static mp_obj_t py_sensor_get_framebuffers()
+{
+    return mp_obj_new_int(framebuffer->n_buffers);
 }
 
 static mp_obj_t py_sensor_set_special_effect(mp_obj_t sde)
@@ -881,6 +906,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_sensor_width_obj,               py_sensor_wi
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_sensor_height_obj,              py_sensor_height);
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_sensor_get_fb_obj,              py_sensor_get_fb);
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_sensor_get_id_obj,              py_sensor_get_id);
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_sensor_get_frame_available_obj, py_sensor_get_frame_available);
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(py_sensor_alloc_extra_fb_obj,      py_sensor_alloc_extra_fb);
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_sensor_dealloc_extra_fb_obj,    py_sensor_dealloc_extra_fb);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_sensor_set_pixformat_obj,       py_sensor_set_pixformat);
@@ -911,6 +937,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_sensor_set_transpose_obj,       py_sensor_se
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_sensor_get_transpose_obj,       py_sensor_get_transpose);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_sensor_set_auto_rotation_obj,   py_sensor_set_auto_rotation);
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_sensor_get_auto_rotation_obj,   py_sensor_get_auto_rotation);
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_sensor_set_framebuffers_obj,    py_sensor_set_framebuffers);
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_sensor_get_framebuffers_obj,    py_sensor_get_framebuffers);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_sensor_set_special_effect_obj,  py_sensor_set_special_effect);
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(py_sensor_set_lens_correction_obj, py_sensor_set_lens_correction);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_sensor_set_vsync_callback_obj,  py_sensor_set_vsync_callback);
@@ -1017,6 +1045,13 @@ STATIC const mp_map_elem_t globals_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_IOCTL_HIMAX_MD_CLEAR),                MP_OBJ_NEW_SMALL_INT(IOCTL_HIMAX_MD_CLEAR)},
     { MP_OBJ_NEW_QSTR(MP_QSTR_IOCTL_HIMAX_OSC_ENABLE),              MP_OBJ_NEW_SMALL_INT(IOCTL_HIMAX_OSC_ENABLE)},
     #endif
+
+    // Framebuffer Sizes
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SINGLE_BUFFER),                       MP_OBJ_NEW_SMALL_INT(1)},
+    { MP_OBJ_NEW_QSTR(MP_QSTR_DOUBLE_BUFFER),                       MP_OBJ_NEW_SMALL_INT(2)},
+    { MP_OBJ_NEW_QSTR(MP_QSTR_TRIPPLE_BUFFER),                      MP_OBJ_NEW_SMALL_INT(3)},
+    { MP_OBJ_NEW_QSTR(MP_QSTR_VIDEO_FIFO),                          MP_OBJ_NEW_SMALL_INT(4)},
+
     // Sensor functions
     { MP_OBJ_NEW_QSTR(MP_QSTR___init__),            (mp_obj_t)&py_sensor__init__obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_reset),               (mp_obj_t)&py_sensor_reset_obj },
@@ -1029,6 +1064,7 @@ STATIC const mp_map_elem_t globals_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_height),              (mp_obj_t)&py_sensor_height_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_get_fb),              (mp_obj_t)&py_sensor_get_fb_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_get_id),              (mp_obj_t)&py_sensor_get_id_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_get_frame_available), (mp_obj_t)&py_sensor_get_frame_available_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_alloc_extra_fb),      (mp_obj_t)&py_sensor_alloc_extra_fb_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_dealloc_extra_fb),    (mp_obj_t)&py_sensor_dealloc_extra_fb_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_set_pixformat),       (mp_obj_t)&py_sensor_set_pixformat_obj },
@@ -1059,6 +1095,8 @@ STATIC const mp_map_elem_t globals_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_get_transpose),       (mp_obj_t)&py_sensor_get_transpose_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_set_auto_rotation),   (mp_obj_t)&py_sensor_set_auto_rotation_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_get_auto_rotation),   (mp_obj_t)&py_sensor_get_auto_rotation_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_set_framebuffers),    (mp_obj_t)&py_sensor_set_framebuffers_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_get_framebuffers),    (mp_obj_t)&py_sensor_get_framebuffers_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_set_special_effect),  (mp_obj_t)&py_sensor_set_special_effect_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_set_lens_correction), (mp_obj_t)&py_sensor_set_lens_correction_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_set_vsync_callback),  (mp_obj_t)&py_sensor_set_vsync_callback_obj },
@@ -1075,4 +1113,5 @@ const mp_obj_module_t sensor_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_t)&globals_dict,
 };
-#endif  //MICROPY_PY_SENSOR
+
+#endif // MICROPY_PY_SENSOR

--- a/src/omv/ports/nrf/main.c
+++ b/src/omv/ports/nrf/main.c
@@ -153,8 +153,8 @@ soft_reset:
     uart_init0();
     #endif
 
-    framebuffer_init0();
     fb_alloc_init0();
+    framebuffer_init0();
 
     #if MICROPY_PY_SENSOR
     sensor_init();
@@ -166,7 +166,7 @@ soft_reset:
             MP_OBJ_NEW_SMALL_INT(0),
             MP_OBJ_NEW_SMALL_INT(115200),
         };
-        MP_STATE_PORT(board_stdio_uart) = 
+        MP_STATE_PORT(board_stdio_uart) =
             machine_hard_uart_type.make_new((mp_obj_t)&machine_hard_uart_type, MP_ARRAY_SIZE(args), 0, args);
     }
     #endif

--- a/src/omv/ports/stm32/main.c
+++ b/src/omv/ports/stm32/main.c
@@ -517,8 +517,8 @@ soft_reset:
     i2c_init0();
     spi_init0();
     uart_init0();
-    framebuffer_init0();
     fb_alloc_init0();
+    framebuffer_init0();
     sensor_init0();
     dma_alloc_init0();
     #ifdef IMLIB_ENABLE_IMAGE_FILE_IO

--- a/src/uvc/src/main.c
+++ b/src/uvc/src/main.c
@@ -179,15 +179,15 @@ int main()
     }
     #endif
 
-    sensor_init0();
-    framebuffer_init0();
     fb_alloc_init0();
+    framebuffer_init0();
+    sensor_init0();
 
     // Initialize the sensor
     if (sensor_init() != 0) {
         __fatal_error();
     }
-    
+
     sensor_reset();
 
     /* Init Device Library */


### PR DESCRIPTION
Adds support for allocating multiple frame buffers in the sensor driver to increase performance. To avoid changing all our scripts the firmware automatically chooses the highest performance buffering size given set_framesize() that fits in RAM that uses less than 1/2 of the framebuffer+fb_alloc space.

Users may increase or decrease the automatically allocated buffer count to suit their application. But, for most users they should automatically see a massive performance boost. 

Finally, if a user wants to record video they can do sensor.set_framebuffers(sensor.VIDEO_FIFO + N) where N is the number of extra frame buffers to allocate.

On the H7 Plus you can set this to 100 with QVGA easily and if you add a pyb.delay(100) to the main script you get cool slow mo effects.

Note: To avoid stale frames filling up the image fifos the queue is cleared when main thread cannot keep up. This keeps snapshot() from returning may milliseconds old frames.

...

Tested by:

GRAYSCALE - OV2640/OV5640/OV7725/MT9V034/HM01B0/LEPTON
RGB565 - OV2640/OV5640/OV7725/LEPTON
BAYER - OV2640/OV5640/OV7725/LEPTON
JPEG  - OV2640/OV5640

On the OpenMV Cam M4, M7, H7 (all sensors supported), H7 Plus (all sensors supported), and Arduino Portenta. Non-transposed and transposed was tested for all supported modes.

Frame buffer sizes of 1, 2, 3, 4, and 5 were tried for all cameras and for each mode. Finally, random delays in calling snapshot were simulated by adding pyb.delay(100) in the main loop to cause frame drops.

...

The code is robust and works. I tested it for hours on all our hardware. I feel good about it. However, because the DCMI_DMA interrupt has a higher priority than the USB interrupt when you enable anything other than single buffering on cameras you will notice the IDE display get choppy.

With the H7/H7+/Portenta once MDMA is added this will no longer be an issue. However, on the M4/M7... there's no hardware offload for the CPU when copying pixels.

Not sure what the solution if any there is for these boards. USB would need to be a higher priority than DCMI_DMA. Not sure if this is doable.

...

Slow MO Fun Stuff (on the OpenMV Cam H7 Plus with the OV7725):

```
import sensor, image, time, pyb

sensor.reset()
sensor.set_pixformat(sensor.GRAYSCALE)
sensor.set_framesize(sensor.QVGA)
sensor.set_framebuffers(200) // 30,720,000 B
print(sensor.get_framebuffers())
sensor.skip_frames(time = 2000)

clock = time.clock()

while(True):
    clock.tick()
    img = sensor.snapshot()
    pyb.delay(30)
    print(clock.fps())
```

You will see jumps with the code when the frame buffer fills up. This is on purpose to keep frames from getting too old.