### PR TITLE
drivers/winc1500: Set NIC to NULL on closing sockets.

### DIFF
--- a/src/omv/ports/stm32/modules/py_winc.c
+++ b/src/omv/ports/stm32/modules/py_winc.c
@@ -429,6 +429,7 @@ static void py_winc_socket_close(mod_network_socket_obj_t *socket)
         socket->fileno = -1; // Mark socket FD as invalid
         m_del(winc_socket_buf_t, socket->_private, 1);
         socket->_private = NULL;
+        socket->nic = MP_OBJ_NULL;
     }
 }
 


### PR DESCRIPTION
* Just in case user code calls functions on closed socket.