### PR TITLE
misc: Use LD wrap for redirecting serial data to TinyUSB debug code.

### DIFF
--- a/src/omv/ports/mimxrt/omv_portconfig.mk
+++ b/src/omv/ports/mimxrt/omv_portconfig.mk
@@ -90,7 +90,8 @@ endif
 CFLAGS += $(HAL_CFLAGS) $(MPY_CFLAGS) $(OMV_CFLAGS)
 # Linker Flags
 LDFLAGS = -mcpu=$(CPU) -mabi=aapcs-linux -mthumb -mfpu=$(FPU) -mfloat-abi=hard -nostdlib \
-          -Wl,--print-memory-usage -Wl,--gc-sections -Wl,-T$(BUILD)/$(LDSCRIPT).lds
+          -Wl,--print-memory-usage -Wl,--gc-sections -Wl,-T$(BUILD)/$(LDSCRIPT).lds \
+          -Wl,--wrap=tud_cdc_rx_cb -Wl,--wrap=mp_hal_stdout_tx_strn
 
 #------------- Libraries ----------------#
 LIBS += $(TOP_DIR)/$(TENSORFLOW_DIR)/$(CPU)/libtf*.a

--- a/src/omv/ports/nrf/omv_portconfig.mk
+++ b/src/omv/ports/nrf/omv_portconfig.mk
@@ -64,7 +64,8 @@ CFLAGS += $(HAL_CFLAGS) $(MPY_CFLAGS) $(OMV_CFLAGS)
 
 # Linker Flags
 LDFLAGS = -mcpu=$(CPU) -mabi=aapcs-linux -mthumb -mfpu=$(FPU) -mfloat-abi=hard\
-          -nostdlib -Wl,--gc-sections -Wl,-T$(BUILD)/$(LDSCRIPT).lds
+          -nostdlib -Wl,--gc-sections -Wl,-T$(BUILD)/$(LDSCRIPT).lds \
+          -Wl,--wrap=tud_cdc_rx_cb -Wl,--wrap=mp_hal_stdout_tx_strn
 
 #------------- Libraries ----------------#
 LIBS += $(TOP_DIR)/$(TENSORFLOW_DIR)/$(CPU)/libtf*.a

--- a/src/omv/ports/rp2/omv_portconfig.cmake
+++ b/src/omv/ports/rp2/omv_portconfig.cmake
@@ -25,6 +25,11 @@ set(MICROPY_MANIFEST_OMV_LIB_DIR    ${TOP_DIR}/../scripts/libraries)
 # Include board cmake fragment
 include(${OMV_BOARD_CONFIG_DIR}/omv_boardconfig.cmake)
 
+target_link_options(${MICROPY_TARGET} PRIVATE
+    -Wl,--wrap=tud_cdc_rx_cb
+    -Wl,--wrap=mp_hal_stdout_tx_strn
+)
+
 target_compile_definitions(${MICROPY_TARGET} PRIVATE
     ARM_MATH_CM0PLUS
     ${OMV_BOARD_MODULES_DEFINITIONS}


### PR DESCRIPTION
Prior to this update, each port had to be patched to call TinyUSB debugging function. Now these wrappers will call the port's functions if debugging is not enabled.