### PR TITLE
Disable full mdma offload for now

### DIFF
--- a/src/omv/ports/stm32/sensor.c
+++ b/src/omv/ports/stm32/sensor.c
@@ -28,7 +28,7 @@
 
 // Higher performance complete MDMA offload.
 #if (OMV_ENABLE_SENSOR_MDMA == 1)
-#define OMV_ENABLE_SENSOR_MDMA_TOTAL_OFFLOAD 1
+#define OMV_ENABLE_SENSOR_MDMA_TOTAL_OFFLOAD 0
 #endif
 
 sensor_t sensor = {};


### PR DESCRIPTION
See https://github.com/openmv/openmv/issues/1407. It will take a lot of playing around with camera drivers to fix this. I have to change the clock settings and find safe modes with this feature on.

In the mean-time. Folks will notice load on the system being higher.