### PR TITLE
ports/stm32: Add CYW43 firmware blob to text section.

### DIFF
--- a/src/omv/ports/stm32/stm32fxxx.ld.S
+++ b/src/omv/ports/stm32/stm32fxxx.ld.S
@@ -85,6 +85,10 @@ SECTIONS
     *(.rodata)          // .rodata sections (constants, strings, etc.)
     . = ALIGN(4);
     *(.rodata*)         // .rodata* sections (constants, strings, etc.)
+    #if !defined(OMV_CYW43_MEMORY)
+    . = ALIGN(512);
+    *(.big_const*)
+    #endif
     . = ALIGN(4);
     _etext = .;         // define a global symbols at end of code
   } >FLASH_TEXT


### PR DESCRIPTION
* If no special memory is defined for CYW43's firmware, add it
to the main firmware text section.