### PR TITLE
scripts/libraries: Fix RSTP library for the winc.

### DIFF
--- a/scripts/examples/08-RPC-Library/36-Web-Servers/rtsp_video_server_lan.py
+++ b/scripts/examples/08-RPC-Library/36-Web-Servers/rtsp_video_server_lan.py
@@ -15,8 +15,8 @@ import network, omv, rtsp, sensor, time
 
 sensor.reset()
 
-sensor.set_pixformat(sensor.JPEG) # Only supported by the OV2640/OV5640.
-sensor.set_framesize(sensor.UXGA)
+sensor.set_pixformat(sensor.RGB565)
+sensor.set_framesize(sensor.VGA)
 
 # Turn off the frame buffer connection to the IDE from the OpenMV Cam side.
 #
@@ -45,10 +45,15 @@ server = rtsp.rtsp_server(network_if)
 # `session` is random number that will change when a new connection is established. You can use
 # session with a dictionary to differentiate different accesses to the same file name.
 
+# Track the current FPS.
+clock = time.clock()
+
 def setup_callback(pathname, session):
     print("Opening \"%s\" in session %d" % (pathname, session))
 
 def play_callback(pathname, session):
+    clock.reset()
+    clock.tick()
     print("Playing \"%s\" in session %d" % (pathname, session))
 
 def pause_callback(pathname, session): # VLC only pauses locally. This is never called.
@@ -62,18 +67,15 @@ server.register_play_cb(play_callback)
 server.register_pause_cb(pause_callback)
 server.register_teardown_cb(teardown_callback)
 
-# Track the current FPS.
-clock = time.clock()
-
 # Called each time a new frame is needed.
 def image_callback(pathname, session):
-    clock.tick()
     img = sensor.snapshot()
     # Markup image and/or do various things.
     print(clock.fps())
+    clock.tick()
     return img
 
 # Stream does not return. It will call `image_callback` when it needs to get an image object to send
 # to the remote rtsp client connecting to the server.
 
-server.stream(image_callback)
+server.stream(image_callback, quality=70)


### PR DESCRIPTION
Fixes the RSTP driver for all OpenMV Cam boards using the winc (WiFi Shield). You can connect to the server multiple times and stream images without the camera crashing. Everything appears to work fine with the default UDP transport. With a TCP data transport it appears some issue happens in the shield firmware that will eventually cause the TCP socket to stop working (no errors are seen in wireshark though... the socket just stops). Anyway, on the socket being closed by the remote partner the camera will reset.

Luckily, the RTP protocol is almost always in UDP mode so the TCP support isn't important. However, It does show a bug in the firmware.

`/ffplay.exe rtsp://x.x.x.x -fflags nobuffer` - UDP transport (the default)
`/ffplay.exe -rtsp_transport tcp rtsp://x.x.x.x -fflags nobuffer` - TCP transport

Boards using the 1DX are still broken. It appears though that accept() does not work at all.

```
s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
s.bind(self.__myaddr)
s.listen(0)
s.settimeout(5)
self.__tcp__socket, self.__client_addr = s.accept()
s.close()
```

The above works fine on the winc and doesn't work on the 1dx.

Was not able to test ethernet on the Portenta yet.