### PR TITLE
fix: added missing close() of socket object.

### DIFF
--- a/scripts/libraries/urequests.py
+++ b/scripts/libraries/urequests.py
@@ -171,8 +171,9 @@ def request(method, url, data=None, json=None, files=None, headers={}, auth=None
         resp_headers = b"\r\n".join(resp_headers)
         content = b"\r\n".join(response)
     except OSError:
-        s.close()
         raise
+    finally:
+        s.close()
 
     return Response(resp_code, resp_reason, resp_headers, content)
 


### PR DESCRIPTION
Your implementation of _urequests_ does not keep a reference to any resources in the `Response` object. So adding a `close()` function to the `Response` object (like the implementation in _micropython-lib_ has) is not possible. However, an unconditional call to `close()` on the socket object solved the problem for me.

fixes #1895