### PR TITLE
port/mimxrt: Improve Sensor Driver.

### DIFF
--- a/src/omv/boards/OPENMV_RT1060/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV_RT1060/omv_boardconfig.h
@@ -109,7 +109,7 @@
 #define OMV_HEAP_SIZE                   (280K)
 #define OMV_SDRAM_SIZE                  (32 * 1024 * 1024)  // This needs to be here for UVC firmware.
 
-#define OMV_LINE_BUF_SIZE               (10 * 1024)  // Image line buffer.
+#define OMV_LINE_BUF_SIZE               (11 * 1024)  // Image line buffer.
 // TODO remove
 #define OMV_MSC_BUF_SIZE                (2K)         // USB MSC bot data
 #define OMV_VFS_BUF_SIZE                (1K)         // VFS struct + FATFS file buffer (624 bytes)

--- a/src/omv/boards/OPENMV_RT1060/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV_RT1060/omv_boardconfig.h
@@ -102,8 +102,8 @@
 #define OMV_VOSPI_MEMORY                OCRM2        // VoSPI buffer memory.
 #define OMV_FB_OVERLAY_MEMORY           OCRM1        // Fast fb_alloc memory.
 
-#define OMV_FB_SIZE                     (10M)        // FB memory: header + VGA/GS image
-#define OMV_FB_ALLOC_SIZE               (2M)         // minimum fb alloc size
+#define OMV_FB_SIZE                     (20M)        // FB memory: header + VGA/GS image
+#define OMV_FB_ALLOC_SIZE               (11M)         // minimum fb alloc size
 #define OMV_FB_OVERLAY_SIZE             (512K)
 #define OMV_STACK_SIZE                  (32K)
 #define OMV_HEAP_SIZE                   (280K)

--- a/src/omv/ports/mimxrt/sensor.c
+++ b/src/omv/ports/mimxrt/sensor.c
@@ -315,6 +315,9 @@ void sensor_line_callback(uint32_t addr) {
         // Release the current framebuffer.
         framebuffer_get_tail(FB_NO_FLAGS);
         CSI_REG_CR3(CSI) &= ~CSI_CR3_DMA_REQ_EN_RFF_MASK;
+        if (sensor.frame_callback) {
+            sensor.frame_callback();
+        }
     }
 }
 

--- a/src/omv/ports/mimxrt/sensor.c
+++ b/src/omv/ports/mimxrt/sensor.c
@@ -195,8 +195,7 @@ void sensor_sof_callback() {
         if (!sensor.disable_full_flush) {
             framebuffer_flush_buffers();
         }
-    }
-    if (buffer->offset < MAIN_FB()->v) {
+    } else if (buffer->offset < resolution[sensor.framesize][1]) {
         // Missed a few lines, reset buffer state and continue.
         buffer->reset_state = true;
     }
@@ -225,93 +224,95 @@ void sensor_line_callback(uint32_t addr) {
     vbuffer_t *buffer = framebuffer_get_tail(FB_PEEK);
 
     if (drop_frame) {
-        if (++buffer->offset == MAIN_FB()->v) {
+        if (++buffer->offset == resolution[sensor.framesize][1]) {
             buffer->offset = 0;
             CSI_REG_CR3(CSI) &= ~CSI_CR3_DMA_REQ_EN_RFF_MASK;
         }
         return;
     }
 
-    // Copy from DMA buffer to framebuffer.
-    uint32_t bytes_per_pixel = sensor_get_src_bpp();
-    uint8_t *src = ((uint8_t *) addr) + (MAIN_FB()->x * bytes_per_pixel);
-    uint8_t *dst = buffer->data;
+    if ((MAIN_FB()->y <= buffer->offset) && (buffer->offset < (MAIN_FB()->y + MAIN_FB()->v))) {
+        // Copy from DMA buffer to framebuffer.
+        uint32_t bytes_per_pixel = sensor_get_src_bpp();
+        uint8_t *src = ((uint8_t *) addr) + (MAIN_FB()->x * bytes_per_pixel);
+        uint8_t *dst = buffer->data;
 
-    // Adjust BPP for Grayscale.
-    if (sensor.pixformat == PIXFORMAT_GRAYSCALE) {
-        bytes_per_pixel = 1;
-    }
+        // Adjust BPP for Grayscale.
+        if (sensor.pixformat == PIXFORMAT_GRAYSCALE) {
+            bytes_per_pixel = 1;
+        }
 
-    if (sensor.transpose) {
-        dst += bytes_per_pixel * buffer->offset;
-    } else {
-        dst += MAIN_FB()->u * bytes_per_pixel * buffer->offset;
-    }
+        if (sensor.transpose) {
+            dst += bytes_per_pixel * (buffer->offset - MAIN_FB()->y);
+        } else {
+            dst += MAIN_FB()->u * bytes_per_pixel * (buffer->offset - MAIN_FB()->y);
+        }
 
-    // Implement per line, per pixel cropping, and image transposing (for image rotation) in
-    // in software using the CPU to transfer the image from the line buffers to the frame buffer.
-    uint16_t *src16 = (uint16_t *) src;
-    uint16_t *dst16 = (uint16_t *) dst;
+        // Implement per line, per pixel cropping, and image transposing (for image rotation) in
+        // in software using the CPU to transfer the image from the line buffers to the frame buffer.
+        uint16_t *src16 = (uint16_t *) src;
+        uint16_t *dst16 = (uint16_t *) dst;
 
-    switch (sensor.pixformat) {
-        case PIXFORMAT_BAYER:
-            #if (OMV_ENABLE_SENSOR_EDMA == 1)
-            edma_memcpy(buffer, dst, src, sizeof(uint8_t), sensor.transpose);
-            #else
-            if (!sensor.transpose) {
-                unaligned_memcpy(dst, src, MAIN_FB()->u);
-            } else {
-                copy_line(dst, src);
-            }
-            #endif
-            break;
-        case PIXFORMAT_GRAYSCALE:
-            #if (OMV_ENABLE_SENSOR_EDMA == 1)
-            edma_memcpy(buffer, dst, src, sizeof(uint8_t), sensor.transpose);
-            #else
-            if (sensor.hw_flags.gs_bpp == 1) {
-                // 1BPP GRAYSCALE.
+        switch (sensor.pixformat) {
+            case PIXFORMAT_BAYER:
+                #if (OMV_ENABLE_SENSOR_EDMA == 1)
+                edma_memcpy(buffer, dst, src, sizeof(uint8_t), sensor.transpose);
+                #else
                 if (!sensor.transpose) {
                     unaligned_memcpy(dst, src, MAIN_FB()->u);
                 } else {
                     copy_line(dst, src);
                 }
-            } else {
-                // Extract Y channel from YUV.
-                if (!sensor.transpose) {
-                    unaligned_2_to_1_memcpy(dst, src16, MAIN_FB()->u);
+                #endif
+                break;
+            case PIXFORMAT_GRAYSCALE:
+                #if (OMV_ENABLE_SENSOR_EDMA == 1)
+                edma_memcpy(buffer, dst, src, sizeof(uint8_t), sensor.transpose);
+                #else
+                if (sensor.hw_flags.gs_bpp == 1) {
+                    // 1BPP GRAYSCALE.
+                    if (!sensor.transpose) {
+                        unaligned_memcpy(dst, src, MAIN_FB()->u);
+                    } else {
+                        copy_line(dst, src);
+                    }
                 } else {
-                    copy_line(dst, src16);
+                    // Extract Y channel from YUV.
+                    if (!sensor.transpose) {
+                        unaligned_2_to_1_memcpy(dst, src16, MAIN_FB()->u);
+                    } else {
+                        copy_line(dst, src16);
+                    }
                 }
-            }
-            #endif
-            break;
-        case PIXFORMAT_RGB565:
-        case PIXFORMAT_YUV422:
-            #if (OMV_ENABLE_SENSOR_EDMA == 1)
-            edma_memcpy(buffer, dst16, src16, sizeof(uint16_t), sensor.transpose);
-            #else
-            if ((sensor.pixformat == PIXFORMAT_RGB565 && sensor.hw_flags.rgb_swap)
-                || (sensor.pixformat == PIXFORMAT_YUV422 && sensor.hw_flags.yuv_swap)) {
-                if (!sensor.transpose) {
-                    unaligned_memcpy_rev16(dst16, src16, MAIN_FB()->u);
+                #endif
+                break;
+            case PIXFORMAT_RGB565:
+            case PIXFORMAT_YUV422:
+                #if (OMV_ENABLE_SENSOR_EDMA == 1)
+                edma_memcpy(buffer, dst16, src16, sizeof(uint16_t), sensor.transpose);
+                #else
+                if ((sensor.pixformat == PIXFORMAT_RGB565 && sensor.hw_flags.rgb_swap)
+                    || (sensor.pixformat == PIXFORMAT_YUV422 && sensor.hw_flags.yuv_swap)) {
+                    if (!sensor.transpose) {
+                        unaligned_memcpy_rev16(dst16, src16, MAIN_FB()->u);
+                    } else {
+                        copy_line_rev(dst16, src16);
+                    }
                 } else {
-                    copy_line_rev(dst16, src16);
+                    if (!sensor.transpose) {
+                        unaligned_memcpy(dst16, src16, MAIN_FB()->u * sizeof(uint16_t));
+                    } else {
+                        copy_line(dst16, src16);
+                    }
                 }
-            } else {
-                if (!sensor.transpose) {
-                    unaligned_memcpy(dst16, src16, MAIN_FB()->u * sizeof(uint16_t));
-                } else {
-                    copy_line(dst16, src16);
-                }
-            }
-            #endif
-            break;
-        default:
-            break;
+                #endif
+                break;
+            default:
+                break;
+        }
     }
 
-    if (++buffer->offset == MAIN_FB()->v) {
+    if (++buffer->offset == resolution[sensor.framesize][1]) {
         // Release the current framebuffer.
         framebuffer_get_tail(FB_NO_FLAGS);
         CSI_REG_CR3(CSI) &= ~CSI_CR3_DMA_REQ_EN_RFF_MASK;


### PR DESCRIPTION
This PR adds all missing features to the IMX sensor driver.

set_windowing() now works.
set_framerate() now works.
Capturing 2592x1944 now works.
vsync callback now works.
frame callback now works.
I fixed the frame buffer memory allocations to use all 32 MB of SDRAM.
sensor.JPEG now works. 

Notably, thanks to the USB HS with sensor.JPEG mode you can stream JPEGs from the camera to the PC at the maximum FPS. E.g. you can move 1270x720 to the PC at 28 FPS and 1920x1080 at 10 FPS.

Fixes 1 in: https://github.com/openmv/openmv/issues/2079
 
I will work on getting the eMDA offload working after this PR is reviewed and merged.