### PR TITLE
imlib: Fix black lines on first frame.

### DIFF
--- a/src/omv/imlib/framebuffer.c
+++ b/src/omv/imlib/framebuffer.c
@@ -368,7 +368,7 @@ void framebuffer_free_current_buffer()
 {
     vbuffer_t *buffer = framebuffer_get_buffer(framebuffer->head);
     #ifdef __DCACHE_PRESENT
-    // Make sure all cached CPU writes are flushed before returning the buffer.
+    // Make sure all cached CPU writes are discarded before returning the buffer.
     SCB_InvalidateDCache_by_Addr(buffer->data, framebuffer_get_buffer_size());
     #endif
 
@@ -379,6 +379,19 @@ void framebuffer_free_current_buffer()
     if (framebuffer->n_buffers == 1) {
         buffer->waiting_for_data = true;
     }
+}
+
+void framebuffer_setup_buffers()
+{
+    #ifdef __DCACHE_PRESENT
+    for (int32_t i = 0; i < framebuffer->n_buffers; i++) {
+        if (i != framebuffer->head) {
+            vbuffer_t *buffer = framebuffer_get_buffer(i);
+            // Make sure all cached CPU writes are discarded before returning the buffer.
+            SCB_InvalidateDCache_by_Addr(buffer->data, framebuffer_get_buffer_size());
+        }
+    }
+    #endif
 }
 
 vbuffer_t *framebuffer_get_head(framebuffer_flags_t flags)

--- a/src/omv/imlib/framebuffer.h
+++ b/src/omv/imlib/framebuffer.h
@@ -116,6 +116,9 @@ void framebuffer_auto_adjust_buffers();
 // Call when done with the current vbuffer to mark it as free.
 void framebuffer_free_current_buffer();
 
+// Call to do any heavy setup before frame capture.
+void framebuffer_setup_buffers();
+
 // Sets the current frame buffer to the latest virtual frame buffer.
 // Returns the buffer if it is ready or NULL if not...
 // Pass FB_PEEK to get the next buffer but not take it.

--- a/src/omv/ports/nrf/sensor.c
+++ b/src/omv/ports/nrf/sensor.c
@@ -183,6 +183,7 @@ int sensor_snapshot(sensor_t *sensor, image_t *image, uint32_t flags)
     }
 
     framebuffer_free_current_buffer();
+    framebuffer_setup_buffers();
     vbuffer_t *buffer = framebuffer_get_tail(FB_NO_FLAGS);
 
     if (!buffer) {

--- a/src/omv/ports/rp2/sensor.c
+++ b/src/omv/ports/rp2/sensor.c
@@ -231,6 +231,8 @@ int sensor_snapshot(sensor_t *sensor, image_t *image, uint32_t flags)
     // If there's no ready buffer in the fifo, and the DMA is Not currently
     // transferring a new buffer, reconfigure and restart the DMA transfer.
     if (buffer == NULL && !dma_channel_is_busy(DCMI_DMA_CHANNEL)) {
+        framebuffer_setup_buffers();
+
         buffer = framebuffer_get_tail(FB_PEEK);
         if (buffer == NULL) {
             return SENSOR_ERROR_FRAMEBUFFER_ERROR;

--- a/src/omv/ports/stm32/sensor.c
+++ b/src/omv/ports/stm32/sensor.c
@@ -762,6 +762,8 @@ int sensor_snapshot(sensor_t *sensor, image_t *image, uint32_t flags)
     // wait for the start of the next frame when it's re-enabled again below. So, we do not
     // need to wait till there's no frame happening before enabling.
     if (!(DCMI->CR & DCMI_CR_ENABLE)) {
+        framebuffer_setup_buffers();
+
         // Setup the size and address of the transfer
         uint32_t bytes_per_pixel = sensor_get_src_bpp();
 


### PR DESCRIPTION
All frame buffers need to be invalidated before starting MDMA frame capture. The invalidation is done as late as possible so that it does not get repeatedly done over and over again in the sensor_set_*() calls.

I added the method to all MCUs so that if we find we need to do anything else in the future it can be put inside this same method.

Fixes  #1580