### PR TITLE
Kwabena/use draw image more

### DIFF
--- a/src/omv/imlib/dmtx.c
+++ b/src/omv/imlib/dmtx.c
@@ -6310,17 +6310,6 @@ dmtxMatrix3Print(DmtxMatrix3 m)
 void imlib_find_datamatrices(list_t *out, image_t *ptr, rectangle_t *roi, int effort)
 {
     uint8_t *grayscale_image = (ptr->pixfmt == PIXFORMAT_GRAYSCALE) ? ptr->data : fb_alloc(roi->w * roi->h, FB_ALLOC_NO_HINT);
-    umm_init_x(fb_avail());
-
-    DmtxImage *image = dmtxImageCreate(grayscale_image,
-                                       (ptr->pixfmt == PIXFORMAT_GRAYSCALE) ? ptr->w : roi->w,
-                                       (ptr->pixfmt == PIXFORMAT_GRAYSCALE) ? ptr->h : roi->h,
-                                       DmtxPack8bppK);
-    DmtxDecode *decode = dmtxDecodeCreate(image, 1);
-    dmtxDecodeSetProp(decode, DmtxPropXmin, (ptr->pixfmt == PIXFORMAT_GRAYSCALE) ? roi->x : 0);
-    dmtxDecodeSetProp(decode, DmtxPropYmin, (ptr->pixfmt == PIXFORMAT_GRAYSCALE) ? roi->y : 0);
-    dmtxDecodeSetProp(decode, DmtxPropXmax, ((ptr->pixfmt == PIXFORMAT_GRAYSCALE) ? roi->x : 0) + (roi->w - 1));
-    dmtxDecodeSetProp(decode, DmtxPropYmax, ((ptr->pixfmt == PIXFORMAT_GRAYSCALE) ? roi->y : 0) + (roi->h - 1));
 
     if (ptr->pixfmt != PIXFORMAT_GRAYSCALE) {
         image_t img;
@@ -6330,6 +6319,19 @@ void imlib_find_datamatrices(list_t *out, image_t *ptr, rectangle_t *roi, int ef
         img.data = grayscale_image;
         imlib_draw_image(&img, ptr, 0, 0, 1.f, 1.f, roi, -1, 256, NULL, NULL, 0, NULL, NULL);
     }
+
+    umm_init_x(fb_avail());
+
+    DmtxImage *image = dmtxImageCreate(grayscale_image,
+                                       (ptr->pixfmt == PIXFORMAT_GRAYSCALE) ? ptr->w : roi->w,
+                                       (ptr->pixfmt == PIXFORMAT_GRAYSCALE) ? ptr->h : roi->h,
+                                       DmtxPack8bppK);
+
+    DmtxDecode *decode = dmtxDecodeCreate(image, 1);
+    dmtxDecodeSetProp(decode, DmtxPropXmin, (ptr->pixfmt == PIXFORMAT_GRAYSCALE) ? roi->x : 0);
+    dmtxDecodeSetProp(decode, DmtxPropYmin, (ptr->pixfmt == PIXFORMAT_GRAYSCALE) ? roi->y : 0);
+    dmtxDecodeSetProp(decode, DmtxPropXmax, ((ptr->pixfmt == PIXFORMAT_GRAYSCALE) ? roi->x : 0) + (roi->w - 1));
+    dmtxDecodeSetProp(decode, DmtxPropYmax, ((ptr->pixfmt == PIXFORMAT_GRAYSCALE) ? roi->y : 0) + (roi->h - 1));
 
     list_init(out, sizeof(find_datamatrices_list_lnk_data_t));
 

--- a/src/omv/imlib/dmtx.c
+++ b/src/omv/imlib/dmtx.c
@@ -2764,7 +2764,7 @@ void Matrix3VMultFast(DmtxVector2 *vIn, DmtxMatrix3 m)
 {
    float w;
    float x, y;
-    
+
    w = vIn->X*m[0][2] + vIn->Y*m[1][2] + m[2][2];
    if(fabsf(w) <= DmtxAlmostZero) {
       vIn->X = FLT_MAX;
@@ -3058,7 +3058,7 @@ GetPointFlow(DmtxDecode *dec, int colorPlane, DmtxPixelLoc loc, int arrive)
    int xAdjust, yAdjust;
    int color, colorPattern[8];
    DmtxPointFlow flow;
-    
+
     // check boundary conditions outside of the loop
     if (loc.X <= 0 || loc.Y <= 0 || loc.X >= dec->image->width-1 || loc.Y >= dec->image->height-1)
         return dmtxBlankEdge; // one or more pixels are past an edge
@@ -6322,32 +6322,13 @@ void imlib_find_datamatrices(list_t *out, image_t *ptr, rectangle_t *roi, int ef
     dmtxDecodeSetProp(decode, DmtxPropXmax, ((ptr->pixfmt == PIXFORMAT_GRAYSCALE) ? roi->x : 0) + (roi->w - 1));
     dmtxDecodeSetProp(decode, DmtxPropYmax, ((ptr->pixfmt == PIXFORMAT_GRAYSCALE) ? roi->y : 0) + (roi->h - 1));
 
-    switch (ptr->pixfmt) {
-        case PIXFORMAT_BINARY: {
-            for (int y = roi->y, yy = roi->y + roi->h; y < yy; y++) {
-                uint32_t *row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(ptr, y);
-                for (int x = roi->x, xx = roi->x + roi->w; x < xx; x++) {
-                    *(grayscale_image++) = COLOR_BINARY_TO_GRAYSCALE(IMAGE_GET_BINARY_PIXEL_FAST(row_ptr, x));
-                }
-            }
-            break;
-        }
-        case PIXFORMAT_GRAYSCALE: {
-            break;
-        }
-        case PIXFORMAT_RGB565: {
-            for (int y = roi->y, yy = roi->y + roi->h; y < yy; y++) {
-                uint16_t *row_ptr = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(ptr, y);
-                for (int x = roi->x, xx = roi->x + roi->w; x < xx; x++) {
-                    *(grayscale_image++) = COLOR_RGB565_TO_GRAYSCALE(IMAGE_GET_RGB565_PIXEL_FAST(row_ptr, x));
-                }
-            }
-            break;
-        }
-        default: {
-            memset(grayscale_image, 0, roi->w * roi->h);
-            break;
-        }
+    if (ptr->pixfmt != PIXFORMAT_GRAYSCALE) {
+        image_t img;
+        img.w = roi->w;
+        img.h = roi->h;
+        img.pixfmt = PIXFORMAT_GRAYSCALE;
+        img.data = grayscale_image;
+        imlib_draw_image(&img, ptr, 0, 0, 1.f, 1.f, roi, -1, 256, NULL, NULL, 0, NULL, NULL);
     }
 
     list_init(out, sizeof(find_datamatrices_list_lnk_data_t));

--- a/src/omv/imlib/qrcode.c
+++ b/src/omv/imlib/qrcode.c
@@ -2971,41 +2971,12 @@ void imlib_find_qrcodes(list_t *out, image_t *ptr, rectangle_t *roi)
     quirc_resize(controller, roi->w, roi->h);
     uint8_t *grayscale_image = quirc_begin(controller, NULL, NULL);
 
-    switch (ptr->pixfmt) {
-        case PIXFORMAT_BINARY: {
-            for (int y = roi->y, yy = roi->y + roi->h; y < yy; y++) {
-                uint32_t *row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(ptr, y);
-                for (int x = roi->x, xx = roi->x + roi->w; x < xx; x++) {
-                    *(grayscale_image++) = COLOR_BINARY_TO_GRAYSCALE(IMAGE_GET_BINARY_PIXEL_FAST(row_ptr, x));
-                }
-            }
-            break;
-        }
-        case PIXFORMAT_GRAYSCALE: {
-            for (int y = roi->y, yy = roi->y + roi->h; y < yy; y++) {
-                uint8_t *row_ptr = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(ptr, y);
-                memcpy(grayscale_image, &row_ptr[roi->x], roi->w);
-                grayscale_image += roi->w;
-//                for (int x = roi->x, xx = roi->x + roi->w; x < xx; x++) {
-//                    *(grayscale_image++) = IMAGE_GET_GRAYSCALE_PIXEL_FAST(row_ptr, x);
-//                }
-            }
-            break;
-        }
-        case PIXFORMAT_RGB565: {
-            for (int y = roi->y, yy = roi->y + roi->h; y < yy; y++) {
-                uint16_t *row_ptr = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(ptr, y);
-                for (int x = roi->x, xx = roi->x + roi->w; x < xx; x++) {
-                    *(grayscale_image++) = COLOR_RGB565_TO_Y(IMAGE_GET_RGB565_PIXEL_FAST(row_ptr, x));
-                }
-            }
-            break;
-        }
-        default: {
-            memset(grayscale_image, 0, roi->w * roi->h);
-            break;
-        }
-    }
+    image_t img;
+    img.w = roi->w;
+    img.h = roi->h;
+    img.pixfmt = PIXFORMAT_GRAYSCALE;
+    img.data = grayscale_image;
+    imlib_draw_image(&img, ptr, 0, 0, 1.f, 1.f, roi, -1, 256, NULL, NULL, 0, NULL, NULL);
 
     quirc_end(controller);
     list_init(out, sizeof(find_qrcodes_list_lnk_data_t));

--- a/src/omv/imlib/zbar.c
+++ b/src/omv/imlib/zbar.c
@@ -8732,32 +8732,13 @@ void imlib_find_barcodes(list_t *out, image_t *ptr, rectangle_t *roi)
     image.seq = 0;
     image.syms = 0;
 
-    switch (ptr->pixfmt) {
-        case PIXFORMAT_BINARY: {
-            for (int y = roi->y, yy = roi->y + roi->h; y < yy; y++) {
-                uint32_t *row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(ptr, y);
-                for (int x = roi->x, xx = roi->x + roi->w; x < xx; x++) {
-                    *(grayscale_image++) = COLOR_BINARY_TO_GRAYSCALE(IMAGE_GET_BINARY_PIXEL_FAST(row_ptr, x));
-                }
-            }
-            break;
-        }
-        case PIXFORMAT_GRAYSCALE: {
-            break;
-        }
-        case PIXFORMAT_RGB565: {
-            for (int y = roi->y, yy = roi->y + roi->h; y < yy; y++) {
-                uint16_t *row_ptr = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(ptr, y);
-                for (int x = roi->x, xx = roi->x + roi->w; x < xx; x++) {
-                    *(grayscale_image++) = COLOR_RGB565_TO_GRAYSCALE(IMAGE_GET_RGB565_PIXEL_FAST(row_ptr, x));
-                }
-            }
-            break;
-        }
-        default: {
-            memset(grayscale_image, 0, roi->w * roi->h);
-            break;
-        }
+    if (ptr->pixfmt != PIXFORMAT_GRAYSCALE) {
+        image_t img;
+        img.w = roi->w;
+        img.h = roi->h;
+        img.pixfmt = PIXFORMAT_GRAYSCALE;
+        img.data = grayscale_image;
+        imlib_draw_image(&img, ptr, 0, 0, 1.f, 1.f, roi, -1, 256, NULL, NULL, 0, NULL, NULL);
     }
 
     list_init(out, sizeof(find_barcodes_list_lnk_data_t));

--- a/src/omv/imlib/zbar.c
+++ b/src/omv/imlib/zbar.c
@@ -8714,7 +8714,18 @@ void zbar_scanner_get_state (const zbar_scanner_t *scn,
 void imlib_find_barcodes(list_t *out, image_t *ptr, rectangle_t *roi)
 {
     uint8_t *grayscale_image = (ptr->pixfmt == PIXFORMAT_GRAYSCALE) ? ptr->data : fb_alloc(roi->w * roi->h, FB_ALLOC_NO_HINT);
+
+    if (ptr->pixfmt != PIXFORMAT_GRAYSCALE) {
+        image_t img;
+        img.w = roi->w;
+        img.h = roi->h;
+        img.pixfmt = PIXFORMAT_GRAYSCALE;
+        img.data = grayscale_image;
+        imlib_draw_image(&img, ptr, 0, 0, 1.f, 1.f, roi, -1, 256, NULL, NULL, 0, NULL, NULL);
+    }
+
     umm_init_x(fb_avail());
+
     zbar_image_scanner_t *scanner = zbar_image_scanner_create();
     zbar_image_scanner_set_config(scanner, 0, ZBAR_CFG_ENABLE, 1);
 
@@ -8731,15 +8742,6 @@ void imlib_find_barcodes(list_t *out, image_t *ptr, rectangle_t *roi)
     image.userdata = 0;
     image.seq = 0;
     image.syms = 0;
-
-    if (ptr->pixfmt != PIXFORMAT_GRAYSCALE) {
-        image_t img;
-        img.w = roi->w;
-        img.h = roi->h;
-        img.pixfmt = PIXFORMAT_GRAYSCALE;
-        img.data = grayscale_image;
-        imlib_draw_image(&img, ptr, 0, 0, 1.f, 1.f, roi, -1, 256, NULL, NULL, 0, NULL, NULL);
-    }
 
     list_init(out, sizeof(find_barcodes_list_lnk_data_t));
 

--- a/src/omv/modules/py_image.c
+++ b/src/omv/modules/py_image.c
@@ -1214,6 +1214,8 @@ static mp_obj_t py_image_compress(uint n_args, const mp_obj_t *args, mp_map_t *k
     PY_ASSERT_FALSE_MSG(jpeg_compress(arg_img, &out, arg_q, false), "Out of Memory!");
     PY_ASSERT_TRUE_MSG(out.size <= image_size(arg_img), "Can't compress in place!");
     memcpy(arg_img->data, out.data, out.size);
+
+    arg_img->pixfmt = PIXFORMAT_JPEG;
     arg_img->size = out.size;
     fb_alloc_free_till_mark();
     py_helper_update_framebuffer(arg_img);
@@ -1236,6 +1238,7 @@ static mp_obj_t py_image_compress_for_ide(uint n_args, const mp_obj_t *args, mp_
     PY_ASSERT_TRUE_MSG(new_size <= image_size(arg_img), "Can't compress in place!");
     fb_encode_for_ide(arg_img->data, &out);
 
+    arg_img->pixfmt = PIXFORMAT_JPEG;
     arg_img->size = new_size;
     fb_alloc_free_till_mark();
     py_helper_update_framebuffer(arg_img);

--- a/src/omv/modules/py_image.c
+++ b/src/omv/modules/py_image.c
@@ -4925,7 +4925,7 @@ static const mp_obj_type_t py_rect_type = {
 
 static mp_obj_t py_image_find_rects(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
 {
-    image_t *arg_img = py_helper_arg_to_image_mutable(args[0]);
+    image_t *arg_img = py_image_cobj(args[0]);
 
     rectangle_t roi;
     py_helper_keyword_rectangle_roi(arg_img, n_args, args, 1, kw_args, &roi);
@@ -5091,7 +5091,7 @@ static const mp_obj_type_t py_qrcode_type = {
 
 static mp_obj_t py_image_find_qrcodes(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
 {
-    image_t *arg_img = py_helper_arg_to_image_mutable(args[0]);
+    image_t *arg_img = py_image_cobj(args[0]);
 
     rectangle_t roi;
     py_helper_keyword_rectangle_roi(arg_img, n_args, args, 1, kw_args, &roi);
@@ -5474,7 +5474,7 @@ static const mp_obj_type_t py_datamatrix_type = {
 
 static mp_obj_t py_image_find_datamatrices(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
 {
-    image_t *arg_img = py_helper_arg_to_image_mutable(args[0]);
+    image_t *arg_img = py_image_cobj(args[0]);
 
     rectangle_t roi;
     py_helper_keyword_rectangle_roi(arg_img, n_args, args, 1, kw_args, &roi);
@@ -5624,7 +5624,7 @@ static const mp_obj_type_t py_barcode_type = {
 
 static mp_obj_t py_image_find_barcodes(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
 {
-    image_t *arg_img = py_helper_arg_to_image_mutable(args[0]);
+    image_t *arg_img = py_image_cobj(args[0]);
 
     rectangle_t roi;
     py_helper_keyword_rectangle_roi(arg_img, n_args, args, 1, kw_args, &roi);

--- a/src/omv/modules/py_tf.h
+++ b/src/omv/modules/py_tf.h
@@ -10,6 +10,7 @@
  */
 #ifndef __PY_TF_H__
 #define __PY_TF_H__
+
 // PyTF model object handle
 typedef struct py_tf_model_obj {
     mp_obj_base_t base;
@@ -19,9 +20,10 @@ typedef struct py_tf_model_obj {
     bool is_float;
 } py_tf_model_obj_t;
 
-// Log buffer stuff
+// Log buffer
 #define PY_TF_PUTCHAR_BUFFER_LEN 1023
 extern char *py_tf_putchar_buffer;
 extern size_t py_tf_putchar_buffer_len;
 void py_tf_alloc_putchar_buffer();
+
 #endif // __PY_TF_H__


### PR DESCRIPTION
* Uses draw_image as the front end for AprilTags/Find_rect/barcode/datamatrix/qrcode - these methods now work on any image type
* Use draw_image as the front end for tensorflow - scaling is better using bilinear interpolation now along with faster code. Works on any image type. However, tensorflow arena memory allocation prevents bayer/jpeg/yuv422 from working due to using up all RAM currently. Once memory allocation is optimized then bayer/jpeg/yuv422 will work too.
* Fixes an issue with compress() and friends.
