### PR TITLE
lib/libtf: Update libtf regression to support 2D input.

### DIFF
--- a/src/lib/libtf/libtf.h
+++ b/src/lib/libtf/libtf.h
@@ -1,5 +1,5 @@
 /* This file is part of the OpenMV project.
- * Copyright (c) 2013-2021 Ibrahim Abdelkader <iabdalkader@openmv.io> & Kwabena W. Agyeman <kwagyeman@openmv.io>
+ * Copyright (c) 2013-2023 Ibrahim Abdelkader <iabdalkader@openmv.io> & Kwabena W. Agyeman <kwagyeman@openmv.io>
  * This work is licensed under the MIT license, see the file LICENSE for details.
  */
 
@@ -72,7 +72,8 @@ int libtf_generate_micro_features(const int16_t *input, // Audio samples
                                   int8_t *output, // Slice data
                                   size_t *num_samples_read); // Number of samples used
 
-int libtf_regression_1Dinput_1Doutput(const unsigned char *model_data, uint8_t* tensor_arena, libtf_parameters_t* params, float* input_data, float* output_data);
+// runs regression on 2D/ 1D input(provided as array) and return 1D output
+int libtf_regression(const unsigned char *model_data, uint8_t* tensor_arena, libtf_parameters_t* params, float* input_data, float* output_data);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Hi @iabdalkader, as discussed, I created a PR to extend the feature requested in https://github.com/openmv/openmv/issues/1751 and https://github.com/openmv/openmv/issues/1739 for 2D inputs

Updated binding for tf_regression to support the functionality of regression models for two-dimensional input and one-dimensional output for the function libtf_regression updated in libtf.cc(PR [here](https://github.com/openmv/tensorflow-lib/pull/13))
This PR aims to build on a previous [PR](https://github.com/openmv/openmv/pull/1762). Tagging it for reference.
Presently, it supports only int8, uint8, and float32 tflite models.

The following are details about how to use the model:
I have used two models to run:
1. Float32 Model with dynamic range quantization(or no quantization) 
The TFLite model can put in the storage memory and can be read from there to could pushed to the firmware source code
Link for the TFLite model: [link](https://drive.google.com/file/d/13z1Trd78ExMKRGmAtE2cFbRVcSVsT8EK/view?usp=sharing)
```python
import tf
from ulab import numpy as np

net = tf.load("force_float32_quant.tflite")
print(net)
arr = np.array([-3, -1, -2,  5, -2, 10, -1,  9,  0,  2,  0,  9,  1, 10,  2, -1,  3,
        5,  3,  9,  3,  9,  6,  2,  6,  7,  5, 10,  6, -1,  7,  4,  7,  8,
        5,  7])

out = tf.regression(net, arr)
print("output:", out)
```
The above code with the float32 model should result in a truth value of 54.4129

2. Int8 Quantization(Full Quantization)
Link for the model: [link](https://drive.google.com/file/d/18rv0yw1m6ohoKAibzMwRlaI1Ptnq1izu/view?usp=sharing)
I am not sure why but I wasn't able to load this model with `tf.load()` with the updated firmware on my fork due [this](https://github.com/openmv/tensorflow-lib/issues/12) reason.
With the development version of official OpenMV, I was able to load it. The reason might be that I am using an old version of `tensorflow-lib` to build the new changes. It would be of great help if you could please once evaluate this at your end. Thank you!
The output for int8 model shall be around 53.7833
The code to test the same wouldn't change.

Input is taken as an ulab array object. Internally, the input gets mapped to the appropriate datatype of int8, uint8, and float32.
Output is returned as a list