### PR TITLE
drivers/WINC1500: Return a non-blocking error on socket timeout.

### DIFF
--- a/src/omv/ports/stm32/modules/py_winc.c
+++ b/src/omv/ports/stm32/modules/py_winc.c
@@ -51,7 +51,7 @@ static int py_winc_mperrno(int32_t err)
         case SOCK_ERR_CONN_ABORTED:
             return MP_ECONNABORTED;
         case SOCK_ERR_TIMEOUT:
-            return MP_ETIMEDOUT;
+            return MP_EWOULDBLOCK;
         case SOCK_ERR_BUFFER_FULL:
             return MP_ENOBUFS;
         case SOCK_ERR_ADDR_ALREADY_IN_USE:


### PR DESCRIPTION
* Return a non-blocking error to MicroPython on socket timeouts, so the socket doesn't get closed.