### PR TITLE
User c modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = src/micropython
 	url = https://github.com/openmv/micropython.git
 	branch = openmv
+[submodule "src/omv/modules/ulab"]
+	path = src/omv/modules/ulab
+	url = https://github.com/v923z/micropython-ulab.git

--- a/src/Makefile
+++ b/src/Makefile
@@ -103,7 +103,7 @@ OMV_SRC_QSTR := $(wildcard $(TOP_DIR)/$(OMV_DIR)/modules/*.c)
 OMV_SRC_QSTR += $(wildcard $(TOP_DIR)/$(OMV_DIR)/ports/$(PORT)/modules/*.c)
 
 # The following command line args are passed to MicroPython's top Makefile.
-MICROPY_ARGS = PORT=$(PORT) BOARD=$(TARGET) DEBUG=$(DEBUG) OMV_SRC_QSTR="$(OMV_SRC_QSTR)" MPY_LIB_DIR=$(MPY_LIB_DIR) MICROPY_ROM_TEXT_COMPRESSION=$(ROM_TEXT_COMPRESSION)
+MICROPY_ARGS = PORT=$(PORT) BOARD=$(TARGET) DEBUG=$(DEBUG) MPY_LIB_DIR=$(MPY_LIB_DIR) MICROPY_ROM_TEXT_COMPRESSION=$(ROM_TEXT_COMPRESSION) USER_C_MODULES=$(TOP_DIR)/$(OMV_DIR) #OMV_SRC_QSTR="$(OMV_SRC_QSTR)"
 
 # Configure additional built-in modules. Note must define both the CFLAGS and the Make command line args.
 ifeq ($(MICROPY_PY_SENSOR), 1)
@@ -171,6 +171,11 @@ endif
 ifeq ($(MICROPY_PY_BUZZER), 1)
 MPY_CFLAGS += -DMICROPY_PY_BUZZER=1
 MICROPY_ARGS += MICROPY_PY_BUZZER=1
+endif
+
+ifeq ($(CUBEAI), 1)
+MPY_CFLAGS += -DMICROPY_PY_CUBEAI=1
+MICROPY_ARGS += MICROPY_PY_CUBEAI=1
 endif
 
 # Include the port Makefile.

--- a/src/omv/Makefile
+++ b/src/omv/Makefile
@@ -41,19 +41,6 @@ SRCS += $(addprefix sensors/,   \
 	paj6100.c                   \
    )
 
-SRCS += $(addprefix modules/,   \
-	py_clock.c                  \
-	py_gif.c                    \
-	py_helper.c                 \
-	py_image.c                  \
-	py_imageio.c                \
-	py_mjpeg.c                  \
-	py_omv.c                    \
-	py_sensor.c                 \
-	py_tf.c                     \
-	py_fir.c                    \
-   )
-
 SRCS += $(addprefix imlib/,     \
 	agast.c                     \
 	apriltag.c                  \
@@ -108,7 +95,6 @@ SRCS += $(addprefix imlib/,     \
    )
 
 SRCS += $(wildcard ports/$(PORT)/*.c)
-SRCS += $(wildcard ports/$(PORT)/modules/*.c)
 
 OBJS = $(addprefix $(BUILD)/, $(SRCS:.c=.o))
 OBJ_DIRS = $(sort $(dir $(OBJS)))

--- a/src/omv/imlib/imlib.h
+++ b/src/omv/imlib/imlib.h
@@ -29,6 +29,12 @@
 #include "imlib_config.h"
 #include "omv_boardconfig.h"
 
+#ifndef M_PI
+#define M_PI    3.14159265f
+#define M_PI_2  1.57079632f
+#define M_PI_4  0.78539816f
+#endif
+
 #define IM_LOG2_2(x)    (((x) &                0x2ULL) ? ( 2                        ) :             1) // NO ({ ... }) !
 #define IM_LOG2_4(x)    (((x) &                0xCULL) ? ( 2 +  IM_LOG2_2((x) >>  2)) :  IM_LOG2_2(x)) // NO ({ ... }) !
 #define IM_LOG2_8(x)    (((x) &               0xF0ULL) ? ( 4 +  IM_LOG2_4((x) >>  4)) :  IM_LOG2_4(x)) // NO ({ ... }) !

--- a/src/omv/modules/examplemodule.c
+++ b/src/omv/modules/examplemodule.c
@@ -1,0 +1,36 @@
+// Include MicroPython API.
+#include "py/runtime.h"
+
+// This is the function which will be called from Python as cexample.add_ints(a, b).
+STATIC mp_obj_t example_add_ints(mp_obj_t a_obj, mp_obj_t b_obj) {
+    // Extract the ints from the micropython input objects.
+    int a = mp_obj_get_int(a_obj);
+    int b = mp_obj_get_int(b_obj);
+
+    // Calculate the addition and convert to MicroPython object.
+    return mp_obj_new_int(a + b);
+}
+// Define a Python reference to the function above.
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(example_add_ints_obj, example_add_ints);
+
+// Define all properties of the module.
+// Table entries are key/value pairs of the attribute name (a string)
+// and the MicroPython object reference.
+// All identifiers and strings are written as MP_QSTR_xxx and will be
+// optimized to word-sized integers by the build system (interned strings).
+STATIC const mp_rom_map_elem_t example_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_cexample) },
+    { MP_ROM_QSTR(MP_QSTR_add_ints), MP_ROM_PTR(&example_add_ints_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(example_module_globals, example_module_globals_table);
+
+// Define module object.
+const mp_obj_module_t example_user_cmodule = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t *)&example_module_globals,
+};
+
+// Register the module to make it available in Python.
+// Note: This module is disabled, set the thrid argument to 1 to enable it, or
+// use a macro like MODULE_CEXAMPLE_ENABLED to conditionally enable this module.
+MP_REGISTER_MODULE(MP_QSTR_cexample, example_user_cmodule, 0);

--- a/src/omv/modules/micropython.mk
+++ b/src/omv/modules/micropython.mk
@@ -1,0 +1,23 @@
+OMV_MOD_DIR := $(USERMOD_DIR)
+OMV_PORT_MOD_DIR := $(OMV_MOD_DIR)/../ports/$(PORT)/modules
+
+# Add OpenMV common modules.
+SRC_USERMOD += $(wildcard $(OMV_MOD_DIR)/*.c)
+
+# Add OpenMV port-specific modules.
+SRC_USERMOD += $(wildcard $(OMV_PORT_MOD_DIR)/*.c)
+
+# Extra module flags.
+CFLAGS_USERMOD += -I$(OMV_MOD_DIR) -I$(OMV_PORT_MOD_DIR) -Wno-float-conversion
+
+# Add CubeAI module if enabled.
+ifeq ($(MICROPY_PY_CUBEAI), 1)
+SRC_USERMOD += $(OMV_MOD_DIR)/../../stm32cubeai/py_st_nn.c
+endif
+
+ifeq ($(MICROPY_PY_ULAB), 1)
+# NOTE: overrides USERMOD_DIR
+# Workaround to build and link ulab.
+USERMOD_DIR := $(USERMOD_DIR)/ulab/code
+include $(USERMOD_DIR)/micropython.mk
+endif

--- a/src/omv/modules/py_fir.c
+++ b/src/omv/modules/py_fir.c
@@ -1265,3 +1265,5 @@ void py_fir_init0()
 {
     py_fir_deinit();
 }
+
+MP_REGISTER_MODULE(MP_QSTR_fir, fir_module, 1);

--- a/src/omv/modules/py_gif.c
+++ b/src/omv/modules/py_gif.c
@@ -155,3 +155,5 @@ const mp_obj_module_t gif_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_t)&globals_dict,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_gif, gif_module, 1);

--- a/src/omv/modules/py_image.c
+++ b/src/omv/modules/py_image.c
@@ -6951,3 +6951,5 @@ const mp_obj_module_t image_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_t) &globals_dict
 };
+
+MP_REGISTER_MODULE(MP_QSTR_image, image_module, 1);

--- a/src/omv/modules/py_mjpeg.c
+++ b/src/omv/modules/py_mjpeg.c
@@ -136,3 +136,5 @@ const mp_obj_module_t mjpeg_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_t)&globals_dict,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_mjpeg, mjpeg_module, 1);

--- a/src/omv/modules/py_omv.c
+++ b/src/omv/modules/py_omv.c
@@ -80,3 +80,5 @@ const mp_obj_module_t omv_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_t) &globals_dict,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_omv, omv_module, 1);

--- a/src/omv/modules/py_sensor.c
+++ b/src/omv/modules/py_sensor.c
@@ -1177,4 +1177,5 @@ const mp_obj_module_t sensor_module = {
     .globals = (mp_obj_t)&globals_dict,
 };
 
+MP_REGISTER_MODULE(MP_QSTR_sensor, sensor_module, MICROPY_PY_SENSOR);
 #endif // MICROPY_PY_SENSOR

--- a/src/omv/modules/py_tf.c
+++ b/src/omv/modules/py_tf.c
@@ -605,3 +605,5 @@ const mp_obj_module_t tf_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_t) &globals_dict
 };
+
+MP_REGISTER_MODULE(MP_QSTR_tf, tf_module, 1);

--- a/src/omv/ports/nrf/modules/py_audio.c
+++ b/src/omv/ports/nrf/modules/py_audio.c
@@ -194,4 +194,5 @@ const mp_obj_module_t audio_module = {
     .globals = (mp_obj_t)&globals_dict,
 };
 
+MP_REGISTER_MODULE(MP_QSTR_audio, audio_module, MICROPY_PY_AUDIO);
 #endif //MICROPY_PY_AUDIO

--- a/src/omv/ports/nrf/omv_portconfig.mk
+++ b/src/omv/ports/nrf/omv_portconfig.mk
@@ -122,19 +122,6 @@ FIRM_OBJ += $(addprefix $(BUILD)/$(OMV_DIR)/sensors/,   \
 	hm01b0.o                    \
    )
 
-FIRM_OBJ += $(addprefix $(BUILD)/$(OMV_DIR)/modules/,   \
-	py_clock.o                  \
-	py_gif.o                    \
-	py_helper.o                 \
-	py_image.o                  \
-	py_imageio.o                \
-	py_mjpeg.o                  \
-	py_omv.o                    \
-	py_sensor.o                 \
-	py_tf.o                     \
-	py_fir.o                    \
-   )
-
 FIRM_OBJ += $(addprefix $(BUILD)/$(OMV_DIR)/imlib/, \
 	agast.o                     \
 	apriltag.o                  \
@@ -189,7 +176,8 @@ FIRM_OBJ += $(addprefix $(BUILD)/$(OMV_DIR)/imlib/, \
    )
 
 FIRM_OBJ += $(wildcard $(BUILD)/$(OMV_DIR)/ports/$(PORT)/*.o)
-FIRM_OBJ += $(wildcard $(BUILD)/$(OMV_DIR)/ports/$(PORT)/modules/*.o)
+FIRM_OBJ += $(wildcard $(BUILD)/$(MICROPY_DIR)/modules/*.o)
+FIRM_OBJ += $(wildcard $(BUILD)/$(MICROPY_DIR)/ports/$(PORT)/modules/*.o)
 
 #------------- MicroPy Objects -------------------#
 FIRM_OBJ += $(wildcard $(BUILD)/$(MICROPY_DIR)/py/*.o)
@@ -300,7 +288,7 @@ FIRM_OBJ += $(addprefix $(BUILD)/$(MICROPY_DIR)/modules/,\
 	)
 
 ifeq ($(MICROPY_PY_ULAB), 1)
-FIRM_OBJ += $(addprefix $(BUILD)/$(MICROPY_DIR)/extmod/ulab/,\
+FIRM_OBJ += $(addprefix $(BUILD)/$(MICROPY_DIR)/modules/ulab/,\
 	code/scipy/optimize/optimize.o      \
 	code/scipy/signal/signal.o          \
 	code/scipy/special/special.o        \

--- a/src/omv/ports/rp2/modules/py_audio.c
+++ b/src/omv/ports/rp2/modules/py_audio.c
@@ -204,4 +204,5 @@ const mp_obj_module_t audio_module = {
     .globals = (mp_obj_t)&globals_dict,
 };
 
+MP_REGISTER_MODULE(MP_QSTR_audio, audio_module, MICROPY_PY_AUDIO);
 #endif //MICROPY_PY_AUDIO

--- a/src/omv/ports/rp2/omv_portconfig.cmake
+++ b/src/omv/ports/rp2/omv_portconfig.cmake
@@ -85,6 +85,8 @@ target_include_directories(${MICROPY_TARGET} PRIVATE
     ${OMV_BOARD_CONFIG_DIR}
 )
 
+file(GLOB OMV_USER_MODULES ${TOP_DIR}/${OMV_DIR}/modules/*.c)
+
 target_sources(${MICROPY_TARGET} PRIVATE
     ${TOP_DIR}/${OMV_DIR}/alloc/xalloc.c
     ${TOP_DIR}/${OMV_DIR}/alloc/fb_alloc.c
@@ -112,17 +114,6 @@ target_sources(${MICROPY_TARGET} PRIVATE
     ${TOP_DIR}/${OMV_DIR}/sensors/lepton.c
     ${TOP_DIR}/${OMV_DIR}/sensors/hm01b0.c
     ${TOP_DIR}/${OMV_DIR}/sensors/gc2145.c
-
-    ${TOP_DIR}/${OMV_DIR}/modules/py_clock.c
-    ${TOP_DIR}/${OMV_DIR}/modules/py_gif.c
-    ${TOP_DIR}/${OMV_DIR}/modules/py_helper.c
-    ${TOP_DIR}/${OMV_DIR}/modules/py_image.c
-    ${TOP_DIR}/${OMV_DIR}/modules/py_imageio.c
-    ${TOP_DIR}/${OMV_DIR}/modules/py_mjpeg.c
-    ${TOP_DIR}/${OMV_DIR}/modules/py_omv.c
-    ${TOP_DIR}/${OMV_DIR}/modules/py_sensor.c
-    ${TOP_DIR}/${OMV_DIR}/modules/py_tf.c
-    ${TOP_DIR}/${OMV_DIR}/modules/py_fir.c
 
     ${TOP_DIR}/${OMV_DIR}/imlib/agast.c
     ${TOP_DIR}/${OMV_DIR}/imlib/apriltag.c
@@ -178,6 +169,8 @@ target_sources(${MICROPY_TARGET} PRIVATE
     ${TOP_DIR}/${OMV_DIR}/ports/${PORT}/main.c
     ${TOP_DIR}/${OMV_DIR}/ports/${PORT}/cambus.c
     ${TOP_DIR}/${OMV_DIR}/ports/${PORT}/sensor.c
+
+    ${OMV_USER_MODULES}
 )
 
 if(MICROPY_PY_SENSOR)
@@ -214,7 +207,7 @@ if(MICROPY_PY_AUDIO)
 endif()
 
 if(MICROPY_PY_ULAB)
-    set(MICROPY_ULAB_DIR "${MICROPY_DIR}/extmod/ulab")
+    set(MICROPY_ULAB_DIR "${TOP_DIR}/${OMV_DIR}/modules/ulab")
 
     target_include_directories(${MICROPY_TARGET} PRIVATE
         ${MICROPY_ULAB_DIR}/code/
@@ -249,6 +242,7 @@ if(MICROPY_PY_ULAB)
 
     target_compile_definitions(${MICROPY_TARGET} PRIVATE
         MICROPY_PY_ULAB=1
+        MODULE_ULAB_ENABLED=1
         ULAB_CONFIG_FILE="${OMV_BOARD_CONFIG_DIR}/ulab_config.h"
     )
 endif()

--- a/src/omv/ports/rp2/omv_portconfig.mk
+++ b/src/omv/ports/rp2/omv_portconfig.mk
@@ -14,7 +14,8 @@ export TOP_DIR
 export CC=
 export CXX=
 
-MICROPY_ARGS += BOARD=$(TARGET) BUILD=$(BUILD)/rp2 OMV_CMAKE=$(TOP_DIR)/$(OMV_DIR)/ports/$(PORT)/omv_portconfig.cmake
+# Note this overrides USER_C_MODULES.
+MICROPY_ARGS += BOARD=$(TARGET) BUILD=$(BUILD)/rp2 OMV_CMAKE=$(TOP_DIR)/$(OMV_DIR)/ports/$(PORT)/omv_portconfig.cmake USER_C_MODULES=""
 
 ###################################################
 all: $(OPENMV)

--- a/src/omv/ports/stm32/modules/py_audio.c
+++ b/src/omv/ports/stm32/modules/py_audio.c
@@ -373,4 +373,5 @@ const mp_obj_module_t audio_module = {
     .globals = (mp_obj_t)&globals_dict,
 };
 
+MP_REGISTER_MODULE(MP_QSTR_audio, audio_module, MICROPY_PY_AUDIO);
 #endif //MICROPY_PY_AUDIO

--- a/src/omv/ports/stm32/modules/py_buzzer.c
+++ b/src/omv/ports/stm32/modules/py_buzzer.c
@@ -109,4 +109,5 @@ void py_buzzer_init0()
     buzzer_setup(OMV_BUZZER_FREQ, 0);
 }
 
+MP_REGISTER_MODULE(MP_QSTR_buzzer, buzzer_module, MICROPY_PY_BUZZER);
 #endif // MICROPY_PY_BUZZER

--- a/src/omv/ports/stm32/modules/py_cpufreq.c
+++ b/src/omv/ports/stm32/modules/py_cpufreq.c
@@ -251,3 +251,5 @@ const mp_obj_module_t cpufreq_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_t)&globals_dict,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_cpufreq, cpufreq_module, 1);

--- a/src/omv/ports/stm32/modules/py_imu.c
+++ b/src/omv/ports/stm32/modules/py_imu.c
@@ -281,4 +281,6 @@ float py_imu_pitch_rotation()
 
     return py_imu_get_pitch();
 }
+
+MP_REGISTER_MODULE(MP_QSTR_imu, imu_module, MICROPY_PY_IMU);
 #endif // MICROPY_PY_IMU

--- a/src/omv/ports/stm32/modules/py_lcd.c
+++ b/src/omv/ports/stm32/modules/py_lcd.c
@@ -1839,4 +1839,5 @@ void py_lcd_init0()
     py_lcd_deinit();
 }
 
+MP_REGISTER_MODULE(MP_QSTR_lcd, lcd_module, MICROPY_PY_LCD);
 #endif // MICROPY_PY_LCD

--- a/src/omv/ports/stm32/modules/py_micro_speech.c
+++ b/src/omv/ports/stm32/modules/py_micro_speech.c
@@ -270,4 +270,6 @@ const mp_obj_module_t micro_speech_module = {
     .base    = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_micro_speech, micro_speech_module, MICROPY_PY_MICRO_SPEECH);
 #endif //MICROPY_PY_MICRO_SPEECH

--- a/src/omv/ports/stm32/modules/py_tv.c
+++ b/src/omv/ports/stm32/modules/py_tv.c
@@ -1108,4 +1108,5 @@ void py_tv_init0()
     py_tv_deinit();
 }
 
+MP_REGISTER_MODULE(MP_QSTR_tv, tv_module, MICROPY_PY_TV);
 #endif // MICROPY_PY_TV

--- a/src/omv/ports/stm32/omv_portconfig.mk
+++ b/src/omv/ports/stm32/omv_portconfig.mk
@@ -156,19 +156,6 @@ FIRM_OBJ += $(addprefix $(BUILD)/$(OMV_DIR)/sensors/,   \
 	paj6100.o                   \
    )
 
-FIRM_OBJ += $(addprefix $(BUILD)/$(OMV_DIR)/modules/,   \
-	py_clock.o                  \
-	py_gif.o                    \
-	py_helper.o                 \
-	py_image.o                  \
-	py_imageio.o                \
-	py_mjpeg.o                  \
-	py_omv.o                    \
-	py_sensor.o                 \
-	py_tf.o                     \
-	py_fir.o                    \
-   )
-
 FIRM_OBJ += $(addprefix $(BUILD)/$(OMV_DIR)/imlib/, \
 	agast.o                     \
 	apriltag.o                  \
@@ -223,7 +210,8 @@ FIRM_OBJ += $(addprefix $(BUILD)/$(OMV_DIR)/imlib/, \
    )
 
 FIRM_OBJ += $(wildcard $(BUILD)/$(OMV_DIR)/ports/$(PORT)/*.o)
-FIRM_OBJ += $(wildcard $(BUILD)/$(OMV_DIR)/ports/$(PORT)/modules/*.o)
+FIRM_OBJ += $(wildcard $(BUILD)/$(MICROPY_DIR)/modules/*.o)
+FIRM_OBJ += $(wildcard $(BUILD)/$(MICROPY_DIR)/ports/$(PORT)/modules/*.o)
 
 #------------- MicroPy Objects -------------------#
 FIRM_OBJ += $(wildcard $(BUILD)/$(MICROPY_DIR)/py/*.o)
@@ -404,7 +392,7 @@ FIRM_OBJ += $(addprefix $(BUILD)/$(MICROPY_DIR)/drivers/,\
 	)
 
 ifeq ($(MICROPY_PY_ULAB), 1)
-FIRM_OBJ += $(addprefix $(BUILD)/$(MICROPY_DIR)/extmod/ulab/,\
+FIRM_OBJ += $(addprefix $(BUILD)/$(MICROPY_DIR)/modules/ulab/,\
 	code/scipy/optimize/optimize.o      \
 	code/scipy/signal/signal.o          \
 	code/scipy/special/special.o        \

--- a/src/stm32cubeai/cube.mk
+++ b/src/stm32cubeai/cube.mk
@@ -10,10 +10,6 @@ CFLAGS += -I$(TOP_DIR)/stm32cubeai/
 CFLAGS += -I$(TOP_DIR)/stm32cubeai/data/
 CFLAGS += -I$(TOP_DIR)/stm32cubeai/AI/Inc/
 
-# Append to OMV_QSTR_DEFS
-OMV_SRC_QSTR += $(TOP_DIR)/stm32cubeai/py_st_nn.c
-
-
 FIRM_OBJ += $(wildcard $(BUILD)/$(CMSIS_DIR)/src/dsp/BasicMathFunctions/*.o)
 FIRM_OBJ += $(wildcard $(BUILD)/$(CMSIS_DIR)/src/dsp/SupportFunctions/*.o)
 FIRM_OBJ += $(wildcard $(BUILD)/$(CMSIS_DIR)/src/dsp/MatrixFunctions/*.o)

--- a/src/stm32cubeai/py_st_nn.c
+++ b/src/stm32cubeai/py_st_nn.c
@@ -92,3 +92,5 @@ STATIC MP_DEFINE_CONST_DICT(globals_dict, globals_dict_table);
 /* Create nn_st_module module + add ref to it in mpconfigport.h file */
 const mp_obj_module_t nn_st_module = {.base = {&mp_type_module},
                                       .globals = (mp_obj_t)&globals_dict};
+
+MP_REGISTER_MODULE(MP_QSTR_nn_st, nn_st_module, MICROPY_PY_CUBEAI);


### PR DESCRIPTION
* Switch to using USER_C_MODULES to add OpenMV Python modules.
* It's no longer necessary to edit mpconfigport.h files to add a modules, or provide qstrs.
* To add a new module just place in omv/modules/example.c and rebuild, it will be picked up and included in the firmware.
* Similarly, port-specific modules can be add to  omv/ports/<port>/modules/example.c
* See example module: omv/modules/examplemodule.c
* NOTE: Took some extra time to fix stm32cubeai module, and test on stm32, nrf and rp2.