### PR TITLE
Kwabena/special sensor stuff

### DIFF
--- a/src/omv/common/sensor.h
+++ b/src/omv/common/sensor.h
@@ -181,6 +181,8 @@ typedef struct _sensor {
     bool transpose;             // Transpose Image
     bool auto_rotation;         // Rotate Image Automatically
     bool detected;              // Set to true when the sensor is initialized.
+    int framedrop_count;        // Number of frames to drop between accepting a frame.
+    int framedrop_counter;      // Current count of dropped frames.
 
     cambus_t bus;               // SCCB/I2C bus.
 
@@ -317,6 +319,9 @@ bool sensor_get_auto_rotation();
 
 // Set the number of virtual frame buffers.
 int sensor_set_framebuffers(int count);
+
+// Set the number of frames to drop between valid frames.
+int sensor_set_framedrop(int count);
 
 // Set special digital effects (SDE).
 int sensor_set_special_effect(sde_t sde);

--- a/src/omv/imlib/framebuffer.h
+++ b/src/omv/imlib/framebuffer.h
@@ -34,6 +34,8 @@ typedef struct framebuffer {
     volatile int32_t tail;
     bool check_head;
     int32_t sampled_head;
+    // Disable autoflush policy on full to prevent stale frames.
+    bool disable_full_flush;
     OMV_ATTR_ALIGNED(uint8_t data[], FRAMEBUFFER_ALIGNMENT);
 } framebuffer_t;
 

--- a/src/omv/modules/py_sensor.c
+++ b/src/omv/modules/py_sensor.c
@@ -572,6 +572,16 @@ static mp_obj_t py_sensor_get_framedrop()
     return mp_obj_new_int(sensor.framedrop_count);
 }
 
+static mp_obj_t py_sensor_disable_full_flush(uint n_args, const mp_obj_t *args)
+{
+    if (!n_args) {
+        return mp_obj_new_bool(framebuffer->disable_full_flush);
+    }
+
+    framebuffer->disable_full_flush = mp_obj_get_int(args[0]);
+    return mp_const_none;
+}
+
 static mp_obj_t py_sensor_set_special_effect(mp_obj_t sde)
 {
     if (sensor_set_special_effect(mp_obj_get_int(sde)) != 0) {
@@ -991,6 +1001,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_sensor_set_framebuffers_obj,    py_sensor_se
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_sensor_get_framebuffers_obj,    py_sensor_get_framebuffers);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_sensor_set_framedrop_obj,       py_sensor_set_framedrop);
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_sensor_get_framedrop_obj,       py_sensor_get_framedrop);
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(py_sensor_disable_full_flush_obj, 0, 1, py_sensor_disable_full_flush);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_sensor_set_special_effect_obj,  py_sensor_set_special_effect);
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(py_sensor_set_lens_correction_obj, py_sensor_set_lens_correction);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_sensor_set_vsync_callback_obj,  py_sensor_set_vsync_callback);
@@ -1152,6 +1163,7 @@ STATIC const mp_map_elem_t globals_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_get_framebuffers),    (mp_obj_t)&py_sensor_get_framebuffers_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_set_framedrop),       (mp_obj_t)&py_sensor_set_framedrop_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_get_framedrop),       (mp_obj_t)&py_sensor_get_framedrop_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_disable_full_flush),  (mp_obj_t)&py_sensor_disable_full_flush_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_set_special_effect),  (mp_obj_t)&py_sensor_set_special_effect_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_set_lens_correction), (mp_obj_t)&py_sensor_set_lens_correction_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_set_vsync_callback),  (mp_obj_t)&py_sensor_set_vsync_callback_obj },

--- a/src/omv/modules/py_sensor.c
+++ b/src/omv/modules/py_sensor.c
@@ -115,7 +115,6 @@ static mp_obj_t py_sensor_snapshot(uint n_args, const mp_obj_t *args, mp_map_t *
 #endif // MICROPY_PY_IMU
 
     mp_obj_t image = py_image(0, 0, 0, 0);
-    // Note: OV2640 JPEG mode can __fatal_error().
     int ret = sensor.snapshot(&sensor, (image_t *) py_image_cobj(image), 0);
 
     if (ret < 0) {
@@ -553,6 +552,26 @@ static mp_obj_t py_sensor_get_framebuffers()
     return mp_obj_new_int(framebuffer->n_buffers);
 }
 
+static mp_obj_t py_sensor_set_framedrop(mp_obj_t count)
+{
+    mp_int_t c = mp_obj_get_int(count);
+
+    if (sensor.framedrop_count == c) {
+        return mp_const_none;
+    }
+
+    if ((c < 0) || (sensor_set_framedrop(c) != 0)) {
+        mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("Invalid framedrop count!"));
+    }
+
+    return mp_const_none;
+}
+
+static mp_obj_t py_sensor_get_framedrop()
+{
+    return mp_obj_new_int(sensor.framedrop_count);
+}
+
 static mp_obj_t py_sensor_set_special_effect(mp_obj_t sde)
 {
     if (sensor_set_special_effect(mp_obj_get_int(sde)) != 0) {
@@ -970,6 +989,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_sensor_set_auto_rotation_obj,   py_sensor_se
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_sensor_get_auto_rotation_obj,   py_sensor_get_auto_rotation);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_sensor_set_framebuffers_obj,    py_sensor_set_framebuffers);
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_sensor_get_framebuffers_obj,    py_sensor_get_framebuffers);
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_sensor_set_framedrop_obj,       py_sensor_set_framedrop);
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_sensor_get_framedrop_obj,       py_sensor_get_framedrop);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_sensor_set_special_effect_obj,  py_sensor_set_special_effect);
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(py_sensor_set_lens_correction_obj, py_sensor_set_lens_correction);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_sensor_set_vsync_callback_obj,  py_sensor_set_vsync_callback);
@@ -1129,6 +1150,8 @@ STATIC const mp_map_elem_t globals_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_get_auto_rotation),   (mp_obj_t)&py_sensor_get_auto_rotation_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_set_framebuffers),    (mp_obj_t)&py_sensor_set_framebuffers_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_get_framebuffers),    (mp_obj_t)&py_sensor_get_framebuffers_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_set_framedrop),       (mp_obj_t)&py_sensor_set_framedrop_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_get_framedrop),       (mp_obj_t)&py_sensor_get_framedrop_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_set_special_effect),  (mp_obj_t)&py_sensor_set_special_effect_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_set_lens_correction), (mp_obj_t)&py_sensor_set_lens_correction_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_set_vsync_callback),  (mp_obj_t)&py_sensor_set_vsync_callback_obj },

--- a/src/omv/ports/nrf/sensor.c
+++ b/src/omv/ports/nrf/sensor.c
@@ -1078,7 +1078,7 @@ int sensor_snapshot(sensor_t *sensor, image_t *image, uint32_t flags)
     uint32_t ulPin = 32; // P1.xx set of GPIO is in 'pin' 32 and above
     NRF_GPIO_Type *port = nrf_gpio_pin_port_decode(&ulPin);
 
-    for (int i = 0; i < sensor.framedrop_count; i++) {
+    for (int i = 0; i < sensor->framedrop_count; i++) {
         while ((*_vsyncPort & _vsyncMask) == 0); // wait for HIGH
         while ((*_vsyncPort & _vsyncMask) != 0); // wait for LOW
     }

--- a/src/omv/ports/stm32/sensor.c
+++ b/src/omv/ports/stm32/sensor.c
@@ -1300,7 +1300,9 @@ void DCMI_DMAConvCpltUser(uint32_t addr)
         HAL_MDMA_DeInit(&DCMI_MDMA_Handle1);
         #endif
         // Reset the queue of frames when we start dropping frames.
-        framebuffer_flush_buffers();
+        if (!MAIN_FB()->disable_full_flush) {
+            framebuffer_flush_buffers();
+        }
         return;
     }
 
@@ -1616,7 +1618,7 @@ int sensor_snapshot(sensor_t *sensor, image_t *image, uint32_t flags)
         // Get the destination buffer address.
         vbuffer_t *buffer = framebuffer_get_tail(FB_PEEK);
 
-        if (!buffer) {
+        if ((!buffer) && ((sensor->pixformat == PIXFORMAT_JPEG) && (sensor->chip_id == OV2640_ID))) {
             return -3;
         }
 


### PR DESCRIPTION
This code allows users to drop frames in the sensor driver and use the image fifo for long term storage of images. Please see this thread: https://forums.openmv.io/t/image-capture-interrupt-handler-registration/5924/16?u=kwagyeman

Basically, if you want frame capture running in the background now always capturing frames while your main code goes and does something else for a very long time this is now possible... and you will not drop any frames and have unstable video.