### PR TITLE
imlib/mjpeg: Vastly improve MJPEG code.

### DIFF
--- a/src/omv/imlib/imlib.h
+++ b/src/omv/imlib/imlib.h
@@ -1163,7 +1163,10 @@ void gif_close(FIL *fp);
 
 /* MJPEG functions */
 void mjpeg_open(FIL *fp, int width, int height);
-void mjpeg_add_frame(FIL *fp, uint32_t *frames, uint32_t *bytes, image_t *img, int quality);
+void mjpeg_write(FIL *fp, int width, int height, uint32_t *frames, uint32_t *bytes,
+                 image_t *img, int quality, rectangle_t *roi, int rgb_channel, int alpha,
+                 const uint16_t *color_palette, const uint8_t *alpha_palette, image_hint_t hint);
+void mjpeg_sync(FIL *fp, uint32_t *frames, uint32_t *bytes, float fps);
 void mjpeg_close(FIL *fp, uint32_t *frames, uint32_t *bytes, float fps);
 
 /* Point functions */

--- a/src/omv/imlib/mjpeg.c
+++ b/src/omv/imlib/mjpeg.c
@@ -1,8 +1,8 @@
 /*
  * This file is part of the OpenMV project.
  *
- * Copyright (c) 2013-2021 Ibrahim Abdelkader <iabdalkader@openmv.io>
- * Copyright (c) 2013-2021 Kwabena W. Agyeman <kwagyeman@openmv.io>
+ * Copyright (c) 2013-2023 Ibrahim Abdelkader <iabdalkader@openmv.io>
+ * Copyright (c) 2013-2023 Kwabena W. Agyeman <kwagyeman@openmv.io>
  *
  * This work is licensed under the MIT license, see the file LICENSE for details.
  *
@@ -11,7 +11,6 @@
 #include "imlib.h"
 #if defined(IMLIB_ENABLE_IMAGE_FILE_IO)
 
-#include "fb_alloc.h"
 #include "ff_wrapper.h"
 
 #define SIZE_OFFSET             (1*4)
@@ -93,27 +92,142 @@ void mjpeg_open(FIL *fp, int width, int height)
     write_data(fp, "movi", 4); // FOURCC fcc; - 55
 }
 
-void mjpeg_add_frame(FIL *fp, uint32_t *frames, uint32_t *bytes, image_t *img, int quality)
+void mjpeg_write(FIL *fp, int width, int height, uint32_t *frames, uint32_t *bytes,
+                 image_t *img, int quality, rectangle_t *roi, int rgb_channel, int alpha,
+                 const uint16_t *color_palette, const uint8_t *alpha_palette, image_hint_t hint)
 {
-    write_data(fp, "00dc", 4); // FOURCC fcc;
-    *frames += 1;
-    if (IM_IS_JPEG(img)) {
-        uint32_t size_padded = (((img->size + 3) / 4) * 4);
-        write_long(fp, size_padded); // DWORD cb;
-        write_data(fp, img->pixels, size_padded); // reading past okay
-        *bytes += size_padded;
-    } else {
-        image_t out = { .w=img->w, .h=img->h, .pixfmt=PIXFORMAT_JPEG, .size=0, .pixels=NULL };
+    float xscale = width / ((float) roi->w);
+    float yscale = height / ((float) roi->h);
+    // MAX == KeepAspectRationByExpanding - MIN == KeepAspectRatio
+    float scale = IM_MIN(xscale, yscale);
+
+    image_t dst_img = {
+        .w      = width,
+        .h      = height,
+        .pixfmt = PIXFORMAT_JPEG,
+        .size   = 0,
+        .data   = NULL
+    };
+
+    bool simple = (xscale == 1) &&
+                  (yscale == 1) &&
+                  (roi->x == 0) &&
+                  (roi->y == 0) &&
+                  (roi->w == img->w) &&
+                  (roi->h == img->h) &&
+                  (rgb_channel == -1) &&
+                  (alpha == 256) &&
+                  (color_palette == NULL) &&
+                  (alpha_palette == NULL);
+
+    fb_alloc_mark();
+
+    if ((dst_img.pixfmt != img->pixfmt) || (!simple)) {
+        image_t temp;
+        memcpy(&temp, img, sizeof(image_t));
+
+        if (img->is_compressed || (!simple)) {
+            temp.w = dst_img.w;
+            temp.h = dst_img.h;
+            temp.pixfmt = PIXFORMAT_RGB565; // TODO PIXFORMAT_ARGB8888
+            temp.size = 0;
+            temp.data = fb_alloc(image_size(&temp), FB_ALLOC_NO_HINT);
+
+            int center_x = fast_floorf((width - (roi->w * scale)) / 2);
+            int center_y = fast_floorf((height - (roi->h * scale)) / 2);
+
+            int x0, x1, y0, y1;
+            bool black = !imlib_draw_image_rectangle(&temp, img, center_x, center_y, scale, scale, roi,
+                                                     alpha, alpha_palette, hint, &x0, &x1, &y0, &y1);
+
+            if (black) { // zero the whole image
+                memset(temp.data, 0, temp.w * temp.h * sizeof(uint16_t));
+            } else {
+                // Zero the top rows
+                if (y0) {
+                    memset(temp.data, 0, temp.w * y0 * sizeof(uint16_t));
+                }
+
+                if (x0) {
+                    for (int i = y0; i < y1; i++) { // Zero left
+                        memset(IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(&temp, i), 0, x0 * sizeof(uint16_t));
+                    }
+                }
+
+                imlib_draw_image(&temp, img, center_x, center_y, scale, scale, roi,
+                                 rgb_channel, alpha, color_palette, alpha_palette,
+                                 (hint & (~IMAGE_HINT_CENTER)) | IMAGE_HINT_BLACK_BACKGROUND,
+                                 NULL, NULL);
+
+                if (temp.w - x1) {
+                    for (int i = y0; i < y1; i++) { // Zero right
+                        memset(IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(&temp, i) + x1,
+                               0, (temp.w - x1) * sizeof(uint16_t));
+                    }
+                }
+
+                // Zero the bottom rows
+                if (temp.h - y1) {
+                    memset(IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(&temp, y1),
+                           0, temp.w * (temp.h - y1) * sizeof(uint16_t));
+                }
+            }
+        }
+
         // When jpeg_compress needs more memory than in currently allocated it
         // will try to realloc. MP will detect that the pointer is outside of
         // the heap and return NULL which will cause an out of memory error.
-        jpeg_compress(img, &out, quality, true);
-        uint32_t size_padded = (((out.size + 3) / 4) * 4);
-        write_long(fp, size_padded); // DWORD cb;
-        write_data(fp, out.pixels, size_padded); // reading past okay
-        *bytes += size_padded;
-        fb_free(); // frees alloc in jpeg_compress()
+        jpeg_compress(&temp, &dst_img, quality, true);
+    } else {
+        dst_img.size = img->size;
+        dst_img.data = img->data;
     }
+
+    uint32_t size_padded = (((dst_img.size + 3) / 4) * 4);
+    write_data(fp, "00dc", 4); // FOURCC fcc;
+    write_long(fp, size_padded); // DWORD cb;
+    write_data(fp, dst_img.data, size_padded); // reading past okay
+
+    *frames += 1;
+    *bytes += size_padded;
+
+    fb_alloc_free_till_mark();
+}
+
+void mjpeg_sync(FIL *fp, uint32_t *frames, uint32_t *bytes, float fps)
+{
+    uint32_t position = f_tell(fp);
+    // Needed
+    file_seek(fp, SIZE_OFFSET);
+    write_long(fp, 216 + (*frames * 8) + *bytes);
+    // Needed
+    file_seek(fp, MICROS_OFFSET);
+    write_long(fp, (!fast_roundf(fps)) ? 0 :
+            fast_roundf(1000000 / fps));
+    write_long(fp, (!(*frames)) ? 0 :
+            fast_roundf((((*frames * 8) + *bytes) * fps) / *frames));
+    // Needed
+    file_seek(fp, FRAMES_OFFSET);
+    write_long(fp, *frames);
+    // Probably not needed but writing it just in case.
+    file_seek(fp, RATE_0_OFFSET);
+    write_long(fp, fast_roundf(fps * 1000));
+    // Probably not needed but writing it just in case.
+    file_seek(fp, LENGTH_0_OFFSET);
+    write_long(fp, (!fast_roundf(fps)) ? 0 :
+            fast_roundf((*frames * 1000) / fps));
+    // Probably not needed but writing it just in case.
+    file_seek(fp, RATE_1_OFFSET);
+    write_long(fp, fast_roundf(fps * 1000));
+    // Probably not needed but writing it just in case.
+    file_seek(fp, LENGTH_1_OFFSET);
+    write_long(fp, (!fast_roundf(fps)) ? 0 :
+            fast_roundf((*frames * 1000) / fps));
+    // Needed
+    file_seek(fp, MOVI_OFFSET);
+    write_long(fp, 4 + (*frames * 8) + *bytes);
+    file_sync(fp);
+    file_seek(fp, position);
 }
 
 void mjpeg_close(FIL *fp, uint32_t *frames, uint32_t *bytes, float fps)
@@ -149,4 +263,5 @@ void mjpeg_close(FIL *fp, uint32_t *frames, uint32_t *bytes, float fps)
     write_long(fp, 4 + (*frames * 8) + *bytes);
     file_close(fp);
 }
-#endif //IMLIB_ENABLE_IMAGE_FILE_IO
+
+#endif // IMLIB_ENABLE_IMAGE_FILE_IO

--- a/src/omv/modules/py_mjpeg.c
+++ b/src/omv/modules/py_mjpeg.c
@@ -1,140 +1,203 @@
 /*
  * This file is part of the OpenMV project.
  *
- * Copyright (c) 2013-2021 Ibrahim Abdelkader <iabdalkader@openmv.io>
- * Copyright (c) 2013-2021 Kwabena W. Agyeman <kwagyeman@openmv.io>
+ * Copyright (c) 2013-2023 Ibrahim Abdelkader <iabdalkader@openmv.io>
+ * Copyright (c) 2013-2023 Kwabena W. Agyeman <kwagyeman@openmv.io>
  *
  * This work is licensed under the MIT license, see the file LICENSE for details.
  *
  * MJPEG Python module.
  */
+#include "imlib_config.h"
+#if defined(IMLIB_ENABLE_IMAGE_FILE_IO)
+
 #include "py/obj.h"
+#include "py/nlr.h"
+#include "py/mphal.h"
 #include "py/runtime.h"
-#include "ff_wrapper.h"
-#include "framebuffer.h"
+
 #include "py_assert.h"
 #include "py_helper.h"
 #include "py_image.h"
 
-static const mp_obj_type_t py_mjpeg_type; // forward declare
-// Mjpeg class
+#include "ff_wrapper.h"
+#include "framebuffer.h"
+#include "omv_boardconfig.h"
+
+STATIC const mp_obj_type_t py_mjpeg_type;
+
 typedef struct py_mjpeg_obj {
     mp_obj_base_t base;
+    bool closed;
     int width;
     int height;
     uint32_t frames;
     uint32_t bytes;
-    #if defined(IMLIB_ENABLE_IMAGE_FILE_IO)
     FIL fp;
-    #endif
 } py_mjpeg_obj_t;
 
-static mp_obj_t py_mjpeg_open(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
+STATIC py_mjpeg_obj_t *py_mjpeg_obj(mp_obj_t self)
 {
-    py_mjpeg_obj_t *mjpeg = m_new_obj(py_mjpeg_obj_t);
-    mjpeg->width  = py_helper_keyword_int(n_args, args, 1, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_width), MAIN_FB()->w);
-    mjpeg->height = py_helper_keyword_int(n_args, args, 2, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_height), MAIN_FB()->h);
-    mjpeg->frames = 0; // private
-    mjpeg->bytes = 0; // private
-    mjpeg->base.type = &py_mjpeg_type;
+    py_mjpeg_obj_t *arg_mjpeg = MP_OBJ_TO_PTR(self);
 
-    #if defined(IMLIB_ENABLE_IMAGE_FILE_IO)
-    file_write_open(&mjpeg->fp, mp_obj_str_get_str(args[0]));
-    mjpeg_open(&mjpeg->fp, mjpeg->width, mjpeg->height);
-    #else
-    mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("Image I/O is not supported"));
-    #endif
-    return mjpeg;
+    if (arg_mjpeg->closed) {
+        mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("File closed!"));
+    }
+
+    return arg_mjpeg;
 }
 
-static mp_obj_t py_mjpeg_width(mp_obj_t mjpeg_obj)
+STATIC void py_mjpeg_print(const mp_print_t *print, mp_obj_t self, mp_print_kind_t kind)
 {
-    py_mjpeg_obj_t *arg_mjpeg = mjpeg_obj;
+    py_mjpeg_obj_t *arg_mjpeg = MP_OBJ_TO_PTR(self);
+    mp_printf(print, "{\"closed\":%s, \"width\":%u, \"height\":%u, \"count\":%u, \"size\":%u}",
+        arg_mjpeg->closed ? "\"true\"" : "\"false\"",
+        arg_mjpeg->width,
+        arg_mjpeg->height,
+        arg_mjpeg->frames,
+        f_size(&arg_mjpeg->fp));
+}
+
+STATIC mp_obj_t py_mjpeg_is_closed(mp_obj_t self)
+{
+    py_mjpeg_obj_t *arg_mjpeg = MP_OBJ_TO_PTR(self);
+    return mp_obj_new_int(arg_mjpeg->closed);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_mjpeg_is_closed_obj, py_mjpeg_is_closed);
+
+STATIC mp_obj_t py_mjpeg_width(mp_obj_t self)
+{
+    py_mjpeg_obj_t *arg_mjpeg = MP_OBJ_TO_PTR(self);
     return mp_obj_new_int(arg_mjpeg->width);
 }
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_mjpeg_width_obj, py_mjpeg_width);
 
-static mp_obj_t py_mjpeg_height(mp_obj_t mjpeg_obj)
+STATIC mp_obj_t py_mjpeg_height(mp_obj_t self)
 {
-    py_mjpeg_obj_t *arg_mjpeg = mjpeg_obj;
+    py_mjpeg_obj_t *arg_mjpeg = MP_OBJ_TO_PTR(self);
     return mp_obj_new_int(arg_mjpeg->height);
 }
-
-static mp_obj_t py_mjpeg_size(mp_obj_t mjpeg_obj)
-{
-    #if defined(IMLIB_ENABLE_IMAGE_FILE_IO)
-    py_mjpeg_obj_t *arg_mjpeg = mjpeg_obj;
-    return mp_obj_new_int(f_size(&arg_mjpeg->fp));
-    #else
-    return mp_obj_new_int(0);
-    #endif
-}
-
-static mp_obj_t py_mjpeg_add_frame(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
-{
-    #if defined(IMLIB_ENABLE_IMAGE_FILE_IO)
-    py_mjpeg_obj_t *arg_mjpeg = args[0];
-    image_t *arg_img = py_image_cobj(args[1]);
-    PY_ASSERT_FALSE_MSG((arg_mjpeg->width != arg_img->w)
-                     || (arg_mjpeg->height != arg_img->h),
-            "Unexpected image geometry");
-
-    int arg_q = py_helper_keyword_int(n_args, args, 2, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_quality), 50);
-    arg_q = IM_MIN(IM_MAX(arg_q, 1), 100);
-    mjpeg_add_frame(&arg_mjpeg->fp, &arg_mjpeg->frames, &arg_mjpeg->bytes, arg_img, arg_q);
-    #else
-    mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("Image I/O is not supported"));
-    #endif
-    return mp_const_none;
-}
-
-static mp_obj_t py_mjpeg_close(mp_obj_t mjpeg_obj, mp_obj_t fps_obj)
-{
-    #if defined(IMLIB_ENABLE_IMAGE_FILE_IO)
-    py_mjpeg_obj_t *arg_mjpeg = mjpeg_obj;
-    mjpeg_close(&arg_mjpeg->fp, &arg_mjpeg->frames, &arg_mjpeg->bytes, mp_obj_get_float(fps_obj));
-    #endif
-    return mp_const_none;
-}
-
-static void py_mjpeg_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind)
-{
-    py_mjpeg_obj_t *self = self_in;
-    mp_printf(print, "<mjpeg width:%d height:%d>", self->width, self->height);
-}
-
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_mjpeg_width_obj, py_mjpeg_width);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_mjpeg_height_obj, py_mjpeg_height);
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_mjpeg_size_obj, py_mjpeg_size);
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_mjpeg_add_frame_obj, 2, py_mjpeg_add_frame);
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(py_mjpeg_close_obj, py_mjpeg_close);
-static const mp_map_elem_t locals_dict_table[] = {
-    { MP_OBJ_NEW_QSTR(MP_QSTR_width),       (mp_obj_t)&py_mjpeg_width_obj     },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_height),      (mp_obj_t)&py_mjpeg_height_obj    },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_size),        (mp_obj_t)&py_mjpeg_size_obj      },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_add_frame),   (mp_obj_t)&py_mjpeg_add_frame_obj },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_close),       (mp_obj_t)&py_mjpeg_close_obj     },
-    { NULL, NULL },
-};
-STATIC MP_DEFINE_CONST_DICT(locals_dict, locals_dict_table);
 
-static const mp_obj_type_t py_mjpeg_type = {
+STATIC mp_obj_t py_mjpeg_count(mp_obj_t self)
+{
+    py_mjpeg_obj_t *arg_mjpeg = MP_OBJ_TO_PTR(self);
+    return mp_obj_new_int(arg_mjpeg->frames);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_mjpeg_count_obj, py_mjpeg_count);
+
+STATIC mp_obj_t py_mjpeg_size(mp_obj_t self)
+{
+    py_mjpeg_obj_t *arg_mjpeg = MP_OBJ_TO_PTR(self);
+    return mp_obj_new_int(f_size(&arg_mjpeg->fp));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_mjpeg_size_obj, py_mjpeg_size);
+
+STATIC mp_obj_t py_mjpeg_write(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
+{
+    py_mjpeg_obj_t *arg_mjpeg = py_mjpeg_obj(args[0]);
+    image_t *arg_img = py_image_cobj(args[1]);
+
+    int arg_q = py_helper_keyword_int(n_args, args, 2, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_quality), 90);
+    if ((arg_q < 1) || (100 < arg_q)) {
+        mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("1 <= quality <= 100!"));
+    }
+
+    rectangle_t arg_roi;
+    py_helper_keyword_rectangle_roi(arg_img, n_args, args, 3, kw_args, &arg_roi);
+
+    int arg_rgb_channel = py_helper_keyword_int(n_args, args, 4, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_rgb_channel), -1);
+    if ((arg_rgb_channel < -1) || (2 < arg_rgb_channel)) {
+        mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("-1 <= rgb_channel <= 2!"));
+    }
+
+    int arg_alpha = py_helper_keyword_int(n_args, args, 5, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_alpha), 256);
+    if ((arg_alpha < 0) || (256 < arg_alpha)) {
+        mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("0 <= alpha <= 256!"));
+    }
+
+    const uint16_t *color_palette = py_helper_keyword_color_palette(n_args, args, 6, kw_args, NULL);
+    const uint8_t *alpha_palette = py_helper_keyword_alpha_palette(n_args, args, 7, kw_args, NULL);
+
+    image_hint_t hint = py_helper_keyword_int(n_args, args, 8, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_hint), 0);
+
+    mjpeg_write(&arg_mjpeg->fp, arg_mjpeg->width, arg_mjpeg->height, &arg_mjpeg->frames, &arg_mjpeg->bytes,
+                arg_img, arg_q, &arg_roi, arg_rgb_channel, arg_alpha,
+                color_palette, alpha_palette, hint);
+
+    return args[0];
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_mjpeg_write_obj, 2, py_mjpeg_write);
+
+STATIC mp_obj_t py_mjpeg_sync(mp_obj_t self, mp_obj_t fps_obj)
+{
+    py_mjpeg_obj_t *arg_mjpeg = py_mjpeg_obj(self);
+    mjpeg_sync(&arg_mjpeg->fp, &arg_mjpeg->frames, &arg_mjpeg->bytes, mp_obj_get_float(fps_obj));
+    return self;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(py_mjpeg_sync_obj, py_mjpeg_sync);
+
+STATIC mp_obj_t py_mjpeg_close(mp_obj_t self, mp_obj_t fps_obj)
+{
+    py_mjpeg_obj_t *arg_mjpeg = py_mjpeg_obj(self);
+    mjpeg_close(&arg_mjpeg->fp, &arg_mjpeg->frames, &arg_mjpeg->bytes, mp_obj_get_float(fps_obj));
+    arg_mjpeg->closed = true;
+    return self;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(py_mjpeg_close_obj, py_mjpeg_close);
+
+STATIC mp_obj_t py_mjpeg_open(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
+{
+    py_mjpeg_obj_t *mjpeg = m_new_obj_with_finaliser(py_mjpeg_obj_t);
+    mjpeg->base.type = &py_mjpeg_type;
+    mjpeg->closed = false;
+    mjpeg->width  = py_helper_keyword_int(n_args, args, 1, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_width), MAIN_FB()->w);
+    mjpeg->height = py_helper_keyword_int(n_args, args, 2, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_height), MAIN_FB()->h);
+    mjpeg->frames = 0;
+    mjpeg->bytes = 0;
+    file_write_open(&mjpeg->fp, mp_obj_str_get_str(args[0]));
+    mjpeg_open(&mjpeg->fp, mjpeg->width, mjpeg->height);
+    return mjpeg;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_mjpeg_open_obj, 1, py_mjpeg_open);
+
+STATIC const mp_rom_map_elem_t py_mjpeg_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__),    MP_ROM_QSTR(MP_QSTR_Mjpeg)          },
+    { MP_ROM_QSTR(MP_QSTR___del__),     MP_ROM_PTR(&py_mjpeg_close_obj)     },
+    { MP_ROM_QSTR(MP_QSTR_is_closed),   MP_ROM_PTR(&py_mjpeg_is_closed_obj) },
+    { MP_ROM_QSTR(MP_QSTR_width),       MP_ROM_PTR(&py_mjpeg_width_obj)     },
+    { MP_ROM_QSTR(MP_QSTR_height),      MP_ROM_PTR(&py_mjpeg_height_obj)    },
+    { MP_ROM_QSTR(MP_QSTR_count),       MP_ROM_PTR(&py_mjpeg_count_obj)     },
+    { MP_ROM_QSTR(MP_QSTR_size),        MP_ROM_PTR(&py_mjpeg_size_obj)      },
+    { MP_ROM_QSTR(MP_QSTR_add_frame),   MP_ROM_PTR(&py_mjpeg_write_obj)     },
+    { MP_ROM_QSTR(MP_QSTR_write),       MP_ROM_PTR(&py_mjpeg_write_obj)     },
+    { MP_ROM_QSTR(MP_QSTR_sync),        MP_ROM_PTR(&py_mjpeg_sync_obj)      },
+    { MP_ROM_QSTR(MP_QSTR_close),       MP_ROM_PTR(&py_mjpeg_close_obj)     },
+};
+
+STATIC MP_DEFINE_CONST_DICT(py_mjpeg_locals_dict, py_mjpeg_locals_dict_table);
+
+STATIC const mp_obj_type_t py_mjpeg_type = {
     { &mp_type_type },
     .name  = MP_QSTR_Mjpeg,
     .print = py_mjpeg_print,
-    .locals_dict = (mp_obj_t)&locals_dict,
+    .locals_dict = (mp_obj_dict_t *) &py_mjpeg_locals_dict,
 };
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_mjpeg_open_obj, 1, py_mjpeg_open);
-static const mp_map_elem_t globals_dict_table[] = {
-    { MP_OBJ_NEW_QSTR(MP_QSTR___name__),    MP_OBJ_NEW_QSTR(MP_QSTR_mjpeg) },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_Mjpeg),       (mp_obj_t)&py_mjpeg_open_obj   },
-    { NULL, NULL },
+STATIC const mp_rom_map_elem_t globals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__),    MP_ROM_QSTR(MP_QSTR_mjpeg)      },
+    { MP_ROM_QSTR(MP_QSTR_mjpeg),       MP_ROM_PTR(&py_mjpeg_open_obj)  },
+    { MP_ROM_QSTR(MP_QSTR_Mjpeg),       MP_ROM_PTR(&py_mjpeg_open_obj)  },
+    { MP_ROM_QSTR(MP_QSTR_MJPEG),       MP_ROM_PTR(&py_mjpeg_open_obj)  },
 };
+
 STATIC MP_DEFINE_CONST_DICT(globals_dict, globals_dict_table);
 
 const mp_obj_module_t mjpeg_module = {
     .base = { &mp_type_module },
-    .globals = (mp_obj_t)&globals_dict,
+    .globals = (mp_obj_t) &globals_dict,
 };
 
 MP_REGISTER_MODULE(MP_QSTR_mjpeg, mjpeg_module);
+
+#endif // IMLIB_ENABLE_IMAGE_FILE_IO


### PR DESCRIPTION
This PR vastly improves the MJPEG code. It upgrades the MJPEG writer to have some of the same features as ImageIO. In particular, it adds sync() support to the object so that you can flush the image stream without having to the close the file. This PR does not however add support for appending/reading/seeking on MJPEG files. This will need to be added in a future PR as this requires much more effort to implement and was not a feature request by the customer.

Additionally, the add_frame() function was improved by integrating draw image support. So, now the function will automatically scale the image to the video size and you can apply all the draw_image color transformations as you like to the image on write.

Finally, life cycle management functions similar to ImageIO were added so you can check if the object is closed, get the frame count, etc.

This PR solves issue: https://github.com/openmv/openmv/issues/1819