### PR TITLE
micropython: Add MICROPY_NLR_JUMP_HOOK.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -66,6 +66,7 @@ DISPLAY_DIR=drivers/display
 LIBPDM_DIR=lib/libpdm
 TENSORFLOW_DIR=lib/libtf
 OMV_BOARD_CONFIG_DIR=$(TOP_DIR)/$(OMV_DIR)/boards/$(TARGET)/
+OMV_PORT_DIR=$(TOP_DIR)/$(OMV_DIR)/ports/$(PORT)
 MP_BOARD_CONFIG_DIR=$(TOP_DIR)/$(MICROPY_DIR)/ports/$(PORT)/boards/$(TARGET)/
 OMV_LIB_DIR=$(TOP_DIR)/../scripts/libraries
 FROZEN_MANIFEST=$(OMV_BOARD_CONFIG_DIR)/manifest.py
@@ -195,9 +196,10 @@ endif
 
 MPY_PENDSV_ENTRIES := $(shell echo $(MPY_PENDSV_ENTRIES) | tr -d '[:space:]')
 MPY_CFLAGS += -DMICROPY_BOARD_PENDSV_ENTRIES="$(MPY_PENDSV_ENTRIES)"
+MPY_CFLAGS += -DMP_CONFIGFILE=\<$(OMV_PORT_DIR)/omv_mpconfigport.h\>
 
 # Include the port Makefile.
-include $(OMV_DIR)/ports/$(PORT)/omv_portconfig.mk
+include $(OMV_PORT_DIR)/omv_portconfig.mk
 
 clean:
 	$(RM) -fr $(BUILD)

--- a/src/omv/alloc/fb_alloc.c
+++ b/src/omv/alloc/fb_alloc.c
@@ -56,8 +56,8 @@ void fb_alloc_mark() {
 
     // Check if allocation overwrites the framebuffer pixels
     if (new_pointer < framebuffer_get_buffers_end()) {
-        nlr_raise_for_fb_alloc_mark(mp_obj_new_exception_msg(&mp_type_MemoryError,
-                                                             MP_ERROR_TEXT("Out of fast frame buffer stack memory")));
+        nlr_jump(MP_OBJ_TO_PTR(mp_obj_new_exception_msg(&mp_type_MemoryError,
+                                                        MP_ERROR_TEXT("Out of fast frame buffer stack memory"))));
     }
 
     // fb_alloc does not allow regions which are a size of 0 to be alloced,

--- a/src/omv/ports/mimxrt/omv_mpconfigport.h
+++ b/src/omv/ports/mimxrt/omv_mpconfigport.h
@@ -1,0 +1,7 @@
+#include <mpconfigport.h>
+
+#define MICROPY_NLR_RAISE_HOOK                 \
+    do {                                       \
+        extern void fb_alloc_free_till_mark(); \
+        fb_alloc_free_till_mark();             \
+    } while (0);

--- a/src/omv/ports/nrf/omv_mpconfigport.h
+++ b/src/omv/ports/nrf/omv_mpconfigport.h
@@ -1,0 +1,7 @@
+#include <mpconfigport.h>
+
+#define MICROPY_NLR_RAISE_HOOK                 \
+    do {                                       \
+        extern void fb_alloc_free_till_mark(); \
+        fb_alloc_free_till_mark();             \
+    } while (0);

--- a/src/omv/ports/rp2/omv_mpconfigport.h
+++ b/src/omv/ports/rp2/omv_mpconfigport.h
@@ -1,0 +1,7 @@
+#include <mpconfigport.h>
+
+#define MICROPY_NLR_RAISE_HOOK                 \
+    do {                                       \
+        extern void fb_alloc_free_till_mark(); \
+        fb_alloc_free_till_mark();             \
+    } while (0);

--- a/src/omv/ports/stm32/omv_mpconfigport.h
+++ b/src/omv/ports/stm32/omv_mpconfigport.h
@@ -1,0 +1,7 @@
+#include <mpconfigport.h>
+
+#define MICROPY_NLR_RAISE_HOOK                 \
+    do {                                       \
+        extern void fb_alloc_free_till_mark(); \
+        fb_alloc_free_till_mark();             \
+    } while (0);


### PR DESCRIPTION
- This can be set from a custom mpconfigport.h file to call fb_alloc_free or any other needed cleanup before an exception.
- The omvdummy stuff is no longer needed since a default empty hook is defined.