### PR TITLE
Portenta: Set default sensor clock to 12MHz.

### DIFF
--- a/src/omv/boards/PORTENTA/omv_boardconfig.h
+++ b/src/omv/boards/PORTENTA/omv_boardconfig.h
@@ -29,7 +29,7 @@
 #define OMV_XCLK_SOURCE         (OMV_XCLK_TIM)
 
 // Sensor external clock timer frequency.
-#define OMV_XCLK_FREQUENCY      (6000000)
+#define OMV_XCLK_FREQUENCY      (12000000)
 
 // Sensor PLL register value.
 #define OMV_OV7725_PLL_CONFIG   (0x41)  // x4

--- a/src/omv/common/sensor_utils.c
+++ b/src/omv/common/sensor_utils.c
@@ -386,6 +386,9 @@ int sensor_probe_init(uint32_t bus_id, uint32_t bus_speed)
 
         #if (OMV_ENABLE_HM01B0 == 1)
         case HM01B0_ID:
+            if (sensor_set_xclk_frequency(HM01B0_XCLK_FREQ) != 0) {
+                return SENSOR_ERROR_TIM_INIT_FAILED;
+            }
             init_ret = hm01b0_init(&sensor);
             break;
         #endif //(OMV_ENABLE_HM01B0 == 1)

--- a/src/omv/sensors/hm01b0.h
+++ b/src/omv/sensors/hm01b0.h
@@ -10,5 +10,6 @@
  */
 #ifndef __HM01B0_H__
 #define __HM01B0_H__
+#define HM01B0_XCLK_FREQ (6000000)
 int hm01b0_init(sensor_t *sensor);
 #endif // __HM01B0_H__


### PR DESCRIPTION
* Support detecting MT9V034.
* Add Himax specific clock.