### PR TITLE
Fix build errors encountered with GNU Arm Embedded Toolchain 10-2020-q4-major

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
   # install ARM GCC
   - pushd .
   - cd ~ && mkdir gcc && cd gcc
-  - GCC_URL="https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2"
+  - GCC_URL="https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2"
   - wget -O gcc.tar.bz2 ${GCC_URL}
   - tar -jxf gcc.tar.bz2 --strip 1
   - exportline="export PATH=\$HOME/gcc/bin:\$PATH"

--- a/src/drivers/winc1500/include/common/include/nm_common.h
+++ b/src/drivers/winc1500/include/common/include/nm_common.h
@@ -239,7 +239,7 @@ NMI_API uint8 m2m_checksum(uint8* buf, int sz);
  * @fn           void (*at_sb_printf)(const char *_format, ...);
  * @brief       Chooses which function to use in order to output debug.
  */
-NMI_API void (*at_sb_printf)(const char *_format, ...);
+extern NMI_API void (*at_sb_printf)(const char *_format, ...);
 #ifdef __cplusplus
 }
  #endif

--- a/src/drivers/winc1500/src/winc.c
+++ b/src/drivers/winc1500/src/winc.c
@@ -353,8 +353,8 @@ static void wifi_callback_sta(uint8_t msg_type, void *msg)
             memcpy(netinfo->mac_addr, con_info->au8MACAddress, WINC_MAC_ADDR_LEN);
 
             // Copy SSID.
+            con_info->acSSID[WINC_MAX_SSID_LEN-1] = 0;
             strncpy(netinfo->ssid, con_info->acSSID, WINC_MAX_SSID_LEN);
-            netinfo->ssid[WINC_MAX_SSID_LEN-1] = 0;
 
             async_request_done = true;
 			break;

--- a/src/drivers/winc1500/src/winc.c
+++ b/src/drivers/winc1500/src/winc.c
@@ -390,8 +390,8 @@ static void wifi_callback_sta(uint8_t msg_type, void *msg)
 
             // Copy BSSID and SSID.
             memcpy(wscan_result.bssid, scan_result->au8BSSID, WINC_MAC_ADDR_LEN);
+            scan_result->au8SSID[WINC_MAX_SSID_LEN-1] = 0;
             strncpy((char*) wscan_result.ssid, (const char *) scan_result->au8SSID, WINC_MAX_SSID_LEN);
-            wscan_result.ssid[WINC_MAX_SSID_LEN-1] = 0;
 
             // Call scan result callback
             scan_arg->cb(&wscan_result, scan_arg->arg);

--- a/src/drivers/winc1500/src/winc.c
+++ b/src/drivers/winc1500/src/winc.c
@@ -353,7 +353,8 @@ static void wifi_callback_sta(uint8_t msg_type, void *msg)
             memcpy(netinfo->mac_addr, con_info->au8MACAddress, WINC_MAC_ADDR_LEN);
 
             // Copy SSID.
-            strncpy(netinfo->ssid, con_info->acSSID, WINC_MAX_SSID_LEN-1);
+            strncpy(netinfo->ssid, con_info->acSSID, WINC_MAX_SSID_LEN);
+            netinfo->ssid[WINC_MAX_SSID_LEN-1] = 0;
 
             async_request_done = true;
 			break;
@@ -389,7 +390,8 @@ static void wifi_callback_sta(uint8_t msg_type, void *msg)
 
             // Copy BSSID and SSID.
             memcpy(wscan_result.bssid, scan_result->au8BSSID, WINC_MAC_ADDR_LEN);
-            strncpy((char*) wscan_result.ssid, (const char *) scan_result->au8SSID, WINC_MAX_SSID_LEN-1);
+            strncpy((char*) wscan_result.ssid, (const char *) scan_result->au8SSID, WINC_MAX_SSID_LEN);
+            wscan_result.ssid[WINC_MAX_SSID_LEN-1] = 0;
 
             // Call scan result callback
             scan_arg->cb(&wscan_result, scan_arg->arg);

--- a/src/omv/modules/py_clock.h
+++ b/src/omv/modules/py_clock.h
@@ -10,5 +10,5 @@
  */
 #ifndef __PY_CLOCK_H__
 #define __PY_CLOCK_H__
-const mp_obj_type_t py_clock_type;
+extern const mp_obj_type_t py_clock_type;
 #endif // __PY_CLOCK_H__

--- a/src/omv/ports/stm32/main.c
+++ b/src/omv/ports/stm32/main.c
@@ -91,7 +91,7 @@
 #endif
 
 int errno;
-extern char _vfs_buf;
+extern char _vfs_buf[];
 static fs_user_mount_t *vfs_fat = (fs_user_mount_t *) &_vfs_buf;
 #if MICROPY_PY_THREAD
 pyb_thread_t pyb_thread_main;

--- a/src/omv/ports/stm32/modules/py_fir_lepton.c
+++ b/src/omv/ports/stm32/modules/py_fir_lepton.c
@@ -62,7 +62,7 @@ static soft_timer_entry_t flir_lepton_spi_rx_timer = {};
 static int fir_lepton_spi_rx_cb_tail = 0;
 static int fir_lepton_spi_rx_cb_expected_pid = 0;
 static int fir_lepton_spi_rx_cb_expected_seg = 0;
-extern int _fir_lepton_buf;
+extern int _fir_lepton_buf[];
 
 STATIC mp_obj_t fir_lepton_spi_resync_callback(mp_obj_t unused)
 {

--- a/src/omv/sensors/lepton.c
+++ b/src/omv/sensors/lepton.c
@@ -55,12 +55,12 @@ static float max_temp = DEFAULT_MAX_TEMP;
 static SPI_HandleTypeDef SPIHandle;
 static DMA_HandleTypeDef DMAHandle;
 LEP_CAMERA_PORT_DESC_T   LEPHandle;
-extern uint8_t _line_buf;
-extern uint8_t _vospi_buf;
+extern uint8_t _line_buf[];
+extern uint8_t _vospi_buf[];
 
 static bool vospi_resync = true;
-static uint8_t *vospi_packet = &_line_buf;
-static uint8_t *vospi_buffer = &_vospi_buf;
+static uint8_t *vospi_packet = _line_buf;
+static uint8_t *vospi_buffer = _vospi_buf;
 static volatile uint32_t vospi_pid = 0;
 static volatile uint32_t vospi_seg = 1;
 static uint32_t vospi_packets = 60;


### PR DESCRIPTION
This series of fixes allows the firmware to be built using gcc10, rather than gcc7 as used in your CI process.

I'm investigating using gcc10, as this is what CircuitPython uses (it appears that micropython uses 9-2019-q4-0ubuntu1 at the moment).

I have **NOT** tested this on hardware, and one change does modify behavior.

Please let me know if you'd prefer this be broken into multiple PRs, as it touches multiple parts of the project.