### PR TITLE
Fix strncpy issue with new GCC

### DIFF
--- a/src/omv/common/ini.c
+++ b/src/omv/common/ini.c
@@ -309,7 +309,7 @@ static char* find_chars_or_comment(const char* s, const char* chars)
 /* Version of strncpy that ensures dest (size bytes) is null-terminated. */
 static char* strncpy0(char* dest, const char* src, size_t size)
 {
-    strncpy(dest, src, size);
+    strncpy(dest, src, size - 1);
     dest[size - 1] = '\0';
     return dest;
 }


### PR DESCRIPTION
Fixes warning preventing compile on GCC 9.2.1