### PR TITLE
ports/stm32: Call GC sweep first before deinitializing SPI.

### DIFF
--- a/src/omv/ports/stm32/main.c
+++ b/src/omv/ports/stm32/main.c
@@ -645,7 +645,6 @@ soft_reset:
     #endif
     timer_deinit();
     i2c_deinit_all();
-    spi_deinit_all();
     uart_deinit_all();
     #if MICROPY_HW_ENABLE_CAN
     can_deinit_all();
@@ -658,7 +657,12 @@ soft_reset:
     #endif
     imlib_deinit_all();
 
+    // Call GC sweep first, before deinitializing the SPI peripheral.
+    // For the WINC1500, we still need the SPI active to close sockets
+    // when their finalizers are called by GC.
     gc_sweep_all();
+    spi_deinit_all();
+
     mp_deinit();
 
     first_soft_reset = false;


### PR DESCRIPTION
* WINC1500 needs SPI active to close sockets, when socket_close is called from the socket finalizer, which is called from gc_sweep.