### PR TITLE
ports/all: Allow sensor_abort() to be called from different contexts.

### DIFF
--- a/src/omv/common/sensor.h
+++ b/src/omv/common/sensor.h
@@ -299,7 +299,7 @@ int sensor_probe_init(uint32_t bus_id, uint32_t bus_speed);
 int sensor_dcmi_config(uint32_t pixformat);
 
 // Abort frame capture and disable IRQs, DMA etc..
-int sensor_abort();
+int sensor_abort(bool fifo_flush, bool in_irq);
 
 // Reset the sensor to its default state.
 int sensor_reset();

--- a/src/omv/common/sensor_utils.c
+++ b/src/omv/common/sensor_utils.c
@@ -164,7 +164,7 @@ __weak int sensor_reset() {
     }
 
     // Reset framebuffers
-    framebuffer_reset_buffers();
+    framebuffer_flush_buffers(true);
 
     return 0;
 }

--- a/src/omv/common/sensor_utils.c
+++ b/src/omv/common/sensor_utils.c
@@ -101,13 +101,13 @@ __weak int sensor_init() {
     return SENSOR_ERROR_CTL_UNSUPPORTED;
 }
 
-__weak int sensor_abort() {
+__weak int sensor_abort(bool fifo_flush, bool in_irq) {
     return SENSOR_ERROR_CTL_UNSUPPORTED;
 }
 
 __weak int sensor_reset() {
     // Disable any ongoing frame capture.
-    sensor_abort();
+    sensor_abort(true, false);
 
     // Reset the sensor state
     sensor.sde = 0;
@@ -472,7 +472,7 @@ __weak bool sensor_is_detected() {
 
 __weak int sensor_sleep(int enable) {
     // Disable any ongoing frame capture.
-    sensor_abort();
+    sensor_abort(true, false);
 
     // Check if the control is supported.
     if (sensor.sleep == NULL) {
@@ -491,7 +491,7 @@ __weak int sensor_shutdown(int enable) {
     int ret = 0;
 
     // Disable any ongoing frame capture.
-    sensor_abort();
+    sensor_abort(true, false);
 
     #if defined(DCMI_POWER_PIN)
     if (enable) {
@@ -568,7 +568,7 @@ __weak int sensor_set_pixformat(pixformat_t pixformat) {
     }
 
     // Disable any ongoing frame capture.
-    sensor_abort();
+    sensor_abort(true, false);
 
     // Flush previous frame.
     framebuffer_update_jpeg_buffer();
@@ -607,7 +607,7 @@ __weak int sensor_set_framesize(framesize_t framesize) {
     }
 
     // Disable any ongoing frame capture.
-    sensor_abort();
+    sensor_abort(true, false);
 
     // Flush previous frame.
     framebuffer_update_jpeg_buffer();
@@ -715,7 +715,7 @@ __weak int sensor_set_windowing(int x, int y, int w, int h) {
     }
 
     // Disable any ongoing frame capture.
-    sensor_abort();
+    sensor_abort(true, false);
 
     // Flush previous frame.
     framebuffer_update_jpeg_buffer();
@@ -945,7 +945,7 @@ __weak int sensor_set_hmirror(int enable) {
     }
 
     // Disable any ongoing frame capture.
-    sensor_abort();
+    sensor_abort(true, false);
 
     // Check if the control is supported.
     if (sensor.set_hmirror == NULL) {
@@ -979,7 +979,7 @@ __weak int sensor_set_vflip(int enable) {
     }
 
     // Disable any ongoing frame capture.
-    sensor_abort();
+    sensor_abort(true, false);
 
     // Check if the control is supported.
     if (sensor.set_vflip == NULL) {
@@ -1013,7 +1013,7 @@ __weak int sensor_set_transpose(bool enable) {
     }
 
     // Disable any ongoing frame capture.
-    sensor_abort();
+    sensor_abort(true, false);
 
     if (sensor.pixformat == PIXFORMAT_JPEG) {
         return SENSOR_ERROR_PIXFORMAT_UNSUPPORTED;
@@ -1036,7 +1036,7 @@ __weak int sensor_set_auto_rotation(bool enable) {
     }
 
     // Disable any ongoing frame capture.
-    sensor_abort();
+    sensor_abort(true, false);
 
     // Operation not supported on JPEG images.
     if (sensor.pixformat == PIXFORMAT_JPEG) {
@@ -1054,7 +1054,7 @@ __weak bool sensor_get_auto_rotation() {
 
 __weak int sensor_set_framebuffers(int count) {
     // Disable any ongoing frame capture.
-    sensor_abort();
+    sensor_abort(true, false);
 
     // Flush previous frame.
     framebuffer_update_jpeg_buffer();
@@ -1100,7 +1100,7 @@ __weak int sensor_set_lens_correction(int enable, int radi, int coef) {
 
 __weak int sensor_ioctl(int request, ... /* arg */) {
     // Disable any ongoing frame capture.
-    sensor_abort();
+    sensor_abort(true, false);
 
     // Check if the control is supported.
     if (sensor.ioctl == NULL) {

--- a/src/omv/imlib/framebuffer.c
+++ b/src/omv/imlib/framebuffer.c
@@ -274,20 +274,18 @@ vbuffer_t *framebuffer_get_buffer(int32_t index) {
     return (vbuffer_t *) (framebuffer->data + offset);
 }
 
-void framebuffer_flush_buffers() {
+void framebuffer_flush_buffers(bool fifo_flush) {
+    if (fifo_flush) {
+        // Drop all frame buffers.
+        for (int32_t i = 0; i < framebuffer->n_buffers; i++) {
+            memset(framebuffer_get_buffer(i), 0, sizeof(vbuffer_t));
+        }
+    }
     // Move the tail pointer to the head which empties the virtual fifo while keeping the same
     // position of the current frame for the rest of the code.
     framebuffer->tail = framebuffer->head;
     framebuffer->check_head = true;
     framebuffer->sampled_head = 0;
-}
-
-void framebuffer_reset_buffers() {
-    for (int32_t i = 0; i < framebuffer->n_buffers; i++) {
-        memset(framebuffer_get_buffer(i), 0, sizeof(vbuffer_t));
-    }
-
-    framebuffer_flush_buffers();
 }
 
 int framebuffer_set_buffers(int32_t n_buffers) {
@@ -307,7 +305,7 @@ int framebuffer_set_buffers(int32_t n_buffers) {
     framebuffer->n_buffers = n_buffers;
     framebuffer->head = 0;
 
-    framebuffer_reset_buffers();
+    framebuffer_flush_buffers(true);
 
     return 0;
 }

--- a/src/omv/imlib/framebuffer.h
+++ b/src/omv/imlib/framebuffer.h
@@ -101,11 +101,9 @@ void framebuffer_init_from_image(image_t *img);
 // if the src is JPEG and fits in the JPEG buffer, or encode and stream src image to the IDE if not.
 void framebuffer_update_jpeg_buffer();
 
-// Clears out all old captures frames in the framebuffer.
-void framebuffer_flush_buffers();
-
-// Resets all buffers (for use after aborting)
-void framebuffer_reset_buffers();
+// Clear the framebuffer FIFO. If fifo_flush is true, reset and discard all framebuffers,
+// otherwise, retain the last frame in the fifo.
+void framebuffer_flush_buffers(bool fifo_flush);
 
 // Controls the number of virtual buffers in the frame buffer.
 int framebuffer_set_buffers(int32_t n_buffers);

--- a/src/omv/ports/mimxrt/sensor.c
+++ b/src/omv/ports/mimxrt/sensor.c
@@ -49,7 +49,7 @@ static bool drop_frame = false;
     }
 
 void sensor_init0() {
-    sensor_abort();
+    sensor_abort(true, false);
 
     // Re-init I2C to reset the bus state after soft reset, which
     // could have interrupted the bus in the middle of a transfer.
@@ -151,7 +151,7 @@ int sensor_dcmi_config(uint32_t pixformat) {
     return 0;
 }
 
-int sensor_abort() {
+int sensor_abort(bool fifo_flush, bool in_irq) {
     NVIC_DisableIRQ(CSI_IRQn);
     CSI_DisableInterrupts(CSI, CSI_IRQ_FLAGS);
     CSI_REG_CR3(CSI) &= ~CSI_CR3_DMA_REQ_EN_RFF_MASK;
@@ -160,7 +160,11 @@ int sensor_abort() {
     drop_frame = false;
     sensor.last_frame_ms = 0;
     sensor.last_frame_ms_valid = false;
-    framebuffer_flush_buffers(true);
+    if (fifo_flush) {
+        framebuffer_flush_buffers(true);
+    } else if (!sensor.disable_full_flush) {
+        framebuffer_flush_buffers(false);
+    }
     return 0;
 }
 
@@ -191,18 +195,7 @@ void sensor_sof_callback() {
     // Get current framebuffer.
     vbuffer_t *buffer = framebuffer_get_tail(FB_PEEK);
     if (buffer == NULL) {
-        NVIC_DisableIRQ(CSI_IRQn);
-        CSI_DisableInterrupts(CSI, CSI_IRQ_FLAGS);
-        CSI_REG_CR3(CSI) &= ~CSI_CR3_DMA_REQ_EN_RFF_MASK;
-        CSI_REG_CR18(CSI) &= ~CSI_CR18_CSI_ENABLE_MASK;
-        first_line = false;
-        drop_frame = false;
-        sensor.last_frame_ms = 0;
-        sensor.last_frame_ms_valid = false;
-        // Reset the queue of frames when we start dropping frames.
-        if (!sensor.disable_full_flush) {
-            framebuffer_flush_buffers(false);
-        }
+        sensor_abort(false, true);
     } else if (buffer->offset < resolution[sensor.framesize][1]) {
         // Missed a few lines, reset buffer state and continue.
         buffer->reset_state = true;
@@ -443,7 +436,7 @@ int sensor_snapshot(sensor_t *sensor, image_t *image, uint32_t flags) {
     for (mp_uint_t ticks = mp_hal_ticks_ms(); buffer == NULL;) {
         MICROPY_EVENT_POLL_HOOK
         if ((mp_hal_ticks_ms() - ticks) > 3000) {
-            sensor_abort();
+            sensor_abort(true, false);
 
             #if defined(DCMI_FSYNC_PIN)
             if (sensor->hw_flags.fsync) {

--- a/src/omv/ports/rp2/sensor.c
+++ b/src/omv/ports/rp2/sensor.c
@@ -137,7 +137,7 @@ int sensor_init() {
     return 0;
 }
 
-int sensor_abort() {
+int sensor_abort(bool fifo_flush, bool in_irq) {
     // Disable DMA channel
     dma_channel_abort(DCMI_DMA_CHANNEL);
     dma_irqn_set_channel_enabled(DCMI_DMA, DCMI_DMA_CHANNEL, false);
@@ -249,7 +249,7 @@ int sensor_snapshot(sensor_t *sensor, image_t *image, uint32_t flags) {
     for (mp_uint_t ticks = mp_hal_ticks_ms(); buffer == NULL;) {
         buffer = framebuffer_get_head(FB_NO_FLAGS);
         if ((mp_hal_ticks_ms() - ticks) > 3000) {
-            sensor_abort();
+            sensor_abort(true, false);
             return SENSOR_ERROR_CAPTURE_TIMEOUT;
         }
     }

--- a/src/omv/ports/stm32/sensor.c
+++ b/src/omv/ports/stm32/sensor.c
@@ -250,7 +250,7 @@ int sensor_abort() {
         sensor.last_frame_ms_valid = false;
     }
 
-    framebuffer_reset_buffers();
+    framebuffer_flush_buffers(true);
 
     return 0;
 }
@@ -488,7 +488,7 @@ void DCMI_DMAConvCpltUser(uint32_t addr) {
         sensor.last_frame_ms_valid = false;
         // Reset the queue of frames when we start dropping frames.
         if (!sensor.disable_full_flush) {
-            framebuffer_flush_buffers();
+            framebuffer_flush_buffers(false);
         }
         return;
     }


### PR DESCRIPTION
This patch removes the duplicated `sensor_abort()` logic in the stm32 and mimxrt ports. This is done by adding a `flush_fifo` argument, which controls the flush operation, and a `in_irq` argument , which indicates whether `sensor_abort()` is called from within an IRQ context or not.
