### PR TITLE
Make FLIR Lepton init reliably on Pure Thermal

### DIFF
--- a/src/omv/ports/stm32/modules/py_fir_lepton.c
+++ b/src/omv/ports/stm32/modules/py_fir_lepton.c
@@ -272,7 +272,7 @@ int fir_lepton_init(cambus_t *bus, int *w, int *h, int *refresh, int *resolution
     // Do not put in HAL_SPI_MspInit as other modules share the SPI2/3 bus.
 
     GPIO_InitTypeDef GPIO_InitStructure;
-    GPIO_InitStructure.Pull      = GPIO_NOPULL;
+    GPIO_InitStructure.Pull      = GPIO_PULLUP;
     GPIO_InitStructure.Mode      = GPIO_MODE_AF_PP;
     GPIO_InitStructure.Speed     = GPIO_SPEED_FREQ_MEDIUM;
 
@@ -312,7 +312,7 @@ int fir_lepton_init(cambus_t *bus, int *w, int *h, int *refresh, int *resolution
     int period = (tclk / OMV_FIR_LEPTON_MCLK_FREQ) - 1;
 
     // GPIO_InitTypeDef GPIO_InitStructure;
-    GPIO_InitStructure.Pull = GPIO_NOPULL;
+    GPIO_InitStructure.Pull = GPIO_PULLUP;
     GPIO_InitStructure.Mode = GPIO_MODE_AF_PP;
     GPIO_InitStructure.Speed = GPIO_SPEED_FREQ_MEDIUM;
     GPIO_InitStructure.Alternate = OMV_FIR_LEPTON_MCLK_ALT;

--- a/src/omv/ports/stm32/stm32fxxx_hal_msp.c
+++ b/src/omv/ports/stm32/stm32fxxx_hal_msp.c
@@ -221,6 +221,26 @@ void HAL_MspInit(void)
 
     #endif // DCMI_RESET_PIN || DCMI_PWDN_PIN || DCMI_FSYNC_PIN
 
+    #if defined(OMV_FIR_LEPTON_RST_PIN_PRESENT)
+    GPIO_InitTypeDef fir_lepton_rst_pin;
+    fir_lepton_rst_pin.Speed = GPIO_SPEED_LOW;
+    fir_lepton_rst_pin.Mode = GPIO_MODE_OUTPUT_PP;
+    fir_lepton_rst_pin.Pin = OMV_FIR_LEPTON_RST_PIN;
+    fir_lepton_rst_pin.Pull = GPIO_NOPULL;
+    HAL_GPIO_Init(OMV_FIR_LEPTON_RST_PORT, &fir_lepton_rst_pin);
+    OMV_FIR_LEPTON_RST_LOW();
+    #endif
+
+    #if defined(OMV_FIR_LEPTON_PWDN_PIN_PRESENT)
+    GPIO_InitTypeDef fir_lepton_pwdn_pin;
+    fir_lepton_pwdn_pin.Speed = GPIO_SPEED_LOW;
+    fir_lepton_pwdn_pin.Mode = GPIO_MODE_OUTPUT_PP;
+    fir_lepton_pwdn_pin.Pin = OMV_FIR_LEPTON_PWDN_PIN;
+    fir_lepton_pwdn_pin.Pull = GPIO_NOPULL;
+    HAL_GPIO_Init(OMV_FIR_LEPTON_PWDN_PORT, &fir_lepton_pwdn_pin);
+    OMV_FIR_LEPTON_PWDN_LOW();
+    #endif
+
     #if defined(MCU_SERIES_H7)
     // This disconnects PA0/PA1 from PA0_C/PA1_C.
     // PA0_C/PA1_C connect to ADC1/2 Channels P0/P1


### PR DESCRIPTION
* SPI bus needs pull ups to soften edges.
* Need to force rst and pwdn low on startup to ensure that lepton is off in order to not disturb sensor_init() (OV5640 and lepton share an I2C bus).