### PR TITLE
modules: Make int/floating image scaling behavior the same.

### DIFF
--- a/src/omv/modules/py_display.c
+++ b/src/omv/modules/py_display.c
@@ -159,7 +159,7 @@ STATIC mp_obj_t py_display_write(uint n_args, const mp_obj_t *pos_args, mp_map_t
 
     float x_scale = 1.0f;
     float y_scale = 1.0f;
-    py_helper_arg_to_scale(args[ARG_x_scale].u_obj, args[ARG_y_scale].u_obj, &x_scale, &y_scale, &roi);
+    py_helper_arg_to_scale(args[ARG_x_scale].u_obj, args[ARG_y_scale].u_obj, &x_scale, &y_scale);
 
     if (y_scale < 0 && !self->triple_buffer) {
         mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("Vertical flip requires triple buffering!"));

--- a/src/omv/modules/py_fir.c
+++ b/src/omv/modules/py_fir.c
@@ -928,7 +928,7 @@ mp_obj_t py_fir_draw_ir(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_args
 
     float x_scale = 1.0f;
     float y_scale = 1.0f;
-    py_helper_arg_to_scale(args[ARG_x_scale].u_obj, args[ARG_y_scale].u_obj, &x_scale, &y_scale, &roi);
+    py_helper_arg_to_scale(args[ARG_x_scale].u_obj, args[ARG_y_scale].u_obj, &x_scale, &y_scale);
 
     float min = FLT_MAX;
     float max = -FLT_MAX;
@@ -1002,7 +1002,7 @@ mp_obj_t py_fir_snapshot(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_arg
 
     float x_scale = 1.0f;
     float y_scale = 1.0f;
-    py_helper_arg_to_scale(args[ARG_x_scale].u_obj, args[ARG_y_scale].u_obj, &x_scale, &y_scale, &roi);
+    py_helper_arg_to_scale(args[ARG_x_scale].u_obj, args[ARG_y_scale].u_obj, &x_scale, &y_scale);
 
     image_t dst_img = {
         .w = fast_floorf(roi.w * x_scale),

--- a/src/omv/modules/py_helper.c
+++ b/src/omv/modules/py_helper.c
@@ -96,17 +96,12 @@ rectangle_t py_helper_arg_to_roi(const mp_obj_t arg, const image_t *img) {
 }
 
 void py_helper_arg_to_scale(const mp_obj_t arg_x_scale, const mp_obj_t arg_y_scale,
-                            float *x_scale, float *y_scale, rectangle_t *roi) {
-    if (mp_obj_is_float(arg_x_scale)) {
+                            float *x_scale, float *y_scale) {
+    if (arg_x_scale != mp_const_none) {
         *x_scale = mp_obj_get_float(arg_x_scale);
-    } else if (mp_obj_is_int(arg_x_scale)) {
-        *x_scale = mp_obj_get_int(arg_x_scale) / (float) roi->w;
     }
-
-    if (mp_obj_is_float(arg_y_scale)) {
+    if (arg_y_scale != mp_const_none) {
         *y_scale = mp_obj_get_float(arg_y_scale);
-    } else if (mp_obj_is_int(arg_y_scale)) {
-        *y_scale = mp_obj_get_int(arg_y_scale) / (float) roi->h;
     }
 
     if (arg_x_scale == mp_const_none && arg_y_scale != mp_const_none) {

--- a/src/omv/modules/py_helper.h
+++ b/src/omv/modules/py_helper.h
@@ -25,7 +25,7 @@ image_t *py_helper_arg_to_image(const mp_obj_t arg, uint32_t flags);
 const void *py_helper_arg_to_palette(const mp_obj_t arg, uint32_t pixfmt);
 rectangle_t py_helper_arg_to_roi(const mp_obj_t arg, const image_t *img);
 void py_helper_arg_to_scale(const mp_obj_t arg_x_scale, const mp_obj_t arg_y_scale,
-                            float *x_scale, float *y_scale, rectangle_t *roi);
+                            float *x_scale, float *y_scale);
 void py_helper_arg_to_minmax(const mp_obj_t minmax, float *min, float *max,
                              const mp_obj_t *array, size_t array_size);
 float py_helper_arg_to_float(const mp_obj_t arg, float default_value);

--- a/src/omv/modules/py_tof.c
+++ b/src/omv/modules/py_tof.c
@@ -426,7 +426,7 @@ mp_obj_t py_tof_draw_depth(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_a
 
     float x_scale = 1.0f;
     float y_scale = 1.0f;
-    py_helper_arg_to_scale(args[ARG_x_scale].u_obj, args[ARG_y_scale].u_obj, &x_scale, &y_scale, &roi);
+    py_helper_arg_to_scale(args[ARG_x_scale].u_obj, args[ARG_y_scale].u_obj, &x_scale, &y_scale);
 
     float min = FLT_MAX;
     float max = -FLT_MAX;
@@ -500,7 +500,7 @@ mp_obj_t py_tof_snapshot(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_arg
 
     float x_scale = 1.0f;
     float y_scale = 1.0f;
-    py_helper_arg_to_scale(args[ARG_x_scale].u_obj, args[ARG_y_scale].u_obj, &x_scale, &y_scale, &roi);
+    py_helper_arg_to_scale(args[ARG_x_scale].u_obj, args[ARG_y_scale].u_obj, &x_scale, &y_scale);
 
     image_t dst_img = {
         .w = fast_floorf(roi.w * x_scale),

--- a/src/omv/modules/py_tv.c
+++ b/src/omv/modules/py_tv.c
@@ -902,7 +902,7 @@ STATIC mp_obj_t py_tv_display(uint n_args, const mp_obj_t *pos_args, mp_map_t *k
 
     float x_scale = 1.0f;
     float y_scale = 1.0f;
-    py_helper_arg_to_scale(args[ARG_x_scale].u_obj, args[ARG_y_scale].u_obj, &x_scale, &y_scale, &roi);
+    py_helper_arg_to_scale(args[ARG_x_scale].u_obj, args[ARG_y_scale].u_obj, &x_scale, &y_scale);
 
     const uint16_t *color_palette = py_helper_arg_to_palette(args[ARG_color_palette].u_obj, PIXFORMAT_RGB565);
     const uint8_t *alpha_palette = py_helper_arg_to_palette(args[ARG_alpha_palette].u_obj, PIXFORMAT_GRAYSCALE);


### PR DESCRIPTION
Having scale turn into a size if you pass an int is too dangerous. Just realized this after going through examples. This makes the behavior scaling and nothing else.