### PR TITLE
modules/py_display: Add user SPI LCD register control.

### DIFF
--- a/scripts/libraries/st7701.py
+++ b/scripts/libraries/st7701.py
@@ -51,76 +51,76 @@ class ST7701:
         self.dc = dc
 
         # Soft-reset
-        dc.dsi_write(DCS_SOFT_RESET)
+        dc.bus_write(DCS_SOFT_RESET)
         time.sleep_ms(200)
 
         # Exit sleep mode
-        dc.dsi_write(DCS_EXIT_SLEEP_MODE)
+        dc.bus_write(DCS_EXIT_SLEEP_MODE)
         time.sleep_ms(800)
 
         # Select bank 0
-        dc.dsi_write(DSI_CMD2_BKX_SEL, b"\x77\x01\x00\x00\x10")
+        dc.bus_write(DSI_CMD2_BKX_SEL, b"\x77\x01\x00\x00\x10")
 
         # Display Control setting
-        dc.dsi_write(DSI_CMD2_BK0_LNESET, b"\x63\x00")
-        dc.dsi_write(DSI_CMD2_BK0_PORCTRL, b"\x11\x02")
-        dc.dsi_write(DSI_CMD2_BK0_INVSEL, b"\x01\x08")
-        # dc.dsi_write(0xCC, b"\x18")
+        dc.bus_write(DSI_CMD2_BK0_LNESET, b"\x63\x00")
+        dc.bus_write(DSI_CMD2_BK0_PORCTRL, b"\x11\x02")
+        dc.bus_write(DSI_CMD2_BK0_INVSEL, b"\x01\x08")
+        # dc.bus_write(0xCC, b"\x18")
         # Gamma cluster settings
-        dc.dsi_write(
+        dc.bus_write(
             0xB0, b"\x40\xc9\x91\x0d\x12\x07\x02\x09\x09\x1f\x04\x50\x0f\xe4\x29\xdf"
         )
-        dc.dsi_write(
+        dc.bus_write(
             0xB1, b"\x40\xcb\xd0\x11\x92\x07\x00\x08\x07\x1c\x06\x53\x12\x63\xeb\xdf"
         )
 
         # Select bank 1
-        dc.dsi_write(DSI_CMD2_BKX_SEL, b"\x77\x01\x00\x00\x11")
+        dc.bus_write(DSI_CMD2_BKX_SEL, b"\x77\x01\x00\x00\x11")
 
         # Power control settings
-        dc.dsi_write(DSI_CMD2_BK1_VRHS, 0x65)
-        dc.dsi_write(DSI_CMD2_BK1_VCOM, 0x34)
-        dc.dsi_write(DSI_CMD2_BK1_VGHSS, 0x87)
-        dc.dsi_write(DSI_CMD2_BK1_TESTCMD, 0x80)
-        dc.dsi_write(DSI_CMD2_BK1_VGLS, 0x49)
-        dc.dsi_write(DSI_CMD2_BK1_PWCTLR1, 0x85)
-        dc.dsi_write(DSI_CMD2_BK1_PWCTLR2, 0x20)
-        dc.dsi_write(DSI_CMD2_BK1_DGMLUTR, 0x10)
-        dc.dsi_write(DSI_CMD2_BK1_SPD1, 0x78)
-        dc.dsi_write(DSI_CMD2_BK1_SPD2, 0x78)
-        dc.dsi_write(DSI_CMD2_BK1_MIPISET1, 0x88)
+        dc.bus_write(DSI_CMD2_BK1_VRHS, 0x65)
+        dc.bus_write(DSI_CMD2_BK1_VCOM, 0x34)
+        dc.bus_write(DSI_CMD2_BK1_VGHSS, 0x87)
+        dc.bus_write(DSI_CMD2_BK1_TESTCMD, 0x80)
+        dc.bus_write(DSI_CMD2_BK1_VGLS, 0x49)
+        dc.bus_write(DSI_CMD2_BK1_PWCTLR1, 0x85)
+        dc.bus_write(DSI_CMD2_BK1_PWCTLR2, 0x20)
+        dc.bus_write(DSI_CMD2_BK1_DGMLUTR, 0x10)
+        dc.bus_write(DSI_CMD2_BK1_SPD1, 0x78)
+        dc.bus_write(DSI_CMD2_BK1_SPD2, 0x78)
+        dc.bus_write(DSI_CMD2_BK1_MIPISET1, 0x88)
         time.sleep_ms(100)
 
         # GIP settings
-        dc.dsi_write(DSI_CMD2_BK1_SECTRL, b"\x00\x00\x02")
-        dc.dsi_write(
+        dc.bus_write(DSI_CMD2_BK1_SECTRL, b"\x00\x00\x02")
+        dc.bus_write(
             DSI_CMD2_BK1_NRCTRL, b"\x08\x00\x0A\x00\x07\x00\x09\x00\x00\x33\x33"
         )
-        dc.dsi_write(
+        dc.bus_write(
             DSI_CMD2_BK1_SRPCTRL,
             b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
         )
-        dc.dsi_write(DSI_CMD2_BK1_CCCTRL, b"\x00\x00\x33\x33")
-        dc.dsi_write(DSI_CMD2_BK1_SKCTRL, b"\x44\x44")
-        dc.dsi_write(
+        dc.bus_write(DSI_CMD2_BK1_CCCTRL, b"\x00\x00\x33\x33")
+        dc.bus_write(DSI_CMD2_BK1_SKCTRL, b"\x44\x44")
+        dc.bus_write(
             0xE5, b"\x0E\x60\xA0\xa0\x10\x60\xA0\xA0\x0A\x60\xA0\xA0\x0C\x60\xA0\xA0"
         )
-        dc.dsi_write(0xE6, b"\x00\x00\x33\x33")
-        dc.dsi_write(0xE7, b"\x44\x44")
-        dc.dsi_write(
+        dc.bus_write(0xE6, b"\x00\x00\x33\x33")
+        dc.bus_write(0xE7, b"\x44\x44")
+        dc.bus_write(
             0xE8, b"\x0D\x60\xA0\xA0\x0F\x60\xA0\xA0\x09\x60\xA0\xA0\x0B\x60\xA0\xA0"
         )
 
-        dc.dsi_write(0xEB, b"\x02\x01\xE4\xE4\x44\x00\x40")
-        dc.dsi_write(0xEC, b"\x02\x01")
-        dc.dsi_write(
+        dc.bus_write(0xEB, b"\x02\x01\xE4\xE4\x44\x00\x40")
+        dc.bus_write(0xEC, b"\x02\x01")
+        dc.bus_write(
             0xED, b"\xAB\x89\x76\x54\x01\xFF\xFF\xFF\xFF\xFF\xFF\x10\x45\x67\x98\xBA"
         )
 
-        dc.dsi_write(DSI_CMD2_BKX_SEL, b"\x77\x01\x00\x00\x00")
+        dc.bus_write(DSI_CMD2_BKX_SEL, b"\x77\x01\x00\x00\x00")
         time.sleep_ms(10)
-        dc.dsi_write(DCS_SET_DISPLAY_ON, dcs=True)
+        dc.bus_write(DCS_SET_DISPLAY_ON, dcs=True)
         time.sleep_ms(200)
 
     def read_id(self):
-        return self.dc.dsi_read(0x04, 3)
+        return self.dc.bus_read(0x04, 3)

--- a/src/omv/modules/py_display.h
+++ b/src/omv/modules/py_display.h
@@ -72,11 +72,8 @@ typedef struct _py_display_p_t {
                    float x_scale, float y_scale, rectangle_t *roi, int rgb_channel, int alpha,
                    const uint16_t *color_palette, const uint8_t *alpha_palette, image_hint_t hint);
     void (*set_backlight) (py_display_obj_t *self, uint32_t intensity);
-    #ifdef OMV_DSI_DISPLAY_CONTROLLER
-    // To be implemented by MIPI DSI controllers.
-    int (*dsi_write) (py_display_obj_t *self, uint8_t cmd, uint8_t *args, size_t n_args, bool dcs);
-    int (*dsi_read) (py_display_obj_t *self, uint8_t cmd, uint8_t *args, size_t n_args, uint8_t *buf, size_t len, bool dcs);
-    #endif
+    int (*bus_write) (py_display_obj_t *self, uint8_t cmd, uint8_t *args, size_t n_args, bool dcs);
+    int (*bus_read) (py_display_obj_t *self, uint8_t cmd, uint8_t *args, size_t n_args, uint8_t *buf, size_t len, bool dcs);
 } py_display_p_t;
 
 extern const mp_obj_type_t py_spi_display_type;

--- a/src/omv/ports/stm32/modules/py_display.c
+++ b/src/omv/ports/stm32/modules/py_display.c
@@ -637,8 +637,8 @@ STATIC const py_display_p_t py_display_p = {
     .set_backlight = display_set_backlight,
     #endif
     #ifdef OMV_DSI_DISPLAY_CONTROLLER
-    .dsi_write = display_dsi_write,
-    .dsi_read = display_dsi_read,
+    .bus_write = display_dsi_write,
+    .bus_read = display_dsi_read,
     #endif
 };
 


### PR DESCRIPTION
I added a stub to allow you to execute register reads and writes to the SPI display. I then implemented the SPI register write. I don't believe read will work for our driver as we didn't hookup that line.

Anyway, code is redundant from the DSI read/write. Thoughts what the API should be?

This fixes: https://github.com/openmv/openmv/issues/2066