### PR TITLE
Add disable full flush logic

### DIFF
--- a/src/omv/common/sensor.h
+++ b/src/omv/common/sensor.h
@@ -164,6 +164,7 @@ typedef struct _sensor {
     uint16_t gs_bpp;            // Grayscale bytes per pixel.
     uint32_t hw_flags;          // Hardware flags (clock polarities/hw capabilities)
     const uint16_t *color_palette;    // Color palette used for color lookup.
+    bool disable_full_flush;    // Turn off default frame buffer flush policy when full.
 
     vsync_cb_t vsync_callback;  // VSYNC callback.
     frame_cb_t frame_callback;  // Frame callback.

--- a/src/omv/modules/py_sensor.c
+++ b/src/omv/modules/py_sensor.c
@@ -553,6 +553,16 @@ static mp_obj_t py_sensor_get_framebuffers()
     return mp_obj_new_int(framebuffer->n_buffers);
 }
 
+static mp_obj_t py_sensor_disable_full_flush(uint n_args, const mp_obj_t *args)
+{
+    if (!n_args) {
+        return mp_obj_new_bool(sensor.disable_full_flush);
+    }
+
+    sensor.disable_full_flush = mp_obj_get_int(args[0]);
+    return mp_const_none;
+}
+
 static mp_obj_t py_sensor_set_special_effect(mp_obj_t sde)
 {
     if (sensor_set_special_effect(mp_obj_get_int(sde)) != 0) {
@@ -970,6 +980,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_sensor_set_auto_rotation_obj,   py_sensor_se
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_sensor_get_auto_rotation_obj,   py_sensor_get_auto_rotation);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_sensor_set_framebuffers_obj,    py_sensor_set_framebuffers);
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_sensor_get_framebuffers_obj,    py_sensor_get_framebuffers);
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(py_sensor_disable_full_flush_obj, 0, 1, py_sensor_disable_full_flush);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_sensor_set_special_effect_obj,  py_sensor_set_special_effect);
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(py_sensor_set_lens_correction_obj, py_sensor_set_lens_correction);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_sensor_set_vsync_callback_obj,  py_sensor_set_vsync_callback);
@@ -1129,6 +1140,7 @@ STATIC const mp_map_elem_t globals_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_get_auto_rotation),   (mp_obj_t)&py_sensor_get_auto_rotation_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_set_framebuffers),    (mp_obj_t)&py_sensor_set_framebuffers_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_get_framebuffers),    (mp_obj_t)&py_sensor_get_framebuffers_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_disable_full_flush),  (mp_obj_t)&py_sensor_disable_full_flush_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_set_special_effect),  (mp_obj_t)&py_sensor_set_special_effect_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_set_lens_correction), (mp_obj_t)&py_sensor_set_lens_correction_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_set_vsync_callback),  (mp_obj_t)&py_sensor_set_vsync_callback_obj },

--- a/src/omv/ports/nrf/sensor.c
+++ b/src/omv/ports/nrf/sensor.c
@@ -429,6 +429,8 @@ int sensor_reset()
     // Reset default color palette.
     sensor.color_palette = rainbow_table;
 
+    sensor.disable_full_flush = false;
+
     // Restore shutdown state on reset.
     sensor_shutdown(false);
 

--- a/src/omv/ports/stm32/sensor.c
+++ b/src/omv/ports/stm32/sensor.c
@@ -578,6 +578,8 @@ int sensor_reset()
     // Reset default color palette.
     sensor.color_palette = rainbow_table;
 
+    sensor.disable_full_flush = false;
+
     // Restore shutdown state on reset.
     sensor_shutdown(false);
 
@@ -1310,7 +1312,9 @@ void DCMI_DMAConvCpltUser(uint32_t addr)
         __HAL_DCMI_DISABLE_IT(&DCMIHandle, DCMI_IT_FRAME);
         __HAL_DCMI_CLEAR_FLAG(&DCMIHandle, DCMI_FLAG_FRAMERI);
         // Reset the queue of frames when we start dropping frames.
-        framebuffer_flush_buffers();
+        if (!sensor.disable_full_flush) {
+            framebuffer_flush_buffers();
+        }
         return;
     }
 
@@ -1630,7 +1634,7 @@ int sensor_snapshot(sensor_t *sensor, image_t *image, uint32_t flags)
         // Get the destination buffer address.
         vbuffer_t *buffer = framebuffer_get_tail(FB_PEEK);
 
-        if (!buffer) {
+        if ((sensor->pixformat == PIXFORMAT_JPEG) && (sensor->chip_id == OV2640_ID) && (!buffer)) {
             return -3;
         }
 


### PR DESCRIPTION
Adds the ability for the user to turn off automatic flushing of the frame buffer when it overflows. This allows the user to use the frame buffer as a long term storage fifo.