### PR TITLE
ports/nrf: Minor fix for mpremote softreboot.

### DIFF
--- a/src/omv/ports/nrf/main.c
+++ b/src/omv/ports/nrf/main.c
@@ -335,6 +335,8 @@ soft_reset:
 
     mp_deinit();
 
+    printf("MPY: soft reboot\n");
+
     #if MICROPY_PY_AUDIO
     py_audio_deinit();
     #endif


### PR DESCRIPTION
* Print missing soft reboot string.