### PR TITLE
boards: Remove raw FB size macro.

### DIFF
--- a/src/omv/boards/ARDUINO_NANO_RP2040_CONNECT/omv_boardconfig.h
+++ b/src/omv/boards/ARDUINO_NANO_RP2040_CONNECT/omv_boardconfig.h
@@ -30,9 +30,6 @@ extern unsigned char *OMV_UNIQUE_ID_ADDR;
 // TODO Not actually used right now, frequency is hardcoded.
 #define OMV_XCLK_FREQUENCY      (12500000)
 
-// RAW buffer size
-#define OMV_RAW_BUF_SIZE        (100*1024)
-
 // Enable hardware JPEG
 #define OMV_HARDWARE_JPEG       (0)
 

--- a/src/omv/boards/NANO33/omv_boardconfig.h
+++ b/src/omv/boards/NANO33/omv_boardconfig.h
@@ -26,9 +26,6 @@
 // Sensor external clock timer frequency.
 #define OMV_XCLK_FREQUENCY      (12000000)
 
-// RAW buffer size
-#define OMV_RAW_BUF_SIZE        (131072)
-
 // Enable hardware JPEG
 #define OMV_HARDWARE_JPEG       (0)
 

--- a/src/omv/boards/NICLAV/omv_boardconfig.h
+++ b/src/omv/boards/NICLAV/omv_boardconfig.h
@@ -35,9 +35,6 @@
 #define OMV_BOOTLDR_LED_PIN     (GPIO_PIN_12)
 #define OMV_BOOTLDR_LED_PORT    (GPIOI)
 
-// RAW buffer size
-#define OMV_RAW_BUF_SIZE        (409600)
-
 // Enable hardware JPEG
 #define OMV_HARDWARE_JPEG       (1)
 

--- a/src/omv/boards/OPENMV2/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV2/omv_boardconfig.h
@@ -43,9 +43,6 @@
 #define OMV_BOOTLDR_LED_PIN     (GPIO_PIN_2)
 #define OMV_BOOTLDR_LED_PORT    (GPIOC)
 
-// RAW buffer size
-#define OMV_RAW_BUF_SIZE        (155648)
-
 // Enable sensor drivers
 #define OMV_ENABLE_OV2640       (1)
 #define OMV_ENABLE_OV5640       (0)

--- a/src/omv/boards/OPENMV3/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV3/omv_boardconfig.h
@@ -43,9 +43,6 @@
 #define OMV_BOOTLDR_LED_PIN     (GPIO_PIN_1)
 #define OMV_BOOTLDR_LED_PORT    (GPIOC)
 
-// RAW buffer size
-#define OMV_RAW_BUF_SIZE        (307200)
-
 // Enable sensor drivers
 #define OMV_ENABLE_OV2640       (0)
 #define OMV_ENABLE_OV5640       (0)

--- a/src/omv/boards/OPENMV4/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4/omv_boardconfig.h
@@ -52,9 +52,6 @@
 #define OMV_BOOTLDR_LED_PIN     (GPIO_PIN_1)
 #define OMV_BOOTLDR_LED_PORT    (GPIOC)
 
-// RAW buffer size
-#define OMV_RAW_BUF_SIZE        (409600)
-
 // Enable hardware JPEG
 #define OMV_HARDWARE_JPEG       (1)
 

--- a/src/omv/boards/OPENMV4P/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4P/omv_boardconfig.h
@@ -56,9 +56,6 @@
 #define OMV_BOOTLDR_LED_PIN     (GPIO_PIN_1)
 #define OMV_BOOTLDR_LED_PORT    (GPIOC)
 
-// RAW buffer size
-#define OMV_RAW_BUF_SIZE        (20971520)
-
 // Enable hardware JPEG
 #define OMV_HARDWARE_JPEG       (1)
 

--- a/src/omv/boards/OPENMVPT/omv_boardconfig.h
+++ b/src/omv/boards/OPENMVPT/omv_boardconfig.h
@@ -53,9 +53,6 @@
 #define OMV_BOOTLDR_LED_PIN             (GPIO_PIN_1)
 #define OMV_BOOTLDR_LED_PORT            (GPIOC)
 
-// RAW buffer size
-#define OMV_RAW_BUF_SIZE                (33554432)
-
 // Enable hardware JPEG
 #define OMV_HARDWARE_JPEG               (1)
 

--- a/src/omv/boards/PICO/omv_boardconfig.h
+++ b/src/omv/boards/PICO/omv_boardconfig.h
@@ -30,9 +30,6 @@ extern unsigned char *OMV_UNIQUE_ID_ADDR;
 // TODO Not actually used right now, frequency is hardcoded.
 #define OMV_XCLK_FREQUENCY      (12500000)
 
-// RAW buffer size
-#define OMV_RAW_BUF_SIZE        (151*1024)
-
 // Enable hardware JPEG
 #define OMV_HARDWARE_JPEG       (0)
 

--- a/src/omv/boards/PORTENTA/omv_boardconfig.h
+++ b/src/omv/boards/PORTENTA/omv_boardconfig.h
@@ -50,9 +50,6 @@
 #define OMV_BOOTLDR_LED_PIN     (GPIO_PIN_6)
 #define OMV_BOOTLDR_LED_PORT    (GPIOK)
 
-// RAW buffer size
-#define OMV_RAW_BUF_SIZE        (4*1024*1024)
-
 // Enable hardware JPEG
 #define OMV_HARDWARE_JPEG       (1)
 

--- a/src/omv/imlib/framebuffer.c
+++ b/src/omv/imlib/framebuffer.c
@@ -18,6 +18,7 @@
 #define CONSERVATIVE_JPEG_BUF_SIZE  (OMV_JPEG_BUF_SIZE-64)
 
 extern char _fb_base;
+extern char _fb_end;
 framebuffer_t *framebuffer = (framebuffer_t *) &_fb_base;
 
 extern char _jpeg_buf;
@@ -248,7 +249,8 @@ static uint32_t framebuffer_raw_buffer_size()
     uint32_t size = (uint32_t) (fb_alloc_stack_pointer() - ((char *) framebuffer->data));
     // We don't want to give all of the frame buffer RAM to the frame buffer. So, we will limit
     // the maximum amount of RAM we return.
-    return IM_MIN(size, OMV_RAW_BUF_SIZE);
+    uint32_t raw_buf_size = (&_fb_end - &_fb_base);
+    return IM_MIN(size, raw_buf_size);
 }
 
 uint32_t framebuffer_get_buffer_size()

--- a/src/omv/ports/nrf/nrf52xxx.ld.S
+++ b/src/omv/ports/nrf/nrf52xxx.ld.S
@@ -104,7 +104,10 @@ SECTIONS
     {
       . = ALIGN(4);
       _fb_base = .;
-      . = . + OMV_FB_SIZE + OMV_FB_ALLOC_SIZE;
+      . += OMV_FB_SIZE;
+
+      _fb_end = .;
+      . += OMV_FB_ALLOC_SIZE;
 
       . = ALIGN(4);
       _fballoc = .;

--- a/src/omv/ports/rp2/rp2.ld.S
+++ b/src/omv/ports/rp2/rp2.ld.S
@@ -188,7 +188,10 @@ SECTIONS
     {
       . = ALIGN(4);
       _fb_base = .;
-      . = . + OMV_FB_SIZE + OMV_FB_ALLOC_SIZE;
+      . += OMV_FB_SIZE;
+
+      _fb_end = .;
+      . += OMV_FB_ALLOC_SIZE;
 
       . = ALIGN(4);
       _fballoc = .;

--- a/src/omv/ports/stm32/stm32fxxx.ld.S
+++ b/src/omv/ports/stm32/stm32fxxx.ld.S
@@ -113,7 +113,10 @@ SECTIONS
   {
     . = ALIGN(4);
     _fb_base = .;
-    . = . + OMV_FB_SIZE + OMV_FB_ALLOC_SIZE;
+    . += OMV_FB_SIZE;
+
+    _fb_end = .;
+    . += OMV_FB_ALLOC_SIZE;
 
     . = ALIGN(4);
     _fballoc = .;

--- a/src/uvc/stm32fxxx.ld.S
+++ b/src/uvc/stm32fxxx.ld.S
@@ -94,7 +94,10 @@ SECTIONS
   {
     . = ALIGN(4);
     _fb_base = .;
-    . = . + OMV_FB_SIZE + OMV_FB_ALLOC_SIZE;
+    . += OMV_FB_SIZE;
+
+    _fb_end = .;
+    . += OMV_FB_ALLOC_SIZE;
 
     . = ALIGN(4);
     _fballoc = .;


### PR DESCRIPTION
* This old macro is very easy to miss when updating OMV_FB_SIZE.
* Use a linker script variable to get the raw framebuffer size.