### PR TITLE
boards/OPENMV_RT1060: Update UMM Heap Size to match H7 Plus.

### DIFF
--- a/src/omv/boards/OPENMV_RT1060/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV_RT1060/omv_boardconfig.h
@@ -75,7 +75,7 @@
 #define JPEG_QUALITY_HIGH               90
 
 // FB Heap Block Size
-#define OMV_UMM_BLOCK_SIZE              16
+#define OMV_UMM_BLOCK_SIZE              256
 
 // USB config.
 #define OMV_USB_IRQN                    (USB_OTG1_IRQn)


### PR DESCRIPTION
Was set for use on non-SDRAM based cameras.

Fixes: https://github.com/openmv/openmv/issues/2078