### PR TITLE
ports/all: Refactor sensor line copy.

### DIFF
--- a/src/omv/boards/ARDUINO_GIGA/omv_boardconfig.h
+++ b/src/omv/boards/ARDUINO_GIGA/omv_boardconfig.h
@@ -31,6 +31,9 @@
 // Enable hardware JPEG
 #define OMV_HARDWARE_JPEG                   (1)
 
+// Enable fast line transfer with DMA.
+#define OMA_ENABLE_DMA_MEMCPY               (1)
+
 // MDMA configuration
 #define OMV_MDMA_CHANNEL_DCMI_0             (0)
 #define OMV_MDMA_CHANNEL_DCMI_1             (1)

--- a/src/omv/boards/ARDUINO_NICLA_VISION/omv_boardconfig.h
+++ b/src/omv/boards/ARDUINO_NICLA_VISION/omv_boardconfig.h
@@ -35,6 +35,9 @@
 // Enable hardware JPEG
 #define OMV_HARDWARE_JPEG                     (1)
 
+// Enable fast line transfer with DMA.
+#define OMA_ENABLE_DMA_MEMCPY                 (1)
+
 // MDMA configuration
 #define OMV_MDMA_CHANNEL_DCMI_0               (0)
 #define OMV_MDMA_CHANNEL_DCMI_1               (1)

--- a/src/omv/boards/ARDUINO_PORTENTA_H7/omv_boardconfig.h
+++ b/src/omv/boards/ARDUINO_PORTENTA_H7/omv_boardconfig.h
@@ -31,6 +31,9 @@
 // Enable hardware JPEG
 #define OMV_HARDWARE_JPEG                   (1)
 
+// Enable fast line transfer with DMA.
+#define OMA_ENABLE_DMA_MEMCPY               (1)
+
 // MDMA configuration
 #define OMV_MDMA_CHANNEL_DCMI_0             (0)
 #define OMV_MDMA_CHANNEL_DCMI_1             (1)

--- a/src/omv/boards/OPENMV4/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4/omv_boardconfig.h
@@ -45,6 +45,9 @@
 // Enable hardware JPEG
 #define OMV_HARDWARE_JPEG                     (1)
 
+// Enable fast line transfer with DMA.
+#define OMA_ENABLE_DMA_MEMCPY                 (1)
+
 // MDMA configuration
 #define OMV_MDMA_CHANNEL_DCMI_0               (0)
 #define OMV_MDMA_CHANNEL_DCMI_1               (1)

--- a/src/omv/boards/OPENMV4P/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4P/omv_boardconfig.h
@@ -45,6 +45,9 @@
 // Enable hardware JPEG
 #define OMV_HARDWARE_JPEG                     (1)
 
+// Enable fast line transfer with DMA.
+#define OMA_ENABLE_DMA_MEMCPY                 (1)
+
 // MDMA configuration
 #define OMV_MDMA_CHANNEL_DCMI_0               (0)
 #define OMV_MDMA_CHANNEL_DCMI_1               (1)

--- a/src/omv/boards/OPENMV4_PRO/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4_PRO/omv_boardconfig.h
@@ -30,6 +30,9 @@
 // Enable hardware JPEG
 #define OMV_HARDWARE_JPEG                     (1)
 
+// Enable fast line transfer with DMA.
+#define OMA_ENABLE_DMA_MEMCPY                 (1)
+
 // MDMA configuration
 #define OMV_MDMA_CHANNEL_DCMI_0               (0)
 #define OMV_MDMA_CHANNEL_DCMI_1               (1)

--- a/src/omv/boards/OPENMVPT/omv_boardconfig.h
+++ b/src/omv/boards/OPENMVPT/omv_boardconfig.h
@@ -45,6 +45,9 @@
 // Enable hardware JPEG
 #define OMV_HARDWARE_JPEG                          (1)
 
+// Enable fast line transfer with DMA.
+#define OMA_ENABLE_DMA_MEMCPY                      (1)
+
 // MDMA configuration
 #define OMV_MDMA_CHANNEL_DCMI_0                    (0)
 #define OMV_MDMA_CHANNEL_DCMI_1                    (1)

--- a/src/omv/common/sensor.h
+++ b/src/omv/common/sensor.h
@@ -14,18 +14,6 @@
 #include "omv_i2c.h"
 #include "imlib.h"
 
-#define copy_transposed_line(dstp, srcp)                   \
-    for (int i = MAIN_FB()->u, h = MAIN_FB()->v; i; i--) { \
-        *dstp = *srcp++;                                   \
-        dstp += h;                                         \
-    }
-
-#define copy_transposed_line_rev16(dstp, srcp)             \
-    for (int i = MAIN_FB()->u, h = MAIN_FB()->v; i; i--) { \
-        *dstp = __REV16(*srcp++);                          \
-        dstp += h;                                         \
-    }
-
 #define OV2640_SLV_ADDR         (0x60)
 #define OV5640_SLV_ADDR         (0x78)
 #define OV7725_SLV_ADDR         (0x42)
@@ -483,6 +471,10 @@ int sensor_check_framebuffer_size();
 
 // Auto-crop frame buffer until it fits in RAM (may switch pixel format to BAYER).
 int sensor_auto_crop_framebuffer();
+
+// Copy a single line buffer to its destination. The copying process is
+// DMA-accelerated, if available, and falls back to slow software if not.
+int sensor_copy_line(void *dma, uint8_t *src, uint8_t *dst);
 
 // Default snapshot function.
 int sensor_snapshot(sensor_t *sensor, image_t *image, uint32_t flags);


### PR DESCRIPTION
Note `sensor_dma_memcpy` can be moved to `omv_dma_memcpy` in `omv_dma.h` and implemented in `omv_dma.c` in each port, if it makes sense to make it generic.