### PR TITLE
modules/py_image: Upgrade ccm to work well with ulab.

### DIFF
--- a/scripts/examples/02-Image-Processing/01-Image-Filters/color_correction.py
+++ b/scripts/examples/02-Image-Processing/01-Image-Filters/color_correction.py
@@ -1,0 +1,111 @@
+# This work is licensed under the MIT license.
+# Copyright (c) 2013-2024 OpenMV LLC. All rights reserved.
+# https://github.com/openmv/openmv/blob/master/LICENSE
+#
+# Color Correction Example
+#
+# This example shows off using the color correction matrix multiplication
+# method to apply generic matrix multiplications to images.
+#
+# In the example below we are going to:
+#     1. Convert the image to YUV from RGB.
+#     2. Apply a rotation matrix to the UV components to cause a Hue Shift.
+#     3. Apply a scaling value to the UV components to cause a Saturation Shift.
+#     4. Convert the image back from YUV to RGB.
+#
+# However, instead of applying these 4 steps to the image one a time we can apply
+# them to each other before hand to produce a 3x3 matrix suitable for feeding to
+# the color correction matrix method.
+#
+# By converting the color space to YUV this separates the "value" of pixels from
+# their "hue" and "saturation". The "hue" then is just the rotation angle given
+# the U/V components and the "saturation" is their magnitude.
+#
+# |Y|   |    0.299,     0.587,     0.114|   |R|
+# |U| = |-0.168736, -0.331264,       0.5| * |G|
+# |V|   |      0.5, -0.418688, -0.081312|   |B|
+#
+# |Y_rot|   |1,           0,            0|   |Y|
+# |U_rot| = |0, math.cos(a), -math.sin(a)| * |U|
+# |V_rot|   |0, math.sin(a),  math.cos(a)|   |V|
+#
+# |Y_rot_scaled|   |1, 0,  0|   |Y|
+# |U_rot_scaled| = |0, s,  0| * |U|
+# |V_rot_scaled|   |0, 0,  s|   |V|
+#
+# |R_rot_scaled|          |    0.299,     0.587,     0.114|   |Y_rot_scaled|
+# |R_rot_scaled| = INVERSE|-0.168736, -0.331264,       0.5| * |U_rot_scaled|
+# |R_rot_scaled|          |      0.5, -0.418688, -0.081312|   |V_rot_scaled|
+#
+# Note: The ccm() method can accept 3x3 and 3x4 matrices. 3x4 matrices are for
+# if you want an offset to by applied. In this case things look like:
+#
+# |Y|   |    0.299,     0.587,     0.114,  y_offset|   |R|
+# |U| = |-0.168736, -0.331264,       0.5,  u_offset| * |G|
+# |V|   |      0.5, -0.418688, -0.081312,  v_offset|   |B|
+#                                                      |1|
+#
+# Keep in mind that the CCM method is just doing:
+#
+# |R'|                |R|      |R'|                |R|
+# |G'| = 3x3 Matrix * |G|  or  |G'| = 3x4 Matrix * |G|
+# |B'|                |B|      |B'|                |B|
+#                                                  |1|
+#
+# If you are creating intermediate values using matrix math you need to end
+# up back at RGB values for the final matrix you pass to CCM().
+#
+# Finally, you are free to do the matrix formation using 4x4 matrices. The last
+# row will be ignored if you pass a 4x4 matrix (e.g. it will be treated as 3x4).
+
+from ulab import numpy as np
+import sensor
+import time
+import math
+
+# Set to 0 for a grayscale image. Set above 1.0 to pump-up the saturation.
+UV_SCALE = 1.0
+
+sensor.reset()
+sensor.set_pixformat(sensor.RGB565)
+sensor.set_framesize(sensor.QVGA)
+sensor.skip_frames(time=2000)
+
+# These are the standard coefficents for converting RGB to YUV.
+rgb2yuv = np.array([[    0.299,     0.587,     0.114], # noqa
+                    [-0.168736, -0.331264,       0.5], # noqa
+                    [      0.5, -0.418688, -0.081312]], dtype=np.float) # noqa
+
+# Now get the inverse so we can get back to RGB from YUV.
+yuv2rgb = np.linalg.inv(rgb2yuv)
+
+clock = time.clock()
+
+# r will be the angle by which we rotate the colors on the UV plane by.
+r = 0
+
+while True:
+    clock.tick()
+
+    # Increment in a loop.
+    r = (r + 1) % 360
+    a = math.radians(r)
+
+    # This is a rotation matrix which we will apply on the UV components of YUV values.
+    # https://en.wikipedia.org/wiki/Rotation_matrix
+    rot = np.array([[1,           0,            0], # noqa
+                    [0, math.cos(a), -math.sin(a)], # noqa
+                    [0, math.sin(a),  math.cos(a)]], dtype=np.float) # noqa
+
+    # This is the scale matrix
+    scale = np.array([[1,        0, 0], # noqa
+                      [0, UV_SCALE, 0], # noqa
+                      [0,        0, UV_SCALE]], dtype=np.float) # noqa
+
+    # Now compute the final matrix using matrix multiplication.
+    m = np.dot(yuv2rgb, np.dot(scale, np.dot(rot, rgb2yuv)))
+
+    # Apply the color transformation (m.flatten().tolist() also works)
+    img = sensor.snapshot().ccm(m.tolist())
+
+    print(clock.fps())

--- a/src/omv/imlib/isp.c
+++ b/src/omv/imlib/isp.c
@@ -963,15 +963,9 @@ void imlib_awb(image_t *img, bool max) {
 }
 
 void imlib_ccm(image_t *img, float *ccm, bool offset) {
-    float rr = ccm[0], rg = ccm[3], rb = ccm[6], ro = 0.f;
-    float gr = ccm[1], gg = ccm[4], gb = ccm[7], go = 0.f;
-    float br = ccm[2], bg = ccm[5], bb = ccm[8], bo = 0.f;
-
-    if (offset) {
-        ro = ccm[9];
-        go = ccm[10];
-        bo = ccm[11];
-    }
+    float rr = ccm[0], rg = ccm[1], rb = ccm[2], ro = ccm[3];
+    float gr = ccm[4], gg = ccm[5], gb = ccm[6], go = ccm[7];
+    float br = ccm[8], bg = ccm[9], bb = ccm[10], bo = ccm[11];
 
     int i_rr = IM_MIN(fast_roundf(rr * 64), 1024);
     int i_rg = IM_MIN(fast_roundf(rg * 32), 512);


### PR DESCRIPTION
I've noticed that we were missing hue/saturation shifting from our algorithm list for a while. However, on thinking about how to implement it, I realized that the current ccm() method is well-suited.

Realizing we have ulab onboard which provides a linear algebra pacakge onboard I wrote up the process below using the ccm() method to apply color shifts like you can do in photoshop. Converting to HSV/YUV to do the color shift and then back would be slower than what's going on below.

Then I updated the ccm() method to accept arrays from ulab more easily.

This shows off a pretty sweet collaboration between OpenMV's code and ulab. It also provides an example for the ccm() function.

...

Note, the purpose of the ccm() function is so that you can apply color correction if you've figured out the color correction matrix by pointing the camera at a color calibration chart. This will be useful for dealing with RAW BAYER sensors that do not have an ISP in the future. However, AWB may be enough.

