### PR TITLE
Make default disk files different per camera

### DIFF
--- a/src/omv/Makefile
+++ b/src/omv/Makefile
@@ -15,6 +15,12 @@ SRCS += $(addprefix alloc/,     \
 	unaligned_memcpy.c          \
    )
 
+SRCS += $(addprefix boards/$(TARGET)/,  \
+	main.py                             \
+	readme.txt                          \
+	selftest.py                         \
+   )
+
 SRCS += $(addprefix common/,    \
 	array.c                     \
 	ff_wrapper.c                \
@@ -98,7 +104,7 @@ SRCS += $(addprefix imlib/,     \
 
 SRCS += $(wildcard ports/$(PORT)/*.c)
 
-OBJS = $(addprefix $(BUILD)/, $(SRCS:.c=.o))
+OBJS = $(addprefix $(BUILD)/, $(patsubst %.py,%_py.o, $(patsubst %.txt,%_txt.o, $(SRCS:.c=.o))))
 OBJ_DIRS = $(sort $(dir $(OBJS)))
 
 all: | $(OBJ_DIRS) $(OBJS)
@@ -112,5 +118,18 @@ $(BUILD)/%.o : %.c
 $(BUILD)/%.o : %.s
 	$(ECHO) "AS $<"
 	$(AS) $(AFLAGS) $< -o $@
+
+define BUILD_RESOURCE =
+$(ECHO) "XXD $<"
+cd $(<D) && xxd -i $(<F) $(@:.o=.c) && sed -i "s/unsigned/const unsigned/g" $(<F) $(@:.o=.c)
+$(ECHO) "CC $(@:.o=.c)"
+$(CC) $(CFLAGS) -c -o $@ $(@:.o=.c) && sed -i "s@$(@:.o=.c)@$(addprefix $(CURDIR)/, $<)@g" $(@:.o=.d)
+endef
+
+$(BUILD)/%_py.o : %.py
+	$(BUILD_RESOURCE)
+
+$(BUILD)/%_txt.o : %.txt
+	$(BUILD_RESOURCE)
 
 -include $(OBJS:%.o=%.d)

--- a/src/omv/boards/ARDUINO_NANO_RP2040_CONNECT/main.py
+++ b/src/omv/boards/ARDUINO_NANO_RP2040_CONNECT/main.py
@@ -1,0 +1,13 @@
+# main.py -- put your code here!
+import pyb, time
+led = pyb.LED(3)
+usb = pyb.USB_VCP()
+while (usb.isconnected()==False):
+    led.on()
+    time.sleep_ms(150)
+    led.off()
+    time.sleep_ms(100)
+    led.on()
+    time.sleep_ms(150)
+    led.off()
+    time.sleep_ms(600)

--- a/src/omv/boards/ARDUINO_NANO_RP2040_CONNECT/readme.txt
+++ b/src/omv/boards/ARDUINO_NANO_RP2040_CONNECT/readme.txt
@@ -1,0 +1,13 @@
+Thank you for supporting the OpenMV project!
+
+To download the IDE, please visit:
+https://openmv.io/pages/download
+
+For tutorials and documentation, please visit:
+http://docs.openmv.io/
+
+For technical support and projects, please visit the forums:
+http://forums.openmv.io/
+
+Please use github to report bugs and issues:
+https://github.com/openmv/openmv

--- a/src/omv/boards/ARDUINO_NANO_RP2040_CONNECT/selftest.py
+++ b/src/omv/boards/ARDUINO_NANO_RP2040_CONNECT/selftest.py
@@ -1,0 +1,2 @@
+if __name__ == '__main__':
+    print('')

--- a/src/omv/boards/BORMIO/main.py
+++ b/src/omv/boards/BORMIO/main.py
@@ -1,0 +1,13 @@
+# main.py -- put your code here!
+import pyb, time
+led = pyb.LED(3)
+usb = pyb.USB_VCP()
+while (usb.isconnected()==False):
+    led.on()
+    time.sleep_ms(150)
+    led.off()
+    time.sleep_ms(100)
+    led.on()
+    time.sleep_ms(150)
+    led.off()
+    time.sleep_ms(600)

--- a/src/omv/boards/BORMIO/readme.txt
+++ b/src/omv/boards/BORMIO/readme.txt
@@ -1,0 +1,13 @@
+Thank you for supporting the OpenMV project!
+
+To download the IDE, please visit:
+https://openmv.io/pages/download
+
+For tutorials and documentation, please visit:
+http://docs.openmv.io/
+
+For technical support and projects, please visit the forums:
+http://forums.openmv.io/
+
+Please use github to report bugs and issues:
+https://github.com/openmv/openmv

--- a/src/omv/boards/BORMIO/selftest.py
+++ b/src/omv/boards/BORMIO/selftest.py
@@ -1,0 +1,71 @@
+import sensor, time, pyb
+
+def test_int_adc():
+    adc  = pyb.ADCAll(12)
+    # Test VBAT
+    vbat = adc.read_core_vbat()
+    vbat_diff = abs(vbat-"OMV_CORE_VBAT")
+    if (vbat_diff > 0.15):
+        raise Exception('INTERNAL ADC TEST FAILED VBAT=%fv'%vbat)
+
+    # Test VREF
+    vref = adc.read_core_vref()
+    vref_diff = abs(vref-1.2)
+    if (vref_diff > 0.1):
+        raise Exception('INTERNAL ADC TEST FAILED VREF=%fv'%vref)
+    adc = None
+    print('INTERNAL ADC TEST PASSED...')
+
+def test_color_bars():
+    sensor.reset()
+    # Set sensor settings
+    sensor.set_brightness(0)
+    sensor.set_saturation(3)
+    sensor.set_gainceiling(8)
+    sensor.set_contrast(2)
+
+    # Set sensor pixel format
+    sensor.set_framesize(sensor.QVGA)
+    sensor.set_pixformat(sensor.RGB565)
+
+    # Enable colorbar test mode
+    sensor.set_colorbar(True)
+
+    # Skip a few frames to allow the sensor settle down
+    for i in range(0, 100):
+        image = sensor.snapshot()
+
+    #color bars thresholds
+    t = [lambda r, g, b: r < 70  and g < 70  and b < 70,   # Black
+         lambda r, g, b: r < 70  and g < 70  and b > 200,  # Blue
+         lambda r, g, b: r > 200 and g < 70  and b < 70,   # Red
+         lambda r, g, b: r > 200 and g < 70  and b > 200,  # Purple
+         lambda r, g, b: r < 70  and g > 200 and b < 70,   # Green
+         lambda r, g, b: r < 70  and g > 200 and b > 200,  # Aqua
+         lambda r, g, b: r > 200 and g > 200 and b < 70,   # Yellow
+         lambda r, g, b: r > 200 and g > 200 and b > 200]  # White
+
+    # color bars are inverted for OV7725
+    if (sensor.get_id() == sensor.OV7725):
+        t = t[::-1]
+
+    #320x240 image with 8 color bars each one is approx 40 pixels.
+    #we start from the center of the frame buffer, and average the
+    #values of 10 sample pixels from the center of each color bar.
+    for i in range(0, 8):
+        avg = (0, 0, 0)
+        idx = 40*i+20 #center of colorbars
+        for off in range(0, 10): #avg 10 pixels
+            rgb = image.get_pixel(idx+off, 120)
+            avg = tuple(map(sum, zip(avg, rgb)))
+
+        if not t[i](avg[0]/10, avg[1]/10, avg[2]/10):
+            raise Exception('COLOR BARS TEST FAILED.'
+            'BAR#(%d): RGB(%d,%d,%d)'%(i+1, avg[0]/10, avg[1]/10, avg[2]/10))
+
+    print('COLOR BARS TEST PASSED...')
+
+if __name__ == '__main__':
+    print('')
+    test_int_adc()
+    if sensor.get_id() == sensor.OV7725: test_color_bars()

--- a/src/omv/boards/NANO33/main.py
+++ b/src/omv/boards/NANO33/main.py
@@ -1,0 +1,13 @@
+# main.py -- put your code here!
+import pyb, time
+led = pyb.LED(3)
+usb = pyb.USB_VCP()
+while (usb.isconnected()==False):
+    led.on()
+    time.sleep_ms(150)
+    led.off()
+    time.sleep_ms(100)
+    led.on()
+    time.sleep_ms(150)
+    led.off()
+    time.sleep_ms(600)

--- a/src/omv/boards/NANO33/readme.txt
+++ b/src/omv/boards/NANO33/readme.txt
@@ -1,0 +1,13 @@
+Thank you for supporting the OpenMV project!
+
+To download the IDE, please visit:
+https://openmv.io/pages/download
+
+For tutorials and documentation, please visit:
+http://docs.openmv.io/
+
+For technical support and projects, please visit the forums:
+http://forums.openmv.io/
+
+Please use github to report bugs and issues:
+https://github.com/openmv/openmv

--- a/src/omv/boards/NANO33/selftest.py
+++ b/src/omv/boards/NANO33/selftest.py
@@ -1,0 +1,2 @@
+if __name__ == '__main__':
+    print('')

--- a/src/omv/boards/OPENMV1/main.py
+++ b/src/omv/boards/OPENMV1/main.py
@@ -1,0 +1,1 @@
+# main.py -- put your code here!

--- a/src/omv/boards/OPENMV1/readme.txt
+++ b/src/omv/boards/OPENMV1/readme.txt
@@ -1,0 +1,13 @@
+Thank you for supporting the OpenMV project!
+
+To download the IDE, please visit:
+https://openmv.io/pages/download
+
+For tutorials and documentation, please visit:
+http://docs.openmv.io/
+
+For technical support and projects, please visit the forums:
+http://forums.openmv.io/
+
+Please use github to report bugs and issues:
+https://github.com/openmv/openmv

--- a/src/omv/boards/OPENMV1/selftest.py
+++ b/src/omv/boards/OPENMV1/selftest.py
@@ -1,0 +1,71 @@
+import sensor, time, pyb
+
+def test_int_adc():
+    adc  = pyb.ADCAll(12)
+    # Test VBAT
+    vbat = adc.read_core_vbat()
+    vbat_diff = abs(vbat-"OMV_CORE_VBAT")
+    if (vbat_diff > 0.15):
+        raise Exception('INTERNAL ADC TEST FAILED VBAT=%fv'%vbat)
+
+    # Test VREF
+    vref = adc.read_core_vref()
+    vref_diff = abs(vref-1.2)
+    if (vref_diff > 0.1):
+        raise Exception('INTERNAL ADC TEST FAILED VREF=%fv'%vref)
+    adc = None
+    print('INTERNAL ADC TEST PASSED...')
+
+def test_color_bars():
+    sensor.reset()
+    # Set sensor settings
+    sensor.set_brightness(0)
+    sensor.set_saturation(3)
+    sensor.set_gainceiling(8)
+    sensor.set_contrast(2)
+
+    # Set sensor pixel format
+    sensor.set_framesize(sensor.QVGA)
+    sensor.set_pixformat(sensor.RGB565)
+
+    # Enable colorbar test mode
+    sensor.set_colorbar(True)
+
+    # Skip a few frames to allow the sensor settle down
+    for i in range(0, 100):
+        image = sensor.snapshot()
+
+    #color bars thresholds
+    t = [lambda r, g, b: r < 70  and g < 70  and b < 70,   # Black
+         lambda r, g, b: r < 70  and g < 70  and b > 200,  # Blue
+         lambda r, g, b: r > 200 and g < 70  and b < 70,   # Red
+         lambda r, g, b: r > 200 and g < 70  and b > 200,  # Purple
+         lambda r, g, b: r < 70  and g > 200 and b < 70,   # Green
+         lambda r, g, b: r < 70  and g > 200 and b > 200,  # Aqua
+         lambda r, g, b: r > 200 and g > 200 and b < 70,   # Yellow
+         lambda r, g, b: r > 200 and g > 200 and b > 200]  # White
+
+    # color bars are inverted for OV7725
+    if (sensor.get_id() == sensor.OV7725):
+        t = t[::-1]
+
+    #320x240 image with 8 color bars each one is approx 40 pixels.
+    #we start from the center of the frame buffer, and average the
+    #values of 10 sample pixels from the center of each color bar.
+    for i in range(0, 8):
+        avg = (0, 0, 0)
+        idx = 40*i+20 #center of colorbars
+        for off in range(0, 10): #avg 10 pixels
+            rgb = image.get_pixel(idx+off, 120)
+            avg = tuple(map(sum, zip(avg, rgb)))
+
+        if not t[i](avg[0]/10, avg[1]/10, avg[2]/10):
+            raise Exception('COLOR BARS TEST FAILED.'
+            'BAR#(%d): RGB(%d,%d,%d)'%(i+1, avg[0]/10, avg[1]/10, avg[2]/10))
+
+    print('COLOR BARS TEST PASSED...')
+
+if __name__ == '__main__':
+    print('')
+    test_int_adc()
+    if sensor.get_id() == sensor.OV7725: test_color_bars()

--- a/src/omv/boards/OPENMV2/main.py
+++ b/src/omv/boards/OPENMV2/main.py
@@ -1,0 +1,13 @@
+# main.py -- put your code here!
+import pyb, time
+led = pyb.LED(3)
+usb = pyb.USB_VCP()
+while (usb.isconnected()==False):
+    led.on()
+    time.sleep_ms(150)
+    led.off()
+    time.sleep_ms(100)
+    led.on()
+    time.sleep_ms(150)
+    led.off()
+    time.sleep_ms(600)

--- a/src/omv/boards/OPENMV2/readme.txt
+++ b/src/omv/boards/OPENMV2/readme.txt
@@ -1,0 +1,13 @@
+Thank you for supporting the OpenMV project!
+
+To download the IDE, please visit:
+https://openmv.io/pages/download
+
+For tutorials and documentation, please visit:
+http://docs.openmv.io/
+
+For technical support and projects, please visit the forums:
+http://forums.openmv.io/
+
+Please use github to report bugs and issues:
+https://github.com/openmv/openmv

--- a/src/omv/boards/OPENMV2/selftest.py
+++ b/src/omv/boards/OPENMV2/selftest.py
@@ -1,0 +1,71 @@
+import sensor, time, pyb
+
+def test_int_adc():
+    adc  = pyb.ADCAll(12)
+    # Test VBAT
+    vbat = adc.read_core_vbat()
+    vbat_diff = abs(vbat-"OMV_CORE_VBAT")
+    if (vbat_diff > 0.15):
+        raise Exception('INTERNAL ADC TEST FAILED VBAT=%fv'%vbat)
+
+    # Test VREF
+    vref = adc.read_core_vref()
+    vref_diff = abs(vref-1.2)
+    if (vref_diff > 0.1):
+        raise Exception('INTERNAL ADC TEST FAILED VREF=%fv'%vref)
+    adc = None
+    print('INTERNAL ADC TEST PASSED...')
+
+def test_color_bars():
+    sensor.reset()
+    # Set sensor settings
+    sensor.set_brightness(0)
+    sensor.set_saturation(3)
+    sensor.set_gainceiling(8)
+    sensor.set_contrast(2)
+
+    # Set sensor pixel format
+    sensor.set_framesize(sensor.QVGA)
+    sensor.set_pixformat(sensor.RGB565)
+
+    # Enable colorbar test mode
+    sensor.set_colorbar(True)
+
+    # Skip a few frames to allow the sensor settle down
+    for i in range(0, 100):
+        image = sensor.snapshot()
+
+    #color bars thresholds
+    t = [lambda r, g, b: r < 70  and g < 70  and b < 70,   # Black
+         lambda r, g, b: r < 70  and g < 70  and b > 200,  # Blue
+         lambda r, g, b: r > 200 and g < 70  and b < 70,   # Red
+         lambda r, g, b: r > 200 and g < 70  and b > 200,  # Purple
+         lambda r, g, b: r < 70  and g > 200 and b < 70,   # Green
+         lambda r, g, b: r < 70  and g > 200 and b > 200,  # Aqua
+         lambda r, g, b: r > 200 and g > 200 and b < 70,   # Yellow
+         lambda r, g, b: r > 200 and g > 200 and b > 200]  # White
+
+    # color bars are inverted for OV7725
+    if (sensor.get_id() == sensor.OV7725):
+        t = t[::-1]
+
+    #320x240 image with 8 color bars each one is approx 40 pixels.
+    #we start from the center of the frame buffer, and average the
+    #values of 10 sample pixels from the center of each color bar.
+    for i in range(0, 8):
+        avg = (0, 0, 0)
+        idx = 40*i+20 #center of colorbars
+        for off in range(0, 10): #avg 10 pixels
+            rgb = image.get_pixel(idx+off, 120)
+            avg = tuple(map(sum, zip(avg, rgb)))
+
+        if not t[i](avg[0]/10, avg[1]/10, avg[2]/10):
+            raise Exception('COLOR BARS TEST FAILED.'
+            'BAR#(%d): RGB(%d,%d,%d)'%(i+1, avg[0]/10, avg[1]/10, avg[2]/10))
+
+    print('COLOR BARS TEST PASSED...')
+
+if __name__ == '__main__':
+    print('')
+    test_int_adc()
+    if sensor.get_id() == sensor.OV7725: test_color_bars()

--- a/src/omv/boards/OPENMV3/main.py
+++ b/src/omv/boards/OPENMV3/main.py
@@ -1,0 +1,13 @@
+# main.py -- put your code here!
+import pyb, time
+led = pyb.LED(3)
+usb = pyb.USB_VCP()
+while (usb.isconnected()==False):
+    led.on()
+    time.sleep_ms(150)
+    led.off()
+    time.sleep_ms(100)
+    led.on()
+    time.sleep_ms(150)
+    led.off()
+    time.sleep_ms(600)

--- a/src/omv/boards/OPENMV3/readme.txt
+++ b/src/omv/boards/OPENMV3/readme.txt
@@ -1,0 +1,13 @@
+Thank you for supporting the OpenMV project!
+
+To download the IDE, please visit:
+https://openmv.io/pages/download
+
+For tutorials and documentation, please visit:
+http://docs.openmv.io/
+
+For technical support and projects, please visit the forums:
+http://forums.openmv.io/
+
+Please use github to report bugs and issues:
+https://github.com/openmv/openmv

--- a/src/omv/boards/OPENMV3/selftest.py
+++ b/src/omv/boards/OPENMV3/selftest.py
@@ -1,0 +1,71 @@
+import sensor, time, pyb
+
+def test_int_adc():
+    adc  = pyb.ADCAll(12)
+    # Test VBAT
+    vbat = adc.read_core_vbat()
+    vbat_diff = abs(vbat-"OMV_CORE_VBAT")
+    if (vbat_diff > 0.15):
+        raise Exception('INTERNAL ADC TEST FAILED VBAT=%fv'%vbat)
+
+    # Test VREF
+    vref = adc.read_core_vref()
+    vref_diff = abs(vref-1.2)
+    if (vref_diff > 0.1):
+        raise Exception('INTERNAL ADC TEST FAILED VREF=%fv'%vref)
+    adc = None
+    print('INTERNAL ADC TEST PASSED...')
+
+def test_color_bars():
+    sensor.reset()
+    # Set sensor settings
+    sensor.set_brightness(0)
+    sensor.set_saturation(3)
+    sensor.set_gainceiling(8)
+    sensor.set_contrast(2)
+
+    # Set sensor pixel format
+    sensor.set_framesize(sensor.QVGA)
+    sensor.set_pixformat(sensor.RGB565)
+
+    # Enable colorbar test mode
+    sensor.set_colorbar(True)
+
+    # Skip a few frames to allow the sensor settle down
+    for i in range(0, 100):
+        image = sensor.snapshot()
+
+    #color bars thresholds
+    t = [lambda r, g, b: r < 70  and g < 70  and b < 70,   # Black
+         lambda r, g, b: r < 70  and g < 70  and b > 200,  # Blue
+         lambda r, g, b: r > 200 and g < 70  and b < 70,   # Red
+         lambda r, g, b: r > 200 and g < 70  and b > 200,  # Purple
+         lambda r, g, b: r < 70  and g > 200 and b < 70,   # Green
+         lambda r, g, b: r < 70  and g > 200 and b > 200,  # Aqua
+         lambda r, g, b: r > 200 and g > 200 and b < 70,   # Yellow
+         lambda r, g, b: r > 200 and g > 200 and b > 200]  # White
+
+    # color bars are inverted for OV7725
+    if (sensor.get_id() == sensor.OV7725):
+        t = t[::-1]
+
+    #320x240 image with 8 color bars each one is approx 40 pixels.
+    #we start from the center of the frame buffer, and average the
+    #values of 10 sample pixels from the center of each color bar.
+    for i in range(0, 8):
+        avg = (0, 0, 0)
+        idx = 40*i+20 #center of colorbars
+        for off in range(0, 10): #avg 10 pixels
+            rgb = image.get_pixel(idx+off, 120)
+            avg = tuple(map(sum, zip(avg, rgb)))
+
+        if not t[i](avg[0]/10, avg[1]/10, avg[2]/10):
+            raise Exception('COLOR BARS TEST FAILED.'
+            'BAR#(%d): RGB(%d,%d,%d)'%(i+1, avg[0]/10, avg[1]/10, avg[2]/10))
+
+    print('COLOR BARS TEST PASSED...')
+
+if __name__ == '__main__':
+    print('')
+    test_int_adc()
+    if sensor.get_id() == sensor.OV7725: test_color_bars()

--- a/src/omv/boards/OPENMV4/main.py
+++ b/src/omv/boards/OPENMV4/main.py
@@ -1,0 +1,13 @@
+# main.py -- put your code here!
+import pyb, time
+led = pyb.LED(3)
+usb = pyb.USB_VCP()
+while (usb.isconnected()==False):
+    led.on()
+    time.sleep_ms(150)
+    led.off()
+    time.sleep_ms(100)
+    led.on()
+    time.sleep_ms(150)
+    led.off()
+    time.sleep_ms(600)

--- a/src/omv/boards/OPENMV4/readme.txt
+++ b/src/omv/boards/OPENMV4/readme.txt
@@ -1,0 +1,13 @@
+Thank you for supporting the OpenMV project!
+
+To download the IDE, please visit:
+https://openmv.io/pages/download
+
+For tutorials and documentation, please visit:
+http://docs.openmv.io/
+
+For technical support and projects, please visit the forums:
+http://forums.openmv.io/
+
+Please use github to report bugs and issues:
+https://github.com/openmv/openmv

--- a/src/omv/boards/OPENMV4/selftest.py
+++ b/src/omv/boards/OPENMV4/selftest.py
@@ -1,0 +1,71 @@
+import sensor, time, pyb
+
+def test_int_adc():
+    adc  = pyb.ADCAll(12)
+    # Test VBAT
+    vbat = adc.read_core_vbat()
+    vbat_diff = abs(vbat-"OMV_CORE_VBAT")
+    if (vbat_diff > 0.15):
+        raise Exception('INTERNAL ADC TEST FAILED VBAT=%fv'%vbat)
+
+    # Test VREF
+    vref = adc.read_core_vref()
+    vref_diff = abs(vref-1.2)
+    if (vref_diff > 0.1):
+        raise Exception('INTERNAL ADC TEST FAILED VREF=%fv'%vref)
+    adc = None
+    print('INTERNAL ADC TEST PASSED...')
+
+def test_color_bars():
+    sensor.reset()
+    # Set sensor settings
+    sensor.set_brightness(0)
+    sensor.set_saturation(3)
+    sensor.set_gainceiling(8)
+    sensor.set_contrast(2)
+
+    # Set sensor pixel format
+    sensor.set_framesize(sensor.QVGA)
+    sensor.set_pixformat(sensor.RGB565)
+
+    # Enable colorbar test mode
+    sensor.set_colorbar(True)
+
+    # Skip a few frames to allow the sensor settle down
+    for i in range(0, 100):
+        image = sensor.snapshot()
+
+    #color bars thresholds
+    t = [lambda r, g, b: r < 70  and g < 70  and b < 70,   # Black
+         lambda r, g, b: r < 70  and g < 70  and b > 200,  # Blue
+         lambda r, g, b: r > 200 and g < 70  and b < 70,   # Red
+         lambda r, g, b: r > 200 and g < 70  and b > 200,  # Purple
+         lambda r, g, b: r < 70  and g > 200 and b < 70,   # Green
+         lambda r, g, b: r < 70  and g > 200 and b > 200,  # Aqua
+         lambda r, g, b: r > 200 and g > 200 and b < 70,   # Yellow
+         lambda r, g, b: r > 200 and g > 200 and b > 200]  # White
+
+    # color bars are inverted for OV7725
+    if (sensor.get_id() == sensor.OV7725):
+        t = t[::-1]
+
+    #320x240 image with 8 color bars each one is approx 40 pixels.
+    #we start from the center of the frame buffer, and average the
+    #values of 10 sample pixels from the center of each color bar.
+    for i in range(0, 8):
+        avg = (0, 0, 0)
+        idx = 40*i+20 #center of colorbars
+        for off in range(0, 10): #avg 10 pixels
+            rgb = image.get_pixel(idx+off, 120)
+            avg = tuple(map(sum, zip(avg, rgb)))
+
+        if not t[i](avg[0]/10, avg[1]/10, avg[2]/10):
+            raise Exception('COLOR BARS TEST FAILED.'
+            'BAR#(%d): RGB(%d,%d,%d)'%(i+1, avg[0]/10, avg[1]/10, avg[2]/10))
+
+    print('COLOR BARS TEST PASSED...')
+
+if __name__ == '__main__':
+    print('')
+    test_int_adc()
+    if sensor.get_id() == sensor.OV7725: test_color_bars()

--- a/src/omv/boards/OPENMV4P/main.py
+++ b/src/omv/boards/OPENMV4P/main.py
@@ -1,0 +1,13 @@
+# main.py -- put your code here!
+import pyb, time
+led = pyb.LED(3)
+usb = pyb.USB_VCP()
+while (usb.isconnected()==False):
+    led.on()
+    time.sleep_ms(150)
+    led.off()
+    time.sleep_ms(100)
+    led.on()
+    time.sleep_ms(150)
+    led.off()
+    time.sleep_ms(600)

--- a/src/omv/boards/OPENMV4P/readme.txt
+++ b/src/omv/boards/OPENMV4P/readme.txt
@@ -1,0 +1,13 @@
+Thank you for supporting the OpenMV project!
+
+To download the IDE, please visit:
+https://openmv.io/pages/download
+
+For tutorials and documentation, please visit:
+http://docs.openmv.io/
+
+For technical support and projects, please visit the forums:
+http://forums.openmv.io/
+
+Please use github to report bugs and issues:
+https://github.com/openmv/openmv

--- a/src/omv/boards/OPENMV4P/selftest.py
+++ b/src/omv/boards/OPENMV4P/selftest.py
@@ -1,0 +1,71 @@
+import sensor, time, pyb
+
+def test_int_adc():
+    adc  = pyb.ADCAll(12)
+    # Test VBAT
+    vbat = adc.read_core_vbat()
+    vbat_diff = abs(vbat-"OMV_CORE_VBAT")
+    if (vbat_diff > 0.15):
+        raise Exception('INTERNAL ADC TEST FAILED VBAT=%fv'%vbat)
+
+    # Test VREF
+    vref = adc.read_core_vref()
+    vref_diff = abs(vref-1.2)
+    if (vref_diff > 0.1):
+        raise Exception('INTERNAL ADC TEST FAILED VREF=%fv'%vref)
+    adc = None
+    print('INTERNAL ADC TEST PASSED...')
+
+def test_color_bars():
+    sensor.reset()
+    # Set sensor settings
+    sensor.set_brightness(0)
+    sensor.set_saturation(3)
+    sensor.set_gainceiling(8)
+    sensor.set_contrast(2)
+
+    # Set sensor pixel format
+    sensor.set_framesize(sensor.QVGA)
+    sensor.set_pixformat(sensor.RGB565)
+
+    # Enable colorbar test mode
+    sensor.set_colorbar(True)
+
+    # Skip a few frames to allow the sensor settle down
+    for i in range(0, 100):
+        image = sensor.snapshot()
+
+    #color bars thresholds
+    t = [lambda r, g, b: r < 70  and g < 70  and b < 70,   # Black
+         lambda r, g, b: r < 70  and g < 70  and b > 200,  # Blue
+         lambda r, g, b: r > 200 and g < 70  and b < 70,   # Red
+         lambda r, g, b: r > 200 and g < 70  and b > 200,  # Purple
+         lambda r, g, b: r < 70  and g > 200 and b < 70,   # Green
+         lambda r, g, b: r < 70  and g > 200 and b > 200,  # Aqua
+         lambda r, g, b: r > 200 and g > 200 and b < 70,   # Yellow
+         lambda r, g, b: r > 200 and g > 200 and b > 200]  # White
+
+    # color bars are inverted for OV7725
+    if (sensor.get_id() == sensor.OV7725):
+        t = t[::-1]
+
+    #320x240 image with 8 color bars each one is approx 40 pixels.
+    #we start from the center of the frame buffer, and average the
+    #values of 10 sample pixels from the center of each color bar.
+    for i in range(0, 8):
+        avg = (0, 0, 0)
+        idx = 40*i+20 #center of colorbars
+        for off in range(0, 10): #avg 10 pixels
+            rgb = image.get_pixel(idx+off, 120)
+            avg = tuple(map(sum, zip(avg, rgb)))
+
+        if not t[i](avg[0]/10, avg[1]/10, avg[2]/10):
+            raise Exception('COLOR BARS TEST FAILED.'
+            'BAR#(%d): RGB(%d,%d,%d)'%(i+1, avg[0]/10, avg[1]/10, avg[2]/10))
+
+    print('COLOR BARS TEST PASSED...')
+
+if __name__ == '__main__':
+    print('')
+    test_int_adc()
+    if sensor.get_id() == sensor.OV7725: test_color_bars()

--- a/src/omv/boards/OPENMVPT/main.py
+++ b/src/omv/boards/OPENMVPT/main.py
@@ -1,0 +1,89 @@
+import sensor, image, time, lcd, fir, math, pyb
+
+from machine import I2C
+from vl53l1x import VL53L1X
+
+# Color Tracking Thresholds (Grayscale Min, Grayscale Max)
+threshold_list = [(200, 255)]
+
+def main():
+
+    i2c = I2C(2)
+    distance = VL53L1X(i2c)
+
+    sensor.reset()
+    sensor.set_pixformat(sensor.RGB565)
+    sensor.set_framesize(sensor.VGA)
+    time.sleep_ms(50)
+
+    fir.init(fir.FIR_LEPTON)
+    fir_img = sensor.alloc_extra_fb(fir.width(), fir.height(), sensor.GRAYSCALE)
+    time.sleep_ms(50)
+
+    lcd.init(lcd.LCD_DISPLAY_WITH_HDMI, framesize=lcd.FWVGA, refresh=60)
+
+    alpha_pal = image.Image(256, 1, sensor.GRAYSCALE)
+    for i in range(256): alpha_pal[i] = int(math.pow((i / 255), 2) * 255)
+
+    to_min = None
+    to_max = None
+
+    def map_g_to_temp(g):
+        return ((g * (to_max - to_min)) / 255.0) + to_min
+
+    while True:
+        img = sensor.snapshot()
+        # ta: Ambient temperature
+        # ir: Object temperatures (IR array)
+        # to_min: Minimum object temperature
+        # to_max: Maximum object temperature
+        ta, ir, to_min, to_max = fir.read_ir()
+
+        fir.draw_ir(fir_img, ir, color_palette = None)
+        fir_img_size = fir_img.width() * fir_img.height()
+
+        # Find IR Blobs
+        blobs = fir_img.find_blobs(threshold_list,
+                                   pixels_threshold = (fir_img_size // 100),
+                                   area_threshold = (fir_img_size // 100),
+                                   merge = True)
+
+        # Collect stats into a list of tuples
+        blob_stats = []
+        for b in blobs:
+            blob_stats.append((b.rect(), map_g_to_temp(img.get_statistics(thresholds = threshold_list,
+                                                                          roi = b.rect()).mean())))
+        x_scale = img.width() / fir_img.width()
+        y_scale = img.height() / fir_img.height()
+        img.draw_image(fir_img, 0, 0, x_scale = x_scale, y_scale = y_scale,
+                       color_palette = sensor.PALETTE_IRONBOW,
+                       alpha_palette = alpha_pal,
+                       hint = image.BICUBIC)
+
+        # Draw stuff on the colored image
+        for b in blobs:
+            img.draw_rectangle(int(b.rect()[0] * x_scale), int(b.rect()[1] * y_scale),
+                               int(b.rect()[2] * x_scale), int(b.rect()[3] * y_scale))
+            img.draw_cross(int(b.cx() * x_scale), int(b.cy() * y_scale))
+        for blob_stat in blob_stats:
+            img.draw_string(int((blob_stat[0][0] * x_scale) + 4), int((blob_stat[0][1] * y_scale) + 1),
+                            "%.2f C" % blob_stat[1], mono_space = False, scale = 2)
+
+        # Draw ambient, min and max temperatures.
+        img.draw_string(4, 0, "Lepton Temp: %0.2f C" % ta, color = (255, 255, 255), mono_space = False, scale = 2)
+        img.draw_string(4, 18, "Min Temp: %0.2f C" % to_min, color = (255, 255, 255), mono_space = False, scale = 2)
+        img.draw_string(4, 36, "Max Temp: %0.2f C" % to_max, color = (255, 255, 255), mono_space = False, scale = 2)
+        img.draw_string(4, 54, "Distance: %d mm" % distance.read(), color = (255, 255, 255), mono_space = False, scale = 2)
+
+        lcd.display(img, x_size = lcd.width(), hint = image.BILINEAR)
+
+try:
+    main()
+except OSError:
+
+    # I2C Bus may be stuck
+    p = pyb.Pin("P4", pyb.Pin.OUT_OD)
+    for i in range(20000):
+        p.value(not p.value())
+
+    pyb.hard_reset()

--- a/src/omv/boards/OPENMVPT/readme.txt
+++ b/src/omv/boards/OPENMVPT/readme.txt
@@ -1,0 +1,13 @@
+Thank you for supporting the OpenMV project!
+
+To download the IDE, please visit:
+https://openmv.io/pages/download
+
+For tutorials and documentation, please visit:
+http://docs.openmv.io/
+
+For technical support and projects, please visit the forums:
+http://forums.openmv.io/
+
+Please use github to report bugs and issues:
+https://github.com/openmv/openmv

--- a/src/omv/boards/OPENMVPT/selftest.py
+++ b/src/omv/boards/OPENMVPT/selftest.py
@@ -1,0 +1,71 @@
+import sensor, time, pyb
+
+def test_int_adc():
+    adc  = pyb.ADCAll(12)
+    # Test VBAT
+    vbat = adc.read_core_vbat()
+    vbat_diff = abs(vbat-"OMV_CORE_VBAT")
+    if (vbat_diff > 0.15):
+        raise Exception('INTERNAL ADC TEST FAILED VBAT=%fv'%vbat)
+
+    # Test VREF
+    vref = adc.read_core_vref()
+    vref_diff = abs(vref-1.2)
+    if (vref_diff > 0.1):
+        raise Exception('INTERNAL ADC TEST FAILED VREF=%fv'%vref)
+    adc = None
+    print('INTERNAL ADC TEST PASSED...')
+
+def test_color_bars():
+    sensor.reset()
+    # Set sensor settings
+    sensor.set_brightness(0)
+    sensor.set_saturation(3)
+    sensor.set_gainceiling(8)
+    sensor.set_contrast(2)
+
+    # Set sensor pixel format
+    sensor.set_framesize(sensor.QVGA)
+    sensor.set_pixformat(sensor.RGB565)
+
+    # Enable colorbar test mode
+    sensor.set_colorbar(True)
+
+    # Skip a few frames to allow the sensor settle down
+    for i in range(0, 100):
+        image = sensor.snapshot()
+
+    #color bars thresholds
+    t = [lambda r, g, b: r < 70  and g < 70  and b < 70,   # Black
+         lambda r, g, b: r < 70  and g < 70  and b > 200,  # Blue
+         lambda r, g, b: r > 200 and g < 70  and b < 70,   # Red
+         lambda r, g, b: r > 200 and g < 70  and b > 200,  # Purple
+         lambda r, g, b: r < 70  and g > 200 and b < 70,   # Green
+         lambda r, g, b: r < 70  and g > 200 and b > 200,  # Aqua
+         lambda r, g, b: r > 200 and g > 200 and b < 70,   # Yellow
+         lambda r, g, b: r > 200 and g > 200 and b > 200]  # White
+
+    # color bars are inverted for OV7725
+    if (sensor.get_id() == sensor.OV7725):
+        t = t[::-1]
+
+    #320x240 image with 8 color bars each one is approx 40 pixels.
+    #we start from the center of the frame buffer, and average the
+    #values of 10 sample pixels from the center of each color bar.
+    for i in range(0, 8):
+        avg = (0, 0, 0)
+        idx = 40*i+20 #center of colorbars
+        for off in range(0, 10): #avg 10 pixels
+            rgb = image.get_pixel(idx+off, 120)
+            avg = tuple(map(sum, zip(avg, rgb)))
+
+        if not t[i](avg[0]/10, avg[1]/10, avg[2]/10):
+            raise Exception('COLOR BARS TEST FAILED.'
+            'BAR#(%d): RGB(%d,%d,%d)'%(i+1, avg[0]/10, avg[1]/10, avg[2]/10))
+
+    print('COLOR BARS TEST PASSED...')
+
+if __name__ == '__main__':
+    print('')
+    test_int_adc()
+    if sensor.get_id() == sensor.OV7725: test_color_bars()

--- a/src/omv/boards/PICO/main.py
+++ b/src/omv/boards/PICO/main.py
@@ -1,0 +1,13 @@
+# main.py -- put your code here!
+import pyb, time
+led = pyb.LED(3)
+usb = pyb.USB_VCP()
+while (usb.isconnected()==False):
+    led.on()
+    time.sleep_ms(150)
+    led.off()
+    time.sleep_ms(100)
+    led.on()
+    time.sleep_ms(150)
+    led.off()
+    time.sleep_ms(600)

--- a/src/omv/boards/PICO/readme.txt
+++ b/src/omv/boards/PICO/readme.txt
@@ -1,0 +1,13 @@
+Thank you for supporting the OpenMV project!
+
+To download the IDE, please visit:
+https://openmv.io/pages/download
+
+For tutorials and documentation, please visit:
+http://docs.openmv.io/
+
+For technical support and projects, please visit the forums:
+http://forums.openmv.io/
+
+Please use github to report bugs and issues:
+https://github.com/openmv/openmv

--- a/src/omv/boards/PICO/selftest.py
+++ b/src/omv/boards/PICO/selftest.py
@@ -1,0 +1,2 @@
+if __name__ == '__main__':
+    print('')

--- a/src/omv/boards/PORTENTA/main.py
+++ b/src/omv/boards/PORTENTA/main.py
@@ -1,0 +1,13 @@
+# main.py -- put your code here!
+import pyb, time
+led = pyb.LED(3)
+usb = pyb.USB_VCP()
+while (usb.isconnected()==False):
+    led.on()
+    time.sleep_ms(150)
+    led.off()
+    time.sleep_ms(100)
+    led.on()
+    time.sleep_ms(150)
+    led.off()
+    time.sleep_ms(600)

--- a/src/omv/boards/PORTENTA/readme.txt
+++ b/src/omv/boards/PORTENTA/readme.txt
@@ -1,0 +1,13 @@
+Thank you for supporting the OpenMV project!
+
+To download the IDE, please visit:
+https://openmv.io/pages/download
+
+For tutorials and documentation, please visit:
+http://docs.openmv.io/
+
+For technical support and projects, please visit the forums:
+http://forums.openmv.io/
+
+Please use github to report bugs and issues:
+https://github.com/openmv/openmv

--- a/src/omv/boards/PORTENTA/selftest.py
+++ b/src/omv/boards/PORTENTA/selftest.py
@@ -1,0 +1,71 @@
+import sensor, time, pyb
+
+def test_int_adc():
+    adc  = pyb.ADCAll(12)
+    # Test VBAT
+    vbat = adc.read_core_vbat()
+    vbat_diff = abs(vbat-"OMV_CORE_VBAT")
+    if (vbat_diff > 0.15):
+        raise Exception('INTERNAL ADC TEST FAILED VBAT=%fv'%vbat)
+
+    # Test VREF
+    vref = adc.read_core_vref()
+    vref_diff = abs(vref-1.2)
+    if (vref_diff > 0.1):
+        raise Exception('INTERNAL ADC TEST FAILED VREF=%fv'%vref)
+    adc = None
+    print('INTERNAL ADC TEST PASSED...')
+
+def test_color_bars():
+    sensor.reset()
+    # Set sensor settings
+    sensor.set_brightness(0)
+    sensor.set_saturation(3)
+    sensor.set_gainceiling(8)
+    sensor.set_contrast(2)
+
+    # Set sensor pixel format
+    sensor.set_framesize(sensor.QVGA)
+    sensor.set_pixformat(sensor.RGB565)
+
+    # Enable colorbar test mode
+    sensor.set_colorbar(True)
+
+    # Skip a few frames to allow the sensor settle down
+    for i in range(0, 100):
+        image = sensor.snapshot()
+
+    #color bars thresholds
+    t = [lambda r, g, b: r < 70  and g < 70  and b < 70,   # Black
+         lambda r, g, b: r < 70  and g < 70  and b > 200,  # Blue
+         lambda r, g, b: r > 200 and g < 70  and b < 70,   # Red
+         lambda r, g, b: r > 200 and g < 70  and b > 200,  # Purple
+         lambda r, g, b: r < 70  and g > 200 and b < 70,   # Green
+         lambda r, g, b: r < 70  and g > 200 and b > 200,  # Aqua
+         lambda r, g, b: r > 200 and g > 200 and b < 70,   # Yellow
+         lambda r, g, b: r > 200 and g > 200 and b > 200]  # White
+
+    # color bars are inverted for OV7725
+    if (sensor.get_id() == sensor.OV7725):
+        t = t[::-1]
+
+    #320x240 image with 8 color bars each one is approx 40 pixels.
+    #we start from the center of the frame buffer, and average the
+    #values of 10 sample pixels from the center of each color bar.
+    for i in range(0, 8):
+        avg = (0, 0, 0)
+        idx = 40*i+20 #center of colorbars
+        for off in range(0, 10): #avg 10 pixels
+            rgb = image.get_pixel(idx+off, 120)
+            avg = tuple(map(sum, zip(avg, rgb)))
+
+        if not t[i](avg[0]/10, avg[1]/10, avg[2]/10):
+            raise Exception('COLOR BARS TEST FAILED.'
+            'BAR#(%d): RGB(%d,%d,%d)'%(i+1, avg[0]/10, avg[1]/10, avg[2]/10))
+
+    print('COLOR BARS TEST PASSED...')
+
+if __name__ == '__main__':
+    print('')
+    test_int_adc()
+    if sensor.get_id() == sensor.OV7725: test_color_bars()

--- a/src/omv/ports/stm32/omv_portconfig.mk
+++ b/src/omv/ports/stm32/omv_portconfig.mk
@@ -131,6 +131,12 @@ FIRM_OBJ += $(addprefix $(BUILD)/$(OMV_DIR)/alloc/, \
 	unaligned_memcpy.o          \
    )
 
+FIRM_OBJ += $(addprefix $(BUILD)/$(OMV_DIR)/boards/$(TARGET)/, \
+	main_py.o                   \
+	readme_txt.o                \
+	selftest_py.o               \
+   )
+
 FIRM_OBJ += $(addprefix $(BUILD)/$(OMV_DIR)/common/, \
 	array.o                     \
 	ff_wrapper.o                \


### PR DESCRIPTION
Files created by main.c on the first disk boot are not specific per board and are actually editable as files now.

I've wanted to add this for a while so that the OpenMV Pure Thermal's main.py boots the board with all it's glory bey default. You'll notice the main.py for it is quite a bit more complex.