### PR TITLE
Execute frozen boot scripts first before filesystem.

### DIFF
--- a/src/omv/ports/nrf/main.c
+++ b/src/omv/ports/nrf/main.c
@@ -211,7 +211,7 @@ soft_reset:
     int ret = vfs_mount_and_chdir((mp_obj_t)&nrf_flash_obj, mount_point);
 
     if ((ret == -MP_ENODEV) || (ret == -MP_EIO)) {
-        pyexec_frozen_module("_mkfs.py"); // Frozen script for formatting flash filesystem.
+        pyexec_frozen_module("_mkfs.py", false); // Frozen script for formatting flash filesystem.
         ret = vfs_mount_and_chdir((mp_obj_t)&nrf_flash_obj, mount_point);
     }
 
@@ -284,8 +284,8 @@ soft_reset:
 
     #if MICROPY_VFS || MICROPY_MBFS || MICROPY_MODULE_FROZEN
     // run boot.py and main.py if they exist.
-    pyexec_file_if_exists("boot.py");
-    pyexec_file_if_exists("main.py");
+    pyexec_file_if_exists("boot.py", false);
+    pyexec_file_if_exists("main.py", false);
     #endif
 
     #if MICROPY_HW_USB_CDC
@@ -326,7 +326,7 @@ soft_reset:
             usbdbg_set_irq_enabled(true);
 
             // Execute the script.
-            pyexec_str(usbdbg_get_script());
+            pyexec_str(usbdbg_get_script(), true);
             nlr_pop();
         } else {
             mp_obj_print_exception(&mp_plat_print, (mp_obj_t)nlr.ret_val);

--- a/src/omv/ports/rp2/main.c
+++ b/src/omv/ports/rp2/main.c
@@ -113,7 +113,7 @@ void exec_boot_script(const char *path, bool interruptible)
         }
 
         // Parse, compile and execute the script.
-        pyexec_file_if_exists(path);
+        pyexec_file_if_exists(path, true);
         nlr_pop();
     } else {
         interrupted = true;
@@ -206,9 +206,9 @@ soft_reset:
 
     // Execute _boot.py to set up the filesystem.
     #if MICROPY_VFS_FAT && MICROPY_HW_USB_MSC
-    pyexec_frozen_module("_boot_fat.py");
+    pyexec_frozen_module("_boot_fat.py", false);
     #else
-    pyexec_frozen_module("_boot.py");
+    pyexec_frozen_module("_boot.py", false);
     #endif
 
     // Execute user scripts.
@@ -247,7 +247,7 @@ soft_reset:
             // Enable IDE interrupt
             usbdbg_set_irq_enabled(true);
             // Execute the script.
-            pyexec_str(usbdbg_get_script());
+            pyexec_str(usbdbg_get_script(), true);
             nlr_pop();
         } else {
             mp_obj_print_exception(&mp_plat_print, (mp_obj_t)nlr.ret_val);


### PR DESCRIPTION
* Run frozen _boot.py if it exists (for early boot stuff).
* Allow freezing main.py and boot.py boot scripts.
* Give frozen boot scripts priority over filesystem boot scripts.
* Add frozen early boot script for OpenMV-PT.