### PR TITLE
ports: Don't deinit the SSEL pin on stm32 and mimxrt.

### DIFF
--- a/src/omv/ports/stm32/omv_spi.c
+++ b/src/omv/ports/stm32/omv_spi.c
@@ -19,6 +19,7 @@
 #include "irq.h"
 #include "omv_common.h"
 #include "dma_utils.h"
+#include "omv_gpio.h"
 #include "omv_spi.h"
 
 // If an SPI handle is already defined in MicroPython, reuse that handle to allow
@@ -433,6 +434,8 @@ int omv_spi_deinit(omv_spi_t *spi) {
         }
         HAL_SPI_DeInit(spi->descr);
         HAL_NVIC_DisableIRQ(spi->irqn);
+        // Deinit the CS pin here versus in HAL_SPI_MspDeInit which is shared code.
+        omv_gpio_deinit(spi->cs);
     }
     return 0;
 }

--- a/src/omv/ports/stm32/stm32fxxx_hal_msp.c
+++ b/src/omv/ports/stm32/stm32fxxx_hal_msp.c
@@ -520,7 +520,9 @@ void HAL_SPI_MspDeInit(SPI_HandleTypeDef *hspi) {
     omv_gpio_deinit(spi_pins.sclk_pin);
     omv_gpio_deinit(spi_pins.miso_pin);
     omv_gpio_deinit(spi_pins.mosi_pin);
-    omv_gpio_deinit(spi_pins.ssel_pin);
+    // Deinited by omv_spi.c so as to not deinit the pin when HAL_SPI_MspDeInit is called
+    // from deiniting the SPI bus from the machine or pyb module.
+    // omv_gpio_deinit(spi_pins.ssel_pin);
 }
 
 #if defined(AUDIO_SAI)


### PR DESCRIPTION
Fixes: https://github.com/openmv/openmv/issues/2042

And: https://github.com/openmv/openmv/issues/1926