### PR TITLE
imlib: Update JPEG decoder and fix memory issues.

### DIFF
--- a/src/omv/imlib/draw.c
+++ b/src/omv/imlib/draw.c
@@ -2743,7 +2743,7 @@ void imlib_draw_image(image_t *dst_img, image_t *src_img, int dst_x_start, int d
                     } else if (src_img->is_yuv) {
                         imlib_deyuv_image(&new_src_img, src_img);
                     } else if (is_jpeg) {
-                        jpeg_decompress_image_to_binary(&new_src_img, src_img);
+                        jpeg_decompress(&new_src_img, src_img);
                     } else if (is_png) {
                         png_decompress(&new_src_img, src_img);
                     }
@@ -2755,7 +2755,7 @@ void imlib_draw_image(image_t *dst_img, image_t *src_img, int dst_x_start, int d
                     } else if (src_img->is_yuv) {
                         imlib_deyuv_image(&new_src_img, src_img);
                     } else if (is_jpeg) {
-                        jpeg_decompress_image_to_grayscale(&new_src_img, src_img);
+                        jpeg_decompress(&new_src_img, src_img);
                     } else if (is_png) {
                         png_decompress(&new_src_img, src_img);
                     }
@@ -2767,7 +2767,7 @@ void imlib_draw_image(image_t *dst_img, image_t *src_img, int dst_x_start, int d
                     } else if (src_img->is_yuv) {
                         imlib_deyuv_image(&new_src_img, src_img);
                     } else if (is_jpeg) {
-                        jpeg_decompress_image_to_rgb565(&new_src_img, src_img);
+                        jpeg_decompress(&new_src_img, src_img);
                     } else if (is_png) {
                         png_decompress(&new_src_img, src_img);
                     }

--- a/src/omv/imlib/imlib.h
+++ b/src/omv/imlib/imlib.h
@@ -1125,9 +1125,7 @@ void imlib_jpeg_compress_init();
 void imlib_jpeg_compress_deinit();
 void jpeg_mdma_irq_handler();
 #endif
-void jpeg_decompress_image_to_binary(image_t *dst, image_t *src);
-void jpeg_decompress_image_to_grayscale(image_t *dst, image_t *src);
-void jpeg_decompress_image_to_rgb565(image_t *dst, image_t *src);
+void jpeg_decompress(image_t *dst, image_t *src);
 bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc);
 int jpeg_clean_trailing_bytes(int bpp, uint8_t *data);
 void jpeg_read_geometry(FIL *fp, image_t *img, const char *path, jpg_read_settings_t *rs);


### PR DESCRIPTION
* Fix MemManage fault on decoding odd images.
* Support decoding YCBCR to Grayscale.
* Support decoding Grayscale to RGB565.
* Minor formatting fixes.
* Use a single decompress function for all formats.
* Fixes #1550