### PR TITLE
modules/py_mjpeg: Calculate MJPEG FPS internally.

### DIFF
--- a/scripts/examples/01-Camera/01-Video-Recording/mjpeg.py
+++ b/scripts/examples/01-Camera/01-Video-Recording/mjpeg.py
@@ -29,10 +29,10 @@ m = mjpeg.Mjpeg("example.mjpeg")
 clock = time.clock()  # Create a clock object to track the FPS.
 for i in range(200):
     clock.tick()
-    m.add_frame(sensor.snapshot())
+    m.write(sensor.snapshot())
     print(clock.fps())
 
-m.close(clock.fps())
+m.close()
 led.off()
 
 raise (Exception("Please reset the camera to see the new file."))

--- a/scripts/examples/01-Camera/01-Video-Recording/mjpeg_on_face_detection.py
+++ b/scripts/examples/01-Camera/01-Video-Recording/mjpeg_on_face_detection.py
@@ -60,9 +60,9 @@ while True:
     clock = time.clock()  # Tracks FPS.
     for i in range(200):
         clock.tick()
-        m.add_frame(sensor.snapshot())
+        m.write(sensor.snapshot())
         print(clock.fps())
 
-    m.close(clock.fps())
+    m.close()
     led.off()
     print("Restarting...")

--- a/scripts/examples/01-Camera/01-Video-Recording/mjpeg_on_movement.py
+++ b/scripts/examples/01-Camera/01-Video-Recording/mjpeg_on_movement.py
@@ -56,9 +56,9 @@ while True:
     clock = time.clock()  # Tracks FPS.
     for i in range(200):
         clock.tick()
-        m.add_frame(sensor.snapshot())
+        m.write(sensor.snapshot())
         print(clock.fps())
 
-    m.close(clock.fps())
+    m.close()
     led.off()
     print("Restarting...")

--- a/src/omv/imlib/imlib.h
+++ b/src/omv/imlib/imlib.h
@@ -1182,8 +1182,8 @@ void mjpeg_open(FIL *fp, int width, int height);
 void mjpeg_write(FIL *fp, int width, int height, uint32_t *frames, uint32_t *bytes,
                  image_t *img, int quality, rectangle_t *roi, int rgb_channel, int alpha,
                  const uint16_t *color_palette, const uint8_t *alpha_palette, image_hint_t hint);
-void mjpeg_sync(FIL *fp, uint32_t *frames, uint32_t *bytes, float fps);
-void mjpeg_close(FIL *fp, uint32_t *frames, uint32_t *bytes, float fps);
+void mjpeg_sync(FIL *fp, uint32_t frames, uint32_t bytes, uint32_t us_avg);
+void mjpeg_close(FIL *fp, uint32_t frames, uint32_t bytes, uint32_t us_avg);
 
 /* Point functions */
 point_t *point_alloc(int16_t x, int16_t y);


### PR DESCRIPTION
FPS is calculated internally now using microsecond resolution.

I noticed the video frame rate matches the camera FPS more consistently now.

Fixes: https://github.com/openmv/openmv/issues/2014