### PR TITLE
Create LED objects only once

### DIFF
--- a/scripts/examples/Arduino/Nano-33-BLE-Sense/00-Board/blinky.py
+++ b/scripts/examples/Arduino/Nano-33-BLE-Sense/00-Board/blinky.py
@@ -2,17 +2,28 @@
 
 import time
 from board import LED
-LED_RED=1
-LED_GREEN=2
-LED_BLUE=3
-LED_YELLOW=4
+
+led_red = LED(1)
+led_green = LED(2)
+led_blue = LED(3)
+led_yellow = LED(4)
 
 while (True):
-    LED(LED_BLUE).on()
-    time.sleep_ms(150)
-    LED(LED_BLUE).off()
-    time.sleep_ms(100)
-    LED(LED_BLUE).on()
-    time.sleep_ms(150)
-    LED(LED_BLUE).off()
-    time.sleep_ms(600)
+    led_blue.on()
+    time.sleep_ms(250)
+    led_blue.off()
+
+    led_red.on()
+    time.sleep_ms(250)
+    led_red.off()
+
+    led_green.on()
+    time.sleep_ms(250)
+    led_green.off()
+
+    led_yellow.on()
+    time.sleep_ms(250)
+    led_yellow.off()
+
+    time.sleep_ms(500)
+    


### PR DESCRIPTION
This PR changes the Nano 33 BLE blink example so that it creates the LED objects only once.