### PR TITLE
misc: Fix typos in src/omw subdirectory

### DIFF
--- a/src/omv/alloc/fb_alloc.h
+++ b/src/omv/alloc/fb_alloc.h
@@ -8,8 +8,8 @@
  * Theory of operation:
  *
  * The frame buffer stack may be used to allocate large areas of RAM very quickly. You can allocate
- * memory using fb_alloc() which returns a poiner to an allocated region of memory equal in size to
- * the amount requested. If the memory is not avaiable fb_alloc() will generate an exception.
+ * memory using fb_alloc() which returns a pointer to an allocated region of memory equal in size to
+ * the amount requested. If the memory is not available fb_alloc() will generate an exception.
  *
  * After RAM is allocated with fb_alloc() you can free it with fb_free() in the order of allocs.
  *

--- a/src/omv/alloc/umm_malloc.c
+++ b/src/omv/alloc/umm_malloc.c
@@ -386,7 +386,7 @@ void *umm_malloc(size_t size) {
          */
 
         if (blockSize == blocks) {
-            /* It's an exact fit and we don't neet to split off a block. */
+            /* It's an exact fit and we don't need to split off a block. */
             DBGLOG_DEBUG("Allocating %6i blocks starting at %6i - exact\n", blocks, cf);
 
             /* Disconnect this block from the FREE list */

--- a/src/omv/boards/ARDUINO_NICLA_VISION/omv_boardconfig.h
+++ b/src/omv/boards/ARDUINO_NICLA_VISION/omv_boardconfig.h
@@ -162,7 +162,7 @@
 
 #define OMV_LINE_BUF_SIZE                     (3 * 1024) // Image line buffer round(640 * 2BPP * 2 buffers).
 #define OMV_MSC_BUF_SIZE                      (2K) // USB MSC bot data
-#define OMV_VFS_BUF_SIZE                      (1K) // VFS sturct + FATFS file buffer (624 bytes)
+#define OMV_VFS_BUF_SIZE                      (1K) // VFS struct + FATFS file buffer (624 bytes)
 #define OMV_FIR_LEPTON_BUF_SIZE               (1K) // FIR Lepton Packet Double Buffer (328 bytes)
 #define OMV_JPEG_BUF_SIZE                     (32 * 1024) // IDE JPEG buffer (header + data).
 

--- a/src/omv/boards/ARDUINO_PORTENTA_H7/omv_boardconfig.h
+++ b/src/omv/boards/ARDUINO_PORTENTA_H7/omv_boardconfig.h
@@ -177,7 +177,7 @@
 
 #define OMV_LINE_BUF_SIZE           (11 * 1024)    // Image line buffer round(2592 * 2BPP * 2 buffers).
 #define OMV_MSC_BUF_SIZE            (2K)    // USB MSC bot data
-#define OMV_VFS_BUF_SIZE            (1K)    // VFS sturct + FATFS file buffer (624 bytes)
+#define OMV_VFS_BUF_SIZE            (1K)    // VFS struct + FATFS file buffer (624 bytes)
 #define OMV_FIR_LEPTON_BUF_SIZE     (1K)    // FIR Lepton Packet Double Buffer (328 bytes)
 #define OMV_JPEG_BUF_SIZE           (1024 * 1024)    // IDE JPEG buffer (header + data).
 

--- a/src/omv/boards/OPENMV2/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV2/omv_boardconfig.h
@@ -108,7 +108,7 @@
 
 #define OMV_LINE_BUF_SIZE                     (2 * 1024) // Image line buffer round(320 * 2BPP * 2 buffers).
 #define OMV_MSC_BUF_SIZE                      (2K) // USB MSC bot data
-#define OMV_VFS_BUF_SIZE                      (1K) // VFS sturct + FATFS file buffer (624 bytes)
+#define OMV_VFS_BUF_SIZE                      (1K) // VFS struct + FATFS file buffer (624 bytes)
 #define OMV_FIR_LEPTON_BUF_SIZE               (1K) // FIR Lepton Packet Double Buffer (328 bytes)
 #define OMV_FFS_BUF_SIZE                      (16K) // Flash filesystem cache
 #define OMV_JPEG_BUF_SIZE                     (8 * 1024) // IDE JPEG buffer size (header + data).

--- a/src/omv/boards/OPENMV3/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV3/omv_boardconfig.h
@@ -108,7 +108,7 @@
 
 #define OMV_LINE_BUF_SIZE                     (3 * 1024) // Image line buffer round(640 * 2BPP * 2 buffers).
 #define OMV_MSC_BUF_SIZE                      (2K) // USB MSC bot data
-#define OMV_VFS_BUF_SIZE                      (1K) // VFS sturct + FATFS file buffer (624 bytes)
+#define OMV_VFS_BUF_SIZE                      (1K) // VFS struct + FATFS file buffer (624 bytes)
 #define OMV_FIR_LEPTON_BUF_SIZE               (1K) // FIR Lepton Packet Double Buffer (328 bytes)
 #define OMV_FFS_BUF_SIZE                      (32K) // Flash filesystem cache
 #define OMV_JPEG_BUF_SIZE                     (22 * 1024) // IDE JPEG buffer (header + data).

--- a/src/omv/boards/OPENMV4/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4/omv_boardconfig.h
@@ -167,7 +167,7 @@
 
 #define OMV_LINE_BUF_SIZE                     (5 * 1024) // Image line buffer.
 #define OMV_MSC_BUF_SIZE                      (2K) // USB MSC bot data
-#define OMV_VFS_BUF_SIZE                      (1K) // VFS sturct + FATFS file buffer (624 bytes)
+#define OMV_VFS_BUF_SIZE                      (1K) // VFS struct + FATFS file buffer (624 bytes)
 #define OMV_FIR_LEPTON_BUF_SIZE               (1K) // FIR Lepton Packet Double Buffer (328 bytes)
 #define OMV_JPEG_BUF_SIZE                     (32 * 1024) // IDE JPEG buffer (header + data).
 

--- a/src/omv/boards/OPENMV4P/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4P/omv_boardconfig.h
@@ -169,7 +169,7 @@
 
 #define OMV_LINE_BUF_SIZE                     (11 * 1024) // Image line buffer round(2592 * 2BPP * 2 buffers).
 #define OMV_MSC_BUF_SIZE                      (2K) // USB MSC bot data
-#define OMV_VFS_BUF_SIZE                      (1K) // VFS sturct + FATFS file buffer (624 bytes)
+#define OMV_VFS_BUF_SIZE                      (1K) // VFS struct + FATFS file buffer (624 bytes)
 #define OMV_FIR_LEPTON_BUF_SIZE               (1K) // FIR Lepton Packet Double Buffer (328 bytes)
 #define OMV_JPEG_BUF_SIZE                     (1024 * 1024) // IDE JPEG buffer (header + data).
 

--- a/src/omv/boards/OPENMV4_PRO/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4_PRO/omv_boardconfig.h
@@ -181,7 +181,7 @@
 
 #define OMV_LINE_BUF_SIZE                     (11 * 1024) // Image line buffer round(2592 * 2BPP * 2 buffers).
 #define OMV_MSC_BUF_SIZE                      (2K) // USB MSC bot data
-#define OMV_VFS_BUF_SIZE                      (1K) // VFS sturct + FATFS file buffer (624 bytes)
+#define OMV_VFS_BUF_SIZE                      (1K) // VFS struct + FATFS file buffer (624 bytes)
 #define OMV_FIR_LEPTON_BUF_SIZE               (1K) // FIR Lepton Packet Double Buffer (328 bytes)
 #define OMV_JPEG_BUF_SIZE                     (1024 * 1024) // IDE JPEG buffer (header + data).
 

--- a/src/omv/boards/OPENMVPT/omv_boardconfig.h
+++ b/src/omv/boards/OPENMVPT/omv_boardconfig.h
@@ -174,7 +174,7 @@
 
 #define OMV_LINE_BUF_SIZE                          (11 * 1024) // Image line buffer round(2592 * 2BPP * 2 buffers).
 #define OMV_MSC_BUF_SIZE                           (2K) // USB MSC bot data
-#define OMV_VFS_BUF_SIZE                           (1K) // VFS sturct + FATFS file buffer (624 bytes)
+#define OMV_VFS_BUF_SIZE                           (1K) // VFS struct + FATFS file buffer (624 bytes)
 #define OMV_FIR_LEPTON_BUF_SIZE                    (1K) // FIR Lepton Packet Double Buffer (328 bytes)
 #define OMV_JPEG_BUF_SIZE                          (1024 * 1024) // IDE JPEG buffer (header + data).
 

--- a/src/omv/boards/OPENMV_RT1060/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV_RT1060/omv_boardconfig.h
@@ -116,7 +116,7 @@
 #define OMV_LINE_BUF_SIZE          (10 * 1024)  // Image line buffer.
 // TODO remove
 #define OMV_MSC_BUF_SIZE           (2K)         // USB MSC bot data
-#define OMV_VFS_BUF_SIZE           (1K)         // VFS sturct + FATFS file buffer (624 bytes)
+#define OMV_VFS_BUF_SIZE           (1K)         // VFS struct + FATFS file buffer (624 bytes)
 #define OMV_FIR_LEPTON_BUF_SIZE    (1K)         // FIR Lepton Packet Double Buffer (328 bytes)
 #define OMV_JPEG_BUF_SIZE          (1024 * 1024)  // IDE JPEG buffer (header + data).
 

--- a/src/omv/common/ff_wrapper.c
+++ b/src/omv/common/ff_wrapper.c
@@ -221,7 +221,7 @@ FRESULT f_touch_helper(const TCHAR *path) {
 // we use a temporary buffer to fix the alignment and to speed everything up.
 
 // We use this temporary buffer for both reads and writes. The buffer allows us
-// to do multi-block reads and writes which signifcantly speed things up.
+// to do multi-block reads and writes which significantly speed things up.
 
 static uint32_t file_buffer_offset = 0;
 static uint8_t *file_buffer_pointer = 0;

--- a/src/omv/common/sensor_utils.c
+++ b/src/omv/common/sensor_utils.c
@@ -91,12 +91,12 @@ const int resolution[][2] = {
 };
 
 __weak void sensor_init0() {
-    // Reset the sesnor state
+    // Reset the sensor state
     memset(&sensor, 0, sizeof(sensor_t));
 }
 
 __weak int sensor_init() {
-    // Reset the sesnor state
+    // Reset the sensor state
     memset(&sensor, 0, sizeof(sensor_t));
     return SENSOR_ERROR_CTL_UNSUPPORTED;
 }

--- a/src/omv/imlib/apriltag.c
+++ b/src/omv/imlib/apriltag.c
@@ -1795,7 +1795,7 @@ matd_t *matd_transpose(const matd_t *a)
 static
 float matd_det_general(const matd_t *a)
 {
-    // Use LU decompositon to calculate the determinant
+    // Use LU decomposition to calculate the determinant
     matd_plu_t *mlu = matd_plu(a);
     matd_t *L = matd_plu_l(mlu);
     matd_t *U = matd_plu_u(mlu);
@@ -9785,7 +9785,7 @@ int fit_quad(apriltag_detector_t *td, image_u8_t *im, zarray_t *cluster, struct 
     if ((!overrideMode) && (dot < 0))
         return 0;
 
-    // we now sort the points according to theta. This is a prepatory
+    // we now sort the points according to theta. This is a preparatory
     // step for segmenting them into four lines.
     if (1) {
         //        zarray_sort(cluster, pt_compare_theta);
@@ -12446,7 +12446,7 @@ void imlib_rotation_corr(image_t *img, float x_rotation, float y_rotation, float
                     break;
                 }
             }
-        } else { // warp persepective
+        } else { // warp perspective
             switch (img->pixfmt) {
                 case PIXFORMAT_BINARY: {
                     uint32_t *tmp = (uint32_t *) data;

--- a/src/omv/imlib/dmtx.c
+++ b/src/omv/imlib/dmtx.c
@@ -3382,7 +3382,7 @@ TrailBlazeContinuous(DmtxDecode *dec, DmtxRegion *reg, DmtxPointFlow flowBegin, 
 }
 
 /**
- * recives bresline, and follows strongest neighbor unless it involves
+ * receives bresline, and follows strongest neighbor unless it involves
  * ratcheting bresline inward or backward (although back + outward is allowed).
  *
  */
@@ -4326,7 +4326,7 @@ dmtxSymbolModuleStatus(DmtxMessage *message, int sizeIdx, int symbolRow, int sym
          symbolCol % (dataRegionCols+2) == 0)
       return (DmtxModuleOnRGB | (!DmtxModuleData));
 
-   /* Horinzontal calibration bars */
+   /* Horizontal calibration bars */
    if((symbolRow+1) % (dataRegionRows+2) == 0)
       return (((symbolCol & 0x01) ? 0 : DmtxModuleOnRGB) | (!DmtxModuleData));
 

--- a/src/omv/imlib/draw.c
+++ b/src/omv/imlib/draw.c
@@ -2872,7 +2872,7 @@ void imlib_draw_image(image_t *dst_img,
     // Clamp start x to image bounds.
     int src_x_start = 0;
     if (dst_x_start < 0) {
-        src_x_start -= dst_x_start; // this is an add becasue dst_x_start is negative
+        src_x_start -= dst_x_start; // this is an add because dst_x_start is negative
         dst_x_start = 0;
     }
 
@@ -2887,7 +2887,7 @@ void imlib_draw_image(image_t *dst_img,
     // Clamp start y to image bounds.
     int src_y_start = 0;
     if (dst_y_start < 0) {
-        src_y_start -= dst_y_start; // this is an add becasue dst_y_start is negative
+        src_y_start -= dst_y_start; // this is an add because dst_y_start is negative
         dst_y_start = 0;
     }
 
@@ -4238,19 +4238,19 @@ void imlib_draw_image(image_t *dst_img,
                             pixel_row_2 = __UHADD8(pixel_row_2, 0);
                             pixel_row_3 = __UHADD8(pixel_row_3, 0);
 
-                            // Need 1/3 gaurd bits.
+                            // Need 1/3 guard bits.
                             pixel_row_0 = __UHADD8(pixel_row_0, 0);
                             pixel_row_1 = __UHADD8(pixel_row_1, 0);
                             pixel_row_2 = __UHADD8(pixel_row_2, 0);
                             pixel_row_3 = __UHADD8(pixel_row_3, 0);
 
-                            // Need 2/3 gaurd bits.
+                            // Need 2/3 guard bits.
                             pixel_row_0 = __UHADD8(pixel_row_0, 0);
                             pixel_row_1 = __UHADD8(pixel_row_1, 0);
                             pixel_row_2 = __UHADD8(pixel_row_2, 0);
                             pixel_row_3 = __UHADD8(pixel_row_3, 0);
 
-                            // Need 3/3 gaurd bits.
+                            // Need 3/3 guard bits.
                             pixel_row_0 = __UHADD8(pixel_row_0, 0);
                             pixel_row_1 = __UHADD8(pixel_row_1, 0);
                             pixel_row_2 = __UHADD8(pixel_row_2, 0);

--- a/src/omv/imlib/fft.c
+++ b/src/omv/imlib/fft.c
@@ -252,7 +252,7 @@ static void unpack_fft(float *in, float *out, int N_pow2) {
 }
 
 // The IFFT takes N real and imaginary pairs to generate N real and imaginary
-// outputs with the imaginary part set to zero. To be more efficent this function
+// outputs with the imaginary part set to zero. To be more efficient this function
 // packs 2N data into an N IFFT so that the N real and imaginary outputs have
 // even/odd real values.
 

--- a/src/omv/imlib/framebuffer.c
+++ b/src/omv/imlib/framebuffer.c
@@ -252,7 +252,7 @@ uint32_t framebuffer_get_buffer_size() {
     // Remove the size of the state header plus alignment padding.
     size -= sizeof(vbuffer_t);
 
-    // Do we have an estimate on the frame size with mutliple buffers? If so, we can reduce the
+    // Do we have an estimate on the frame size with multiple buffers? If so, we can reduce the
     // RAM each buffer takes up giving some space back to fb_alloc().
     if ((framebuffer->n_buffers != 1) && framebuffer->u && framebuffer->v) {
         // Typically a framebuffer will not need more than u*v*2 bytes.

--- a/src/omv/imlib/imlib.c
+++ b/src/omv/imlib/imlib.c
@@ -75,7 +75,7 @@ void point_min_area_rectangle(point_t *corners, point_t *new_corners, int corner
     float i_r = 0;
 
     // This algorithm aligns the 4 edges produced by the 4 corners to the x axis and then computes the
-    // min area rect for each alignment. The smallest rect is choosen and then re-rotated and returned.
+    // min area rect for each alignment. The smallest rect is chosen and then re-rotated and returned.
     for (int i = 0; i < corners_len; i++) {
         int16_t x0 = corners[i].x, y0 = corners[i].y;
         int x_diff = corners[(i + 1) % corners_len].x - corners[i].x;

--- a/src/omv/imlib/jpeg.c
+++ b/src/omv/imlib/jpeg.c
@@ -1200,7 +1200,7 @@ bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc) {
     // Set output size.
     dst->size = JPEG_out_data_length;
 
-    // STM32H7 BUG FIX! The JPEG Encoder will ocassionally trigger the EOCF interrupt before writing
+    // STM32H7 BUG FIX! The JPEG Encoder will occasionally trigger the EOCF interrupt before writing
     // a final 0x000000D9 long into the output fifo as the end of the JPEG image. When this occurs
     // the output fifo will have a single 0 value in it after the encoding process finishes.
     if (__HAL_JPEG_GET_FLAG(&JPEG_Handle, JPEG_FLAG_OFNEF) && (!JPEG_Handle.Instance->DOR)) {

--- a/src/omv/imlib/jpegd.c
+++ b/src/omv/imlib/jpegd.c
@@ -850,7 +850,7 @@ static int JPEGMakeHuffTables(JPEGIMAGE *pJPEG, int bThumbnail) {
                         repeat = 1 << ucMag;
                         iLoop = 1 << (count - ucMag);
                         for (j = 0; j < repeat; j++) {
-                            // calcuate the magnitude coeff already
+                            // calculate the magnitude coeff already
                             if (j & 1 << (ucMag - 1)) {
                                 // positive number
                                 ucCoeff = (unsigned char) j;

--- a/src/omv/imlib/lodepng.h
+++ b/src/omv/imlib/lodepng.h
@@ -936,7 +936,7 @@ unsigned lodepng_chunk_append(unsigned char **out, size_t *outsize, const unsign
    Appends new chunk to out. The chunk to append is given by giving its length, type
    and data separately. The type is a 4-letter string.
    The out variable and outsize are updated to reflect the new reallocated buffer.
-   Returne error code (0 if it went ok)
+   Return error code (0 if it went ok)
  */
 unsigned lodepng_chunk_create(unsigned char **out, size_t *outsize, unsigned length,
                               const char *type, const unsigned char *data);
@@ -1813,7 +1813,7 @@ unsigned compress(std::vector < unsigned char >& out, const std::vector < unsign
    state.info_raw.colortype: desired color type for decoded image
    state.info_raw.bitdepth: desired bit depth for decoded image
    state.info_raw....: more color settings, see struct LodePNGColorMode
-   state.info_png....: no settings for decoder but ouput, see struct LodePNGInfo
+   state.info_png....: no settings for decoder but output, see struct LodePNGInfo
 
    For encoding:
 

--- a/src/omv/imlib/lsd.c
+++ b/src/omv/imlib/lsd.c
@@ -1785,7 +1785,7 @@ static rect_iter *ri_ini(struct rect *r) {
 
     return i;
 }
-// We don't need to spend time allocating and freeing the interator structure
+// We don't need to spend time allocating and freeing the iterator structure
 // since we only use 1 at a time and it's small enough to safely use as a stack var
 void ri_ini_fast(rect_iter *i, struct rect *r) {
     float vx[4], vy[4];

--- a/src/omv/imlib/orb.c
+++ b/src/omv/imlib/orb.c
@@ -515,7 +515,7 @@ array_t *orb_find_keypoints(image_t *img, bool normalized, int threshold,
     return kpts;
 }
 
-// This is a modifed popcount that counts every 2 different bits as 1.
+// This is a modified popcount that counts every 2 different bits as 1.
 // This is what should actually be used with wta_k == 3 or 4.
 static inline uint32_t popcount(uint32_t i) {
     i = i - ((i >> 1) & 0x55555555);

--- a/src/omv/imlib/qrcode.c
+++ b/src/omv/imlib/qrcode.c
@@ -980,7 +980,7 @@ static void threshold(struct quirc *q)
     if (threshold_s < THRESHOLD_S_MIN)
         threshold_s = THRESHOLD_S_MIN;
 
-    fracmul = (32768 * (threshold_s - 1)) / threshold_s; // to use multipy instead of divide (not too many bits or we'll overflow)
+    fracmul = (32768 * (threshold_s - 1)) / threshold_s; // to use multiply instead of divide (not too many bits or we'll overflow)
     // to get the effect used below (a fraction of threshold_s-1/threshold_s
     // The second constant is to reduce the averaged values to compare with the current pixel
     fracmul2 = (0x100000 * (100 - THRESHOLD_T)) / (200 * threshold_s); // use as many bits as possible without overflowing

--- a/src/omv/imlib/rectangle.c
+++ b/src/omv/imlib/rectangle.c
@@ -74,9 +74,9 @@ static void rectangle_div(rectangle_t *r, int c) {
 array_t *rectangle_merge(array_t *rectangles) {
     array_t *objects; array_alloc(&objects, xfree);
     array_t *overlap; array_alloc(&overlap, xfree);
-    /* merge overlaping detections */
+    /* merge overlapping detections */
     while (array_length(rectangles)) {
-        /* check for overlaping detections */
+        /* check for overlapping detections */
         rectangle_t *rect = (rectangle_t *) array_take(rectangles, 0);
         for (int j = 0; j < array_length(rectangles); j++) {
             // do not cache bound
@@ -84,14 +84,14 @@ array_t *rectangle_merge(array_t *rectangles) {
                 array_push_back(overlap, array_take(rectangles, j--));
             }
         }
-        /* add the overlaping detections */
+        /* add the overlapping detections */
         int count = array_length(overlap);
         for (int i = 0; i < count; i++) {
             rectangle_t *overlap_rect = (rectangle_t *) array_pop_back(overlap);
             rectangle_add(rect, overlap_rect);
             xfree(overlap_rect);
         }
-        /* average the overlaping detections */
+        /* average the overlapping detections */
         rectangle_div(rect, count + 1);
         array_push_back(objects, rect);
     }

--- a/src/omv/imlib/zbar.c
+++ b/src/omv/imlib/zbar.c
@@ -6859,7 +6859,7 @@ static inline unsigned postprocess_c (zbar_decoder_t *dcode,
 {
     unsigned i, j;
 
-    /* expand buffer to accomodate 2x set C characters (2 digits per-char) */
+    /* expand buffer to accommodate 2x set C characters (2 digits per-char) */
     unsigned delta = end - start;
     unsigned newlen = dcode->code128.character + delta;
     size_buf(dcode, newlen);

--- a/src/omv/ports/mimxrt/mimxrt.ld.S
+++ b/src/omv/ports/mimxrt/mimxrt.ld.S
@@ -231,7 +231,7 @@ SECTIONS
     . = . + OMV_MSC_BUF_SIZE;
 
     . = ALIGN(16);
-    _vfs_buf  = .;      // VFS sturct + FATFS file buffer  (around 624 bytes)
+    _vfs_buf  = .;      // VFS struct + FATFS file buffer  (around 624 bytes)
     . = . + OMV_VFS_BUF_SIZE;
 
     . = ALIGN(16);

--- a/src/omv/ports/mimxrt/mimxrt_hal.c
+++ b/src/omv/ports/mimxrt/mimxrt_hal.c
@@ -87,7 +87,7 @@ void mimxrt_hal_init() {
                          );
     #endif
 
-    // Confgure and enable EDMA
+    // Configure and enable EDMA
     edma_config_t edma_config = {0};
     EDMA_GetDefaultConfig(&edma_config);
     EDMA_Init(DMA0, &edma_config);

--- a/src/omv/ports/mimxrt/sensor.c
+++ b/src/omv/ports/mimxrt/sensor.c
@@ -75,7 +75,7 @@ int sensor_init() {
     omv_gpio_write(DCMI_RESET_PIN, 1);
     #endif
 
-    // Reset the sesnor state
+    // Reset the sensor state
     memset(&sensor, 0, sizeof(sensor_t));
 
     // Set default snapshot function.

--- a/src/omv/ports/nrf/main.c
+++ b/src/omv/ports/nrf/main.c
@@ -92,7 +92,7 @@
 #include "sensor.h"
 
 uint32_t HAL_GetHalVersion() {
-    // Hard-coded becasue it's not defined in SDK
+    // Hard-coded because it's not defined in SDK
     return ((2 << 24) | (0 << 16) | (0 << 8) | (0 << 0));
 }
 

--- a/src/omv/ports/nrf/sensor.c
+++ b/src/omv/ports/nrf/sensor.c
@@ -58,7 +58,7 @@ int sensor_init() {
     nrf_gpio_pin_write(DCMI_RESET_PIN, 1);
     #endif
 
-    // Reset the sesnor state
+    // Reset the sensor state
     memset(&sensor, 0, sizeof(sensor_t));
 
     // Set default snapshot function.

--- a/src/omv/ports/rp2/modules/py_audio.c
+++ b/src/omv/ports/rp2/modules/py_audio.c
@@ -105,7 +105,7 @@ static void dma_irq_handler() {
         dma_irqn_acknowledge_channel(PDM_DMA, audio_data->dma_channel);
 
         // Set the next PDM buffer and retrigger the DMA channel
-        // immediatley while PDM samples are converted to PCM samples.
+        // immediately while PDM samples are converted to PCM samples.
         dma_channel_set_write_addr(audio_data->dma_channel,
                                    &audio_data->pdm_buffer[(audio_data->dma_buf_idx ^ 1) * PDM_BUFFER_SIZE], true);
 

--- a/src/omv/ports/rp2/rp2.ld.S
+++ b/src/omv/ports/rp2/rp2.ld.S
@@ -60,7 +60,7 @@ SECTIONS
         /* bit of a hack right now to exclude all floating point and time critical (e.g. memset, memcpy) code from
          * FLASH ... we will include any thing excluded here in .data below by default */
         *(.init)
-        /* Change for MicroPython... excluse gc.c, parse.c, vm.c from flash */
+        /* Change for MicroPython... exclude gc.c, parse.c, vm.c from flash */
         *(EXCLUDE_FILE(*libgcc.a: *libc.a: *lib_a-mem*.o *libm.a: *gc.c.obj *vm.c.obj *parse.c.obj) .text*)
         *(.fini)
         /* Pull all c'tors into .text */

--- a/src/omv/ports/rp2/sensor.c
+++ b/src/omv/ports/rp2/sensor.c
@@ -83,7 +83,7 @@ int sensor_init() {
     gpio_put(DCMI_RESET_PIN, 1);
     #endif
 
-    // Reset the sesnor state
+    // Reset the sensor state
     memset(&sensor, 0, sizeof(sensor_t));
 
     // Set default snapshot function.

--- a/src/omv/ports/stm32/modules/py_winc.c
+++ b/src/omv/ports/stm32/modules/py_winc.c
@@ -582,7 +582,7 @@ static const mp_rom_map_elem_t winc_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_WEP),           MP_OBJ_NEW_SMALL_INT(M2M_WIFI_SEC_WEP) },    // Security type WEP.
     { MP_ROM_QSTR(MP_QSTR_WPA_PSK),       MP_OBJ_NEW_SMALL_INT(M2M_WIFI_SEC_WPA_PSK) },// Network secured with WPA/WPA2 personal(PSK).
     { MP_ROM_QSTR(MP_QSTR_802_1X),        MP_OBJ_NEW_SMALL_INT(M2M_WIFI_SEC_802_1X) }, // Network is secured with WPA/WPA2 Enterprise.
-    { MP_ROM_QSTR(MP_QSTR_MODE_STA),      MP_OBJ_NEW_SMALL_INT(WINC_MODE_STA) },       // Start in Staion mode.
+    { MP_ROM_QSTR(MP_QSTR_MODE_STA),      MP_OBJ_NEW_SMALL_INT(WINC_MODE_STA) },       // Start in Station mode.
     { MP_ROM_QSTR(MP_QSTR_MODE_AP),       MP_OBJ_NEW_SMALL_INT(WINC_MODE_AP) },        // Start in Access Point mode.
     { MP_ROM_QSTR(MP_QSTR_MODE_P2P),      MP_OBJ_NEW_SMALL_INT(WINC_MODE_P2P) },       // Start in P2P (WiFi Direct) mode.
     { MP_ROM_QSTR(MP_QSTR_MODE_BSP),      MP_OBJ_NEW_SMALL_INT(WINC_MODE_BSP) },       // Init BSP.

--- a/src/omv/ports/stm32/sensor.c
+++ b/src/omv/ports/stm32/sensor.c
@@ -120,7 +120,7 @@ int sensor_init() {
         #endif
     };
 
-    // Reset the sesnor state
+    // Reset the sensor state
     memset(&sensor, 0, sizeof(sensor_t));
 
     // Set default snapshot function.
@@ -535,7 +535,7 @@ void DCMI_DMAConvCpltUser(uint32_t addr) {
         bytes_per_pixel = sizeof(uint8_t);
     }
 
-    // For all non-JPEG and non-transposed modes we can completely offload image catpure to MDMA
+    // For all non-JPEG and non-transposed modes we can completely offload image capture to MDMA
     // and we do not need to receive any line interrupts for the rest of the frame until it ends.
     #if (OMV_ENABLE_SENSOR_MDMA == 1)
     if (!sensor.transpose) {

--- a/src/omv/ports/stm32/stm32fxxx.ld.S
+++ b/src/omv/ports/stm32/stm32fxxx.ld.S
@@ -148,7 +148,7 @@ SECTIONS
     . = . + OMV_MSC_BUF_SIZE;
 
     . = ALIGN(16);
-    _vfs_buf  = .;      // VFS sturct + FATFS file buffer  (around 624 bytes)
+    _vfs_buf  = .;      // VFS struct + FATFS file buffer  (around 624 bytes)
     . = . + OMV_VFS_BUF_SIZE;
 
     . = ALIGN(16);
@@ -219,7 +219,7 @@ SECTIONS
   .bss (NOLOAD) :
   {
     . = ALIGN(4);
-    _sbss = .;          // Used by the startup to initialize the .bss secion
+    _sbss = .;          // Used by the startup to initialize the .bss section
     . = ALIGN(4);
     *(.bss*)
     . = ALIGN(4);

--- a/src/omv/sensors/gc2145.c
+++ b/src/omv/sensors/gc2145.c
@@ -726,7 +726,7 @@ static int reset(sensor_t *sensor) {
     readout_w = ACTIVE_SENSOR_WIDTH;
     readout_h = ACTIVE_SENSOR_HEIGHT;
 
-    // Write default regsiters
+    // Write default registers
     for (int i = 0; default_regs[i][0]; i++) {
         ret |= omv_i2c_writeb(&sensor->i2c_bus, sensor->slv_addr, default_regs[i][0], default_regs[i][1]);
     }

--- a/src/omv/sensors/hm01b0.c
+++ b/src/omv/sensors/hm01b0.c
@@ -34,7 +34,7 @@ static const uint16_t default_regs[][2] = {
     {BLC_TGT,              0x08},          //  BLC target :8  at 8 bit mode
     {BLC2_TGT,             0x08},          //  BLI target :8  at 8 bit mode
     {0x3044,               0x0A},          //  Increase CDS time for settling
-    {0x3045,               0x00},          //  Make symetric for cds_tg and rst_tg
+    {0x3045,               0x00},          //  Make symmetric for cds_tg and rst_tg
     {0x3047,               0x0A},          //  Increase CDS time for settling
     {0x3050,               0xC0},          //  Make negative offset up to 4x
     {0x3051,               0x42},
@@ -145,7 +145,7 @@ static int reset(sensor_t *sensor) {
         mp_hal_delay_ms(10);
     }
 
-    // Write default regsiters
+    // Write default registers
     int ret = 0;
     for (int i = 0; default_regs[i][0] && ret == 0; i++) {
         ret |= omv_i2c_writeb2(&sensor->i2c_bus, sensor->slv_addr, default_regs[i][0], default_regs[i][1]);

--- a/src/omv/sensors/hm0360.c
+++ b/src/omv/sensors/hm0360.c
@@ -346,7 +346,7 @@ static int reset(sensor_t *sensor) {
         mp_hal_delay_ms(10);
     }
 
-    // Write default regsiters
+    // Write default registers
     int ret = 0;
     for (int i = 0; default_regs[i][0] && ret == 0; i++) {
         ret |= omv_i2c_writeb2(&sensor->i2c_bus, sensor->slv_addr, default_regs[i][0], default_regs[i][1]);

--- a/src/omv/sensors/ov2640.c
+++ b/src/omv/sensors/ov2640.c
@@ -353,7 +353,7 @@ static int reset(sensor_t *sensor) {
     // Delay 5 ms
     mp_hal_delay_ms(5);
 
-    // Write default regsiters
+    // Write default registers
     for (int i = 0; default_regs[i][0]; i++) {
         ret |= omv_i2c_writeb(&sensor->i2c_bus, sensor->slv_addr, default_regs[i][0], default_regs[i][1]);
     }
@@ -412,7 +412,7 @@ static int set_pixformat(sensor_t *sensor, pixformat_t pixformat) {
             return -1;
     }
 
-    // Write regsiters
+    // Write registers
     for (int i = 0; regs[i][0]; i++) {
         ret |= omv_i2c_writeb(&sensor->i2c_bus, sensor->slv_addr, regs[i][0], regs[i][1]);
     }
@@ -429,7 +429,7 @@ static int set_framesize(sensor_t *sensor, framesize_t framesize) {
     uint16_t h = resolution[framesize][1];
 
     if ((w % 4) || (h % 4) || (w > UXGA_WIDTH) || (h > UXGA_HEIGHT)) {
-        // w/h must be divisble by 4
+        // w/h must be divisible by 4
         return -1;
     }
 
@@ -448,7 +448,7 @@ static int set_framesize(sensor_t *sensor, framesize_t framesize) {
         sensor_h = UXGA_HEIGHT;
     }
 
-    // Write setup regsiters
+    // Write setup registers
     for (int i = 0; regs[i][0]; i++) {
         ret |= omv_i2c_writeb(&sensor->i2c_bus, sensor->slv_addr, regs[i][0], regs[i][1]);
     }

--- a/src/omv/sensors/ov5640.c
+++ b/src/omv/sensors/ov5640.c
@@ -659,7 +659,7 @@ static int reset(sensor_t *sensor) {
     // Delay 5 ms
     mp_hal_delay_ms(5);
 
-    // Write default regsiters
+    // Write default registers
     for (int i = 0; default_regs[i][0]; i++) {
         int addr = (default_regs[i][0] << 8) | (default_regs[i][1] << 0);
         int data = default_regs[i][2];

--- a/src/omv/sensors/ov7670.c
+++ b/src/omv/sensors/ov7670.c
@@ -332,7 +332,7 @@ static int reset(sensor_t *sensor) {
     // Delay 2 ms
     mp_hal_delay_ms(2);
 
-    // Write default regsiters
+    // Write default registers
     for (int i = 0; default_regs[i][0] != 0xff; i++) {
         ret |= omv_i2c_writeb(&sensor->i2c_bus, sensor->slv_addr, default_regs[i][0], default_regs[i][1]);
     }

--- a/src/omv/sensors/ov7690.c
+++ b/src/omv/sensors/ov7690.c
@@ -190,7 +190,7 @@ static int reset(sensor_t *sensor) {
     // Delay 2 ms
     mp_hal_delay_ms(2);
 
-    // Write default regsiters
+    // Write default registers
     for (int i = 0; default_regs[i][0]; i++) {
         ret |= omv_i2c_writeb(&sensor->i2c_bus, sensor->slv_addr, default_regs[i][0], default_regs[i][1]);
     }

--- a/src/omv/sensors/ov7725.c
+++ b/src/omv/sensors/ov7725.c
@@ -157,7 +157,7 @@ static int reset(sensor_t *sensor) {
     // Delay 2 ms
     mp_hal_delay_ms(2);
 
-    // Write default regsiters
+    // Write default registers
     for (int i = 0; default_regs[i][0]; i++) {
         ret |= omv_i2c_writeb(&sensor->i2c_bus, sensor->slv_addr, default_regs[i][0], default_regs[i][1]);
     }

--- a/src/omv/sensors/ov9650.c
+++ b/src/omv/sensors/ov9650.c
@@ -73,7 +73,7 @@ static const uint8_t default_regs[][2] = {
     {REG_COM23,  0x00}, /* Disable Color bar/Analog Color Gain */
     {REG_PSHFT,  0x00}, /* Pixel delay after HREF  */
     {REG_COM10,  0x00}, /* Slave mode, HREF vs HSYNC, signals negate */
-    {REG_EDGE,   0xa6}, /* Edge enhancement treshhold and factor */
+    {REG_EDGE,   0xa6}, /* Edge enhancement threshold and factor */
     {REG_COM6,   0x43}, /* HREF & ADBLC options */
     {REG_COM22,  0x20}, /* Edge enhancement/Denoising */
 
@@ -212,7 +212,7 @@ static int reset(sensor_t *sensor) {
     /* delay n ms */
     mp_hal_delay_ms(10);
 
-    /* Write initial regsiters */
+    /* Write initial registers */
     while (regs[i][0]) {
         omv_i2c_writeb(&sensor->i2c_bus, sensor->slv_addr, regs[i][0], regs[i][1]);
         i++;

--- a/src/omv/sensors/paj6100.c
+++ b/src/omv/sensors/paj6100.c
@@ -56,7 +56,7 @@ static int8_t init_res;
 
 static int16_t bank_cache = -1;
 
-// Exposure time related paramaters +
+// Exposure time related parameters +
 #define QVGA_MAX_EXPO_PA         85161
 #define QQVGA_MAX_EXPO_PA        25497
 
@@ -83,7 +83,7 @@ static uint8_t skip_frame = 0;
 
 static bool is_ae_enabled = true;
 static int exp_us_cache = -1;
-// Exposure time related paramaters -
+// Exposure time related parameters -
 
 static int set_auto_gain(sensor_t *sensor, int enable,
                          float gain_db, float gain_db_ceiling);

--- a/src/stm32cubeai/nn_st.c
+++ b/src/stm32cubeai/nn_st.c
@@ -67,7 +67,7 @@ __STATIC_INLINE void aiPrintLayoutBuffer(const char *msg, int idx,
 }
 
 /**
- * @brief Displays informations about the network to serial port
+ * @brief Displays information about the network to serial port
  *
  * @param report - An ai_network_report structure to be displayed
  */
@@ -105,7 +105,7 @@ ai_u32 aiBufferSize(const ai_buffer *buffer) {
 }
 
 /**
- * @brief Displays informations about the errors which can occur with Cube.AI C
+ * @brief Displays information about the errors which can occur with Cube.AI C
  * API
  *
  * @param err an ai_error struct
@@ -120,7 +120,7 @@ void aiLogErr(const ai_error err, const char *fct) {
 }
 
 /**
- * @brief Intitialization code for the network
+ * @brief Initialization code for the network
  *
  * @param nn_name the name of the network
  * @return int error code, 0 if it's ok, anything else is error

--- a/src/uvc/src/sdram.c
+++ b/src/uvc/src/sdram.c
@@ -251,7 +251,7 @@ bool __attribute__((optimize("O0"))) sdram_test(bool fast) {
         }
     }
 
-    /* Check for aliasing (overlaping addresses) */
+    /* Check for aliasing (overlapping addresses) */
     mem_base[0] = antipattern;
     for (uint32_t i = 1; i < OMV_SDRAM_SIZE; i <<= 1) {
         if (mem_base[i] != pattern) {

--- a/src/uvc/src/usbd_core.c
+++ b/src/uvc/src/usbd_core.c
@@ -87,7 +87,7 @@
 
 /**
 * @brief  USBD_Init
-*         Initailizes the device stack and load the class driver
+*         Initializes the device stack and loads the class driver
 * @param  pdev: device instance
 * @param  core_address: USB OTG core ID
 * @param  pdesc: Descriptor structure address

--- a/src/uvc/src/usbd_uvc.c
+++ b/src/uvc/src/usbd_uvc.c
@@ -380,7 +380,7 @@ __ALIGN_BEGIN struct usbd_uvc_cfg USBD_UVC_CfgFSDesc __ALIGN_END = {
       .bDescriptorSubType = UVC_VC_OUTPUT_TERMINAL, // 3 (OUTPUT_TERMINAL)
       .bTerminalID = VC_OUTPUT_TERMINAL_ID,    // 2 ID of this Terminal
       .wTerminalType = UVC_TT_STREAMING,           // 0x0101 USB streaming terminal
-      .bAssocTerminal = 0x00,                      // 0 no Terminal assiciated
+      .bAssocTerminal = 0x00,                      // 0 no Terminal associated
       .bSourceID = 0x03,                           // 1 input pin connected to output pin unit 1
       .iTerminal = 0x00,                           // 0 no description available
     },

--- a/src/uvc/src/usbd_uvc_if.c
+++ b/src/uvc/src/usbd_uvc_if.c
@@ -361,7 +361,7 @@ static int8_t UVC_VS_ControlSet(uint8_t cmd, uint8_t* pbuf, uint16_t length, uin
   *           
   *         @note
   *         This function will block any OUT packet reception on USB endpoint 
-  *         untill exiting this function. If you exit this function before transfer
+  *         until exiting this function. If you exit this function before transfer
   *         is complete on UVC interface (ie. using DMA controller) it will result 
   *         in receiving more data while previous ones are still not sent.
   *                 

--- a/src/uvc/stm32fxxx.ld.S
+++ b/src/uvc/stm32fxxx.ld.S
@@ -125,7 +125,7 @@ SECTIONS
     . = . + OMV_MSC_BUF_SIZE;
 
     . = ALIGN(16);
-    _vfs_buf  = .;      // VFS sturct + FATFS file buffer  (around 624 bytes)
+    _vfs_buf  = .;      // VFS struct + FATFS file buffer  (around 624 bytes)
     . = . + OMV_VFS_BUF_SIZE;
 
     . = ALIGN(16);


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.pgm,*.ppm,./src/hal,./src/drivers" -L als,dout,erro,extint,hsi,inout,ois,paeth,re-use,ser,serie`

Follow-up to #1931