### PR TITLE
imlib: Invalidate vbuffers before returning them.

### DIFF
--- a/src/omv/imlib/framebuffer.c
+++ b/src/omv/imlib/framebuffer.c
@@ -342,6 +342,7 @@ void framebuffer_auto_adjust_buffers() {
 
 void framebuffer_free_current_buffer() {
     vbuffer_t *buffer = framebuffer_get_buffer(framebuffer->head);
+
     #ifdef __DCACHE_PRESENT
     // Make sure all cached CPU writes are discarded before returning the buffer.
     SCB_InvalidateDCache_by_Addr(buffer->data, framebuffer_get_buffer_size());
@@ -400,7 +401,14 @@ vbuffer_t *framebuffer_get_head(framebuffer_flags_t flags) {
         framebuffer->head = new_head;
     }
 
-    return framebuffer_get_buffer(new_head);
+    vbuffer_t *buffer = framebuffer_get_buffer(new_head);
+
+    #ifdef __DCACHE_PRESENT
+    // Make sure any cached CPU reads are dropped before returning the buffer.
+    SCB_InvalidateDCache_by_Addr(buffer->data, framebuffer_get_buffer_size());
+    #endif
+
+    return buffer;
 }
 
 vbuffer_t *framebuffer_get_tail(framebuffer_flags_t flags) {


### PR DESCRIPTION
The CPU might fetch lines, speculatively, from a vbuffer after an invalidate and before the [M/E]DMA is done writing to it. In this case, when the DMA is done, the CPU will have some "outdated" lines in cache. Speculative access in CM7 is documented here https://developer.arm.com/documentation/ddi0489/f/memory-system/speculative-accesses

> Speculative cache linefills can be initiated to any Cacheable memory address, and in rare cases, regardless of whether there is any instruction that causes the cache linefill.

This change invalidates the buffer after the DMA is done and before returning it, to ensure the CPU drops any cached lines of that vbuffer.

* Fixes #2216 