### PR TITLE
imlib: Enable loading images from paths in all situations.

### DIFF
--- a/src/omv/imlib/mjpeg.c
+++ b/src/omv/imlib/mjpeg.c
@@ -118,8 +118,6 @@ void mjpeg_write(FIL *fp, int width, int height, uint32_t *frames, uint32_t *byt
                   (color_palette == NULL) &&
                   (alpha_palette == NULL);
 
-    fb_alloc_mark();
-
     if ((dst_img.pixfmt != img->pixfmt) || (!simple)) {
         image_t temp;
         memcpy(&temp, img, sizeof(image_t));
@@ -192,8 +190,6 @@ void mjpeg_write(FIL *fp, int width, int height, uint32_t *frames, uint32_t *byt
 
     *frames += 1;
     *bytes += size_padded;
-
-    fb_alloc_free_till_mark();
 }
 
 void mjpeg_sync(FIL *fp, uint32_t *frames, uint32_t *bytes, float fps) {

--- a/src/omv/modules/py_display.c
+++ b/src/omv/modules/py_display.c
@@ -145,6 +145,7 @@ STATIC mp_obj_t py_display_write(uint n_args, const mp_obj_t *pos_args, mp_map_t
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
+    fb_alloc_mark();
     image_t *image = py_helper_arg_to_image(args[ARG_image].u_obj, 0);
     rectangle_t roi = py_helper_arg_to_roi(args[ARG_roi].u_obj, image);
 
@@ -167,7 +168,6 @@ STATIC mp_obj_t py_display_write(uint n_args, const mp_obj_t *pos_args, mp_map_t
     const uint16_t *color_palette = py_helper_arg_to_palette(args[ARG_color_palette].u_obj, PIXFORMAT_RGB565);
     const uint8_t *alpha_palette = py_helper_arg_to_palette(args[ARG_alpha_palette].u_obj, PIXFORMAT_GRAYSCALE);
 
-    fb_alloc_mark();
     py_display_p_t *display_p = (py_display_p_t *) MP_OBJ_TYPE_GET_SLOT(self->base.type, protocol);
     display_p->write(self, image, args[ARG_x].u_int, args[ARG_y].u_int, x_scale, y_scale, &roi,
                      args[ARG_channel].u_int, args[ARG_alpha].u_int, color_palette, alpha_palette, args[ARG_hint].u_int);

--- a/src/omv/modules/py_fir.c
+++ b/src/omv/modules/py_fir.c
@@ -850,6 +850,7 @@ mp_obj_t py_fir_read_ir(uint n_args, const mp_obj_t *args, mp_map_t *kw_args) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_fir_read_ir_obj, 0, py_fir_read_ir);
 
 mp_obj_t py_fir_draw_ir(uint n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    fb_alloc_mark();
     image_t *dst_img = py_helper_arg_to_image(args[0], ARG_IMAGE_MUTABLE);
 
     image_t src_img;
@@ -998,8 +999,6 @@ mp_obj_t py_fir_draw_ir(uint n_args, const mp_obj_t *args, mp_map_t *kw_args) {
         }
     }
 
-    fb_alloc_mark();
-
     src_img.data = fb_alloc(src_img.w * src_img.h * sizeof(uint8_t), FB_ALLOC_NO_HINT);
     fir_fill_image_float_obj(&src_img, arg_to, min, max);
 
@@ -1017,6 +1016,7 @@ mp_obj_t py_fir_snapshot(uint n_args, const mp_obj_t *args, mp_map_t *kw_args) {
         return mp_const_none;
     }
 
+    fb_alloc_mark();
     bool arg_hmirror = py_helper_keyword_int(n_args, args, 0, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_hmirror), false);
     bool arg_vflip = py_helper_keyword_int(n_args, args, 1, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_vflip), false);
     bool arg_transpose = py_helper_keyword_int(n_args, args, 2, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_transpose), false);
@@ -1138,7 +1138,6 @@ mp_obj_t py_fir_snapshot(uint n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     int arg_timeout = py_helper_keyword_int(n_args, args, 16, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_timeout), -1);
     #endif
 
-    fb_alloc_mark();
     src_img.data = fb_alloc(src_img.w * src_img.h * sizeof(uint8_t), FB_ALLOC_NO_HINT);
 
     switch (fir_sensor) {

--- a/src/omv/modules/py_gif.c
+++ b/src/omv/modules/py_gif.c
@@ -79,6 +79,7 @@ static mp_obj_t py_gif_loop(mp_obj_t gif_obj) {
 
 static mp_obj_t py_gif_add_frame(uint n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     #if defined(IMLIB_ENABLE_IMAGE_FILE_IO)
+    fb_alloc_mark();
     py_gif_obj_t *arg_gif = args[0];
     image_t *arg_img = py_image_cobj(args[1]);
     PY_ASSERT_FALSE_MSG(IM_IS_JPEG(arg_img),   "Operation not supported on JPEG images.");
@@ -89,6 +90,7 @@ static mp_obj_t py_gif_add_frame(uint n_args, const mp_obj_t *args, mp_map_t *kw
     int delay = py_helper_keyword_int(n_args, args, 2, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_delay), 10);
 
     gif_add_frame(&arg_gif->fp, arg_img, delay);
+    fb_alloc_free_till_mark();
     #else
     mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("Image I/O is not supported"));
     #endif

--- a/src/omv/modules/py_helper.c
+++ b/src/omv/modules/py_helper.c
@@ -100,8 +100,8 @@ void py_helper_arg_to_scale(const mp_obj_t arg_x_scale, const mp_obj_t arg_y_sca
     }
 }
 
-image_t *py_helper_keyword_to_image_mutable(uint n_args, const mp_obj_t *args, uint arg_index,
-                                            mp_map_t *kw_args, mp_obj_t kw, image_t *default_val) {
+image_t *py_helper_keyword_to_image(uint n_args, const mp_obj_t *args, uint arg_index,
+                                    mp_map_t *kw_args, mp_obj_t kw, image_t *default_val) {
     mp_map_elem_t *kw_arg = mp_map_lookup(kw_args, kw, MP_MAP_LOOKUP);
 
     if (kw_arg) {
@@ -111,21 +111,6 @@ image_t *py_helper_keyword_to_image_mutable(uint n_args, const mp_obj_t *args, u
     }
 
     return default_val;
-}
-
-image_t *py_helper_keyword_to_image_mutable_mask(uint n_args, const mp_obj_t *args, uint arg_index,
-                                                 mp_map_t *kw_args) {
-    return py_helper_keyword_to_image_mutable(n_args, args, arg_index, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_mask), NULL);
-}
-
-image_t *py_helper_keyword_to_image_mutable_color_palette(uint n_args, const mp_obj_t *args, uint arg_index,
-                                                          mp_map_t *kw_args) {
-    return py_helper_keyword_to_image_mutable(n_args, args, arg_index, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_color_palette), NULL);
-}
-
-image_t *py_helper_keyword_to_image_mutable_alpha_palette(uint n_args, const mp_obj_t *args, uint arg_index,
-                                                          mp_map_t *kw_args) {
-    return py_helper_keyword_to_image_mutable(n_args, args, arg_index, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_alpha_palette), NULL);
 }
 
 void py_helper_keyword_rectangle(image_t *img, uint n_args, const mp_obj_t *args, uint arg_index,
@@ -478,7 +463,8 @@ const uint16_t *py_helper_keyword_color_palette(uint n_args, const mp_obj_t *arg
         }
     } else {
         image_t *arg_color_palette =
-            py_helper_keyword_to_image_mutable_color_palette(n_args, args, arg_index, kw_args);
+            py_helper_keyword_to_image(n_args, args, arg_index, kw_args,
+                                       MP_OBJ_NEW_QSTR(MP_QSTR_color_palette), NULL);
 
         if (arg_color_palette) {
             if (arg_color_palette->pixfmt != PIXFORMAT_RGB565) {
@@ -501,7 +487,7 @@ const uint16_t *py_helper_keyword_color_palette(uint n_args, const mp_obj_t *arg
 const uint8_t *py_helper_keyword_alpha_palette(uint n_args, const mp_obj_t *args,
                                                uint arg_index, mp_map_t *kw_args, const uint8_t *default_alpha_palette) {
     image_t *arg_alpha_palette =
-        py_helper_keyword_to_image_mutable_alpha_palette(n_args, args, 9, kw_args);
+        py_helper_keyword_to_image(n_args, args, 9, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_alpha_palette), NULL);
 
     if (arg_alpha_palette) {
         if (arg_alpha_palette->pixfmt != PIXFORMAT_GRAYSCALE) {

--- a/src/omv/modules/py_helper.h
+++ b/src/omv/modules/py_helper.h
@@ -25,14 +25,8 @@ const void *py_helper_arg_to_palette(const mp_obj_t arg, uint32_t pixfmt);
 rectangle_t py_helper_arg_to_roi(const mp_obj_t arg, const image_t *img);
 void py_helper_arg_to_scale(const mp_obj_t arg_x_scale, const mp_obj_t arg_y_scale,
                             float *x_scale, float *y_scale, rectangle_t *roi);
-image_t *py_helper_keyword_to_image_mutable(uint n_args, const mp_obj_t *args, uint arg_index,
-                                            mp_map_t *kw_args, mp_obj_t kw, image_t *default_val);
-image_t *py_helper_keyword_to_image_mutable_mask(uint n_args, const mp_obj_t *args, uint arg_index,
-                                                 mp_map_t *kw_args);
-image_t *py_helper_keyword_to_image_mutable_color_palette(uint n_args, const mp_obj_t *args, uint arg_index,
-                                                          mp_map_t *kw_args);
-image_t *py_helper_keyword_to_image_mutable_alpha_palette(uint n_args, const mp_obj_t *args, uint arg_index,
-                                                          mp_map_t *kw_args);
+image_t *py_helper_keyword_to_image(uint n_args, const mp_obj_t *args, uint arg_index,
+                                    mp_map_t *kw_args, mp_obj_t kw, image_t *default_val);
 void py_helper_keyword_rectangle(image_t *img, uint n_args, const mp_obj_t *args, uint arg_index,
                                  mp_map_t *kw_args, mp_obj_t kw, rectangle_t *r);
 void py_helper_keyword_rectangle_roi(image_t *img, uint n_args, const mp_obj_t *args, uint arg_index,

--- a/src/omv/modules/py_imageio.c
+++ b/src/omv/modules/py_imageio.c
@@ -171,6 +171,7 @@ STATIC mp_obj_t py_imageio_size(mp_obj_t self) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_imageio_size_obj, py_imageio_size);
 
 STATIC mp_obj_t py_imageio_write(mp_obj_t self, mp_obj_t img_obj) {
+    fb_alloc_mark();
     py_imageio_obj_t *stream = py_imageio_obj(self);
     image_t *image = py_image_cobj(img_obj);
 
@@ -241,6 +242,7 @@ STATIC mp_obj_t py_imageio_write(mp_obj_t self, mp_obj_t img_obj) {
 
     stream->offset += 1;
 
+    fb_alloc_free_till_mark();
     return self;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(py_imageio_write_obj, py_imageio_write);
@@ -309,7 +311,7 @@ STATIC void int_py_imageio_read_chunk(py_imageio_obj_t *stream, image_t *image, 
 #endif
 
 STATIC mp_obj_t py_imageio_read(uint n_args, const mp_obj_t *args, mp_map_t *kw_args) {
-
+    fb_alloc_mark();
     py_imageio_obj_t *stream = py_imageio_obj(args[0]);
 
     mp_obj_t copy_to_fb_obj = py_helper_keyword_object(n_args, args, 1, kw_args,
@@ -336,6 +338,7 @@ STATIC mp_obj_t py_imageio_read(uint n_args, const mp_obj_t *args, mp_map_t *kw_
 
         if (f_eof(fp)) {
             if (!py_helper_keyword_int(n_args, args, 2, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_loop), true)) {
+                fb_alloc_free_till_mark();
                 return mp_const_none;
             }
 
@@ -345,6 +348,7 @@ STATIC mp_obj_t py_imageio_read(uint n_args, const mp_obj_t *args, mp_map_t *kw_
 
             if (f_eof(fp)) {
                 // empty file
+                fb_alloc_free_till_mark();
                 return mp_const_none;
             }
         }
@@ -418,6 +422,7 @@ STATIC mp_obj_t py_imageio_read(uint n_args, const mp_obj_t *args, mp_map_t *kw_
         framebuffer_update_jpeg_buffer();
     }
 
+    fb_alloc_free_till_mark();
     return py_image_from_struct(&image);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_imageio_read_obj, 1, py_imageio_read);

--- a/src/omv/modules/py_mjpeg.c
+++ b/src/omv/modules/py_mjpeg.c
@@ -87,6 +87,7 @@ STATIC mp_obj_t py_mjpeg_size(mp_obj_t self) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_mjpeg_size_obj, py_mjpeg_size);
 
 STATIC mp_obj_t py_mjpeg_write(uint n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    fb_alloc_mark();
     py_mjpeg_obj_t *arg_mjpeg = py_mjpeg_obj(args[0]);
     image_t *arg_img = py_image_cobj(args[1]);
 
@@ -117,6 +118,7 @@ STATIC mp_obj_t py_mjpeg_write(uint n_args, const mp_obj_t *args, mp_map_t *kw_a
                 arg_img, arg_q, &arg_roi, arg_rgb_channel, arg_alpha,
                 color_palette, alpha_palette, hint);
 
+    fb_alloc_free_till_mark();
     return args[0];
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_mjpeg_write_obj, 2, py_mjpeg_write);

--- a/src/omv/modules/py_tof.c
+++ b/src/omv/modules/py_tof.c
@@ -360,6 +360,7 @@ mp_obj_t py_tof_read_depth(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_tof_read_depth_obj, 0, py_tof_read_depth);
 
 mp_obj_t py_tof_draw_depth(uint n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    fb_alloc_mark();
     image_t *dst_img = py_helper_arg_to_image(args[0], ARG_IMAGE_MUTABLE);
 
     image_t src_img;
@@ -508,8 +509,6 @@ mp_obj_t py_tof_draw_depth(uint n_args, const mp_obj_t *args, mp_map_t *kw_args)
         }
     }
 
-    fb_alloc_mark();
-
     src_img.data = fb_alloc(src_img.w * src_img.h * sizeof(uint8_t), FB_ALLOC_NO_HINT);
     tof_fill_image_float_obj(&src_img, arg_to, min, max);
 
@@ -527,6 +526,7 @@ mp_obj_t py_tof_snapshot(uint n_args, const mp_obj_t *args, mp_map_t *kw_args) {
         return mp_const_none;
     }
 
+    fb_alloc_mark();
     bool arg_hmirror = py_helper_keyword_int(n_args, args, 0, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_hmirror), false);
     bool arg_vflip = py_helper_keyword_int(n_args, args, 1, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_vflip), false);
     bool arg_transpose = py_helper_keyword_int(n_args, args, 2, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_transpose), false);
@@ -646,7 +646,6 @@ mp_obj_t py_tof_snapshot(uint n_args, const mp_obj_t *args, mp_map_t *kw_args) {
 
     int arg_timeout = py_helper_keyword_int(n_args, args, 16, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_timeout), 1000);
 
-    fb_alloc_mark();
     src_img.data = fb_alloc(src_img.w * src_img.h * sizeof(uint8_t), FB_ALLOC_NO_HINT);
 
     switch (tof_sensor) {

--- a/src/omv/modules/py_tv.c
+++ b/src/omv/modules/py_tv.c
@@ -868,6 +868,7 @@ STATIC mp_obj_t py_tv_channel(uint n_args, const mp_obj_t *args) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(py_tv_channel_obj, 0, 1, py_tv_channel);
 
 STATIC mp_obj_t py_tv_display(uint n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    fb_alloc_mark();
     image_t *arg_img = py_image_cobj(args[0]);
 
     int arg_x_off = 0;
@@ -954,10 +955,8 @@ STATIC mp_obj_t py_tv_display(uint n_args, const mp_obj_t *args, mp_map_t *kw_ar
     switch (tv_type) {
         #ifdef OMV_SPI_DISPLAY_CONTROLLER
         case TV_SHIELD: {
-            fb_alloc_mark();
             spi_tv_display(arg_img, arg_x_off, arg_y_off, arg_x_scale, arg_y_scale, &arg_roi,
                            arg_rgb_channel, arg_alpha, color_palette, alpha_palette, hint);
-            fb_alloc_free_till_mark();
             break;
         }
         #endif
@@ -966,6 +965,7 @@ STATIC mp_obj_t py_tv_display(uint n_args, const mp_obj_t *args, mp_map_t *kw_ar
         }
     }
 
+    fb_alloc_free_till_mark();
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_tv_display_obj, 1, py_tv_display);

--- a/src/stm32cubeai/nn_st.c
+++ b/src/stm32cubeai/nn_st.c
@@ -200,7 +200,6 @@ int aiRun(stnn_t *net, image_t *img, rectangle_t *roi) {
   ai_i32 nbatch;
   ai_error err;
 
-  fb_alloc_mark();
   AI_ALIGNED(4)
   ai_u8 *activations = fb_alloc(AI_NETWORK_DATA_ACTIVATIONS_SIZE, FB_ALLOC_NO_HINT);
   AI_ALIGNED(4)
@@ -244,8 +243,6 @@ int aiRun(stnn_t *net, image_t *img, rectangle_t *roi) {
   }
 
   net->nn_exec_ctx_ptr->report.outputs->data = out_data;
-
-  fb_alloc_free_till_mark();
 
   return 0;
 }

--- a/src/stm32cubeai/py_st_nn.c
+++ b/src/stm32cubeai/py_st_nn.c
@@ -38,6 +38,7 @@ STATIC void py_net_print(const mp_print_t *print, mp_obj_t self_in,
  * pointed to by args[1]*/
 STATIC mp_obj_t __attribute__((optimize("O0")))
 py_net_predict(uint n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+  fb_alloc_mark();
   stnn_t *net = py_st_net_cobj(args[0]);
   image_t *img = py_helper_arg_to_image_mutable(args[1]);
 
@@ -53,6 +54,7 @@ py_net_predict(uint n_args, const mp_obj_t *args, mp_map_t *kw_args) {
   for (int i = 0; i < AI_NETWORK_OUT_1_SIZE; i++) {
     mp_obj_list_append(output_list, mp_obj_new_float(*(out_data + i)));
   }
+  fb_alloc_free_till_mark();
   return output_list;
 }
 


### PR DESCRIPTION
This PR globally unlocks loading images from paths in all functions.

E.g.

```
# Hello World Example
#
# Welcome to the OpenMV IDE! Click on the green run arrow button below to run the script!

import sensor
import time

sensor.reset()  # Reset and initialize the sensor.
sensor.set_pixformat(sensor.RGB565)  # Set pixel format to RGB565 (or GRAYSCALE)
sensor.set_framesize(sensor.VGA)  # Set frame size to QVGA (320x240)
#sensor.skip_frames(time=2000)  # Wait for settings take effect.
clock = time.clock()  # Create a clock object to track the FPS.

while True:
    clock.tick()  # Update the FPS clock.
    img = sensor.snapshot()  # Take a picture and return the image.
    img.draw_image("arduino-mini-logo.jpg", 0, 0)
    print(clock.fps())  # Note: OpenMV Cam runs about half as fast when connected
    # to the IDE. The FPS should increase once disconnected.
```

![arduino-mini-logo](https://github.com/openmv/openmv/assets/5694981/4d26964f-e676-4016-8b0f-dcd15ae3ac00)

Just works. Pretty much anywhere you can pass an image object you can now pass a path.