### PR TITLE
Add frame complete callback support

### DIFF
--- a/src/omv/common/sensor.h
+++ b/src/omv/common/sensor.h
@@ -149,6 +149,7 @@ typedef enum {
 #define SENSOR_HW_FLAGS_CLR(s, x)    ((s)->hw_flags &= ~(1<<x))
 
 typedef void (*vsync_cb_t)(uint32_t vsync);
+typedef void (*frame_cb_t)();
 
 typedef struct _sensor sensor_t;
 typedef struct _sensor {
@@ -162,6 +163,7 @@ typedef struct _sensor {
     const uint16_t *color_palette;    // Color palette used for color lookup.
 
     vsync_cb_t vsync_callback;  // VSYNC callback.
+    frame_cb_t frame_callback;  // Frame callback.
     polarity_t pwdn_pol;        // PWDN polarity (TODO move to hw_flags)
     polarity_t reset_pol;       // Reset polarity (TODO move to hw_flags)
 
@@ -324,6 +326,9 @@ int sensor_ioctl(int request, ...);
 
 // Set vsync callback function.
 int sensor_set_vsync_callback(vsync_cb_t vsync_cb);
+
+// Set frame callback function.
+int sensor_set_frame_callback(frame_cb_t vsync_cb);
 
 // Set color palette
 int sensor_set_color_palette(const uint16_t *color_palette);

--- a/src/omv/modules/py_sensor.c
+++ b/src/omv/modules/py_sensor.c
@@ -30,6 +30,7 @@
 
 extern sensor_t sensor;
 static mp_obj_t vsync_callback = mp_const_none;
+static mp_obj_t frame_callback = mp_const_none;
 
 #if MICROPY_PY_IMU
 static void do_auto_rotation(int pitch_deadzone, int roll_activezone)
@@ -586,6 +587,27 @@ static mp_obj_t py_sensor_set_vsync_callback(mp_obj_t vsync_callback_obj)
         vsync_callback = vsync_callback_obj;
         sensor_set_vsync_callback(sensor_vsync_callback);
     }
+
+    return mp_const_none;
+}
+
+static void sensor_frame_callback()
+{
+    if (mp_obj_is_callable(frame_callback)) {
+        mp_call_function_0(frame_callback);
+    }
+}
+
+static mp_obj_t py_sensor_set_frame_callback(mp_obj_t frame_callback_obj)
+{
+    if (!mp_obj_is_callable(frame_callback_obj)) {
+        frame_callback = mp_const_none;
+        sensor_set_frame_callback(NULL);
+    } else {
+        frame_callback = frame_callback_obj;
+        sensor_set_frame_callback(sensor_frame_callback);
+    }
+
     return mp_const_none;
 }
 
@@ -952,6 +974,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_sensor_get_framebuffers_obj,    py_sensor_ge
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_sensor_set_special_effect_obj,  py_sensor_set_special_effect);
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(py_sensor_set_lens_correction_obj, py_sensor_set_lens_correction);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_sensor_set_vsync_callback_obj,  py_sensor_set_vsync_callback);
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_sensor_set_frame_callback_obj,  py_sensor_set_frame_callback);
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(py_sensor_ioctl_obj, 1, 5, py_sensor_ioctl);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_sensor_set_color_palette_obj,   py_sensor_set_color_palette);
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_sensor_get_color_palette_obj,   py_sensor_get_color_palette);
@@ -1110,6 +1133,7 @@ STATIC const mp_map_elem_t globals_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_set_special_effect),  (mp_obj_t)&py_sensor_set_special_effect_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_set_lens_correction), (mp_obj_t)&py_sensor_set_lens_correction_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_set_vsync_callback),  (mp_obj_t)&py_sensor_set_vsync_callback_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_set_frame_callback),  (mp_obj_t)&py_sensor_set_frame_callback_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_ioctl),               (mp_obj_t)&py_sensor_ioctl_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_set_color_palette),   (mp_obj_t)&py_sensor_set_color_palette_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_get_color_palette),   (mp_obj_t)&py_sensor_get_color_palette_obj },

--- a/src/omv/ports/nrf/sensor.c
+++ b/src/omv/ports/nrf/sensor.c
@@ -409,6 +409,7 @@ int sensor_reset()
     sensor.auto_rotation = false;
     #endif // MICROPY_PY_IMU
     sensor.vsync_callback= NULL;
+    sensor.frame_callback= NULL;
 
     // Reset default color palette.
     sensor.color_palette = rainbow_table;
@@ -889,6 +890,12 @@ int sensor_set_vsync_callback(vsync_cb_t vsync_cb)
     return 0;
 }
 
+int sensor_set_frame_callback(frame_cb_t vsync_cb)
+{
+    sensor.frame_callback = vsync_cb;
+    return 0;
+}
+
 int sensor_set_color_palette(const uint16_t *color_palette)
 {
     sensor.color_palette = color_palette;
@@ -1061,6 +1068,11 @@ int sensor_snapshot(sensor_t *sensor, image_t *image, uint32_t flags)
     }
 
     interrupts();
+
+    // Not useful for the NRF but must call to keep API the same.
+    if (sensor->frame_callback) {
+        sensor->frame_callback();
+    }
 
     // Fix the BPP.
     switch (sensor->pixformat) {

--- a/src/omv/ports/stm32/sensor.c
+++ b/src/omv/ports/stm32/sensor.c
@@ -526,6 +526,7 @@ int sensor_reset()
     sensor.auto_rotation = false;
     #endif // MICROPY_PY_IMU
     sensor.vsync_callback= NULL;
+    sensor.frame_callback= NULL;
 
     // Reset default color palette.
     sensor.color_palette = rainbow_table;
@@ -1036,6 +1037,12 @@ int sensor_set_vsync_callback(vsync_cb_t vsync_cb)
     return 0;
 }
 
+int sensor_set_frame_callback(frame_cb_t vsync_cb)
+{
+    sensor.frame_callback = vsync_cb;
+    return 0;
+}
+
 int sensor_set_color_palette(const uint16_t *color_palette)
 {
     sensor.color_palette = color_palette;
@@ -1156,6 +1163,10 @@ static void sensor_check_buffsize()
 void HAL_DCMI_FrameEventCallback(DCMI_HandleTypeDef *hdcmi)
 {
     framebuffer_get_tail(FB_NO_FLAGS);
+
+    if (sensor.frame_callback) {
+        sensor.frame_callback();
+    }
 }
 
 #if (OMV_ENABLE_SENSOR_MDMA == 1)


### PR DESCRIPTION
This completes non-blocking snapshot support. The user has two methods to determine if a new frame is available.

1. They can poll the frame_available() method until it is True.
2. They can use set_frame_callback() to do something when a new frame is ready. Like schedule via micropython.schedule() a function that calls snapshot() to grab the frame and process it while keeping the main loop working on something else.

The user may choose whichever one is better for their application.