### PR TITLE
drivers/winc: Fix AP mode.

### DIFF
--- a/src/drivers/winc1500/src/winc.c
+++ b/src/drivers/winc1500/src/winc.c
@@ -573,18 +573,11 @@ int winc_connect(const char *ssid, uint8_t security, const char *key, uint16_t c
 int winc_start_ap(const char *ssid, uint8_t security, const char *key, uint16_t channel) {
     tstrM2MAPConfig apconfig;
 
-    if (security == M2M_WIFI_SEC_WEP && key == NULL) {
-        return -1;
-    }
-
-    if (security != M2M_WIFI_SEC_OPEN && security != M2M_WIFI_SEC_WEP) {
-        return -1;
-    }
-
     memset(&apconfig, 0, sizeof(tstrM2MAPConfig));
     strcpy((char *) &apconfig.au8SSID, ssid);
     apconfig.u8ListenChannel = channel;
     apconfig.u8SecType = security;
+    apconfig.u8SsidHide = false;
 
     apconfig.au8DHCPServerIP[0] = 192;
     apconfig.au8DHCPServerIP[1] = 168;
@@ -597,9 +590,9 @@ int winc_start_ap(const char *ssid, uint8_t security, const char *key, uint16_t 
     memcpy(ifconfig.dns_addr, apconfig.au8DHCPServerIP, WINC_IPV4_ADDR_LEN);
 
     if (security != M2M_WIFI_SEC_OPEN) {
-        strcpy((char *) &apconfig.au8WepKey, key);
-        apconfig.u8KeySz = WEP_40_KEY_STRING_SIZE;
-        apconfig.u8KeyIndx = 1;
+        size_t size = OMV_MIN(strlen(key), M2M_MAX_PSK_LEN);
+        memcpy(&apconfig.au8Key, key, size);
+        apconfig.u8KeySz = size;
     }
 
     // Initialize WiFi in AP mode.

--- a/src/omv/ports/stm32/modules/py_winc.c
+++ b/src/omv/ports/stm32/modules/py_winc.c
@@ -161,19 +161,14 @@ static mp_obj_t py_winc_connect(mp_uint_t n_args, const mp_obj_t *pos_args, mp_m
     }
 
     if (self->itf == WINC_MODE_STA) {
-        // Connect to AP
+        // Initialize WiFi in STA mode.
         if (winc_connect(ssid, security, key, M2M_WIFI_CH_ALL) != 0) {
             mp_raise_msg_varg(&mp_type_OSError,
                               MP_ERROR_TEXT("could not connect to ssid=%s, sec=%d, key=%s\n"), ssid, security, key);
         }
     } else {
-        mp_uint_t channel = args[3].u_int;
-
-        if (security != M2M_WIFI_SEC_OPEN && security != M2M_WIFI_SEC_WEP) {
-            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("AP mode supports WEP security only."));
-        }
-
         // Initialize WiFi in AP mode.
+        mp_uint_t channel = args[3].u_int;
         if (winc_start_ap(ssid, security, key, channel) != 0) {
             mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("failed to start in AP mode"));
         }
@@ -571,7 +566,6 @@ static const mp_rom_map_elem_t winc_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_fw_update),     MP_ROM_PTR(&py_winc_fw_update_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_OPEN),          MP_OBJ_NEW_SMALL_INT(M2M_WIFI_SEC_OPEN) },   // Network is not secured.
-    { MP_ROM_QSTR(MP_QSTR_WEP),           MP_OBJ_NEW_SMALL_INT(M2M_WIFI_SEC_WEP) },    // Security type WEP.
     { MP_ROM_QSTR(MP_QSTR_WPA_PSK),       MP_OBJ_NEW_SMALL_INT(M2M_WIFI_SEC_WPA_PSK) },// Network secured with WPA/WPA2 personal(PSK).
     { MP_ROM_QSTR(MP_QSTR_802_1X),        MP_OBJ_NEW_SMALL_INT(M2M_WIFI_SEC_802_1X) }, // Network is secured with WPA/WPA2 Enterprise.
     { MP_ROM_QSTR(MP_QSTR_MODE_STA),      MP_OBJ_NEW_SMALL_INT(WINC_MODE_STA) },       // Start in Station mode.


### PR DESCRIPTION
The `WEP` security mode has been deprecated since firmware 19.7.6 the only two supported modes now are open and WPA.

Fixes #1849