### PR TITLE
usbdbg: Check USB IRQs when blocking on commands.

### DIFF
--- a/src/omv/common/usbdbg.c
+++ b/src/omv/common/usbdbg.c
@@ -58,7 +58,7 @@ void usbdbg_init()
 
 void usbdbg_wait_for_command(uint32_t timeout)
 {
-    for (mp_uint_t ticks = mp_hal_ticks_ms(); ((mp_hal_ticks_ms() - ticks) < timeout) && (cmd != USBDBG_NONE); );
+    for (mp_uint_t ticks = mp_hal_ticks_ms(); irq_enabled && ((mp_hal_ticks_ms() - ticks) < timeout) && (cmd != USBDBG_NONE); );
 }
 
 bool usbdbg_script_ready()


### PR DESCRIPTION
* If USB IRQs are disabled the command will never finish.