### PR TITLE
drivers/pixart: Fix buffer overflow case.

### DIFF
--- a/src/drivers/pixart/src/pixspi.c
+++ b/src/drivers/pixart/src/pixspi.c
@@ -112,7 +112,7 @@ int pixspi_regs_read(uint8_t addr, uint8_t *data, uint16_t length) {
 }
 
 int pixspi_regs_write(uint8_t addr, const uint8_t *data, uint16_t length) {
-    uint8_t buff[64] = {};
+    uint8_t buff[256] = {};
     if (addr & 0x80) {
         debug_printf("pixspi_regs_read() address (0x%x) overflow.\n", addr);
         return -1;


### PR DESCRIPTION
Noticed this bug in the pixart driver code. Nothing would trigger it but thought to fix it.