### PR TITLE
OPENMVPT: Disable RTC LSE clock source.

### DIFF
--- a/src/omv/boards/OPENMVPT/omv_boardconfig.h
+++ b/src/omv/boards/OPENMVPT/omv_boardconfig.h
@@ -136,12 +136,13 @@
 #define OMV_OSC_USB_CLKSOURCE           RCC_USBCLKSOURCE_PLL
 #define OMV_OSC_RNG_CLKSOURCE           RCC_RNGCLKSOURCE_HSI48
 #define OMV_OSC_ADC_CLKSOURCE           RCC_ADCCLKSOURCE_PLL2
-#define OMV_OSC_RTC_CLKSOURCE           RCC_RTCCLKSOURCE_LSE
+//#define OMV_OSC_RTC_CLKSOURCE           RCC_RTCCLKSOURCE_LSE
 #define OMV_OSC_SPI123_CLKSOURCE        RCC_SPI123CLKSOURCE_PLL2
 
 // HSE/HSI/CSI State
-#define OMV_OSC_LSE_STATE               (RCC_LSE_ON)
-#define OMV_OSC_LSE_DRIVE               (RCC_LSEDRIVE_HIGH)
+// The LSE is not configured due to an issue with the LSE crystal oscillator.
+// #define OMV_OSC_LSE_STATE               (RCC_LSE_ON)
+// #define OMV_OSC_LSE_DRIVE               (RCC_LSEDRIVE_HIGH)
 #define OMV_OSC_HSE_STATE               (RCC_HSE_ON)
 #define OMV_OSC_HSI48_STATE             (RCC_HSI48_ON)
 


### PR DESCRIPTION
* Due to an issue with the crystal oscillator, the LSE can't be enabled without reworking the board, otherwise it will never start.