### PR TITLE
ports/stm32: Share GPIO IRQ descriptor with other ports.

### DIFF
--- a/src/drivers/winc1500/src/nm_bsp.c
+++ b/src/drivers/winc1500/src/nm_bsp.c
@@ -53,7 +53,7 @@ void nm_bsp_sleep(uint32 u32TimeMsec) {
     mp_hal_delay_ms(u32TimeMsec);
 }
 
-static void nm_bsp_extint_callback(omv_gpio_t pin, void *data) {
+static void nm_bsp_extint_callback(void *data) {
     if (gpfIsr) {
         gpfIsr();
     }

--- a/src/omv/common/omv_gpio.h
+++ b/src/omv/common/omv_gpio.h
@@ -17,7 +17,17 @@
 // Config options are defined in ports so they can be used
 // directly to initialize peripherals without remapping them.
 
-typedef void (*omv_gpio_callback_t)(omv_gpio_t pin, void *data);
+typedef void (*omv_gpio_callback_t)(void *data);
+
+typedef struct _omv_gpio_irq_descr {
+    bool enabled;
+    void *data;
+    omv_gpio_callback_t callback;
+    #ifdef OMV_GPIO_IRQ_DESCR_PORT_BITS
+    // Additional port-specific fields used internally.
+    OMV_GPIO_IRQ_DESCR_PORT_BITS
+    #endif
+} omv_gpio_irq_descr_t;
 
 void omv_gpio_init0(void);
 void omv_gpio_config(omv_gpio_t pin, uint32_t mode, uint32_t pull, uint32_t speed, uint32_t af);

--- a/src/omv/ports/stm32/modules/py_fir_lepton.c
+++ b/src/omv/ports/stm32/modules/py_fir_lepton.c
@@ -201,7 +201,7 @@ static void fir_lepton_spi_callback_full(SPI_HandleTypeDef *hspi)
 #if defined(OMV_FIR_LEPTON_VSYNC_PIN)
 static mp_obj_t fir_lepton_vsync_cb = NULL;
 
-static void fir_lepton_extint_callback(omv_gpio_t pin, void *data)
+static void fir_lepton_extint_callback(void *data)
 {
     if (fir_lepton_vsync_cb) {
         mp_call_function_0(fir_lepton_vsync_cb);

--- a/src/omv/ports/stm32/modules/py_lcd.c
+++ b/src/omv/ports/stm32/modules/py_lcd.c
@@ -1220,7 +1220,7 @@ static mp_obj_t ltdc_dvi_get_display_id_data()
 }
 #endif // OMV_DDC_PRESENT
 
-static void ltdc_dvi_extint_callback(omv_gpio_t pin, void *data)
+static void ltdc_dvi_extint_callback(void *data)
 {
     if (ltdc_dvi_user_cb) {
         mp_call_function_1(ltdc_dvi_user_cb, ltdc_dvi_get_display_connected());

--- a/src/omv/ports/stm32/modules/py_lcd_cec.c
+++ b/src/omv/ports/stm32/modules/py_lcd_cec.c
@@ -524,7 +524,7 @@ mp_obj_t lcd_cec_receive_frame(uint n_args, const mp_obj_t *args, mp_map_t *kw_a
     mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("Expected destination address!"));
 }
 
-static void lcd_cec_extint_callback(omv_gpio_t pin, void *data)
+static void lcd_cec_extint_callback(void *data)
 {
     if (lcd_cec_user_cb && lcd_cec_receive_frame_int(lcd_cec_dst_addr, false)) {
         mp_call_function_0(lcd_cec_user_cb);

--- a/src/omv/ports/stm32/modules/py_lcd_touch.c
+++ b/src/omv/ports/stm32/modules/py_lcd_touch.c
@@ -132,7 +132,7 @@ mp_obj_t lcd_touch_update_touch_points()
     mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("Failed to update the number of touch points!"));
 }
 
-static void lcd_touch_extint_callback(omv_gpio_t pin, void *data)
+static void lcd_touch_extint_callback(void *data)
 {
     if (lcd_touch_user_cb) {
         mp_call_function_1(lcd_touch_user_cb, lcd_touch_update_touch_points());

--- a/src/omv/ports/stm32/omv_portconfig.h
+++ b/src/omv/ports/stm32/omv_portconfig.h
@@ -45,6 +45,11 @@ typedef struct {
 
 typedef const stm32_gpio_t *omv_gpio_t;
 
+#define OMV_GPIO_IRQ_DESCR_PORT_BITS \
+struct {                             \
+    uint32_t gpio;                   \
+};
+
 // Dummy AF for pins defined as I/O
 #define GPIO_NONE_GPIO    (0)
 

--- a/src/omv/ports/stm32/sensor.c
+++ b/src/omv/ports/stm32/sensor.c
@@ -339,7 +339,7 @@ int sensor_shutdown(int enable)
     return ret;
 }
 
-static void sensor_vsync_callback(omv_gpio_t pin, void *data)
+static void sensor_vsync_callback(void *data)
 {
     if (sensor.vsync_callback != NULL) {
         sensor.vsync_callback(omv_gpio_read(DCMI_VSYNC_PIN));


### PR DESCRIPTION
* Move GPIO IRQ descriptor to common HAL to share it with other ports, and reduce the default descriptor size, while allow ports to add bits.