### PR TITLE
Make frame buffer readout locking more fair

### DIFF
--- a/src/omv/common/mutex.c
+++ b/src/omv/common/mutex.c
@@ -20,6 +20,7 @@ void mutex_init(mutex_t *mutex)
     __DMB();
     mutex->tid = 0;
     mutex->lock = 0;
+    mutex->last_tid = 0;
 }
 
 void mutex_lock(mutex_t *mutex, uint32_t tid)
@@ -62,6 +63,18 @@ int mutex_try_lock(mutex_t *mutex, uint32_t tid)
     }
 
     return (locked == 0);
+}
+
+int mutex_try_lock_alternate(mutex_t *mutex, uint32_t tid)
+{
+    if (mutex->last_tid != tid) {
+        if (mutex_try_lock(mutex, tid)) {
+            mutex->last_tid = tid;
+            return 1;
+        }
+    }
+
+    return 0;
 }
 
 int mutex_lock_timeout(mutex_t *mutex, uint32_t tid, uint32_t timeout)

--- a/src/omv/common/mutex.h
+++ b/src/omv/common/mutex.h
@@ -17,10 +17,13 @@
 typedef volatile struct {
     uint32_t tid;
     uint32_t lock;
+    uint32_t last_tid;
 } mutex_t;
+
 void mutex_init(mutex_t *mutex);
 void mutex_lock(mutex_t *mutex, uint32_t tid);
 int mutex_try_lock(mutex_t *mutex, uint32_t tid);
+int mutex_try_lock_alternate(mutex_t *mutex, uint32_t tid);
 int mutex_lock_timeout(mutex_t *mutex, uint32_t tid, uint32_t timeout);
 void mutex_unlock(mutex_t *mutex, uint32_t tid);
 #endif /* __MUTEX_H__ */

--- a/src/omv/common/usbdbg.c
+++ b/src/omv/common/usbdbg.c
@@ -121,7 +121,7 @@ void usbdbg_data_in(void *buffer, int length)
             // Return 0 if FB is locked or not ready.
             ((uint32_t*)buffer)[0] = 0;
             // Try to lock FB. If header size == 0 frame is not ready
-            if (mutex_try_lock(&JPEG_FB()->lock, MUTEX_TID_IDE)) {
+            if (mutex_try_lock_alternate(&JPEG_FB()->lock, MUTEX_TID_IDE)) {
                 // If header size == 0 frame is not ready
                 if (JPEG_FB()->size == 0) {
                     // unlock FB
@@ -375,7 +375,7 @@ void usbdbg_control(void *buffer, uint8_t request, uint32_t length)
             NVIC_SystemReset();
             break;
         }
-        
+
         case USBDBG_FB_ENABLE: {
             xfer_bytes = 0;
             xfer_length = length;

--- a/src/omv/imlib/framebuffer.c
+++ b/src/omv/imlib/framebuffer.c
@@ -127,7 +127,7 @@ void framebuffer_update_jpeg_buffer()
         if (src->bpp > 3) {
             bool does_not_fit = false;
 
-            if (mutex_try_lock(&jpeg_framebuffer->lock, MUTEX_TID_OMV)) {
+            if (mutex_try_lock_alternate(&jpeg_framebuffer->lock, MUTEX_TID_OMV)) {
                 if(CONSERVATIVE_JPEG_BUF_SIZE < src->bpp) {
                     initialize_jpeg_buf_from_image(NULL);
                     does_not_fit = true;
@@ -149,7 +149,7 @@ void framebuffer_update_jpeg_buffer()
                 fb_alloc_free_till_mark();
             }
         } else if (src->bpp >= 0) {
-            if (mutex_try_lock(&jpeg_framebuffer->lock, MUTEX_TID_OMV)) {
+            if (mutex_try_lock_alternate(&jpeg_framebuffer->lock, MUTEX_TID_OMV)) {
                 image_t dst = {.w=src->w, .h=src->h, .bpp=CONSERVATIVE_JPEG_BUF_SIZE, .pixels=jpeg_framebuffer->pixels};
                 // Note: lower quality saves USB bandwidth and results in a faster IDE FPS.
                 bool overflow = jpeg_compress(src, &dst, jpeg_framebuffer->quality, false);


### PR DESCRIPTION
This fixes the frame buffer stutters with the new framebuffer speedup code by making readout locking more fair.

I examined priority locking and all sorts of other methods... and found myself writing race conditions. This method below is simple, effective, does the job, and doesn't have race conditions.

It works fine for fixing the issue of the IDE polling the frame buffer and nothing more. Note that IDE poll rate is 200 Hz. Faster than a screen refresh. So, this should always result in a smooth result on screen.