### PR TITLE
Unsigned var in count down loop fixed

### DIFF
--- a/src/omv/modules/py_tf.c
+++ b/src/omv/modules/py_tf.c
@@ -259,7 +259,7 @@ STATIC void py_tf_input_data_callback(void *callback_data,
                      -1, 256, NULL, NULL, IMAGE_HINT_BILINEAR | IMAGE_HINT_BLACK_BACKGROUND,
                      NULL, NULL);
 
-    unsigned int size = (input_width * input_height) - 1;
+    int size = (input_width * input_height) - 1;
 
     if (input_channels == 1) { // GRAYSCALE
         if (!is_float) {
@@ -285,7 +285,7 @@ STATIC void py_tf_input_data_callback(void *callback_data,
             }
         }
     } else if (input_channels == 3) { // RGB888
-        unsigned int rgb_size = size * 3;
+        int rgb_size = size * 3;
 
         if (!is_float) {
             uint16_t *model_input_u16 = (uint16_t *) model_input;


### PR DESCRIPTION
GCC doesn't feature a warning for this... maybe we should just change all loops to like this blog?

https://nachtimwald.com/2019/06/02/unsigned-count-down/

Anyway, this is not the issue that's crashing TensorFlow in the later release. I found this issue already.