### PR TITLE
imlib: Fix SIMD YCbCr to RGB conversion.

### DIFF
--- a/src/omv/imlib/jpegd.c
+++ b/src/omv/imlib/jpegd.c
@@ -2277,7 +2277,9 @@ static void JPEGPixelLE(uint16_t *pDest, int iY, int iCb, int iCr)
 {
     uint32_t ulPixel;
     uint32_t ulCbCr = (iCb | (iCr << 16));
-    uint32_t ulTmp  = -1409 | (-2925 << 16);          // for green calc
+    uint32_t ulTmp;                                   // for green calc
+    ulTmp    = -1409;
+    ulTmp    = (ulTmp & 0xffff) | (-2925 << 16);
     ulCbCr   = __SSUB16(ulCbCr, 0x00800080);          // dual 16-bit subtraction
     ulPixel  = __SMLAD(ulCbCr, ulTmp, iY) >> 14;      // G
     ulPixel  = __USAT16(ulPixel, 6) << 5;             // range limit to 6 bits
@@ -2294,7 +2296,9 @@ static void JPEGPixel2LE(uint16_t *pDest, int iY1, int iY2, int iCb, int iCr)
 {
     uint32_t ulPixel1, ulPixel2;
     uint32_t ulCbCr = (iCb | (iCr << 16));
-    uint32_t ulTmp2, ulTmp = -1409 | (-2925 << 16);     // for green calc
+    uint32_t ulTmp2, ulTmp;                             // for green calc
+    ulTmp     = -1409;
+    ulTmp     = (ulTmp & 0xffff) | (-2925 << 16);    
     ulCbCr    = __SSUB16(ulCbCr, 0x00800080);           // dual 16-bit subtraction
     ulPixel1  = __SMLAD(ulCbCr, ulTmp, iY1) >> 14;      // G for pixel 1
     ulPixel2  = __SMLAD(ulCbCr, ulTmp, iY2) >> 14;      // G for pixel 2


### PR DESCRIPTION
Masking top half of negative constant for SIMD 16/16 multiply fixes incorrect color values.

Fixes #1597 