### PR TITLE
Fix usbdbg flushing before script end

### DIFF
--- a/src/omv/common/usbdbg.c
+++ b/src/omv/common/usbdbg.c
@@ -55,6 +55,11 @@ void usbdbg_init()
     mp_const_ide_interrupt = mp_obj_new_exception_msg(&mp_type_Exception, "IDE interrupt");
 }
 
+void usbdbg_wait_for_command(uint32_t timeout)
+{
+    for (mp_uint_t ticks = mp_hal_ticks_ms(); ((mp_hal_ticks_ms() - ticks) < timeout) && (cmd != USBDBG_NONE); );
+}
+
 bool usbdbg_script_ready()
 {
     return script_ready;

--- a/src/omv/common/usbdbg.h
+++ b/src/omv/common/usbdbg.h
@@ -10,6 +10,7 @@
  */
 #ifndef __USBDBG_H__
 #define __USBDBG_H__
+
 /**
   * Firmware version (major, minor and patch numbers).
   *
@@ -47,7 +48,9 @@ enum usbdbg_cmd {
     USBDBG_TX_BUF           =0x8F,
     USBDBG_SENSOR_ID        =0x90
 };
+
 void usbdbg_init();
+void usbdbg_wait_for_command(uint32_t timeout);
 bool usbdbg_script_ready();
 vstr_t *usbdbg_get_script();
 bool usbdbg_get_irq_enabled();
@@ -56,4 +59,5 @@ void usbdbg_set_script_running(bool running);
 void usbdbg_data_in(void *buffer, int length);
 void usbdbg_data_out(void *buffer, int length);
 void usbdbg_control(void *buffer, uint8_t brequest, uint32_t wlength);
+
 #endif /* __USBDBG_H__ */

--- a/src/omv/ports/nrf/main.c
+++ b/src/omv/ports/nrf/main.c
@@ -286,6 +286,8 @@ soft_reset:
         }
     }
 
+    usbdbg_wait_for_command(1000);
+
     usbdbg_set_irq_enabled(false);
 
     mp_deinit();

--- a/src/omv/ports/stm32/main.c
+++ b/src/omv/ports/stm32/main.c
@@ -761,6 +761,8 @@ soft_reset:
         }
     } while (openmv_config.wifidbg == true);
 
+    usbdbg_wait_for_command(1000);
+
     #if MICROPY_PY_LWIP
     // Must call GC sweep here to close open sockets.
     gc_sweep_all();


### PR DESCRIPTION
Gives the IDE time to drain the jpeg frame buffer and text buffer after script stop.