### PR TITLE
scripts/examples: Fix GIGA display script.

### DIFF
--- a/scripts/examples/50-Arduino-Boards/Giga-H7/51-Display/display.py
+++ b/scripts/examples/50-Arduino-Boards/Giga-H7/51-Display/display.py
@@ -31,6 +31,7 @@ touch = GT911(
     irq_pin="PI1",
     touch_points=5,
     refresh_rate=240,
+    reverse_x=True,
     touch_callback=lambda pin: globals().update(touch_detected=True),
 )
 


### PR DESCRIPTION
The image is rotated after drawing the touch points, now that we're using the new draw flags, so the touch X axis needs to be reversed.