### PR TITLE
scripts/examples: Fix typo in MAVLink Apriltag example.

### DIFF
--- a/scripts/examples/07-Interface-Library/02-MAVLink/mavlink_apriltags_landing_target.py
+++ b/scripts/examples/07-Interface-Library/02-MAVLink/mavlink_apriltags_landing_target.py
@@ -79,7 +79,7 @@ MAV_LANDING_TARGET_extra_crc = 200
 
 # http://mavlink.org/messages/common#LANDING_TARGET
 # https://github.com/mavlink/c_library_v1/blob/master/common/mavlink_msg_landing_target.h
-def send_landing_target_packet(tag, dist_cm, w, h):
+def send_landing_target_packet(tag, dist_mm, w, h):
     global packet_sequence
     temp = struct.pack("<qfffffbb",
                        0,


### PR DESCRIPTION
I apologize for this little bug which was introduced in #1716.  I tested the script before submitting PR #1716 and it was all working fine. But then I discovered this bug while reading the code today. The script would work fine even without this fix but it is still very important to fix it.
Again, sorry for mistakenly introducing this one in that PR. Looking forward to getting it merged soon :)