### PR TITLE
boards: Enable OV5640 Autofocus firmware and add example.

### DIFF
--- a/scripts/examples/01-Camera/07-Sensor-Control/autofocus.py
+++ b/scripts/examples/01-Camera/07-Sensor-Control/autofocus.py
@@ -1,0 +1,28 @@
+# This work is licensed under the MIT license.
+# Copyright (c) 2013-2024 OpenMV LLC. All rights reserved.
+# https://github.com/openmv/openmv/blob/master/LICENSE
+#
+# Auto Focus Example
+#
+# This example shows off how to auto-focus on cameras that support the feature.
+
+import sensor
+import time
+
+sensor.reset()  # Reset and initialize the sensor.
+sensor.set_pixformat(sensor.RGB565)  # Set pixel format to RGB565 (or GRAYSCALE)
+sensor.set_framesize(sensor.QVGA)  # Set frame size to QVGA (320x240)
+sensor.skip_frames(time=2000)  # Wait for settings take effect.
+clock = time.clock()  # Create a clock object to track the FPS.
+
+try:
+    # The camera will now focus on whatever is in front of it.
+    sensor.ioctl(sensor.IOCTL_TRIGGER_AUTO_FOCUS)
+except:
+    raise (Exception("Auto focus is not supported by your sensor/board combination."))
+
+while True:
+    clock.tick()  # Update the FPS clock.
+    img = sensor.snapshot()  # Take a picture and return the image.
+    print(clock.fps())  # Note: OpenMV Cam runs about half as fast when connected
+    # to the IDE. The FPS should increase once disconnected.

--- a/src/omv/boards/OPENMV4/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4/omv_boardconfig.h
@@ -77,7 +77,7 @@
 #define OMV_OV7670_CLKRC                      (0)
 
 // Enable sensor features
-#define OMV_ENABLE_OV5640_AF                  (0)
+#define OMV_ENABLE_OV5640_AF                  (1)
 
 // Enable WiFi debug
 #define OMV_ENABLE_WIFIDBG                    (1)

--- a/src/omv/boards/OPENMV4P/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4P/omv_boardconfig.h
@@ -76,7 +76,7 @@
 #define OMV_ENABLE_GPIO_BANK_I                (1)
 
 // Enable sensor features
-#define OMV_ENABLE_OV5640_AF                  (0)
+#define OMV_ENABLE_OV5640_AF                  (1)
 
 // Enable WiFi debug
 #define OMV_ENABLE_WIFIDBG                    (1)

--- a/src/omv/boards/OPENMV_RT1060/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV_RT1060/omv_boardconfig.h
@@ -30,7 +30,7 @@
 #define OMV_OV7725_BANDING              (0x7F)
 
 // OV5640 Sensor Settings
-#define OMV_ENABLE_OV5640_AF            (0)
+#define OMV_ENABLE_OV5640_AF            (1)
 #define OMV_OV5640_XCLK_FREQ            (24000000)
 #define OMV_OV5640_PLL_CTRL2            (0x64)
 #define OMV_OV5640_PLL_CTRL3            (0x13)


### PR DESCRIPTION
Fixes: https://github.com/openmv/openmv/issues/2081

Now that JPEG is merged we should have space for the firmware since the software decoder is gone for the H7 line.