### PR TITLE
imlib: Fix py_lcd cache alignment and handling.

### DIFF
--- a/src/omv/imlib/draw.c
+++ b/src/omv/imlib/draw.c
@@ -449,7 +449,7 @@ void imlib_draw_row_setup(imlib_draw_row_data_t *data)
     size_t image_row_size = image_size(&temp) / data->dst_img->h;
 
     data->toggle = 0;
-    data->row_buffer[0] = fb_alloc(image_row_size, FB_ALLOC_NO_HINT);
+    data->row_buffer[0] = fb_alloc(image_row_size, FB_ALLOC_CACHE_ALIGN);
 
 #ifdef IMLIB_ENABLE_DMA2D
     data->dma2d_enabled = false;
@@ -461,7 +461,7 @@ void imlib_draw_row_setup(imlib_draw_row_data_t *data)
         ((data->src_img_pixfmt == PIXFORMAT_GRAYSCALE) ||
         ((data->src_img_pixfmt == PIXFORMAT_RGB565) && (data->rgb_channel < 0)
          && (data->alpha != 256) && (!data->color_palette) && (!data->alpha_palette)))) {
-        data->row_buffer[1] = fb_alloc(image_row_size, FB_ALLOC_NO_HINT);
+        data->row_buffer[1] = fb_alloc(image_row_size, FB_ALLOC_CACHE_ALIGN);
         data->dma2d_enabled = true;
         data->dma2d_initialized = true;
 

--- a/src/omv/ports/stm32/modules/py_lcd.c
+++ b/src/omv/ports/stm32/modules/py_lcd.c
@@ -451,7 +451,7 @@ static void spi_lcd_display(image_t *src_img, int dst_x_start, int dst_y_start, 
 
         #ifdef __DCACHE_PRESENT
         // Flush data for DMA
-        SCB_CleanDCache();
+        SCB_CleanDCache_by_Addr((uint32_t *) dst_img.data, image_size(&dst_img));
         #endif
 
         // Update tail which means a new image is ready.
@@ -1030,7 +1030,7 @@ static void ltdc_display(image_t *src_img, int dst_x_start, int dst_y_start, flo
 
     #ifdef __DCACHE_PRESENT
     // Flush data for DMA
-    if (!black) SCB_CleanDCache();
+    if (!black) SCB_CleanDCache_by_Addr((uint32_t *) dst_img.data, image_size(&dst_img));
     #endif
 
     // Update tail which means a new image is ready.


### PR DESCRIPTION
Minor fixes for the LCD output on the OpenMV PT. These fixes don't appear to help any bugs. However, the previous code was not the best.