### PR TITLE
ports/mimxrt: Add machine.CAN driver.

### DIFF
--- a/src/omv/ports/mimxrt/main.c
+++ b/src/omv/ports/mimxrt/main.c
@@ -123,9 +123,6 @@ soft_reset:
     #endif // MICROPY_PY_BUZZER
     imlib_init_all();
     readline_init0();
-    #if MICROPY_HW_ENABLE_CAN
-    can_init0();
-    #endif
     fb_alloc_init0();
     framebuffer_init0();
     sensor_init0();
@@ -277,6 +274,9 @@ soft_reset:
     }
 
     mp_printf(MP_PYTHON_PRINTER, "MPY: soft reboot\n");
+    #if MICROPY_HW_ENABLE_CAN
+    machine_can_irq_deinit();
+    #endif
     machine_pin_irq_deinit();
     machine_rtc_irq_deinit();
     #if MICROPY_PY_LWIP

--- a/src/omv/ports/mimxrt/omv_portconfig.mk
+++ b/src/omv/ports/mimxrt/omv_portconfig.mk
@@ -14,6 +14,7 @@ CFLAGS += -DCPU_$(MCU_VARIANT)\
           -D__FPU_PRESENT=1 -D__VFP_FP__\
           -DHSE_VALUE=$(OMV_HSE_VALUE) \
           -DMICROPY_PY_MACHINE_SDCARD=1 \
+          -DMICROPY_HW_ENABLE_CAN=1 \
           -DXIP_EXTERNAL_FLASH=1 \
 	      -DXIP_BOOT_HEADER_ENABLE=1 \
 	      -DFSL_SDK_ENABLE_DRIVER_CACHE_CONTROL=1 \
@@ -231,6 +232,7 @@ FIRM_OBJ += $(addprefix $(BUILD)/$(MICROPY_DIR)/,\
 	led.o                               \
 	machine_adc.o                       \
 	machine_bitstream.o                 \
+	machine_can.o                       \
 	machine_i2c.o                       \
 	machine_i2s.o                       \
 	machine_led.o                       \


### PR DESCRIPTION
After https://github.com/openmv/micropython/pull/114 is merged this enables CAN support for our board.