### PR TITLE
ports: Minor sensor cleanup.

### DIFF
--- a/src/omv/common/sensor.h
+++ b/src/omv/common/sensor.h
@@ -14,6 +14,18 @@
 #include "omv_i2c.h"
 #include "imlib.h"
 
+#define copy_transposed_line(dstp, srcp)                   \
+    for (int i = MAIN_FB()->u, h = MAIN_FB()->v; i; i--) { \
+        *dstp = *srcp++;                                   \
+        dstp += h;                                         \
+    }
+
+#define copy_transposed_line_rev16(dstp, srcp)             \
+    for (int i = MAIN_FB()->u, h = MAIN_FB()->v; i; i--) { \
+        *dstp = __REV16(*srcp++);                          \
+        dstp += h;                                         \
+    }
+
 #define OV2640_SLV_ADDR         (0x60)
 #define OV5640_SLV_ADDR         (0x78)
 #define OV7725_SLV_ADDR         (0x42)

--- a/src/omv/common/sensor.h
+++ b/src/omv/common/sensor.h
@@ -252,6 +252,8 @@ typedef struct _sensor {
     pixformat_t pixformat;      // Pixel format
     framesize_t framesize;      // Frame size
     int framerate;              // Frame rate
+    bool first_line;            // Set to true when the first line of the frame is being read.
+    bool drop_frame;            // Set to true to drop the current frame.
     uint32_t last_frame_ms;     // Last sampled frame timestamp in milliseconds.
     bool last_frame_ms_valid;   // Last sampled frame timestamp in milliseconds valid.
     gainceiling_t gainceiling;  // AGC gainceiling

--- a/src/omv/common/sensor.h
+++ b/src/omv/common/sensor.h
@@ -204,10 +204,31 @@ typedef enum {
 
 // Bayer patterns.
 // NOTE: These must match the Bayer subformats in imlib.h
+//
+// BGGR matches the bayer pattern of BGBG... etc. coming out of the sensor.
+//                                   GRGR... etc.
+//
+// GBRG matches the bayer pattern of GBGB... etc. coming out of the sensor.
+//                                   RGRG... etc.
+//
+// GRBG matches the bayer pattern of GRGR... etc. coming out of the sensor.
+//                                   BGBG... etc.
+//
+// RGGB matches the bayer pattern of RGRG... etc. coming out of the sensor.
+//                                   GBGB... etc.
+//
 #define SENSOR_HW_FLAGS_BAYER_BGGR    (SUBFORMAT_ID_BGGR)
 #define SENSOR_HW_FLAGS_BAYER_GBRG    (SUBFORMAT_ID_GBRG)
 #define SENSOR_HW_FLAGS_BAYER_GRBG    (SUBFORMAT_ID_GRBG)
 #define SENSOR_HW_FLAGS_BAYER_RGGB    (SUBFORMAT_ID_RGGB)
+
+// YUV patterns.
+// NOTE: These must match the YUV subformats in imlib.h
+//
+// YUV422 matches the YUV pattern of YUYV... etc. coming out of the sensor.
+//
+// YVU422 matches the YUV pattern of YVYU... etc. coming out of the sensor.
+//
 #define SENSOR_HW_FLAGS_YUV422        (SUBFORMAT_ID_YUV422)
 #define SENSOR_HW_FLAGS_YVU422        (SUBFORMAT_ID_YVU422)
 

--- a/src/omv/common/sensor_utils.c
+++ b/src/omv/common/sensor_utils.c
@@ -114,6 +114,8 @@ __weak int sensor_reset() {
     sensor.pixformat = 0;
     sensor.framesize = 0;
     sensor.framerate = 0;
+    sensor.first_line = false;
+    sensor.drop_frame = false;
     sensor.last_frame_ms = 0;
     sensor.last_frame_ms_valid = false;
     sensor.gainceiling = 0;

--- a/src/omv/ports/mimxrt/sensor.c
+++ b/src/omv/ports/mimxrt/sensor.c
@@ -28,9 +28,6 @@
 sensor_t sensor = {};
 extern uint8_t _line_buf[OMV_LINE_BUF_SIZE];
 
-static bool first_line = false;
-static bool drop_frame = false;
-
 #define CSI_IRQ_FLAGS    (CSI_CR1_SOF_INTEN_MASK            \
                           | CSI_CR1_FB2_DMA_DONE_INTEN_MASK \
                           | CSI_CR1_FB1_DMA_DONE_INTEN_MASK)
@@ -144,8 +141,8 @@ int sensor_abort(bool fifo_flush, bool in_irq) {
     CSI_DisableInterrupts(CSI, CSI_IRQ_FLAGS);
     CSI_REG_CR3(CSI) &= ~CSI_CR3_DMA_REQ_EN_RFF_MASK;
     CSI_REG_CR18(CSI) &= ~CSI_CR18_CSI_ENABLE_MASK;
-    first_line = false;
-    drop_frame = false;
+    sensor.first_line = false;
+    sensor.drop_frame = false;
     sensor.last_frame_ms = 0;
     sensor.last_frame_ms_valid = false;
     if (fifo_flush) {
@@ -178,8 +175,8 @@ uint32_t sensor_get_xclk_frequency() {
 }
 
 void sensor_sof_callback() {
-    first_line = false;
-    drop_frame = false;
+    sensor.first_line = false;
+    sensor.drop_frame = false;
     // Get current framebuffer.
     vbuffer_t *buffer = framebuffer_get_tail(FB_PEEK);
     if (buffer == NULL) {
@@ -191,8 +188,8 @@ void sensor_sof_callback() {
 }
 
 void sensor_line_callback(uint32_t addr) {
-    if (!first_line) {
-        first_line = true;
+    if (!sensor.first_line) {
+        sensor.first_line = true;
         uint32_t tick = mp_hal_ticks_ms();
         uint32_t framerate_ms = IM_DIV(1000, sensor.framerate);
 
@@ -200,7 +197,7 @@ void sensor_line_callback(uint32_t addr) {
         // SRAM/SDRAM when dropping to save CPU cycles/energy that would be wasted.
         // If framerate is zero then this does nothing...
         if (sensor.last_frame_ms_valid && ((tick - sensor.last_frame_ms) < framerate_ms)) {
-            drop_frame = true;
+            sensor.drop_frame = true;
         } else if (sensor.last_frame_ms_valid) {
             sensor.last_frame_ms += framerate_ms;
         } else {
@@ -213,7 +210,7 @@ void sensor_line_callback(uint32_t addr) {
     vbuffer_t *buffer = framebuffer_get_tail(FB_PEEK);
 
     if (sensor.pixformat == PIXFORMAT_JPEG) {
-        if (drop_frame) {
+        if (sensor.drop_frame) {
             return;
         }
         bool jpeg_end = false;
@@ -260,12 +257,12 @@ void sensor_line_callback(uint32_t addr) {
             if (sensor.frame_callback) {
                 sensor.frame_callback();
             }
-            drop_frame = true;
+            sensor.drop_frame = true;
         }
         return;
     }
 
-    if (drop_frame) {
+    if (sensor.drop_frame) {
         if (++buffer->offset == resolution[sensor.framesize][1]) {
             buffer->offset = 0;
             CSI_REG_CR3(CSI) &= ~CSI_CR3_DMA_REQ_EN_RFF_MASK;

--- a/src/omv/ports/mimxrt/sensor.c
+++ b/src/omv/ports/mimxrt/sensor.c
@@ -36,18 +36,6 @@ static bool drop_frame = false;
                           | CSI_CR1_FB1_DMA_DONE_INTEN_MASK)
 //CSI_CR1_RF_OR_INTEN_MASK
 
-#define copy_line(dstp, srcp)                              \
-    for (int i = MAIN_FB()->u, h = MAIN_FB()->v; i; i--) { \
-        *dstp = *srcp++;                                   \
-        dstp += h;                                         \
-    }
-
-#define copy_line_rev(dstp, srcp)                          \
-    for (int i = MAIN_FB()->u, h = MAIN_FB()->v; i; i--) { \
-        *dstp = __REV16(*srcp++);                          \
-        dstp += h;                                         \
-    }
-
 void sensor_init0() {
     sensor_abort(true, false);
 
@@ -315,7 +303,7 @@ void sensor_line_callback(uint32_t addr) {
                 if (!sensor.transpose) {
                     unaligned_memcpy(dst, src, MAIN_FB()->u);
                 } else {
-                    copy_line(dst, src);
+                    copy_transposed_line(dst, src);
                 }
                 #endif
                 break;
@@ -328,14 +316,14 @@ void sensor_line_callback(uint32_t addr) {
                     if (!sensor.transpose) {
                         unaligned_memcpy(dst, src, MAIN_FB()->u);
                     } else {
-                        copy_line(dst, src);
+                        copy_transposed_line(dst, src);
                     }
                 } else {
                     // Extract Y channel from YUV.
                     if (!sensor.transpose) {
                         unaligned_2_to_1_memcpy(dst, src16, MAIN_FB()->u);
                     } else {
-                        copy_line(dst, src16);
+                        copy_transposed_line(dst, src16);
                     }
                 }
                 #endif
@@ -350,13 +338,13 @@ void sensor_line_callback(uint32_t addr) {
                     if (!sensor.transpose) {
                         unaligned_memcpy_rev16(dst16, src16, MAIN_FB()->u);
                     } else {
-                        copy_line_rev(dst16, src16);
+                        copy_transposed_line_rev16(dst16, src16);
                     }
                 } else {
                     if (!sensor.transpose) {
                         unaligned_memcpy(dst16, src16, MAIN_FB()->u * sizeof(uint16_t));
                     } else {
-                        copy_line(dst16, src16);
+                        copy_transposed_line(dst16, src16);
                     }
                 }
                 #endif

--- a/src/omv/ports/stm32/sensor.c
+++ b/src/omv/ports/stm32/sensor.c
@@ -41,9 +41,6 @@ static MDMA_HandleTypeDef DCMI_MDMA_Handle1;
 SPI_HandleTypeDef ISC_SPIHandle = {.Instance = ISC_SPI};
 #endif // ISC_SPI
 
-static bool first_line = false;
-static bool drop_frame = false;
-
 extern uint8_t _line_buf;
 extern uint32_t hal_get_exti_gpio(uint32_t line);
 
@@ -249,8 +246,8 @@ int sensor_abort(bool fifo_flush, bool in_irq) {
         #endif
         __HAL_DCMI_DISABLE_IT(&DCMIHandle, DCMI_IT_FRAME);
         __HAL_DCMI_CLEAR_FLAG(&DCMIHandle, DCMI_FLAG_FRAMERI);
-        first_line = false;
-        drop_frame = false;
+        sensor.first_line = false;
+        sensor.drop_frame = false;
         sensor.last_frame_ms = 0;
         sensor.last_frame_ms_valid = false;
     }
@@ -407,9 +404,9 @@ void HAL_DCMI_FrameEventCallback(DCMI_HandleTypeDef *hdcmi) {
     #endif
 
     // Reset DCMI_DMAConvCpltUser frame drop state.
-    first_line = false;
-    if (drop_frame) {
-        drop_frame = false;
+    sensor.first_line = false;
+    if (sensor.drop_frame) {
+        sensor.drop_frame = false;
         return;
     }
 
@@ -429,7 +426,7 @@ static void mdma_memcpy(vbuffer_t *buffer, void *dst, void *src, int bpp, bool t
 
     // Drop the frame if MDMA is not keeping up as the image will be corrupt.
     if (handle->Instance->CCR & MDMA_CCR_EN) {
-        drop_frame = true;
+        sensor.drop_frame = true;
         return;
     }
 
@@ -449,8 +446,8 @@ static void mdma_memcpy(vbuffer_t *buffer, void *dst, void *src, int bpp, bool t
 // with a pointer to the line buffer that was used. At this point the
 // DMA transfers the next line to the other half of the line buffer.
 void DCMI_DMAConvCpltUser(uint32_t addr) {
-    if (!first_line) {
-        first_line = true;
+    if (!sensor.first_line) {
+        sensor.first_line = true;
         uint32_t tick = HAL_GetTick();
         uint32_t framerate_ms = IM_DIV(1000, sensor.framerate);
 
@@ -458,7 +455,7 @@ void DCMI_DMAConvCpltUser(uint32_t addr) {
         // SRAM/SDRAM when dropping to save CPU cycles/energy that would be wasted.
         // If framerate is zero then this does nothing...
         if (sensor.last_frame_ms_valid && ((tick - sensor.last_frame_ms) < framerate_ms)) {
-            drop_frame = true;
+            sensor.drop_frame = true;
         } else if (sensor.last_frame_ms_valid) {
             sensor.last_frame_ms += framerate_ms;
         } else {
@@ -467,7 +464,7 @@ void DCMI_DMAConvCpltUser(uint32_t addr) {
         }
     }
 
-    if (drop_frame) {
+    if (sensor.drop_frame) {
         // If we're dropping a frame in full offload mode it's safe to disable this interrupt saving
         // ourselves from having to service the DMA complete callback.
         #if defined(OMV_MDMA_CHANNEL_DCMI_0)

--- a/src/omv/ports/stm32/sensor.c
+++ b/src/omv/ports/stm32/sensor.c
@@ -596,10 +596,7 @@ void DCMI_DMAConvCpltUser(uint32_t addr) {
             if (!sensor.transpose) {
                 unaligned_memcpy(dst, src, MAIN_FB()->u);
             } else {
-                for (int i = MAIN_FB()->u, h = MAIN_FB()->v; i; i--) {
-                    *dst = *src++;
-                    dst += h;
-                }
+                copy_transposed_line(dst, src);
             }
             #endif
             break;
@@ -612,20 +609,14 @@ void DCMI_DMAConvCpltUser(uint32_t addr) {
                 if (!sensor.transpose) {
                     unaligned_memcpy(dst, src, MAIN_FB()->u);
                 } else {
-                    for (int i = MAIN_FB()->u, h = MAIN_FB()->v; i; i--) {
-                        *dst = *src++;
-                        dst += h;
-                    }
+                    copy_transposed_line(dst, src);
                 }
             } else {
                 // Extract Y channel from YUV.
                 if (!sensor.transpose) {
                     unaligned_2_to_1_memcpy(dst, src16, MAIN_FB()->u);
                 } else {
-                    for (int i = MAIN_FB()->u, h = MAIN_FB()->v; i; i--) {
-                        *dst = *src16++;
-                        dst += h;
-                    }
+                    copy_transposed_line(dst, src16);
                 }
             }
             #endif
@@ -640,19 +631,13 @@ void DCMI_DMAConvCpltUser(uint32_t addr) {
                 if (!sensor.transpose) {
                     unaligned_memcpy_rev16(dst16, src16, MAIN_FB()->u);
                 } else {
-                    for (int i = MAIN_FB()->u, h = MAIN_FB()->v; i; i--) {
-                        *dst16 = __REV16(*src16++);
-                        dst16 += h;
-                    }
+                    copy_transposed_line_rev16(dst16, src16);
                 }
             } else {
                 if (!sensor.transpose) {
                     unaligned_memcpy(dst16, src16, MAIN_FB()->u * sizeof(uint16_t));
                 } else {
-                    for (int i = MAIN_FB()->u, h = MAIN_FB()->v; i; i--) {
-                        *dst16 = *src16++;
-                        dst16 += h;
-                    }
+                    copy_transposed_line(dst16, src16);
                 }
             }
             #endif


### PR DESCRIPTION
There's an opportunity for more cleanup to move the:

```
    sensor.first_line = false;
    sensor.drop_frame = false;
    sensor.last_frame_ms = 0;
    sensor.last_frame_ms_valid = false;
    if (fifo_flush) {
        framebuffer_flush_buffers(true);
    } else if (!sensor.disable_full_flush) {
        framebuffer_flush_buffers(false);
    }
```

Into a function and also:

```
if (!sensor.first_line) {
    sensor.first_line = true;
    uint32_t tick = mp_hal_ticks_ms();
    uint32_t framerate_ms = IM_DIV(1000, sensor.framerate);

    // Drops frames to match the frame rate requested by the user. The frame is NOT copied to
    // SRAM/SDRAM when dropping to save CPU cycles/energy that would be wasted.
    // If framerate is zero then this does nothing...
    if (sensor.last_frame_ms_valid && ((tick - sensor.last_frame_ms) < framerate_ms)) {
        sensor.drop_frame = true;
    } else if (sensor.last_frame_ms_valid) {
        sensor.last_frame_ms += framerate_ms;
    } else {
        sensor.last_frame_ms = tick;
        sensor.last_frame_ms_valid = true;
    }
}
```

Into a function too in sensor_utils.c. I can do this if you'd like. This will remove duplicate code in stm32 and mimxrt.
