### PR TITLE
scripts/examples: Fix MAVLINK apriltag example.

### DIFF
--- a/scripts/examples/07-Interface-Library/02-MAVLink/mavlink_apriltags_landing_target.py
+++ b/scripts/examples/07-Interface-Library/02-MAVLink/mavlink_apriltags_landing_target.py
@@ -13,7 +13,6 @@ uart_baudrate = 115200
 
 MAV_system_id = 1
 MAV_component_id = 0x54
-MAX_DISTANCE_SENSOR_enable = True
 
 lens_mm = 2.8 # Standard Lens.
 lens_to_camera_mm = 22 # Standard Lens.
@@ -50,8 +49,8 @@ c_y = y_res / 2
 h_fov = 2 * math.atan((sensor_w_mm / 2) / lens_mm)
 v_fov = 2 * math.atan((sensor_h_mm / 2) / lens_mm)
 
-def z_to_mm(z_translation, tag_size): # z_translation is in decimeters...
-    return (((z_translation * 100) * tag_size) / 165) - lens_to_camera_mm
+def translation_to_mm(translation, tag_size): # translation is in decimeters...
+    return (((translation * 100) * tag_size) / 165)
 
 # Link Setup
 
@@ -72,42 +71,6 @@ def checksum(data, extra): # https://github.com/mavlink/c_library_v1/blob/master
     output = ((output >> 8) ^ (tmp << 8) ^ (tmp << 3) ^ (tmp >> 4)) & 0xFFFF
     return output
 
-MAV_DISTANCE_SENSOR_message_id = 132
-MAV_DISTANCE_SENSOR_min_distance = 1 # in cm
-MAV_DISTANCE_SENSOR_max_distance = 10000 # in cm
-MAV_DISTANCE_SENSOR_type = 0 # MAV_DISTANCE_SENSOR_LASER
-MAV_DISTANCE_SENSOR_id = 0 # unused
-MAV_DISTANCE_SENSOR_orientation = 25 # MAV_SENSOR_ROTATION_PITCH_270
-MAV_DISTANCE_SENSOR_covariance = 0 # unused
-MAV_DISTANCE_SENSOR_extra_crc = 85
-
-# http://mavlink.org/messages/common#DISTANCE_SENSOR
-# https://github.com/mavlink/c_library_v1/blob/master/common/mavlink_msg_distance_sensor.h
-def send_distance_sensor_packet(tag, tag_size):
-    global packet_sequence
-    temp = struct.pack("<lhhhbbbb",
-                       0,
-                       MAV_DISTANCE_SENSOR_min_distance,
-                       MAV_DISTANCE_SENSOR_max_distance,
-                       min(max(int(z_to_mm(tag.z_translation(), tag_size) / 10), MAV_DISTANCE_SENSOR_min_distance), MAV_DISTANCE_SENSOR_max_distance),
-                       MAV_DISTANCE_SENSOR_type,
-                       MAV_DISTANCE_SENSOR_id,
-                       MAV_DISTANCE_SENSOR_orientation,
-                       MAV_DISTANCE_SENSOR_covariance)
-    temp = struct.pack("<bbbbb14s",
-                       14,
-                       packet_sequence & 0xFF,
-                       MAV_system_id,
-                       MAV_component_id,
-                       MAV_DISTANCE_SENSOR_message_id,
-                       temp)
-    temp = struct.pack("<b19sh",
-                       0xFE,
-                       temp,
-                       checksum(temp, MAV_DISTANCE_SENSOR_extra_crc))
-    packet_sequence += 1
-    uart.write(temp)
-
 MAV_LANDING_TARGET_message_id = 149
 MAV_LANDING_TARGET_min_distance = 1/100 # in meters
 MAV_LANDING_TARGET_max_distance = 10000/100 # in meters
@@ -116,13 +79,13 @@ MAV_LANDING_TARGET_extra_crc = 200
 
 # http://mavlink.org/messages/common#LANDING_TARGET
 # https://github.com/mavlink/c_library_v1/blob/master/common/mavlink_msg_landing_target.h
-def send_landing_target_packet(tag, w, h, tag_size):
+def send_landing_target_packet(tag, dist_cm, w, h):
     global packet_sequence
     temp = struct.pack("<qfffffbb",
                        0,
                        ((tag.cx() / w) - 0.5) * h_fov,
                        ((tag.cy() / h) - 0.5) * v_fov,
-                       min(max(z_to_mm(tag.z_translation(), tag_size) / 1000, MAV_LANDING_TARGET_min_distance), MAV_LANDING_TARGET_max_distance),
+                       min(max(dist_mm * 0.001, MAV_LANDING_TARGET_min_distance), MAV_LANDING_TARGET_max_distance),
                        0.0,
                        0.0,
                        0,
@@ -150,10 +113,11 @@ while(True):
     tags = sorted(img.find_apriltags(fx=f_x, fy=f_y, cx=c_x, cy=c_y), key = lambda x: x.w() * x.h(), reverse = True)
 
     if tags and (tags[0].id() in valid_tag_ids):
-        if MAX_DISTANCE_SENSOR_enable: send_distance_sensor_packet(tags[0], valid_tag_ids[tags[0].id()])
-        send_landing_target_packet(tags[0], img.width(), img.height(), valid_tag_ids[tags[0].id()])
+        tag_size = valid_tag_ids[tags[0].id()]
+        dist_mm = math.sqrt(translation_to_mm(tags[0].x_translation(), tag_size) ** 2 + translation_to_mm(tags[0].y_translation(), tag_size) ** 2 + translation_to_mm(tags[0].z_translation(), tag_size) ** 2)
+        send_landing_target_packet(tags[0], dist_mm, img.width(), img.height())
         img.draw_rectangle(tags[0].rect())
         img.draw_cross(tags[0].cx(), tags[0].cy())
-        print("Distance %f mm - FPS %f" % (z_to_mm(tags[0].z_translation(), valid_tag_ids[tags[0].id()]), clock.fps()))
+        print("Distance %f mm - FPS %f" % (dist_mm, clock.fps()))
     else:
         print("FPS %f" % clock.fps())

--- a/scripts/examples/07-Interface-Library/02-MAVLink/mavlink_apriltags_landing_target.py
+++ b/scripts/examples/07-Interface-Library/02-MAVLink/mavlink_apriltags_landing_target.py
@@ -16,8 +16,8 @@ MAV_component_id = 0x54
 
 lens_mm = 2.8 # Standard Lens.
 lens_to_camera_mm = 22 # Standard Lens.
-sensor_w_mm = 3.984 # For OV7725 sensor - see datasheet.
-sensor_h_mm = 2.952 # For OV7725 sensor - see datasheet.
+sensor_w_mm = 4.592 # For OV5650 sensor
+sensor_h_mm = 3.423 # For OV5650 sensor
 
 # Only tags with a tag ID in the dictionary below will be accepted by this
 # code. You may add as many tag IDs to the below dictionary as you want...

--- a/scripts/examples/07-Interface-Library/02-MAVLink/mavlink_apriltags_landing_target.py
+++ b/scripts/examples/07-Interface-Library/02-MAVLink/mavlink_apriltags_landing_target.py
@@ -50,7 +50,7 @@ h_fov = 2 * math.atan((sensor_w_mm / 2) / lens_mm)
 v_fov = 2 * math.atan((sensor_h_mm / 2) / lens_mm)
 
 def translation_to_mm(translation, tag_size): # translation is in decimeters...
-    return (((translation * 100) * tag_size) / 165)
+    return (((translation * 100) * tag_size) / 210)
 
 # Link Setup
 


### PR DESCRIPTION
This PR brings few changes to the MAVLINK apriltag landing target example after testing with [ArduPilot](http://ardupilot.org/) firmware while working on a project. The changes are:
- Remove the DISTANCE_SENSOR message stuff since it is not required and the distance can be sent within LANDING_TARGET message
- Update the sensor height and width as per the latest OV5650 sensor specifications
- The translation function doesn't seem to be right. The distance values received from the existing translation function are not near to the real values. After this fix, the distance values are quite accurate.
- Add a flashing led to indicate if the target is in sight. The LED flashes red when the camera can't see a target and green when the camera can see it.