### PR TITLE
Use pre-defined GCC macro to test for the architecture.

### DIFF
--- a/src/omv/alloc/unaligned_memcpy.c
+++ b/src/omv/alloc/unaligned_memcpy.c
@@ -6,7 +6,7 @@
 // ARM Cortex-M4/M7 Processors can access memory using unaligned 32-bit reads/writes.
 void *unaligned_memcpy(void *dest, void *src, size_t n)
 {
-    #if (CPU==cortex-m4) || (CPU==cortex-m7)
+    #if (__ARM_ARCH > 6)
     // TODO: Make this faster using only 32-bit aligned reads/writes with data shifting.
     uint32_t *dest32 = (uint32_t *) dest;
     uint32_t *src32 = (uint32_t *) src;
@@ -34,7 +34,7 @@ void *unaligned_memcpy_rev16(void *dest, void *src, size_t n)
     uint32_t *dest32 = (uint32_t *) dest;
     uint32_t *src32 = (uint32_t *) src;
 
-    #if (CPU==cortex-m4) || (CPU==cortex-m7)
+    #if (__ARM_ARCH > 6)
     // TODO: Make this faster using only 32-bit aligned reads/writes with data shifting.
     for (; n > 2; n -= 2) {
         *dest32++ = __REV16(*src32++);
@@ -56,7 +56,7 @@ void *unaligned_2_to_1_memcpy(void *dest, void *src, size_t n)
     uint32_t *dest32 = (uint32_t *) dest;
     uint32_t *src32 = (uint32_t *) src;
 
-    #if (CPU==cortex-m4) || (CPU==cortex-m7)
+    #if (__ARM_ARCH > 6)
     // TODO: Make this faster using only 32-bit aligned reads/writes with data shifting.
     for (; n > 4; n -= 4) {
         uint32_t tmp1 = *src32++;

--- a/src/omv/common/mutex.c
+++ b/src/omv/common/mutex.c
@@ -27,7 +27,7 @@ void mutex_init0(omv_mutex_t *mutex)
 
 static void _mutex_lock(omv_mutex_t *mutex, uint32_t tid, bool blocking)
 {
-    #if (CPU==cortex-m0)
+    #if (__ARM_ARCH < 7)
     do {
         __disable_irq();
         if (mutex->lock == 0) {
@@ -35,7 +35,6 @@ static void _mutex_lock(omv_mutex_t *mutex, uint32_t tid, bool blocking)
             mutex->tid = tid;
         }
         __enable_irq();
-        __WFI();
     } while (mutex->tid != tid && blocking);
     #else
     do {

--- a/src/omv/imlib/fmath.c
+++ b/src/omv/imlib/fmath.c
@@ -22,6 +22,33 @@ const float __atanf_lut[4] = {
     +0.9997878412794807f     //p1
 };
 
+#if (__ARM_ARCH < 7)
+#include <math.h>
+float OMV_ATTR_ALWAYS_INLINE fast_sqrtf(float x)
+{
+    return sqrtf(x);
+}
+
+int OMV_ATTR_ALWAYS_INLINE fast_floorf(float x)
+{
+    return floorf(x);
+}
+
+int OMV_ATTR_ALWAYS_INLINE fast_ceilf(float x)
+{
+    return ceilf(x);
+}
+
+int OMV_ATTR_ALWAYS_INLINE fast_roundf(float x)
+{
+    return roundf(x);
+}
+
+float OMV_ATTR_ALWAYS_INLINE fast_fabsf(float x)
+{
+    return fabsf(x);
+}
+#else
 float OMV_ATTR_ALWAYS_INLINE fast_sqrtf(float x)
 {
     asm volatile (
@@ -62,6 +89,17 @@ int OMV_ATTR_ALWAYS_INLINE fast_roundf(float x)
     return i;
 }
 
+float OMV_ATTR_ALWAYS_INLINE fast_fabsf(float x)
+{
+    asm volatile (
+            "vabs.f32  %[r], %[x]\n"
+            : [r] "=t" (x)
+            : [x] "t"  (x));
+    return x;
+}
+
+#endif
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 typedef union{
@@ -101,15 +139,6 @@ float fast_cbrtf(float x)
    v.ix = v.ix + v.ix/256;
    v.ix = 0x2a511cd0 + v.ix;  // Initial guess.
    return v.x;
-}
-
-float OMV_ATTR_ALWAYS_INLINE fast_fabsf(float x)
-{
-    asm volatile (
-            "vabs.f32  %[r], %[x]\n"
-            : [r] "=t" (x)
-            : [x] "t"  (x));
-    return x;
 }
 
 inline float fast_atanf(float xx)


### PR DESCRIPTION
* CPU macro was not actually defined, which made the test pass on all MCUs.