### PR TITLE
ports/stm32: Re-initialize IMU after every soft-reset.

### DIFF
--- a/src/omv/ports/stm32/main.c
+++ b/src/omv/ports/stm32/main.c
@@ -432,10 +432,11 @@ soft_reset:
     // mounting the file-system to log errors (if any).
     if (first_soft_reset) {
         sensor_init();
-        #if MICROPY_PY_IMU
-        py_imu_init();
-        #endif // MICROPY_PY_IMU
     }
+
+    #if MICROPY_PY_IMU
+    py_imu_init();
+    #endif // MICROPY_PY_IMU
 
     mod_network_init();
 


### PR DESCRIPTION
* Fixes #1734.
* On soft-reset all SPI instance are deinitialized, if IMU SPI bus is enabled in MicroPython it needs to be reinitialized.