### PR TITLE
boards/OPENMV_RT1060: Enable high res apriltags.

### DIFF
--- a/src/omv/boards/OPENMV_RT1060/imlib_config.h
+++ b/src/omv/boards/OPENMV_RT1060/imlib_config.h
@@ -106,7 +106,7 @@
 // #define IMLIB_ENABLE_FINE_APRILTAGS
 
 // Enable high res find_apriltags() - uses more RAM
-// #define IMLIB_ENABLE_HIGH_RES_APRILTAGS
+#define IMLIB_ENABLE_HIGH_RES_APRILTAGS
 
 // Enable find_datamatrices() (26 KB)
 #define IMLIB_ENABLE_DATAMATRICES


### PR DESCRIPTION
Fixes: https://forums.openmv.io/t/apriltag-resolution-for-the-rt1062/9001