### PR TITLE
Make built-in person detection changable

### DIFF
--- a/src/omv/boards/ARDUINO_NANO_RP2040_CONNECT/imlib_config.h
+++ b/src/omv/boards/ARDUINO_NANO_RP2040_CONNECT/imlib_config.h
@@ -126,6 +126,18 @@
 //#define IMLIB_ENABLE_TF
 #endif
 
+#ifndef IMLIB_TF_BUILT_IN_NETWORK_NAME
+//#define IMLIB_TF_BUILT_IN_NETWORK_NAME "person_detection"
+#endif
+
+#ifndef IMLIB_TF_BUILT_IN_NETWORK_DATA
+//#define IMLIB_TF_BUILT_IN_NETWORK_DATA g_person_detect_model_data
+#endif
+
+#ifndef IMLIB_TF_BUILT_IN_NETWORK_DATA_LEN
+//#define IMLIB_TF_BUILT_IN_NETWORK_DATA_LEN g_person_detect_model_data_len
+#endif
+
 // Enable FAST (20+ KBs).
 // #define IMLIB_ENABLE_FAST
 

--- a/src/omv/boards/BORMIO/imlib_config.h
+++ b/src/omv/boards/BORMIO/imlib_config.h
@@ -125,6 +125,18 @@
 #define IMLIB_ENABLE_TF
 #endif
 
+#ifndef IMLIB_TF_BUILT_IN_NETWORK_NAME
+#define IMLIB_TF_BUILT_IN_NETWORK_NAME "person_detection"
+#endif
+
+#ifndef IMLIB_TF_BUILT_IN_NETWORK_DATA
+#define IMLIB_TF_BUILT_IN_NETWORK_DATA g_person_detect_model_data
+#endif
+
+#ifndef IMLIB_TF_BUILT_IN_NETWORK_DATA_LEN
+#define IMLIB_TF_BUILT_IN_NETWORK_DATA_LEN g_person_detect_model_data_len
+#endif
+
 // Enable FAST (20+ KBs).
 #define IMLIB_ENABLE_FAST
 

--- a/src/omv/boards/OPENMV3/imlib_config.h
+++ b/src/omv/boards/OPENMV3/imlib_config.h
@@ -125,6 +125,18 @@
 #define IMLIB_ENABLE_TF
 #endif
 
+#ifndef IMLIB_TF_BUILT_IN_NETWORK_NAME
+#define IMLIB_TF_BUILT_IN_NETWORK_NAME "person_detection"
+#endif
+
+#ifndef IMLIB_TF_BUILT_IN_NETWORK_DATA
+#define IMLIB_TF_BUILT_IN_NETWORK_DATA g_person_detect_model_data
+#endif
+
+#ifndef IMLIB_TF_BUILT_IN_NETWORK_DATA_LEN
+#define IMLIB_TF_BUILT_IN_NETWORK_DATA_LEN g_person_detect_model_data_len
+#endif
+
 // Enable FAST (20+ KBs).
 #define IMLIB_ENABLE_FAST
 

--- a/src/omv/boards/OPENMV4/imlib_config.h
+++ b/src/omv/boards/OPENMV4/imlib_config.h
@@ -125,6 +125,18 @@
 #define IMLIB_ENABLE_TF
 #endif
 
+#ifndef IMLIB_TF_BUILT_IN_NETWORK_NAME
+#define IMLIB_TF_BUILT_IN_NETWORK_NAME "person_detection"
+#endif
+
+#ifndef IMLIB_TF_BUILT_IN_NETWORK_DATA
+#define IMLIB_TF_BUILT_IN_NETWORK_DATA g_person_detect_model_data
+#endif
+
+#ifndef IMLIB_TF_BUILT_IN_NETWORK_DATA_LEN
+#define IMLIB_TF_BUILT_IN_NETWORK_DATA_LEN g_person_detect_model_data_len
+#endif
+
 // Enable FAST (20+ KBs).
 // #define IMLIB_ENABLE_FAST
 

--- a/src/omv/boards/OPENMV4P/imlib_config.h
+++ b/src/omv/boards/OPENMV4P/imlib_config.h
@@ -125,6 +125,18 @@
 #define IMLIB_ENABLE_TF
 #endif
 
+#ifndef IMLIB_TF_BUILT_IN_NETWORK_NAME
+#define IMLIB_TF_BUILT_IN_NETWORK_NAME "person_detection"
+#endif
+
+#ifndef IMLIB_TF_BUILT_IN_NETWORK_DATA
+#define IMLIB_TF_BUILT_IN_NETWORK_DATA g_person_detect_model_data
+#endif
+
+#ifndef IMLIB_TF_BUILT_IN_NETWORK_DATA_LEN
+#define IMLIB_TF_BUILT_IN_NETWORK_DATA_LEN g_person_detect_model_data_len
+#endif
+
 // Enable FAST (20+ KBs).
 // #define IMLIB_ENABLE_FAST
 

--- a/src/omv/boards/OPENMVPT/imlib_config.h
+++ b/src/omv/boards/OPENMVPT/imlib_config.h
@@ -125,6 +125,18 @@
 #define IMLIB_ENABLE_TF
 #endif
 
+#ifndef IMLIB_TF_BUILT_IN_NETWORK_NAME
+#define IMLIB_TF_BUILT_IN_NETWORK_NAME "person_detection"
+#endif
+
+#ifndef IMLIB_TF_BUILT_IN_NETWORK_DATA
+#define IMLIB_TF_BUILT_IN_NETWORK_DATA g_person_detect_model_data
+#endif
+
+#ifndef IMLIB_TF_BUILT_IN_NETWORK_DATA_LEN
+#define IMLIB_TF_BUILT_IN_NETWORK_DATA_LEN g_person_detect_model_data_len
+#endif
+
 // Enable FAST (20+ KBs).
 // #define IMLIB_ENABLE_FAST
 

--- a/src/omv/boards/PICO/imlib_config.h
+++ b/src/omv/boards/PICO/imlib_config.h
@@ -126,6 +126,18 @@
 //#define IMLIB_ENABLE_TF
 #endif
 
+#ifndef IMLIB_TF_BUILT_IN_NETWORK_NAME
+//#define IMLIB_TF_BUILT_IN_NETWORK_NAME "person_detection"
+#endif
+
+#ifndef IMLIB_TF_BUILT_IN_NETWORK_DATA
+//#define IMLIB_TF_BUILT_IN_NETWORK_DATA g_person_detect_model_data
+#endif
+
+#ifndef IMLIB_TF_BUILT_IN_NETWORK_DATA_LEN
+//#define IMLIB_TF_BUILT_IN_NETWORK_DATA_LEN g_person_detect_model_data_len
+#endif
+
 // Enable FAST (20+ KBs).
 // #define IMLIB_ENABLE_FAST
 

--- a/src/omv/boards/PORTENTA/imlib_config.h
+++ b/src/omv/boards/PORTENTA/imlib_config.h
@@ -125,6 +125,18 @@
 #define IMLIB_ENABLE_TF
 #endif
 
+#ifndef IMLIB_TF_BUILT_IN_NETWORK_NAME
+#define IMLIB_TF_BUILT_IN_NETWORK_NAME "person_detection"
+#endif
+
+#ifndef IMLIB_TF_BUILT_IN_NETWORK_DATA
+#define IMLIB_TF_BUILT_IN_NETWORK_DATA g_person_detect_model_data
+#endif
+
+#ifndef IMLIB_TF_BUILT_IN_NETWORK_DATA_LEN
+#define IMLIB_TF_BUILT_IN_NETWORK_DATA_LEN g_person_detect_model_data_len
+#endif
+
 // Enable FAST (20+ KBs).
 //#define IMLIB_ENABLE_FAST
 

--- a/src/omv/modules/py_tf.c
+++ b/src/omv/modules/py_tf.c
@@ -156,9 +156,9 @@ STATIC mp_obj_t int_py_tf_load(mp_obj_t path_obj, bool alloc_mode, bool helper_m
     py_tf_model_obj_t *tf_model = m_new_obj(py_tf_model_obj_t);
     tf_model->base.type = &py_tf_model_type;
 
-    if (!strcmp(path, "person_detection")) {
-        tf_model->model_data = (unsigned char *) g_person_detect_model_data;
-        tf_model->model_data_len = g_person_detect_model_data_len;
+    if (!strcmp(path, IMLIB_TF_BUILT_IN_NETWORK_NAME)) {
+        tf_model->model_data = (unsigned char *) IMLIB_TF_BUILT_IN_NETWORK_DATA;
+        tf_model->model_data_len = IMLIB_TF_BUILT_IN_NETWORK_DATA_LEN;
     } else {
         #if defined(IMLIB_ENABLE_IMAGE_FILE_IO)
         FIL fp;


### PR DESCRIPTION
Allows EdgeImpulse to compile our firmware and inject their own model files without needing to modify our firmware. Here are the steps:

1. Convert the tensorflow lite file to a C array using xxd.
2. Compile and turn the C file into a library archive file (see here for example flags) https://github.com/openmv/tensorflow-lib/blob/master/make.py#L176
3. Drop the library file into here: https://github.com/openmv/openmv/tree/master/src/lib/libtf/ for the target architecture being built (or drop into all)
4. Inject new CFLAGS into the make file build by doing something like: CFLAGS=-DIMLIB_TF_BUILT_IN_NETWORK_DATA=name make TARGET=OPENMV4

This will then build the firmware with the new network in place of the old one.

@iabdalkader - If you have a better cleaner way for all of this please add it. We just want to make it easy for Edge Impulse to patch a new network .tflite file into our firmware as a binary object. Maybe objcopy might be better for doing this.

