### PR TITLE
ports/stm32: Fix unhandled exception in main.c.

### DIFF
--- a/src/omv/ports/stm32/main.c
+++ b/src/omv/ports/stm32/main.c
@@ -621,7 +621,10 @@ soft_reset:
             }
         } while (openmv_config.wifidbg == true);
 
-        usbdbg_wait_for_command(1000);
+        nlr_buf_t nlr;
+        if (nlr_push(&nlr) == 0) {
+            usbdbg_wait_for_command(1000);
+        }
     }
 
     // soft reset


### PR DESCRIPTION
* usbdbg_wait_for_command could raise exception when scripts end uninterrupted.