### PR TITLE
scripts/examples: Update thermal scripts for new refectored API.

### DIFF
--- a/scripts/examples/01-Camera/06-Time-of-Flight/tof_camera.py
+++ b/scripts/examples/01-Camera/06-Time-of-Flight/tof_camera.py
@@ -11,13 +11,11 @@ import image
 import time
 import tof
 
-IMAGE_SCALE = 10  # Higher scaling uses more memory.
+IMAGE_SCALE = 10  # Scale image to 10x.
 drawing_hint = image.BILINEAR  # or image.BILINEAR or 0 (nearest neighbor)
 
 # Initialize the ToF sensor
 tof.init()  # Auto-detects the connected sensor.
-w = tof.width() * IMAGE_SCALE
-h = tof.height() * IMAGE_SCALE
 
 # FPS clock
 clock = time.clock()
@@ -27,8 +25,8 @@ while True:
 
     try:
         img = tof.snapshot(
-            x_size=w,
-            y_size=h,
+            x_scale=IMAGE_SCALE,
+            y_scale=IMAGE_SCALE,
             color_palette=tof.PALETTE_IRONBOW,
             hint=drawing_hint,
             copy_to_fb=True,

--- a/scripts/examples/50-Arduino-Boards/Nano-33-BLE-Sense/53-Thermal/thermal_camera.py
+++ b/scripts/examples/50-Arduino-Boards/Nano-33-BLE-Sense/53-Thermal/thermal_camera.py
@@ -11,6 +11,7 @@ import image
 import time
 import fir
 
+IMAGE_SCALE = 5  # Scale image to 5x.
 drawing_hint = image.BICUBIC  # or image.BILINEAR or 0 (nearest neighbor)
 
 # Initialize the thermal sensor
@@ -18,18 +19,8 @@ fir.init()
 w = fir.width()
 h = fir.height()
 
-if fir.type() == fir.FIR_MLX90621:
-    w = w * 5
-    h = h * 5
-elif fir.type() == fir.FIR_MLX90640:
-    w = w * 5
-    h = h * 5
-elif fir.type() == fir.FIR_MLX90641:
-    w = w * 5
-    h = h * 5
-elif fir.type() == fir.FIR_AMG8833:
-    w = w * 10
-    h = h * 10
+if fir.type() == fir.FIR_AMG8833:
+    IMAGE_SCALE = IMAGE_SCALE * 2
 
 # FPS clock
 clock = time.clock()
@@ -39,8 +30,8 @@ while True:
 
     try:
         img = fir.snapshot(
-            x_size=w,
-            y_size=h,
+            x_scale=IMAGE_SCALE,
+            y_scale=IMAGE_SCALE,
             color_palette=image.PALETTE_IRONBOW,
             hint=drawing_hint,
             copy_to_fb=True,

--- a/scripts/examples/50-Arduino-Boards/Nano-RP2040/53-Thermal/thermal_camera.py
+++ b/scripts/examples/50-Arduino-Boards/Nano-RP2040/53-Thermal/thermal_camera.py
@@ -11,13 +11,11 @@ import image
 import time
 import fir
 
-IMAGE_SCALE = 5  # Higher scaling uses more memory.
+IMAGE_SCALE = 5  # Scale image to 5x.
 drawing_hint = image.BICUBIC  # or image.BILINEAR or 0 (nearest neighbor)
 
 # Initialize the thermal sensor
 fir.init()  # Auto-detects the connected sensor.
-w = fir.width() * IMAGE_SCALE
-h = fir.height() * IMAGE_SCALE
 
 # FPS clock
 clock = time.clock()
@@ -27,8 +25,8 @@ while True:
 
     try:
         img = fir.snapshot(
-            x_size=w,
-            y_size=h,
+            x_scale=IMAGE_SCALE,
+            y_scale=IMAGE_SCALE,
             color_palette=image.PALETTE_IRONBOW,
             hint=drawing_hint,
             copy_to_fb=True,

--- a/scripts/examples/50-OpenMV-Boards/54-Thermopile-Shield/thermal_camera.py
+++ b/scripts/examples/50-OpenMV-Boards/54-Thermopile-Shield/thermal_camera.py
@@ -11,25 +11,14 @@ import image
 import time
 import fir
 
+IMAGE_SCALE = 10  # Scale image to 10x.
 drawing_hint = image.BICUBIC  # or image.BILINEAR or 0 (nearest neighbor)
 
 # Initialize the thermal sensor
 fir.init()
-w = fir.width()
-h = fir.height()
 
-if fir.type() == fir.FIR_MLX90621:
-    w = w * 10
-    h = h * 10
-elif fir.type() == fir.FIR_MLX90640:
-    w = w * 10
-    h = h * 10
-elif fir.type() == fir.FIR_MLX90641:
-    w = w * 10
-    h = h * 10
-elif fir.type() == fir.FIR_AMG8833:
-    w = w * 20
-    h = h * 20
+if fir.type() == fir.FIR_AMG8833:
+    IMAGE_SCALE = IMAGE_SCALE * 2
 
 # FPS clock
 clock = time.clock()
@@ -39,8 +28,8 @@ while True:
 
     try:
         img = fir.snapshot(
-            x_size=w,
-            y_size=h,
+            x_scale=IMAGE_SCALE,
+            y_scale=IMAGE_SCALE,
             color_palette=image.PALETTE_IRONBOW,
             hint=drawing_hint,
             copy_to_fb=True,

--- a/scripts/examples/50-OpenMV-Boards/54-Thermopile-Shield/thermal_overlay.py
+++ b/scripts/examples/50-OpenMV-Boards/54-Thermopile-Shield/thermal_overlay.py
@@ -12,7 +12,8 @@ import image
 import time
 import fir
 
-drawing_hint = image.BICUBIC  # or image.BILINEAR or 0 (nearest neighbor)
+# or image.BILINEAR or 0 (nearest neighbor)
+drawing_hint = image.BICUBIC | image.CENTER | image.SCALE_ASPECT_KEEP
 
 ALT_OVERLAY = False  # Set to True to allocate a second ir image.
 

--- a/scripts/examples/50-OpenMV-Boards/54-Thermopile-Shield/thermal_overlay_lcd.py
+++ b/scripts/examples/50-OpenMV-Boards/54-Thermopile-Shield/thermal_overlay_lcd.py
@@ -13,7 +13,8 @@ import time
 import fir
 import display
 
-drawing_hint = image.BICUBIC  # or image.BILINEAR or 0 (nearest neighbor)
+# or image.BILINEAR or 0 (nearest neighbor)
+drawing_hint = image.BICUBIC | image.CENTER | image.SCALE_ASPECT_KEEP
 
 ALT_OVERLAY = False  # Set to True to allocate a second ir image.
 


### PR DESCRIPTION
Having to pass floats for the scale here to avoid issues made me realize we have to drop the size feature on scale being an int. See: https://github.com/openmv/openmv/pull/2028