### PR TITLE
Add method to get actual xclk freq

### DIFF
--- a/src/omv/common/sensor.h
+++ b/src/omv/common/sensor.h
@@ -224,6 +224,9 @@ typedef struct _sensor {
 // Resolution table
 extern const int resolution[][2];
 
+// Returns the xclk freq in hz.
+int sensor_xclk_freq();
+
 // Initialize the sensor hardware and probe the image sensor.
 int sensor_init();
 


### PR DESCRIPTION
It's been an issue that we don't know the real xclk freq on boards. This allows you to get that so that the exposure time calculations in camera sensor driver code are actually correct.