### PR TITLE
misc: Refactor board config files.

### DIFF
--- a/src/drivers/lepton/src/LEPTON_I2C_Service.c
+++ b/src/drivers/lepton/src/LEPTON_I2C_Service.c
@@ -68,7 +68,7 @@
 /** INCLUDE FILES                                                            **/
 /******************************************************************************/
 #include "omv_boardconfig.h"
-#if ((OMV_ENABLE_LEPTON == 1) || (OMV_ENABLE_FIR_LEPTON == 1))
+#if ((OMV_LEPTON_ENABLE == 1) || (OMV_FIR_LEPTON_ENABLE == 1))
 
 #include "LEPTON_Types.h"
 #include "LEPTON_ErrorCodes.h"
@@ -232,4 +232,4 @@ LEP_RESULT LEP_I2C_MasterStatus(omv_i2c_t *bus,
     return(result);
 }
 
-#endif // ((OMV_ENABLE_LEPTON == 1) || (OMV_ENABLE_FIR_LEPTON == 1))
+#endif // ((OMV_LEPTON_ENABLE == 1) || (OMV_FIR_LEPTON_ENABLE == 1))

--- a/src/drivers/pixart/src/pixspi.c
+++ b/src/drivers/pixart/src/pixspi.c
@@ -10,7 +10,7 @@
  * Pixart SPI driver.
  */
 #include "omv_boardconfig.h"
-#ifdef ISC_SPI_ID
+#ifdef OMV_CSI_SPI_ID
 
 #include <stdio.h>
 #include <string.h>
@@ -80,7 +80,7 @@ static int spi_send_recv(uint8_t *txbuf, uint8_t *rxbuf, uint16_t len) {
 bool pixspi_init() {
     // Init SPI
     omv_spi_config_t spi_config;
-    omv_spi_default_config(&spi_config, ISC_SPI_ID);
+    omv_spi_default_config(&spi_config, OMV_CSI_SPI_ID);
 
     spi_config.baudrate = 5000000;
     spi_config.nss_enable = false;  // Soft NSS

--- a/src/drivers/vl53l5cx/src/platform.c
+++ b/src/drivers/vl53l5cx/src/platform.c
@@ -10,7 +10,7 @@
  */
 
 #include "omv_boardconfig.h"
-#if (OMV_ENABLE_TOF_VL53L5CX == 1)
+#if (OMV_TOF_VL53L5CX_ENABLE == 1)
 
 #include "py/mphal.h"
 #include "omv_i2c.h"
@@ -112,4 +112,4 @@ uint8_t WaitMs(VL53L5CX_Platform *platform, uint32_t ms)
     mp_hal_delay_ms(ms);
     return 0;
 }
-#endif // #if (OMV_ENABLE_TOF_VL53L5CX == 1)
+#endif // #if (OMV_TOF_VL53L5CX_ENABLE == 1)

--- a/src/drivers/winc1500/src/nm_bsp.c
+++ b/src/drivers/winc1500/src/nm_bsp.c
@@ -27,11 +27,11 @@ sint8 nm_bsp_init(void) {
     gpfIsr = NULL;
 
     // Configure GPIO pins
-    omv_gpio_config(WINC_EN_PIN, OMV_GPIO_MODE_OUTPUT, OMV_GPIO_PULL_UP, OMV_GPIO_SPEED_LOW, -1);
-    omv_gpio_write(WINC_EN_PIN, 1);
+    omv_gpio_config(OMV_WINC_EN_PIN, OMV_GPIO_MODE_OUTPUT, OMV_GPIO_PULL_UP, OMV_GPIO_SPEED_LOW, -1);
+    omv_gpio_write(OMV_WINC_EN_PIN, 1);
 
-    omv_gpio_config(WINC_RST_PIN, OMV_GPIO_MODE_OUTPUT, OMV_GPIO_PULL_UP, OMV_GPIO_SPEED_LOW, -1);
-    omv_gpio_write(WINC_RST_PIN, 1);
+    omv_gpio_config(OMV_WINC_RST_PIN, OMV_GPIO_MODE_OUTPUT, OMV_GPIO_PULL_UP, OMV_GPIO_SPEED_LOW, -1);
+    omv_gpio_write(OMV_WINC_RST_PIN, 1);
 
     // Perform chip reset.
     nm_bsp_reset();
@@ -40,12 +40,12 @@ sint8 nm_bsp_init(void) {
 }
 
 void nm_bsp_reset(void) {
-    omv_gpio_write(WINC_EN_PIN, 0);
-    omv_gpio_write(WINC_RST_PIN, 0);
+    omv_gpio_write(OMV_WINC_EN_PIN, 0);
+    omv_gpio_write(OMV_WINC_RST_PIN, 0);
     nm_bsp_sleep(100);
-    omv_gpio_write(WINC_EN_PIN, 1);
+    omv_gpio_write(OMV_WINC_EN_PIN, 1);
     nm_bsp_sleep(100);
-    omv_gpio_write(WINC_RST_PIN, 1);
+    omv_gpio_write(OMV_WINC_RST_PIN, 1);
     nm_bsp_sleep(100);
 }
 
@@ -61,11 +61,11 @@ static void nm_bsp_extint_callback(void *data) {
 
 void nm_bsp_register_isr(tpfNmBspIsr pfIsr) {
     gpfIsr = pfIsr;
-    omv_gpio_config(WINC_IRQ_PIN, OMV_GPIO_MODE_IT_FALL, OMV_GPIO_PULL_UP, OMV_GPIO_SPEED_LOW, -1);
-    omv_gpio_irq_register(WINC_IRQ_PIN, nm_bsp_extint_callback, NULL);
-    omv_gpio_irq_enable(WINC_IRQ_PIN, true);
+    omv_gpio_config(OMV_WINC_IRQ_PIN, OMV_GPIO_MODE_IT_FALL, OMV_GPIO_PULL_UP, OMV_GPIO_SPEED_LOW, -1);
+    omv_gpio_irq_register(OMV_WINC_IRQ_PIN, nm_bsp_extint_callback, NULL);
+    omv_gpio_irq_enable(OMV_WINC_IRQ_PIN, true);
 }
 
 void nm_bsp_interrupt_ctrl(uint8 enable) {
-    omv_gpio_irq_enable(WINC_IRQ_PIN, enable);
+    omv_gpio_irq_enable(OMV_WINC_IRQ_PIN, enable);
 }

--- a/src/drivers/winc1500/src/nm_bus_wrapper.c
+++ b/src/drivers/winc1500/src/nm_bus_wrapper.c
@@ -36,9 +36,9 @@ sint8 nm_bus_init(void *pvinit) {
 	sint8 result = M2M_SUCCESS;
 
     omv_spi_config_t spi_config;
-    omv_spi_default_config(&spi_config, WINC_SPI_ID);
+    omv_spi_default_config(&spi_config, OMV_WINC_SPI_ID);
 
-    spi_config.baudrate    = WINC_SPI_BAUDRATE;
+    spi_config.baudrate    = OMV_WINC_SPI_BAUDRATE;
     spi_config.nss_enable  = false; // Soft NSS
 
     if (omv_spi_init(&spi_bus, &spi_config) != 0) {

--- a/src/omv/boards/ARDUINO_GIGA/omv_boardconfig.h
+++ b/src/omv/boards/ARDUINO_GIGA/omv_boardconfig.h
@@ -1,8 +1,8 @@
 /*
  * This file is part of the OpenMV project.
  *
- * Copyright (c) 2023 Ibrahim Abdelkader <iabdalkader@openmv.io>
- * Copyright (c) 2023 Kwabena W. Agyeman <kwagyeman@openmv.io>
+ * Copyright (c) 2013-2024 Ibrahim Abdelkader <iabdalkader@openmv.io>
+ * Copyright (c) 2013-2024 Kwabena W. Agyeman <kwagyeman@openmv.io>
  *
  * This work is licensed under the MIT license, see the file LICENSE for details.
  *
@@ -11,88 +11,38 @@
 #ifndef __OMV_BOARDCONFIG_H__
 #define __OMV_BOARDCONFIG_H__
 
-// Architecture info
-#define OMV_ARCH_STR                        "GIGA H7 8192 SDRAM"    // 33 chars max
+// Board info
+#define OMV_BOARD_ARCH                      "GIGA H7 8192 SDRAM"    // 33 chars max
 #define OMV_BOARD_TYPE                      "H7"
-#define OMV_UNIQUE_ID_ADDR                  0x1FF1E800    // Unique ID address.
-#define OMV_UNIQUE_ID_SIZE                  3       // Unique ID size in words.
-#define OMV_UNIQUE_ID_OFFSET                4       // Bytes offset for multi-word UIDs.
+#define OMV_BOARD_UID_ADDR                  0x1FF1E800  // Unique ID address.
+#define OMV_BOARD_UID_SIZE                  3           // Unique ID size in words.
+#define OMV_BOARD_UID_OFFSET                4           // Bytes offset for multi-word UIDs.
 
-#define OMV_XCLK_MCO                        (0U)
-#define OMV_XCLK_TIM                        (1U)
-#define OMV_XCLK_OSC                        (2U)
+// JPEG configuration.
+#define OMV_JPEG_CODEC_ENABLE               (1)
+#define OMV_JPEG_QUALITY_LOW                50
+#define OMV_JPEG_QUALITY_HIGH               90
+#define OMV_JPEG_QUALITY_THRESHOLD          (320 * 240 * 2)
 
-// Sensor external clock source.
-#define OMV_XCLK_SOURCE                     (OMV_XCLK_TIM)
-
-// Sensor external clock timer frequency.
-#define OMV_XCLK_FREQUENCY                  (12000000)
-
-// Enable hardware JPEG
-#define OMV_HARDWARE_JPEG                   (1)
-
-// Enable fast line transfer with DMA.
-#define OMA_ENABLE_DMA_MEMCPY               (1)
-
-// MDMA configuration
-#define OMV_MDMA_CHANNEL_DCMI_0             (0)
-#define OMV_MDMA_CHANNEL_DCMI_1             (1)
-#define OMV_MDMA_CHANNEL_JPEG_IN            (7) // in has a lower pri than out
-#define OMV_MDMA_CHANNEL_JPEG_OUT           (6) // out has a higher pri than in
-
-// OV5640 sensor settings
-#define OMV_OV5640_XCLK_FREQ                (12000000)
+// Image sensor drivers configuration.
+#define OMV_OV5640_ENABLE                   (1)
+#define OMV_OV5640_AF_ENABLE                (1)
 #define OMV_OV5640_PLL_CTRL2                (0x90)
 #define OMV_OV5640_PLL_CTRL3                (0x13)
+#define OMV_OV5640_XCLK_FREQ                (12000000)
 
-// Enable additional GPIO banks.
-#define OMV_ENABLE_GPIO_BANK_F              (1)
-#define OMV_ENABLE_GPIO_BANK_G              (1)
-#define OMV_ENABLE_GPIO_BANK_H              (1)
-#define OMV_ENABLE_GPIO_BANK_I              (1)
-#define OMV_ENABLE_GPIO_BANK_J              (1)
-#define OMV_ENABLE_GPIO_BANK_K              (1)
-
-// Enable sensor drivers
-#define OMV_ENABLE_OV2640                   (0)
-#define OMV_ENABLE_OV5640                   (1)
-#define OMV_ENABLE_OV7670                   (1)
-#define OMV_ENABLE_OV7690                   (0)
-#define OMV_ENABLE_OV7725                   (0)
-#define OMV_ENABLE_OV9650                   (0)
-#define OMV_ENABLE_MT9M114                  (0)
-#define OMV_ENABLE_MT9V0XX                  (0)
-#define OMV_ENABLE_LEPTON                   (0)
-#define OMV_ENABLE_HM01B0                   (0)
-#define OMV_ENABLE_PAJ6100                  (0)
-#define OMV_ENABLE_FROGEYE2020              (0)
-#define OMV_ENABLE_FIR_MLX90621             (1)
-#define OMV_ENABLE_FIR_MLX90640             (1)
-#define OMV_ENABLE_FIR_MLX90641             (1)
-#define OMV_ENABLE_FIR_AMG8833              (1)
-#define OMV_ENABLE_FIR_LEPTON               (0)
-
-// Set which OV767x sensor is used
+#define OMV_OV7670_ENABLE                   (1)
 #define OMV_OV7670_VERSION                  (75)
-
-// OV7670 clock divider
 #define OMV_OV7670_CLKRC                    (0)
 
-// Enable sensor features
-#define OMV_ENABLE_OV5640_AF                (1)
+// FIR sensor drivers configuration.
+#define OMV_FIR_MLX90621_ENABLE             (1)
+#define OMV_FIR_MLX90640_ENABLE             (1)
+#define OMV_FIR_MLX90641_ENABLE             (1)
+#define OMV_FIR_AMG8833_ENABLE              (1)
+#define OMV_FIR_LEPTON_ENABLE               (0)
 
-// Enable WiFi debug
-#define OMV_ENABLE_WIFIDBG                  (0)
-
-// If buffer size is bigger than this threshold, the quality is reduced.
-// This is only used for JPEG images sent to the IDE not normal compression.
-#define JPEG_QUALITY_THRESH                 (320 * 240 * 2)
-
-// Low and high JPEG QS.
-#define JPEG_QUALITY_LOW                    50
-#define JPEG_QUALITY_HIGH                   90
-
-// FB Heap Block Size
+// UMM heap block size
 #define OMV_UMM_BLOCK_SIZE                  256
 
 // USB IRQn.
@@ -219,84 +169,92 @@
 #define OMV_DMA_REGION_D3_BASE              (OMV_SRAM4_ORIGIN + (16 * 1024))
 #define OMV_DMA_REGION_D3_SIZE              MPU_REGION_SIZE_4KB
 
+// MDMA configuration
+#define OMV_MDMA_CHANNEL_DCMI_0             (0)
+#define OMV_MDMA_CHANNEL_DCMI_1             (1)
+#define OMV_MDMA_CHANNEL_JPEG_IN            (7) // in has a lower pri than out
+#define OMV_MDMA_CHANNEL_JPEG_OUT           (6) // out has a higher pri than in
+
 // AXI QoS - Low-High (0:15) - default 0
 #define OMV_AXI_QOS_MDMA_R_PRI              15
 #define OMV_AXI_QOS_MDMA_W_PRI              15
 #define OMV_AXI_QOS_LTDC_R_PRI              14
-//#define OMV_AXI_QOS_DMA2D_R_PRI             14
-//#define OMV_AXI_QOS_DMA2D_W_PRI             14
+
+// Enable additional GPIO ports.
+#define OMV_GPIO_PORT_F_ENABLE              (1)
+#define OMV_GPIO_PORT_G_ENABLE              (1)
+#define OMV_GPIO_PORT_H_ENABLE              (1)
+#define OMV_GPIO_PORT_I_ENABLE              (1)
+#define OMV_GPIO_PORT_J_ENABLE              (1)
+#define OMV_GPIO_PORT_K_ENABLE              (1)
 
 // Image sensor I2C
-#define ISC_I2C_ID                          (4)
-#define ISC_I2C_SPEED                       (OMV_I2C_SPEED_STANDARD)
+#define OMV_CSI_I2C_ID                      (4)
+#define OMV_CSI_I2C_SPEED                   (OMV_I2C_SPEED_STANDARD)
 
 // FIR I2C
-#define FIR_I2C_ID                          (1)
-#define FIR_I2C_SPEED                       (OMV_I2C_SPEED_STANDARD)
+#define OMV_FIR_I2C_ID                      (1)
+#define OMV_FIR_I2C_SPEED                   (OMV_I2C_SPEED_STANDARD)
 
-// Soft I2C bus.
-///#define SOFT_I2C_SIOC_PIN                   (&omv_pin_B10_GPIO)
-///#define SOFT_I2C_SIOD_PIN                   (&omv_pin_B11_GPIO)
-///#define SOFT_I2C_SPIN_DELAY                 64
+// Camera Interface
+#define OMV_CSI_XCLK_SOURCE                 (XCLK_SOURCE_TIM)
+#define OMV_CSI_XCLK_FREQUENCY              (12000000)
+#define OMV_CSI_TIM                         (TIM1)
+#define OMV_CSI_TIM_PIN                     (&omv_pin_J9_TIM1)
+#define OMV_CSI_TIM_CHANNEL                 (TIM_CHANNEL_3)
+#define OMV_CSI_TIM_CLK_ENABLE()            __TIM1_CLK_ENABLE()
+#define OMV_CSI_TIM_CLK_DISABLE()           __TIM1_CLK_DISABLE()
+#define OMV_CSI_TIM_PCLK_FREQ()             HAL_RCC_GetPCLK2Freq()
+#define OMV_CSI_DMA_MEMCPY_ENABLE           (1)
 
-// DCMI timer.
-#define DCMI_TIM                            (TIM1)
-#define DCMI_TIM_PIN                        (&omv_pin_J9_TIM1)
-#define DCMI_TIM_CHANNEL                    (TIM_CHANNEL_3)
-#define DCMI_TIM_CLK_ENABLE()               __TIM1_CLK_ENABLE()
-#define DCMI_TIM_CLK_DISABLE()              __TIM1_CLK_DISABLE()
-#define DCMI_TIM_PCLK_FREQ()                HAL_RCC_GetPCLK2Freq()
+#define OMV_CSI_D0_PIN                      (&omv_pin_H9_DCMI)
+#define OMV_CSI_D1_PIN                      (&omv_pin_H10_DCMI)
+#define OMV_CSI_D2_PIN                      (&omv_pin_H11_DCMI)
+#define OMV_CSI_D3_PIN                      (&omv_pin_G11_DCMI)
+#define OMV_CSI_D4_PIN                      (&omv_pin_H14_DCMI)
+#define OMV_CSI_D5_PIN                      (&omv_pin_I4_DCMI)
+#define OMV_CSI_D6_PIN                      (&omv_pin_I6_DCMI)
+#define OMV_CSI_D7_PIN                      (&omv_pin_I7_DCMI)
 
-// DCMI pins.
-//#define DCMI_RESET_PIN                      (&omv_pin_A1_GPIO)
-#define DCMI_POWER_PIN                      (&omv_pin_D4_GPIO)
-
-#define DCMI_D0_PIN                         (&omv_pin_H9_DCMI)
-#define DCMI_D1_PIN                         (&omv_pin_H10_DCMI)
-#define DCMI_D2_PIN                         (&omv_pin_H11_DCMI)
-#define DCMI_D3_PIN                         (&omv_pin_G11_DCMI)
-#define DCMI_D4_PIN                         (&omv_pin_H14_DCMI)
-#define DCMI_D5_PIN                         (&omv_pin_I4_DCMI)
-#define DCMI_D6_PIN                         (&omv_pin_I6_DCMI)
-#define DCMI_D7_PIN                         (&omv_pin_I7_DCMI)
-
-#define DCMI_HSYNC_PIN                      (&omv_pin_H8_DCMI)
-#define DCMI_VSYNC_PIN                      (&omv_pin_I5_DCMI)
-#define DCMI_PXCLK_PIN                      (&omv_pin_A6_DCMI)
+#define OMV_CSI_HSYNC_PIN                   (&omv_pin_H8_DCMI)
+#define OMV_CSI_VSYNC_PIN                   (&omv_pin_I5_DCMI)
+#define OMV_CSI_PXCLK_PIN                   (&omv_pin_A6_DCMI)
+//#define OMV_CSI_RESET_PIN                   (&omv_pin_A1_GPIO)
+#define OMV_CSI_POWER_PIN                   (&omv_pin_D4_GPIO)
 
 // Physical I2C buses.
 // I2C bus 1
-#define I2C1_ID                             (1)
-#define I2C1_SCL_PIN                        (&omv_pin_B8_I2C1)
-#define I2C1_SDA_PIN                        (&omv_pin_B9_I2C1)
+#define OMV_I2C1_ID                         (1)
+#define OMV_I2C1_SCL_PIN                    (&omv_pin_B8_I2C1)
+#define OMV_I2C1_SDA_PIN                    (&omv_pin_B9_I2C1)
 
 // I2C bus 4
-#define I2C4_ID                             (4)
-#define I2C4_SCL_PIN                        (&omv_pin_B6_I2C4)
-#define I2C4_SDA_PIN                        (&omv_pin_H12_I2C4)
+#define OMV_I2C4_ID                         (4)
+#define OMV_I2C4_SCL_PIN                    (&omv_pin_B6_I2C4)
+#define OMV_I2C4_SDA_PIN                    (&omv_pin_H12_I2C4)
 
 // DFSDM1
-#define AUDIO_DFSDM                         (DFSDM1_Channel0)
-#define AUDIO_DFSDM_CHANNEL                 (DFSDM_CHANNEL_0)
+#define OMV_DFSDM                           (DFSDM1_Channel0)
+#define OMV_DFSDM_CHANNEL                   (DFSDM_CHANNEL_0)
 // DFSDM output clock is derived from the Aclk (set in SAI1SEL[2:0])
 // for SAI1 and DFSDM1, which is clocked from PLL1Q by default (48MHz).
-#define AUDIO_DFSDM_FREQMHZ                 (48)
-#define AUDIO_MAX_CHANNELS                  (1) // Maximum number of channels.
+#define OMV_DFSDM_FREQMHZ                   (48)
+#define OMV_AUDIO_MAX_CHANNELS              (1) // Maximum number of channels.
 
-#define AUDIO_DFSDM_CK_PIN                  (&omv_pin_D3_DFSDM1)
-#define AUDIO_DFSDM_D1_PIN                  (&omv_pin_C1_DFSDM1)
+#define OMV_DFSDM_CK_PIN                    (&omv_pin_D3_DFSDM1)
+#define OMV_DFSDM_D1_PIN                    (&omv_pin_C1_DFSDM1)
 
-#define AUDIO_DFSDM_FLT0                    DFSDM1_Filter0
-#define AUDIO_DFSDM_FLT0_IRQ                DFSDM1_FLT0_IRQn
-#define AUDIO_DFSDM_FLT0_IRQHandler         DFSDM1_FLT0_IRQHandler
-#define AUDIO_DFSDM_FLT0_DMA_STREAM         DMA1_Stream1
-#define AUDIO_DFSDM_FLT0_DMA_REQUEST        DMA_REQUEST_DFSDM1_FLT0
-#define AUDIO_DFSDM_FLT0_DMA_IRQ            DMA1_Stream1_IRQn
-#define AUDIO_DFSDM_FLT0_DMA_IRQHandler     DMA1_Stream1_IRQHandler
+#define OMV_DFSDM_FLT0                      DFSDM1_Filter0
+#define OMV_DFSDM_FLT0_IRQ                  DFSDM1_FLT0_IRQn
+#define OMV_DFSDM_FLT0_IRQHandler           DFSDM1_FLT0_IRQHandler
+#define OMV_DFSDM_FLT0_DMA_STREAM           DMA1_Stream1
+#define OMV_DFSDM_FLT0_DMA_REQUEST          DMA_REQUEST_DFSDM1_FLT0
+#define OMV_DFSDM_FLT0_DMA_IRQ              DMA1_Stream1_IRQn
+#define OMV_DFSDM_FLT0_DMA_IRQHandler       DMA1_Stream1_IRQHandler
 
-#define AUDIO_DFSDM_CLK_ENABLE()            __HAL_RCC_DFSDM1_CLK_ENABLE()
-#define AUDIO_DFSDM_CLK_DISABLE()           __HAL_RCC_DFSDM1_CLK_DISABLE()
-#define AUDIO_DFSDM_DMA_CLK_ENABLE()        __HAL_RCC_DMA1_CLK_ENABLE()
+#define OMV_DFSDM_CLK_ENABLE()              __HAL_RCC_DFSDM1_CLK_ENABLE()
+#define OMV_DFSDM_CLK_DISABLE()             __HAL_RCC_DFSDM1_CLK_DISABLE()
+#define OMV_DFSDM_DMA_CLK_ENABLE()          __HAL_RCC_DMA1_CLK_ENABLE()
 
 // LCD Interface
 #define OMV_RGB_DISPLAY_CONTROLLER          (LTDC)

--- a/src/omv/boards/ARDUINO_NANO_33_BLE_SENSE/omv_boardconfig.h
+++ b/src/omv/boards/ARDUINO_NANO_33_BLE_SENSE/omv_boardconfig.h
@@ -1,8 +1,8 @@
 /*
  * This file is part of the OpenMV project.
  *
- * Copyright (c) 2013-2021 Ibrahim Abdelkader <iabdalkader@openmv.io>
- * Copyright (c) 2013-2021 Kwabena W. Agyeman <kwagyeman@openmv.io>
+ * Copyright (c) 2013-2024 Ibrahim Abdelkader <iabdalkader@openmv.io>
+ * Copyright (c) 2013-2024 Kwabena W. Agyeman <kwagyeman@openmv.io>
  *
  * This work is licensed under the MIT license, see the file LICENSE for details.
  *
@@ -12,68 +12,34 @@
 #define __OMV_BOARDCONFIG_H__
 
 // Architecture info
-#define OMV_ARCH_STR               "NANO33 M4" // 33 chars max
+#define OMV_BOARD_ARCH             "NANO33 M4"  // 33 chars max
 #define OMV_BOARD_TYPE             "NANO33"
-#define OMV_UNIQUE_ID_ADDR         0x10000060 // Unique ID address.
-#define OMV_UNIQUE_ID_SIZE         2        // Unique ID size in words.
-#define OMV_UNIQUE_ID_OFFSET       4        // Bytes offset for multi-word UIDs.
+#define OMV_BOARD_UID_ADDR         0x10000060   // Unique ID address.
+#define OMV_BOARD_UID_SIZE         2            // Unique ID size in words.
+#define OMV_BOARD_UID_OFFSET       4            // Bytes offset for multi-word UIDs.
 
-#define OMV_XCLK_MCO               (0U)
-#define OMV_XCLK_TIM               (1U)
+// JPEG configuration.
+#define OMV_JPEG_CODEC_ENABLE      (0)
+#define OMV_JPEG_QUALITY_LOW       50
+#define OMV_JPEG_QUALITY_HIGH      90
+#define OMV_JPEG_QUALITY_THRESHOLD (320 * 240)
 
-// Sensor external clock source.
-#define OMV_XCLK_SOURCE            (OMV_XCLK_TIM)
-
-// Sensor external clock timer frequency.
-#define OMV_XCLK_FREQUENCY         (12000000)
-
-// Enable hardware JPEG
-#define OMV_HARDWARE_JPEG          (0)
-
-// Enable sensor drivers
-#define OMV_ENABLE_OV2640          (0)
-#define OMV_ENABLE_OV5640          (0)
-#define OMV_ENABLE_OV7670          (1)
-#define OMV_ENABLE_OV7690          (0)
-#define OMV_ENABLE_OV7725          (0)
-#define OMV_ENABLE_OV9650          (0)
-#define OMV_ENABLE_MT9M114         (0)
-#define OMV_ENABLE_MT9V0XX         (0)
-#define OMV_ENABLE_LEPTON          (0)
-#define OMV_ENABLE_HM01B0          (0)
-#define OMV_ENABLE_PAJ6100         (0)
-#define OMV_ENABLE_FROGEYE2020     (0)
-
-// FIR Module
-#define OMV_ENABLE_FIR_MLX90621    (1)
-#define OMV_ENABLE_FIR_MLX90640    (1)
-#define OMV_ENABLE_FIR_MLX90641    (1)
-#define OMV_ENABLE_FIR_AMG8833     (1)
-#define OMV_ENABLE_FIR_LEPTON      (0)
-
-// Set which OV767x sensor is used
+// Image sensor drivers configuration.
+#define OMV_OV7670_ENABLE          (1)
 #define OMV_OV7670_VERSION         (75)
-
-// OV7670 clock divider
 #define OMV_OV7670_CLKRC           (2)
 
-// Enable sensor features
-#define OMV_ENABLE_OV5640_AF       (0)
+// FIR sensor drivers configuration.
+#define OMV_FIR_MLX90621_ENABLE    (1)
+#define OMV_FIR_MLX90640_ENABLE    (1)
+#define OMV_FIR_MLX90641_ENABLE    (1)
+#define OMV_FIR_AMG8833_ENABLE     (1)
 
-// Enable WiFi debug
-#define OMV_ENABLE_WIFIDBG         (0)
-#define OMV_ENABLE_TUSBDBG         (1)
+// Debugging configuration.
+#define OMV_TUSBDBG_ENABLE         (1)
 #define OMV_TUSBDBG_PACKET         (64)
 
-// If buffer size is bigger than this threshold, the quality is reduced.
-// This is only used for JPEG images sent to the IDE not normal compression.
-#define JPEG_QUALITY_THRESH        (320 * 240)
-
-// Low and high JPEG QS.
-#define JPEG_QUALITY_LOW           50
-#define JPEG_QUALITY_HIGH          90
-
-// FB Heap Block Size
+// UMM heap block size
 #define OMV_UMM_BLOCK_SIZE         16
 
 // USB IRQn.
@@ -101,50 +67,46 @@
 #define OMV_SRAM_LENGTH            240K     // RAM_SIZE - SD_RAM_SIZE
 
 // FIR I2C
-#define FIR_I2C_ID                 (0)
-#define FIR_I2C_SCL_PIN            (2)
-#define FIR_I2C_SDA_PIN            (31)
-#define FIR_I2C_SPEED              (OMV_I2C_SPEED_FULL)
+#define OMV_FIR_I2C_ID             (0)
+#define OMV_FIR_I2C_SPEED          (OMV_I2C_SPEED_FULL)
 
 // ISC I2C
-#define ISC_I2C_ID                 (0)
-#define ISC_I2C_SCL_PIN            (2)
-#define ISC_I2C_SDA_PIN            (31)
-#define ISC_I2C_SPEED              (OMV_I2C_SPEED_STANDARD)
+#define OMV_CSI_I2C_ID             (0)
+#define OMV_CSI_I2C_SPEED          (OMV_I2C_SPEED_STANDARD)
 
 // I2C0
-#define TWI0_ID                    (0)
-#define TWI0_SCL_PIN               (2)
-#define TWI0_SDA_PIN               (31)
-#define TWI0_SPEED                 (OMV_I2C_SPEED_FULL)
+#define OMV_I2C0_ID                (0)
+#define OMV_I2C0_SCL_PIN           (2)
+#define OMV_I2C0_SDA_PIN           (31)
 
 // I2C1
-#define TWI1_ID                    (1)
-#define TWI1_SCL_PIN               (15)
-#define TWI1_SDA_PIN               (14)
-#define TWI1_SPEED                 (OMV_I2C_SPEED_FULL)
+#define OMV_I2C1_ID                (1)
+#define OMV_I2C1_SCL_PIN           (15)
+#define OMV_I2C1_SDA_PIN           (14)
 
 // PDM/MIC
-#define PDM_DIN_PIN                (25)
-#define PDM_CLK_PIN                (26)
-#define PDM_PWR_PIN                (17)
+#define OMV_PDM_DIN_PIN            (25)
+#define OMV_PDM_CLK_PIN            (26)
+#define OMV_PDM_PWR_PIN            (17)
 
-// DCMI
-#define DCMI_POWER_PIN             (29)
-#define DCMI_RESET_PIN             (30)
+// Camera interface.
+#define OMV_CSI_XCLK_SOURCE        (XCLK_SOURCE_TIM)
+#define OMV_CSI_XCLK_FREQUENCY     (12000000)
 
-#define DCMI_D0_PIN                (32 + 2)
-#define DCMI_D1_PIN                (32 + 3)
-#define DCMI_D2_PIN                (32 + 10)
-#define DCMI_D3_PIN                (32 + 11)
-#define DCMI_D4_PIN                (32 + 12)
-#define DCMI_D5_PIN                (32 + 13)
-#define DCMI_D6_PIN                (32 + 14)
-#define DCMI_D7_PIN                (32 + 15)
+#define OMV_CSI_D0_PIN             (32 + 2)
+#define OMV_CSI_D1_PIN             (32 + 3)
+#define OMV_CSI_D2_PIN             (32 + 10)
+#define OMV_CSI_D3_PIN             (32 + 11)
+#define OMV_CSI_D4_PIN             (32 + 12)
+#define OMV_CSI_D5_PIN             (32 + 13)
+#define OMV_CSI_D6_PIN             (32 + 14)
+#define OMV_CSI_D7_PIN             (32 + 15)
 
-#define DCMI_VSYNC_PIN             (21)
-#define DCMI_HSYNC_PIN             (5)
-#define DCMI_PXCLK_PIN             (4)
-#define DCMI_XCLK_PIN              (27)
+#define OMV_CSI_VSYNC_PIN          (21)
+#define OMV_CSI_HSYNC_PIN          (5)
+#define OMV_CSI_PXCLK_PIN          (4)
+#define OMV_CSI_MXCLK_PIN          (27)
+#define OMV_CSI_POWER_PIN          (29)
+#define OMV_CSI_RESET_PIN          (30)
 
 #endif //__OMV_BOARDCONFIG_H__

--- a/src/omv/boards/ARDUINO_NANO_RP2040_CONNECT/dcmi.pio
+++ b/src/omv/boards/ARDUINO_NANO_RP2040_CONNECT/dcmi.pio
@@ -78,33 +78,33 @@ int sensor_dcmi_config(uint32_t pixformat)
     uint offset;
     pio_sm_config config;
 
-    pio_sm_set_enabled(DCMI_PIO, DCMI_SM, false);
-    pio_sm_clear_fifos(DCMI_PIO, DCMI_SM);
+    pio_sm_set_enabled(OMV_CSI_PIO, OMV_CSI_SM, false);
+    pio_sm_clear_fifos(OMV_CSI_PIO, OMV_CSI_SM);
 
-    for(uint i=DCMI_D0_PIN; i<DCMI_D0_PIN+7; i++) {
-        pio_gpio_init(DCMI_PIO, i);
+    for(uint i=OMV_CSI_D0_PIN; i<OMV_CSI_D0_PIN+7; i++) {
+        pio_gpio_init(OMV_CSI_PIO, i);
     }
-    pio_sm_set_consecutive_pindirs(DCMI_PIO, DCMI_SM, DCMI_D0_PIN, 7, false);
+    pio_sm_set_consecutive_pindirs(OMV_CSI_PIO, OMV_CSI_SM, OMV_CSI_D0_PIN, 7, false);
 
     if (pixformat == PIXFORMAT_GRAYSCALE) {
-        offset = pio_add_program(DCMI_PIO, &dcmi_odd_byte_program);
+        offset = pio_add_program(OMV_CSI_PIO, &dcmi_odd_byte_program);
         config = dcmi_odd_byte_program_get_default_config(offset);
     } else {
-        offset = pio_add_program(DCMI_PIO, &dcmi_default_program);
+        offset = pio_add_program(OMV_CSI_PIO, &dcmi_default_program);
         config = dcmi_default_program_get_default_config(offset);
     }
 
     sm_config_set_clkdiv(&config, 1);
-    sm_config_set_in_pins(&config, DCMI_D0_PIN);
+    sm_config_set_in_pins(&config, OMV_CSI_D0_PIN);
 
-    gpio_init(DCMI_D7_PIN);
-    gpio_set_dir(DCMI_D7_PIN, GPIO_IN);
-    sm_config_set_jmp_pin(&config, DCMI_D7_PIN);
+    gpio_init(OMV_CSI_D7_PIN);
+    gpio_set_dir(OMV_CSI_D7_PIN, GPIO_IN);
+    sm_config_set_jmp_pin(&config, OMV_CSI_D7_PIN);
 
     sm_config_set_in_shift(&config, true, true, 32);
 
-    pio_sm_init(DCMI_PIO, DCMI_SM, offset, &config);
-    pio_sm_set_enabled(DCMI_PIO, DCMI_SM, true);
+    pio_sm_init(OMV_CSI_PIO, OMV_CSI_SM, offset, &config);
+    pio_sm_set_enabled(OMV_CSI_PIO, OMV_CSI_SM, true);
     return 0;
 }
 %}

--- a/src/omv/boards/ARDUINO_NANO_RP2040_CONNECT/omv_boardconfig.h
+++ b/src/omv/boards/ARDUINO_NANO_RP2040_CONNECT/omv_boardconfig.h
@@ -1,8 +1,8 @@
 /*
  * This file is part of the OpenMV project.
  *
- * Copyright (c) 2013-2021 Ibrahim Abdelkader <iabdalkader@openmv.io>
- * Copyright (c) 2013-2021 Kwabena W. Agyeman <kwagyeman@openmv.io>
+ * Copyright (c) 2013-2024 Ibrahim Abdelkader <iabdalkader@openmv.io>
+ * Copyright (c) 2013-2024 Kwabena W. Agyeman <kwagyeman@openmv.io>
  *
  * This work is licensed under the MIT license, see the file LICENSE for details.
  *
@@ -12,70 +12,33 @@
 #define __OMV_BOARDCONFIG_H__
 
 // Architecture info
-#define OMV_ARCH_STR               "PICO M0" // 33 chars max
+#define OMV_BOARD_ARCH             "PICO M0" // 33 chars max
 #define OMV_BOARD_TYPE             "PICO"
-
 #ifndef LINKER_SCRIPT
-extern unsigned char *OMV_UNIQUE_ID_ADDR;   // Unique address.
+extern unsigned char *OMV_BOARD_UID_ADDR;    // Unique address.
 #endif
-#define OMV_UNIQUE_ID_SIZE         2        // Unique ID size in words.
-#define OMV_UNIQUE_ID_OFFSET       4        // Bytes offset for multi-word UIDs.
+#define OMV_BOARD_UID_SIZE         2         // Unique ID size in words.
+#define OMV_BOARD_UID_OFFSET       4         // Bytes offset for multi-word UIDs.
 
+// JPEG configuration.
+#define OMV_JPEG_CODEC_ENABLE      (0)
+#define OMV_JPEG_QUALITY_LOW       (35)
+#define OMV_JPEG_QUALITY_HIGH      (60)
+#define OMV_JPEG_QUALITY_THRESHOLD (160 * 120)
 
-#define OMV_XCLK_MCO               (0U)
-#define OMV_XCLK_TIM               (1U)
-
-// Sensor external clock source.
-#define OMV_XCLK_SOURCE            (OMV_XCLK_TIM)
-
-// Sensor external clock timer frequency.
-// TODO Not actually used right now, frequency is hardcoded.
-#define OMV_XCLK_FREQUENCY         (12500000)
-
-// Enable hardware JPEG
-#define OMV_HARDWARE_JPEG          (0)
-
-// Enable sensor drivers
-#define OMV_ENABLE_OV2640          (0)
-#define OMV_ENABLE_OV5640          (0)
-#define OMV_ENABLE_OV7670          (1)
-#define OMV_ENABLE_OV7690          (0)
-#define OMV_ENABLE_OV7725          (0)
-#define OMV_ENABLE_OV9650          (0)
-#define OMV_ENABLE_MT9V0XX         (0)
-#define OMV_ENABLE_LEPTON          (0)
-#define OMV_ENABLE_HM01B0          (0)
-
-// Set which OV767x sensor is used
+// Image sensor drivers configuration.
+#define OMV_OV7670_ENABLE          (1)
 #define OMV_OV7670_VERSION         (70)
-
-// OV7670 clock divider
 #define OMV_OV7670_CLKRC           (0x00)
 
-// FIR Module
-#define OMV_ENABLE_FIR_MLX90621    (0)
-#define OMV_ENABLE_FIR_MLX90640    (0)
-#define OMV_ENABLE_FIR_MLX90641    (0)
-#define OMV_ENABLE_FIR_AMG8833     (1)
-#define OMV_ENABLE_FIR_LEPTON      (0)
+// FIR sensor drivers configuration.
+#define OMV_FIR_AMG8833_ENABLE     (1)
 
-// Enable sensor features
-#define OMV_ENABLE_OV5640_AF       (0)
-
-// Enable WiFi debug
-#define OMV_ENABLE_WIFIDBG         (0)
-#define OMV_ENABLE_TUSBDBG         (1)
+// Debugging configuration.
+#define OMV_TUSBDBG_ENABLE         (1)
 #define OMV_TUSBDBG_PACKET         (64)
 
-// If buffer size is bigger than this threshold, the quality is reduced.
-// This is only used for JPEG images sent to the IDE not normal compression.
-#define JPEG_QUALITY_THRESH        (160 * 120)
-
-// Low and high JPEG QS.
-#define JPEG_QUALITY_LOW           35
-#define JPEG_QUALITY_HIGH          60
-
-// FB Heap Block Size
+// UMM heap block size
 #define OMV_UMM_BLOCK_SIZE         16
 
 // USB IRQn.
@@ -94,74 +57,66 @@ extern unsigned char *OMV_UNIQUE_ID_ADDR;   // Unique address.
 #define OMV_JPEG_BUF_SIZE          (20 * 1024) // IDE JPEG buffer (header + data).
 
 // GP LED
-#define LED_PIN                    (6)
+#define OMV_LED_PIN                (6)
 
 // FIR I2C
-#define FIR_I2C_ID                 (0)
-#define FIR_I2C_SCL_PIN            (13)
-#define FIR_I2C_SDA_PIN            (12)
-#define FIR_I2C_SPEED              (OMV_I2C_SPEED_FULL)
+#define OMV_FIR_I2C_ID             (0)
+#define OMV_FIR_I2C_SPEED          (OMV_I2C_SPEED_FULL)
 
 // ISC I2C
-#define ISC_I2C_ID                 (0)
-#define ISC_I2C_SCL_PIN            (13)
-#define ISC_I2C_SDA_PIN            (12)
-#define ISC_I2C_SPEED              (OMV_I2C_SPEED_STANDARD)
+#define OMV_CSI_I2C_ID             (0)
+#define OMV_CSI_I2C_SPEED          (OMV_I2C_SPEED_STANDARD)
 
 // I2C0
-#define I2C0_ID                    (0)
-#define I2C0_SCL_PIN               (13)
-#define I2C0_SDA_PIN               (12)
-#define I2C0_SPEED                 (OMV_I2C_SPEED_FULL)
+#define OMV_I2C0_ID                (0)
+#define OMV_I2C0_SCL_PIN           (13)
+#define OMV_I2C0_SDA_PIN           (12)
 
 // I2C1
-#define I2C1_ID                    (1)
-#define I2C1_SCL_PIN               (27)
-#define I2C1_SDA_PIN               (26)
-#define I2C1_SPEED                 (OMV_I2C_SPEED_FULL)
+#define OMV_I2C1_ID                (1)
+#define OMV_I2C1_SCL_PIN           (27)
+#define OMV_I2C1_SDA_PIN           (26)
 
 // LCD config.
-#define LCD_SPI                    (spi0)
-#define LCD_CS_PIN                 (5)
-#define LCD_MOSI_PIN               (7)
-#define LCD_SCLK_PIN               (6)
-#define LCD_RST_PIN                (4)
-#define LCD_RS_PIN                 (0)
+#define OMV_LCD_SPI                (spi0)
+#define OMV_LCD_CS_PIN             (5)
+#define OMV_LCD_MOSI_PIN           (7)
+#define OMV_LCD_SCLK_PIN           (6)
+#define OMV_LCD_RST_PIN            (4)
+#define OMV_LCD_RS_PIN             (0)
 
 // AUDIO config.
-#define PDM_PIO                    (pio1)
-#define PDM_SM                     (0)
-#define PDM_DMA                    (1)
-#define PDM_DMA_IRQ                (DMA_IRQ_1)
-#define PDM_DMA_CHANNEL            (0)
+#define OMV_PDM_PIO                (pio1)
+#define OMV_PDM_SM                 (0)
+#define OMV_PDM_DMA                (1)
+#define OMV_PDM_DMA_IRQ            (DMA_IRQ_1)
+#define OMV_PDM_DMA_CHANNEL        (0)
+#define OMV_PDM_CLK_PIN            (23)
+#define OMV_PDM_DIN_PIN            (22)
 
-#define PDM_CLK_PIN                (23)
-#define PDM_DIN_PIN                (22)
+// Camera interface
+#define OMV_CSI_PIO                (pio0)
+#define OMV_CSI_SM                 (0)
+#define OMV_CSI_DMA                (0)
+#define OMV_CSI_DMA_IRQ            (DMA_IRQ_0)
+#define OMV_CSI_DMA_CHANNEL        (0)
+#define OMV_CSI_XCLK_SOURCE        (XCLK_SOURCE_TIM)
+#define OMV_CSI_XCLK_FREQUENCY     (12500000)
 
-// DCMI config.
-#define DCMI_PIO                   (pio0)
-#define DCMI_SM                    (0)
-#define DCMI_DMA                   (0)
-#define DCMI_DMA_IRQ               (DMA_IRQ_0)
-#define DCMI_DMA_CHANNEL           (0)
+#define OMV_CSI_D0_PIN             (15)
+#define OMV_CSI_D1_PIN             (16)
+#define OMV_CSI_D2_PIN             (17)
+#define OMV_CSI_D3_PIN             (18)
+#define OMV_CSI_D4_PIN             (19)
+#define OMV_CSI_D5_PIN             (20)
+#define OMV_CSI_D6_PIN             (21)
+#define OMV_CSI_D7_PIN             (25) // MSB is read separately.
 
-#define DCMI_POWER_PIN             (0)
-#define DCMI_RESET_PIN             (1)
-
-#define DCMI_D0_PIN                (15)
-#define DCMI_D1_PIN                (16)
-#define DCMI_D2_PIN                (17)
-#define DCMI_D3_PIN                (18)
-#define DCMI_D4_PIN                (19)
-#define DCMI_D5_PIN                (20)
-#define DCMI_D6_PIN                (21)
-#define DCMI_D7_PIN                (25) // MSB is read separately.
-
-#define DCMI_XCLK_PIN              (28)
-
-// Must match the pins defined in dcmi.pio.
-#define DCMI_PXCLK_PIN             (29)
-#define DCMI_HSYNC_PIN             (27)
-#define DCMI_VSYNC_PIN             (26)
+#define OMV_CSI_HSYNC_PIN          (27)
+#define OMV_CSI_VSYNC_PIN          (26)
+#define OMV_CSI_PXCLK_PIN          (29)
+#define OMV_CSI_MXCLK_PIN          (28)
+#define OMV_CSI_POWER_PIN          (0)
+#define OMV_CSI_RESET_PIN          (1)
 
 #endif //__OMV_BOARDCONFIG_H__

--- a/src/omv/boards/ARDUINO_NICLA_VISION/omv_boardconfig.h
+++ b/src/omv/boards/ARDUINO_NICLA_VISION/omv_boardconfig.h
@@ -12,77 +12,30 @@
 #define __OMV_BOARDCONFIG_H__
 
 // Architecture info
-#define OMV_ARCH_STR                          "NICLAV H7 1024" // 33 chars max
+#define OMV_BOARD_ARCH                        "NICLAV H7 1024"  // 33 chars max
 #define OMV_BOARD_TYPE                        "NICLAV"
-#define OMV_UNIQUE_ID_ADDR                    0x1FF1E800 // Unique ID address.
-#define OMV_UNIQUE_ID_SIZE                    3 // Unique ID size in words.
-#define OMV_UNIQUE_ID_OFFSET                  4 // Bytes offset for multi-word UIDs.
+#define OMV_BOARD_UID_ADDR                    0x1FF1E800    // Unique ID address.
+#define OMV_BOARD_UID_SIZE                    3             // Unique ID size in words.
+#define OMV_BOARD_UID_OFFSET                  4             // Bytes offset for multi-word UIDs.
 
+// JPEG configuration.
+#define OMV_JPEG_CODEC_ENABLE                 (1)
+#define OMV_JPEG_QUALITY_LOW                  (50)
+#define OMV_JPEG_QUALITY_HIGH                 (90)
+#define OMV_JPEG_QUALITY_THRESHOLD            (320 * 240 * 2)
 
-#define OMV_XCLK_MCO                          (0U)
-#define OMV_XCLK_TIM                          (1U)
-#define OMV_XCLK_OSC                          (2U)
-
-// Sensor external clock source
-#define OMV_XCLK_SOURCE                       (OMV_XCLK_TIM)
-
-// Sensor external clock timer frequency
-#define OMV_XCLK_FREQUENCY                    (12000000)
-
-// GC4145 Sensor Settings
+// Image sensor drivers configuration.
+#define OMV_GC2145_ENABLE                     (1)
 #define OMV_GC2145_ROTATE                     (1)
 
-// Enable hardware JPEG
-#define OMV_HARDWARE_JPEG                     (1)
+// FIR sensor drivers configuration.
+#define OMV_FIR_MLX90621_ENABLE               (1)
+#define OMV_FIR_MLX90640_ENABLE               (1)
+#define OMV_FIR_MLX90641_ENABLE               (1)
+#define OMV_FIR_AMG8833_ENABLE                (1)
+#define OMV_FIR_LEPTON_ENABLE                 (1)
 
-// Enable fast line transfer with DMA.
-#define OMA_ENABLE_DMA_MEMCPY                 (1)
-
-// MDMA configuration
-#define OMV_MDMA_CHANNEL_DCMI_0               (0)
-#define OMV_MDMA_CHANNEL_DCMI_1               (1)
-#define OMV_MDMA_CHANNEL_JPEG_IN              (7) // in has a lower pri than out
-#define OMV_MDMA_CHANNEL_JPEG_OUT             (6) // out has a higher pri than in
-
-// Enable additional GPIO banks
-#define OMV_ENABLE_GPIO_BANK_F                (1)
-#define OMV_ENABLE_GPIO_BANK_G                (1)
-#define OMV_ENABLE_GPIO_BANK_H                (1)
-#define OMV_ENABLE_GPIO_BANK_I                (1)
-#define OMV_ENABLE_GPIO_BANK_J                (1)
-#define OMV_ENABLE_GPIO_BANK_K                (1)
-
-// Configure image sensor drivers
-#define OMV_ENABLE_OV2640                     (0)
-#define OMV_ENABLE_OV5640                     (0)
-#define OMV_ENABLE_OV7690                     (1)
-#define OMV_ENABLE_OV7725                     (0)
-#define OMV_ENABLE_OV9650                     (0)
-#define OMV_ENABLE_MT9V0XX                    (0)
-#define OMV_ENABLE_MT9M114                    (0)
-#define OMV_ENABLE_LEPTON                     (0)
-#define OMV_ENABLE_HM01B0                     (0)
-#define OMV_ENABLE_GC2145                     (1)
-
-// Configure FIR sensors drivers
-#define OMV_ENABLE_FIR_MLX90621               (1)
-#define OMV_ENABLE_FIR_MLX90640               (1)
-#define OMV_ENABLE_FIR_MLX90641               (1)
-#define OMV_ENABLE_FIR_AMG8833                (1)
-#define OMV_ENABLE_FIR_LEPTON                 (1)
-
-// Enable WiFi debug
-#define OMV_ENABLE_WIFIDBG                    (0)
-
-// If buffer size is bigger than this threshold, the quality is reduced.
-// This is only used for JPEG images sent to the IDE not normal compression.
-#define JPEG_QUALITY_THRESH                   (320 * 240 * 2)
-
-// Low and high JPEG QS.
-#define JPEG_QUALITY_LOW                      50
-#define JPEG_QUALITY_HIGH                     90
-
-// FB Heap Block Size
+// UMM heap block size
 #define OMV_UMM_BLOCK_SIZE                    16
 
 // USB IRQn.
@@ -213,22 +166,36 @@
 #define OMV_DMA_REGION_D3_BASE                (OMV_SRAM4_ORIGIN + (16 * 1024))
 #define OMV_DMA_REGION_D3_SIZE                MPU_REGION_SIZE_4KB
 
+// MDMA configuration
+#define OMV_MDMA_CHANNEL_DCMI_0               (0)
+#define OMV_MDMA_CHANNEL_DCMI_1               (1)
+#define OMV_MDMA_CHANNEL_JPEG_IN              (7) // in has a lower pri than out
+#define OMV_MDMA_CHANNEL_JPEG_OUT             (6) // out has a higher pri than in
+
 // AXI QoS - Low-High (0:15) - default 0
 #define OMV_AXI_QOS_MDMA_R_PRI                15 // Max pri to move data.
 #define OMV_AXI_QOS_MDMA_W_PRI                15 // Max pri to move data.
 
+// Enable additional GPIO ports
+#define OMV_GPIO_PORT_F_ENABLE                (1)
+#define OMV_GPIO_PORT_G_ENABLE                (1)
+#define OMV_GPIO_PORT_H_ENABLE                (1)
+#define OMV_GPIO_PORT_I_ENABLE                (1)
+#define OMV_GPIO_PORT_J_ENABLE                (1)
+#define OMV_GPIO_PORT_K_ENABLE                (1)
+
 // Main image sensor I2C bus
-#define ISC_I2C_ID                            (3)
-#define ISC_I2C_SPEED                         (OMV_I2C_SPEED_STANDARD)
+#define OMV_CSI_I2C_ID                        (3)
+#define OMV_CSI_I2C_SPEED                     (OMV_I2C_SPEED_STANDARD)
 
 // Thermal image sensor I2C bus
-#define FIR_I2C_ID                            (1)
-#define FIR_I2C_SPEED                         (OMV_I2C_SPEED_FULL)
+#define OMV_FIR_I2C_ID                        (1)
+#define OMV_FIR_I2C_SPEED                     (OMV_I2C_SPEED_FULL)
 
 // Soft I2C bus
-#define SOFT_I2C_SIOC_PIN                     (&omv_pin_B8_GPIO)
-#define SOFT_I2C_SIOD_PIN                     (&omv_pin_B9_GPIO)
-#define SOFT_I2C_SPIN_DELAY                   64
+#define OMV_SOFT_I2C_SIOC_PIN                 (&omv_pin_B8_GPIO)
+#define OMV_SOFT_I2C_SIOD_PIN                 (&omv_pin_B9_GPIO)
+#define OMV_SOFT_I2C_SPIN_DELAY               64
 
 // IMU SPI bus
 #define IMU_SPI_ID                            (5)
@@ -237,89 +204,90 @@
 #define OMV_IMU_X_Y_ROTATION_DEGREES          90
 #define OMV_IMU_MOUNTING_Z_DIRECTION          -1
 
-// DCMI timer
-#define DCMI_TIM                              (TIM3)
-#define DCMI_TIM_PIN                          (&omv_pin_A7_TIM3)
-#define DCMI_TIM_CHANNEL                      (TIM_CHANNEL_2)
-#define DCMI_TIM_CLK_ENABLE()                 __TIM3_CLK_ENABLE()
-#define DCMI_TIM_CLK_DISABLE()                __TIM3_CLK_DISABLE()
-#define DCMI_TIM_PCLK_FREQ()                  HAL_RCC_GetPCLK1Freq()
+// Camera Interface
+#define OMV_CSI_XCLK_SOURCE                   (XCLK_SOURCE_TIM)
+#define OMV_CSI_XCLK_FREQUENCY                (12000000)
+#define OMV_CSI_TIM                           (TIM3)
+#define OMV_CSI_TIM_PIN                       (&omv_pin_A7_TIM3)
+#define OMV_CSI_TIM_CHANNEL                   (TIM_CHANNEL_2)
+#define OMV_CSI_TIM_CLK_ENABLE()              __TIM3_CLK_ENABLE()
+#define OMV_CSI_TIM_CLK_DISABLE()             __TIM3_CLK_DISABLE()
+#define OMV_CSI_TIM_PCLK_FREQ()               HAL_RCC_GetPCLK1Freq()
+#define OMV_CSI_DMA_MEMCPY_ENABLE             (1)
 
-// DCMI pins
-//#define DCMI_RESET_PIN                      (&omv_pin_A10_GPIO)
-//#define DCMI_POWER_PIN                      (&omv_pin_G3_GPIO)
-//#define DCMI_FSYNC_PIN                      (&omv_pin_B4_GPIO)
+#define OMV_CSI_D0_PIN                        (&omv_pin_C6_DCMI)
+#define OMV_CSI_D1_PIN                        (&omv_pin_C7_DCMI)
+#define OMV_CSI_D2_PIN                        (&omv_pin_E0_DCMI)
+#define OMV_CSI_D3_PIN                        (&omv_pin_E1_DCMI)
+#define OMV_CSI_D4_PIN                        (&omv_pin_E4_DCMI)
+#define OMV_CSI_D5_PIN                        (&omv_pin_D3_DCMI)
+#define OMV_CSI_D6_PIN                        (&omv_pin_E5_DCMI)
+#define OMV_CSI_D7_PIN                        (&omv_pin_E6_DCMI)
 
-#define DCMI_D0_PIN                           (&omv_pin_C6_DCMI)
-#define DCMI_D1_PIN                           (&omv_pin_C7_DCMI)
-#define DCMI_D2_PIN                           (&omv_pin_E0_DCMI)
-#define DCMI_D3_PIN                           (&omv_pin_E1_DCMI)
-#define DCMI_D4_PIN                           (&omv_pin_E4_DCMI)
-#define DCMI_D5_PIN                           (&omv_pin_D3_DCMI)
-#define DCMI_D6_PIN                           (&omv_pin_E5_DCMI)
-#define DCMI_D7_PIN                           (&omv_pin_E6_DCMI)
-
-#define DCMI_HSYNC_PIN                        (&omv_pin_A4_DCMI)
-#define DCMI_VSYNC_PIN                        (&omv_pin_G9_DCMI)
-#define DCMI_PXCLK_PIN                        (&omv_pin_A6_DCMI)
+#define OMV_CSI_HSYNC_PIN                     (&omv_pin_A4_DCMI)
+#define OMV_CSI_VSYNC_PIN                     (&omv_pin_G9_DCMI)
+#define OMV_CSI_PXCLK_PIN                     (&omv_pin_A6_DCMI)
+//#define OMV_CSI_RESET_PIN                   (&omv_pin_A10_GPIO)
+//#define OMV_CSI_POWER_PIN                   (&omv_pin_G3_GPIO)
+//#define OMV_CSI_FSYNC_PIN                   (&omv_pin_B4_GPIO)
 
 // DFSDM1
-#define AUDIO_DFSDM                           (DFSDM1_Channel2)
-#define AUDIO_DFSDM_CHANNEL                   (DFSDM_CHANNEL_2)
+#define OMV_DFSDM                             (DFSDM1_Channel2)
+#define OMV_DFSDM_CHANNEL                     (DFSDM_CHANNEL_2)
 // DFSDM output clock is derived from the Aclk (set in SAI1SEL[2:0])
 // for SAI1 and DFSDM1, which is clocked from PLL1Q by default (50MHz).
-#define AUDIO_DFSDM_FREQMHZ                   (50)
-#define AUDIO_MAX_CHANNELS                    (1) // Maximum number of channels.
+#define OMV_DFSDM_FREQMHZ                     (50)
+#define OMV_AUDIO_MAX_CHANNELS                (1) // Maximum number of channels.
 
-#define AUDIO_DFSDM_CK_PIN                    (&omv_pin_D10_DFSDM1)
-#define AUDIO_DFSDM_D1_PIN                    (&omv_pin_E7_DFSDM1)
+#define OMV_DFSDM_CK_PIN                      (&omv_pin_D10_DFSDM1)
+#define OMV_DFSDM_D1_PIN                      (&omv_pin_E7_DFSDM1)
 
-#define AUDIO_DFSDM_FLT0                      DFSDM1_Filter0
-#define AUDIO_DFSDM_FLT0_IRQ                  DFSDM1_FLT0_IRQn
-#define AUDIO_DFSDM_FLT0_IRQHandler           DFSDM1_FLT0_IRQHandler
-#define AUDIO_DFSDM_FLT0_DMA_STREAM           DMA1_Stream1
-#define AUDIO_DFSDM_FLT0_DMA_REQUEST          DMA_REQUEST_DFSDM1_FLT0
-#define AUDIO_DFSDM_FLT0_DMA_IRQ              DMA1_Stream1_IRQn
-#define AUDIO_DFSDM_FLT0_DMA_IRQHandler       DMA1_Stream1_IRQHandler
+#define OMV_DFSDM_FLT0                        DFSDM1_Filter0
+#define OMV_DFSDM_FLT0_IRQ                    DFSDM1_FLT0_IRQn
+#define OMV_DFSDM_FLT0_IRQHandler             DFSDM1_FLT0_IRQHandler
+#define OMV_DFSDM_FLT0_DMA_STREAM             DMA1_Stream1
+#define OMV_DFSDM_FLT0_DMA_REQUEST            DMA_REQUEST_DFSDM1_FLT0
+#define OMV_DFSDM_FLT0_DMA_IRQ                DMA1_Stream1_IRQn
+#define OMV_DFSDM_FLT0_DMA_IRQHandler         DMA1_Stream1_IRQHandler
 
-#define AUDIO_DFSDM_CLK_ENABLE()              __HAL_RCC_DFSDM1_CLK_ENABLE()
-#define AUDIO_DFSDM_CLK_DISABLE()             __HAL_RCC_DFSDM1_CLK_DISABLE()
-#define AUDIO_DFSDM_DMA_CLK_ENABLE()          __HAL_RCC_DMA1_CLK_ENABLE()
+#define OMV_DFSDM_CLK_ENABLE()                __HAL_RCC_DFSDM1_CLK_ENABLE()
+#define OMV_DFSDM_CLK_DISABLE()               __HAL_RCC_DFSDM1_CLK_DISABLE()
+#define OMV_DFSDM_DMA_CLK_ENABLE()            __HAL_RCC_DMA1_CLK_ENABLE()
 
 // Physical I2C buses.
 
 // I2C bus 1
-#define I2C1_ID                               (1)
-#define I2C1_SCL_PIN                          (&omv_pin_B8_I2C1)
-#define I2C1_SDA_PIN                          (&omv_pin_B9_I2C1)
+#define OMV_I2C1_ID                           (1)
+#define OMV_I2C1_SCL_PIN                      (&omv_pin_B8_I2C1)
+#define OMV_I2C1_SDA_PIN                      (&omv_pin_B9_I2C1)
 
 // I2C bus 3
-#define I2C3_ID                               (3)
-#define I2C3_SCL_PIN                          (&omv_pin_A8_I2C3)
-#define I2C3_SDA_PIN                          (&omv_pin_C9_I2C3)
+#define OMV_I2C3_ID                           (3)
+#define OMV_I2C3_SCL_PIN                      (&omv_pin_A8_I2C3)
+#define OMV_I2C3_SDA_PIN                      (&omv_pin_C9_I2C3)
 
 // Physical SPI buses.
 
 // SPI bus 4
-#define SPI4_ID                               (4)
-#define SPI4_SCLK_PIN                         (&omv_pin_E12_SPI4)
-#define SPI4_MISO_PIN                         (&omv_pin_E13_SPI4)
-#define SPI4_MOSI_PIN                         (&omv_pin_E14_SPI4)
-#define SPI4_SSEL_PIN                         (&omv_pin_E11_SPI4)
-#define SPI4_DMA_TX_CHANNEL                   (DMA2_Stream4)
-#define SPI4_DMA_RX_CHANNEL                   (DMA2_Stream3)
+#define OMV_SPI4_ID                           (4)
+#define OMV_SPI4_SCLK_PIN                     (&omv_pin_E12_SPI4)
+#define OMV_SPI4_MISO_PIN                     (&omv_pin_E13_SPI4)
+#define OMV_SPI4_MOSI_PIN                     (&omv_pin_E14_SPI4)
+#define OMV_SPI4_SSEL_PIN                     (&omv_pin_E11_SPI4)
+#define OMV_SPI4_DMA_TX_CHANNEL               (DMA2_Stream4)
+#define OMV_SPI4_DMA_RX_CHANNEL               (DMA2_Stream3)
 
 // SPI bus 5
-#define SPI5_ID                               (5)
-#define SPI5_SCLK_PIN                         (&omv_pin_F7_SPI5)
-#define SPI5_MISO_PIN                         (&omv_pin_F8_SPI5)
-#define SPI5_MOSI_PIN                         (&omv_pin_F11_SPI5)
-#define SPI5_SSEL_PIN                         (&omv_pin_F6_SPI5)
-#define SPI5_DMA_TX_CHANNEL                   (DMA2_Stream4)
-#define SPI5_DMA_RX_CHANNEL                   (DMA2_Stream3)
+#define OMV_SPI5_ID                           (5)
+#define OMV_SPI5_SCLK_PIN                     (&omv_pin_F7_SPI5)
+#define OMV_SPI5_MISO_PIN                     (&omv_pin_F8_SPI5)
+#define OMV_SPI5_MOSI_PIN                     (&omv_pin_F11_SPI5)
+#define OMV_SPI5_SSEL_PIN                     (&omv_pin_F6_SPI5)
+#define OMV_SPI5_DMA_TX_CHANNEL               (DMA2_Stream4)
+#define OMV_SPI5_DMA_RX_CHANNEL               (DMA2_Stream3)
 
 // SPI LCD Interface
-#define OMV_SPI_DISPLAY_CONTROLLER            (SPI4_ID)
+#define OMV_SPI_DISPLAY_CONTROLLER            (OMV_SPI4_ID)
 #define OMV_SPI_DISPLAY_MOSI_PIN              (&omv_pin_E14_SPI4)
 #define OMV_SPI_DISPLAY_MISO_PIN              (&omv_pin_E13_SPI4)
 #define OMV_SPI_DISPLAY_SCLK_PIN              (&omv_pin_E12_SPI4)
@@ -329,10 +297,10 @@
 #define OMV_SPI_DISPLAY_RST_PIN               (&omv_pin_G1_GPIO)
 
 // FIR Lepton
-#define OMV_FIR_LEPTON_I2C_BUS                (FIR_I2C_ID)
-#define OMV_FIR_LEPTON_I2C_BUS_SPEED          (FIR_I2C_SPEED)
+#define OMV_FIR_LEPTON_I2C_BUS                (OMV_FIR_I2C_ID)
+#define OMV_FIR_LEPTON_I2C_BUS_SPEED          (OMV_FIR_I2C_SPEED)
 
-#define OMV_FIR_LEPTON_SPI_BUS                (SPI4_ID)
+#define OMV_FIR_LEPTON_SPI_BUS                (OMV_SPI4_ID)
 #define OMV_FIR_LEPTON_MOSI_PIN               (&omv_pin_E14_SPI4)
 #define OMV_FIR_LEPTON_MISO_PIN               (&omv_pin_E13_SPI4)
 #define OMV_FIR_LEPTON_SCLK_PIN               (&omv_pin_E12_SPI4)

--- a/src/omv/boards/ARDUINO_PORTENTA_H7/omv_boardconfig.h
+++ b/src/omv/boards/ARDUINO_PORTENTA_H7/omv_boardconfig.h
@@ -1,8 +1,8 @@
 /*
  * This file is part of the OpenMV project.
  *
- * Copyright (c) 2013-2021 Ibrahim Abdelkader <iabdalkader@openmv.io>
- * Copyright (c) 2013-2021 Kwabena W. Agyeman <kwagyeman@openmv.io>
+ * Copyright (c) 2013-2024 Ibrahim Abdelkader <iabdalkader@openmv.io>
+ * Copyright (c) 2013-2024 Kwabena W. Agyeman <kwagyeman@openmv.io>
  *
  * This work is licensed under the MIT license, see the file LICENSE for details.
  *
@@ -12,64 +12,21 @@
 #define __OMV_BOARDCONFIG_H__
 
 // Architecture info
-#define OMV_ARCH_STR                        "PORTENTA H7 8192 SDRAM"    // 33 chars max
+#define OMV_BOARD_ARCH                      "PORTENTA H7 8192 SDRAM"    // 33 chars max
 #define OMV_BOARD_TYPE                      "H7"
-#define OMV_UNIQUE_ID_ADDR                  0x1FF1E800    // Unique ID address.
-#define OMV_UNIQUE_ID_SIZE                  3       // Unique ID size in words.
-#define OMV_UNIQUE_ID_OFFSET                4       // Bytes offset for multi-word UIDs.
+#define OMV_BOARD_UID_ADDR                  0x1FF1E800  // Unique ID address.
+#define OMV_BOARD_UID_SIZE                  3           // Unique ID size in words.
+#define OMV_BOARD_UID_OFFSET                4           // Bytes offset for multi-word UIDs.
 
-#define OMV_XCLK_MCO                        (0U)
-#define OMV_XCLK_TIM                        (1U)
-#define OMV_XCLK_OSC                        (2U)
+// JPEG configuration.
+#define OMV_JPEG_CODEC_ENABLE               (1)
+#define OMV_JPEG_QUALITY_LOW                (50)
+#define OMV_JPEG_QUALITY_HIGH               (90)
+#define OMV_JPEG_QUALITY_THRESHOLD          (320 * 240 * 2)
 
-// Sensor external clock source.
-#define OMV_XCLK_SOURCE                     (OMV_XCLK_TIM)
-
-// Sensor external clock timer frequency.
-#define OMV_XCLK_FREQUENCY                  (12000000)
-
-// Enable hardware JPEG
-#define OMV_HARDWARE_JPEG                   (1)
-
-// Enable fast line transfer with DMA.
-#define OMA_ENABLE_DMA_MEMCPY               (1)
-
-// MDMA configuration
-#define OMV_MDMA_CHANNEL_DCMI_0             (0)
-#define OMV_MDMA_CHANNEL_DCMI_1             (1)
-#define OMV_MDMA_CHANNEL_JPEG_IN            (7) // in has a lower pri than out
-#define OMV_MDMA_CHANNEL_JPEG_OUT           (6) // out has a higher pri than in
-
-// Enable additional GPIO banks.
-#define OMV_ENABLE_GPIO_BANK_F              (1)
-#define OMV_ENABLE_GPIO_BANK_G              (1)
-#define OMV_ENABLE_GPIO_BANK_H              (1)
-#define OMV_ENABLE_GPIO_BANK_I              (1)
-#define OMV_ENABLE_GPIO_BANK_J              (1)
-#define OMV_ENABLE_GPIO_BANK_K              (1)
-
-// Enable sensor drivers
-#define OMV_ENABLE_OV2640                   (0)
-#define OMV_ENABLE_OV5640                   (0)
-#define OMV_ENABLE_OV7690                   (0)
-#define OMV_ENABLE_OV7725                   (0)
-#define OMV_ENABLE_OV9650                   (0)
-#define OMV_ENABLE_MT9M114                  (0)
-#define OMV_ENABLE_MT9V0XX                  (0)
-#define OMV_ENABLE_LEPTON                   (0)
-#define OMV_ENABLE_HM01B0                   (1)
-#define OMV_ENABLE_HM0360                   (1)
-#define OMV_ENABLE_GC2145                   (0)
-
-// OV7725 sensor settings
-#define OMV_OV7725_PLL_CONFIG               (0x41)    // x4
-#define OMV_OV7725_BANDING                  (0x7F)
-
-// MT9V0XX sensor settings
-#define MT9V0XX_XCLK_FREQ                   (25000000)
-
-// OV5640 sensor settings
-#define OMV_ENABLE_OV5640_AF                (1)
+// Image sensor drivers configuration.
+#define OMV_OV5640_ENABLE                   (0)
+#define OMV_OV5640_AF_ENABLE                (1)
 #define OMV_OV5640_XCLK_FREQ                (12500000)
 #define OMV_OV5640_PLL_CTRL2                (0x7E)
 #define OMV_OV5640_PLL_CTRL3                (0x13)
@@ -78,25 +35,17 @@
 #define OMV_OV5640_REV_Y_CTRL2              (0x7E)
 #define OMV_OV5640_REV_Y_CTRL3              (0x13)
 
-// FIR Module
-#define OMV_ENABLE_FIR_MLX90621             (1)
-#define OMV_ENABLE_FIR_MLX90640             (1)
-#define OMV_ENABLE_FIR_MLX90641             (1)
-#define OMV_ENABLE_FIR_AMG8833              (1)
-#define OMV_ENABLE_FIR_LEPTON               (1)
+#define OMV_HM01B0_ENABLE                   (1)
+#define OMV_HM0360_ENABLE                   (1)
 
-// Enable WiFi debug
-#define OMV_ENABLE_WIFIDBG                  (0)
+// FIR sensor drivers configuration.
+#define OMV_FIR_MLX90621_ENABLE             (1)
+#define OMV_FIR_MLX90640_ENABLE             (1)
+#define OMV_FIR_MLX90641_ENABLE             (1)
+#define OMV_FIR_AMG8833_ENABLE              (1)
+#define OMV_FIR_LEPTON_ENABLE               (1)
 
-// If buffer size is bigger than this threshold, the quality is reduced.
-// This is only used for JPEG images sent to the IDE not normal compression.
-#define JPEG_QUALITY_THRESH                 (320 * 240 * 2)
-
-// Low and high JPEG QS.
-#define JPEG_QUALITY_LOW                    50
-#define JPEG_QUALITY_HIGH                   90
-
-// FB Heap Block Size
+// UMM heap block size
 #define OMV_UMM_BLOCK_SIZE                  256
 
 // USB IRQn.
@@ -226,127 +175,138 @@
 #define OMV_DMA_REGION_D3_BASE              (OMV_SRAM4_ORIGIN + (0 * 1024))
 #define OMV_DMA_REGION_D3_SIZE              MPU_REGION_SIZE_64KB
 
+// MDMA configuration
+#define OMV_MDMA_CHANNEL_DCMI_0             (0)
+#define OMV_MDMA_CHANNEL_DCMI_1             (1)
+#define OMV_MDMA_CHANNEL_JPEG_IN            (7) // in has a lower pri than out
+#define OMV_MDMA_CHANNEL_JPEG_OUT           (6) // out has a higher pri than in
+
 // AXI QoS - Low-High (0:15) - default 0
 #define OMV_AXI_QOS_MDMA_R_PRI              14    // Max pri to move data.
 #define OMV_AXI_QOS_MDMA_W_PRI              15    // Max pri to move data.
 #define OMV_AXI_QOS_LTDC_R_PRI              15    // Max pri to read out the frame buffer.
 
+// Enable additional GPIO ports.
+#define OMV_GPIO_PORT_F_ENABLE              (1)
+#define OMV_GPIO_PORT_G_ENABLE              (1)
+#define OMV_GPIO_PORT_H_ENABLE              (1)
+#define OMV_GPIO_PORT_I_ENABLE              (1)
+#define OMV_GPIO_PORT_J_ENABLE              (1)
+#define OMV_GPIO_PORT_K_ENABLE              (1)
+
 // Image sensor I2C
-#define ISC_I2C_ID                          (3)
-#define ISC_I2C_SPEED                       (OMV_I2C_SPEED_STANDARD)
+#define OMV_CSI_I2C_ID                      (3)
+#define OMV_CSI_I2C_SPEED                   (OMV_I2C_SPEED_STANDARD)
 
 // Alternate I2C bus for the Portenta breakout
-#define ISC_I2C_ALT_ID                      (4)
-#define ISC_I2C_ALT_SPEED                   (OMV_I2C_SPEED_STANDARD)
+#define OMV_CSI_I2C_ALT_ID                  (4)
+#define OMV_CSI_I2C_ALT_SPEED               (OMV_I2C_SPEED_STANDARD)
 
 // Thermal image sensor I2C bus
-#define FIR_I2C_ID                          (3)
-#define FIR_I2C_SPEED                       (OMV_I2C_SPEED_STANDARD)
+#define OMV_FIR_I2C_ID                      (3)
+#define OMV_FIR_I2C_SPEED                   (OMV_I2C_SPEED_STANDARD)
 
-// Soft I2C bus
-//#define SOFT_I2C_SIOC_PIN                 (&omv_pin_PH7_GPIO)
-//#define SOFT_I2C_SIOD_PIN                 (&omv_pin_PH8_GPIO)
-//#define SOFT_I2C_SPIN_DELAY               64
+// Camera interface.
+#define OMV_CSI_XCLK_SOURCE                 (XCLK_SOURCE_TIM)
+#define OMV_CSI_XCLK_FREQUENCY              (12000000)
+#define OMV_CSI_TIM                         (TIM1)
+#define OMV_CSI_TIM_PIN                     (&omv_pin_K1_TIM1)
+// Enable TIM1-CH1 on PA8 too for Portenta breakout.
+#define OMV_CSI_TIM_EXT_PIN                 (&omv_pin_A8_TIM1)
+#define OMV_CSI_TIM_CHANNEL                 (TIM_CHANNEL_1)
+#define OMV_CSI_TIM_CLK_ENABLE()            __TIM1_CLK_ENABLE()
+#define OMV_CSI_TIM_CLK_DISABLE()           __TIM1_CLK_DISABLE()
+#define OMV_CSI_TIM_PCLK_FREQ()             HAL_RCC_GetPCLK2Freq()
+#define OMV_CSI_DMA_MEMCPY_ENABLE           (1)
 
+#define OMV_CSI_D0_PIN                      (&omv_pin_H9_DCMI)
+#define OMV_CSI_D1_PIN                      (&omv_pin_H10_DCMI)
+#define OMV_CSI_D2_PIN                      (&omv_pin_H11_DCMI)
+#define OMV_CSI_D3_PIN                      (&omv_pin_H12_DCMI)
+#define OMV_CSI_D4_PIN                      (&omv_pin_H14_DCMI)
+#define OMV_CSI_D5_PIN                      (&omv_pin_I4_DCMI)
+#define OMV_CSI_D6_PIN                      (&omv_pin_I6_DCMI)
+#define OMV_CSI_D7_PIN                      (&omv_pin_I7_DCMI)
+
+#define OMV_CSI_HSYNC_PIN                   (&omv_pin_A4_DCMI)
+#define OMV_CSI_VSYNC_PIN                   (&omv_pin_I5_DCMI)
+#define OMV_CSI_PXCLK_PIN                   (&omv_pin_A6_DCMI)
 // GPIO.0 is connected to the sensor module reset pin on the Portenta
 // breakout board and to the LDO's LDO_ENABLE pin on the Himax shield.
 // The sensor probing process will detect the right reset or powerdown
 // polarity, so it should be fine to enable it for both boards.
-#define DCMI_RESET_PIN                      (&omv_pin_C13_GPIO)
+#define OMV_CSI_RESET_PIN                   (&omv_pin_C13_GPIO)
 
 // GPIO.1 is connected to the sensor module frame sync pin (OUTPUT) on
 // the Portenta breakout board and to the INT pin (OUTPUT) on the Himax
 // shield, so it can't be enabled for the two boards at the same time.
-//#define DCMI_FSYNC_PIN                    (&omv_pin_C15_GPIO)
+//#define OMV_CSI_FSYNC_PIN                    (&omv_pin_C15_GPIO)
 
 // GPIO.3 is connected to the powerdown pin on the Portenta breakout board,
 // and to the STROBE pin on the Himax shield, however it's not actually
 // used on the Himax shield and can be safely enable for the two boards.
-#define DCMI_POWER_PIN                      (&omv_pin_D5_GPIO)
-
-/* DCMI */
-#define DCMI_TIM                            (TIM1)
-#define DCMI_TIM_PIN                        (&omv_pin_K1_TIM1)
-// Enable TIM1-CH1 on PA8 too for Portenta breakout.
-#define DCMI_TIM_EXT_PIN                    (&omv_pin_A8_TIM1)
-#define DCMI_TIM_CHANNEL                    (TIM_CHANNEL_1)
-#define DCMI_TIM_CLK_ENABLE()               __TIM1_CLK_ENABLE()
-#define DCMI_TIM_CLK_DISABLE()              __TIM1_CLK_DISABLE()
-#define DCMI_TIM_PCLK_FREQ()                HAL_RCC_GetPCLK2Freq()
-
-#define DCMI_D0_PIN                         (&omv_pin_H9_DCMI)
-#define DCMI_D1_PIN                         (&omv_pin_H10_DCMI)
-#define DCMI_D2_PIN                         (&omv_pin_H11_DCMI)
-#define DCMI_D3_PIN                         (&omv_pin_H12_DCMI)
-#define DCMI_D4_PIN                         (&omv_pin_H14_DCMI)
-#define DCMI_D5_PIN                         (&omv_pin_I4_DCMI)
-#define DCMI_D6_PIN                         (&omv_pin_I6_DCMI)
-#define DCMI_D7_PIN                         (&omv_pin_I7_DCMI)
-
-#define DCMI_HSYNC_PIN                      (&omv_pin_A4_DCMI)
-#define DCMI_VSYNC_PIN                      (&omv_pin_I5_DCMI)
-#define DCMI_PXCLK_PIN                      (&omv_pin_A6_DCMI)
+#define OMV_CSI_POWER_PIN                   (&omv_pin_D5_GPIO)
 
 // Physical I2C buses.
 
 // I2C bus 3
-#define I2C3_ID                             (3)
-#define I2C3_SCL_PIN                        (&omv_pin_H7_I2C3)
-#define I2C3_SDA_PIN                        (&omv_pin_H8_I2C3)
+#define OMV_I2C3_ID                         (3)
+#define OMV_I2C3_SCL_PIN                    (&omv_pin_H7_I2C3)
+#define OMV_I2C3_SDA_PIN                    (&omv_pin_H8_I2C3)
 
 // I2C bus 4
-#define I2C4_ID                             (4)
-#define I2C4_SCL_PIN                        (&omv_pin_H11_I2C4)
-#define I2C4_SDA_PIN                        (&omv_pin_H12_I2C4)
+#define OMV_I2C4_ID                         (4)
+#define OMV_I2C4_SCL_PIN                    (&omv_pin_H11_I2C4)
+#define OMV_I2C4_SDA_PIN                    (&omv_pin_H12_I2C4)
 
 // Physical SPI buses.
 
 // SPI bus 2
-#define SPI2_ID                             (2)
-#define SPI2_SCLK_PIN                       (&omv_pin_I1_SPI2)
-#define SPI2_MISO_PIN                       (&omv_pin_C2_SPI2)
-#define SPI2_MOSI_PIN                       (&omv_pin_C3_SPI2)
-#define SPI2_SSEL_PIN                       (&omv_pin_I0_SPI2)
-#define SPI2_DMA_TX_CHANNEL                 (DMA1_Stream4)
-#define SPI2_DMA_RX_CHANNEL                 (DMA1_Stream3)
+#define OMV_SPI2_ID                         (2)
+#define OMV_SPI2_SCLK_PIN                   (&omv_pin_I1_SPI2)
+#define OMV_SPI2_MISO_PIN                   (&omv_pin_C2_SPI2)
+#define OMV_SPI2_MOSI_PIN                   (&omv_pin_C3_SPI2)
+#define OMV_SPI2_SSEL_PIN                   (&omv_pin_I0_SPI2)
+#define OMV_SPI2_DMA_TX_CHANNEL             (DMA1_Stream4)
+#define OMV_SPI2_DMA_RX_CHANNEL             (DMA1_Stream3)
 
 // SAI4
-#define AUDIO_SAI                           (SAI4_Block_A)
+#define OMV_SAI                             (SAI4_Block_A)
 // SCKx frequency = SAI_KER_CK / MCKDIV / 2
-#define AUDIO_SAI_MCKDIV                    (12)
-#define AUDIO_SAI_FREQKHZ                   (2048U) // 2048KHz
-#define AUDIO_MAX_CHANNELS                  (2) // Maximum number of channels.
+#define OMV_SAI_MCKDIV                      (12)
+#define OMV_SAI_FREQKHZ                     (2048U) // 2048KHz
+#define OMV_AUDIO_MAX_CHANNELS              (2) // Maximum number of channels.
 
-#define AUDIO_SAI_CK_PIN                    (&omv_pin_E2_SAI4)
-#define AUDIO_SAI_D1_PIN                    (&omv_pin_B2_SAI4)
+#define OMV_SAI_CK_PIN                      (&omv_pin_E2_SAI4)
+#define OMV_SAI_D1_PIN                      (&omv_pin_B2_SAI4)
 
-#define AUDIO_SAI_DMA_STREAM                BDMA_Channel1
-#define AUDIO_SAI_DMA_REQUEST               BDMA_REQUEST_SAI4_A
-#define AUDIO_SAI_DMA_IRQ                   BDMA_Channel1_IRQn
-#define AUDIO_SAI_DMA_IRQHandler            BDMA_Channel1_IRQHandler
+#define OMV_SAI_DMA_STREAM                  BDMA_Channel1
+#define OMV_SAI_DMA_REQUEST                 BDMA_REQUEST_SAI4_A
+#define OMV_SAI_DMA_IRQ                     BDMA_Channel1_IRQn
+#define OMV_SAI_DMA_IRQHandler              BDMA_Channel1_IRQHandler
 
-#define AUDIO_SAI_CLK_ENABLE()              __HAL_RCC_SAI4_CLK_ENABLE()
-#define AUDIO_SAI_CLK_DISABLE()             __HAL_RCC_SAI4_CLK_DISABLE()
-#define AUDIO_SAI_DMA_CLK_ENABLE()          __HAL_RCC_BDMA_CLK_ENABLE()
+#define OMV_SAI_CLK_ENABLE()                __HAL_RCC_SAI4_CLK_ENABLE()
+#define OMV_SAI_CLK_DISABLE()               __HAL_RCC_SAI4_CLK_DISABLE()
+#define OMV_SAI_DMA_CLK_ENABLE()            __HAL_RCC_BDMA_CLK_ENABLE()
 
 // SAI1
 // Set SAI1 clock source in system ex: Sai1ClockSelection = RCC_SAI1CLKSOURCE_PLL;
-//#define AUDIO_SAI                         (SAI1_Block_A)
-//#define AUDIO_SAI_MCKDIV                  (12)
-//#define AUDIO_SAI_FREQKHZ                 (2048U) // 2048KHz
-//#define AUDIO_MAX_CHANNELS                (2) // Maximum number of channels.
+//#define OMV_SAI                             (SAI1_Block_A)
+//#define OMV_SAI_MCKDIV                      (12)
+//#define OMV_SAI_FREQKHZ                     (2048U) // 2048KHz
+//#define OMV_AUDIO_MAX_CHANNELS                    (2) // Maximum number of channels.
 //
-//#define AUDIO_SAI_CK_PIN                  (&omv_pin_E2_SAI1)
-//#define AUDIO_SAI_D1_PIN                  (&omv_pin_B2_SAI1)
+//#define OMV_SAI_CK_PIN                      (&omv_pin_E2_SAI1)
+//#define OMV_SAI_D1_PIN                      (&omv_pin_B2_SAI1)
 //
-//#define AUDIO_SAI_DMA_STREAM              DMA2_Stream6
-//#define AUDIO_SAI_DMA_REQUEST             DMA_REQUEST_SAI1_A
-//#define AUDIO_SAI_DMA_IRQ                 DMA2_Stream6_IRQn
-//#define AUDIO_SAI_DMA_IRQHandler          DMA2_Stream6_IRQHandler
+//#define OMV_SAI_DMA_STREAM                  DMA2_Stream6
+//#define OMV_SAI_DMA_REQUEST                 DMA_REQUEST_SAI1_A
+//#define OMV_SAI_DMA_IRQ                     DMA2_Stream6_IRQn
+//#define OMV_SAI_DMA_IRQHandler              DMA2_Stream6_IRQHandler
 //
-//#define AUDIO_SAI_CLK_ENABLE()            __HAL_RCC_SAI1_CLK_ENABLE()
-//#define AUDIO_SAI_CLK_DISABLE()           __HAL_RCC_SAI1_CLK_DISABLE()
-//#define AUDIO_SAI_DMA_CLK_ENABLE()        __HAL_RCC_DMA2_CLK_ENABLE()
+//#define OMV_SAI_CLK_ENABLE()                __HAL_RCC_SAI1_CLK_ENABLE()
+//#define OMV_SAI_CLK_DISABLE()               __HAL_RCC_SAI1_CLK_DISABLE()
+//#define OMV_SAI_DMA_CLK_ENABLE()            __HAL_RCC_DMA2_CLK_ENABLE()
 
 // LCD Interface
 #define OMV_RGB_DISPLAY_CONTROLLER          (LTDC)
@@ -363,7 +323,7 @@
 //#define OMV_DSI_DISPLAY_RELEASE_RESET()   __HAL_RCC_DSI_RELEASE_RESET()
 
 // SPI LCD Interface
-#define OMV_SPI_DISPLAY_CONTROLLER          (SPI2_ID)
+#define OMV_SPI_DISPLAY_CONTROLLER          (OMV_SPI2_ID)
 #define OMV_SPI_DISPLAY_MOSI_PIN            (&omv_pin_C3_SPI2)
 #define OMV_SPI_DISPLAY_MISO_PIN            (&omv_pin_C2_SPI2)
 #define OMV_SPI_DISPLAY_SCLK_PIN            (&omv_pin_I1_SPI2)
@@ -374,10 +334,10 @@
 #define OMV_SPI_DISPLAY_TRIPLE_BUFFER       (1)
 
 // FIR Lepton
-#define OMV_FIR_LEPTON_I2C_BUS              (FIR_I2C_ID)
-#define OMV_FIR_LEPTON_I2C_BUS_SPEED        (FIR_I2C_SPEED)
+#define OMV_FIR_LEPTON_I2C_BUS              (OMV_FIR_I2C_ID)
+#define OMV_FIR_LEPTON_I2C_BUS_SPEED        (OMV_FIR_I2C_SPEED)
 
-#define OMV_FIR_LEPTON_SPI_BUS              (SPI2_ID)
+#define OMV_FIR_LEPTON_SPI_BUS              (OMV_SPI2_ID)
 #define OMV_FIR_LEPTON_MOSI_PIN             (&omv_pin_C3_SPI2)
 #define OMV_FIR_LEPTON_MISO_PIN             (&omv_pin_C2_SPI2)
 #define OMV_FIR_LEPTON_SCLK_PIN             (&omv_pin_I1_SPI2)

--- a/src/omv/boards/OPENMV1/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV1/omv_boardconfig.h
@@ -1,8 +1,8 @@
 /*
  * This file is part of the OpenMV project.
  *
- * Copyright (c) 2013-2021 Ibrahim Abdelkader <iabdalkader@openmv.io>
- * Copyright (c) 2013-2021 Kwabena W. Agyeman <kwagyeman@openmv.io>
+ * Copyright (c) 2013-2024 Ibrahim Abdelkader <iabdalkader@openmv.io>
+ * Copyright (c) 2013-2024 Kwabena W. Agyeman <kwagyeman@openmv.io>
  *
  * This work is licensed under the MIT license, see the file LICENSE for details.
  *
@@ -11,8 +11,6 @@
 #ifndef __OMV_BOARDCONFIG_H__
 #define __OMV_BOARDCONFIG_H__
 
-// Sensor external clock frequency.
-#define OMV_XCLK_FREQUENCY        (12000000)
 // Max integral image.
 #define OMV_MAX_INT_FRAME         FRAMESIZE_QCIF
 #define OMV_MAX_INT_FRAME_STR     "QCIF"
@@ -64,52 +62,53 @@
 #define SCCB_SCL_PIN              (GPIO_PIN_8)
 #define SCCB_SDA_PIN              (GPIO_PIN_9)
 
-/* DCMI */
-#define DCMI_TIM                  (TIM1)
-#define DCMI_TIM_PIN              (GPIO_PIN_9)
-#define DCMI_TIM_PORT             (GPIOE)
-#define DCMI_TIM_AF               (GPIO_AF1_TIM1)
-#define DCMI_TIM_CHANNEL          (TIM_CHANNEL_1)
-#define DCMI_TIM_CLK_ENABLE()     __TIM1_CLK_ENABLE()
-#define DCMI_TIM_CLK_DISABLE()    __TIM1_CLK_DISABLE()
+// Camera interface
+#define OMV_CSI_XCLK_FREQUENCY    (12000000)
+#define OMV_CSI_TIM               (TIM1)
+#define OMV_CSI_TIM_PIN           (GPIO_PIN_9)
+#define OMV_CSI_TIM_PORT          (GPIOE)
+#define OMV_CSI_TIM_AF            (GPIO_AF1_TIM1)
+#define OMV_CSI_TIM_CHANNEL       (TIM_CHANNEL_1)
+#define OMV_CSI_TIM_CLK_ENABLE()  __TIM1_CLK_ENABLE()
+#define OMV_CSI_TIM_CLK_DISABLE() __TIM1_CLK_DISABLE()
 
-#define DCMI_RESET_PIN            (GPIO_PIN_10)
-#define DCMI_RESET_PORT           (GPIOA)
+#define OMV_CSI_RESET_PIN         (GPIO_PIN_10)
+#define OMV_CSI_RESET_PORT        (GPIOA)
 
-#define DCMI_PWDN_PIN             (GPIO_PIN_5)
-#define DCMI_PWDN_PORT            (GPIOB)
+#define OMV_CSI_PWDN_PIN          (GPIO_PIN_5)
+#define OMV_CSI_PWDN_PORT         (GPIOB)
 
-#define DCMI_D0_PIN               (GPIO_PIN_6)
-#define DCMI_D1_PIN               (GPIO_PIN_7)
-#define DCMI_D2_PIN               (GPIO_PIN_0)
-#define DCMI_D3_PIN               (GPIO_PIN_1)
-#define DCMI_D4_PIN               (GPIO_PIN_4)
-#define DCMI_D5_PIN               (GPIO_PIN_5)
-#define DCMI_D6_PIN               (GPIO_PIN_6)
-#define DCMI_D7_PIN               (GPIO_PIN_6)
+#define OMV_CSI_D0_PIN            (GPIO_PIN_6)
+#define OMV_CSI_D1_PIN            (GPIO_PIN_7)
+#define OMV_CSI_D2_PIN            (GPIO_PIN_0)
+#define OMV_CSI_D3_PIN            (GPIO_PIN_1)
+#define OMV_CSI_D4_PIN            (GPIO_PIN_4)
+#define OMV_CSI_D5_PIN            (GPIO_PIN_5)
+#define OMV_CSI_D6_PIN            (GPIO_PIN_6)
+#define OMV_CSI_D7_PIN            (GPIO_PIN_6)
 
-#define DCMI_D0_PORT              (GPIOC)
-#define DCMI_D1_PORT              (GPIOC)
-#define DCMI_D2_PORT              (GPIOE)
-#define DCMI_D3_PORT              (GPIOE)
-#define DCMI_D4_PORT              (GPIOE)
-#define DCMI_D5_PORT              (GPIOE)
-#define DCMI_D6_PORT              (GPIOE)
-#define DCMI_D7_PORT              (GPIOB)
+#define OMV_CSI_D0_PORT           (GPIOC)
+#define OMV_CSI_D1_PORT           (GPIOC)
+#define OMV_CSI_D2_PORT           (GPIOE)
+#define OMV_CSI_D3_PORT           (GPIOE)
+#define OMV_CSI_D4_PORT           (GPIOE)
+#define OMV_CSI_D5_PORT           (GPIOE)
+#define OMV_CSI_D6_PORT           (GPIOE)
+#define OMV_CSI_D7_PORT           (GPIOB)
 
-#define DCMI_HSYNC_PIN            (GPIO_PIN_7)
-#define DCMI_VSYNC_PIN            (GPIO_PIN_4)
-#define DCMI_PXCLK_PIN            (GPIO_PIN_6)
+#define OMV_CSI_HSYNC_PIN         (GPIO_PIN_7)
+#define OMV_CSI_VSYNC_PIN         (GPIO_PIN_4)
+#define OMV_CSI_PXCLK_PIN         (GPIO_PIN_6)
 
-#define DCMI_HSYNC_PORT           (GPIOB)
-#define DCMI_VSYNC_PORT           (GPIOA)
-#define DCMI_PXCLK_PORT           (GPIOA)
+#define OMV_CSI_HSYNC_PORT        (GPIOB)
+#define OMV_CSI_VSYNC_PORT        (GPIOA)
+#define OMV_CSI_PXCLK_PORT        (GPIOA)
 
-#define DCMI_RESET_LOW()          HAL_GPIO_WritePin(DCMI_RESET_PORT, DCMI_RESET_PIN, GPIO_PIN_RESET)
-#define DCMI_RESET_HIGH()         HAL_GPIO_WritePin(DCMI_RESET_PORT, DCMI_RESET_PIN, GPIO_PIN_SET)
+#define OMV_CSI_RESET_LOW()       HAL_GPIO_WritePin(OMV_CSI_RESET_PORT, OMV_CSI_RESET_PIN, GPIO_PIN_RESET)
+#define OMV_CSI_RESET_HIGH()      HAL_GPIO_WritePin(OMV_CSI_RESET_PORT, OMV_CSI_RESET_PIN, GPIO_PIN_SET)
 
-#define DCMI_PWDN_LOW()           HAL_GPIO_WritePin(DCMI_PWDN_PORT, DCMI_PWDN_PIN, GPIO_PIN_RESET)
-#define DCMI_PWDN_HIGH()          HAL_GPIO_WritePin(DCMI_PWDN_PORT, DCMI_PWDN_PIN, GPIO_PIN_SET)
+#define OMV_CSI_PWDN_LOW()        HAL_GPIO_WritePin(OMV_CSI_PWDN_PORT, OMV_CSI_PWDN_PIN, GPIO_PIN_RESET)
+#define OMV_CSI_PWDN_HIGH()       HAL_GPIO_WritePin(OMV_CSI_PWDN_PORT, OMV_CSI_PWDN_PIN, GPIO_PIN_SET)
 
 /* uSD */
 #define SD_SPI                    (SPI2)

--- a/src/omv/boards/OPENMV2/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV2/omv_boardconfig.h
@@ -1,8 +1,8 @@
 /*
  * This file is part of the OpenMV project.
  *
- * Copyright (c) 2013-2021 Ibrahim Abdelkader <iabdalkader@openmv.io>
- * Copyright (c) 2013-2021 Kwabena W. Agyeman <kwagyeman@openmv.io>
+ * Copyright (c) 2013-2024 Ibrahim Abdelkader <iabdalkader@openmv.io>
+ * Copyright (c) 2013-2024 Kwabena W. Agyeman <kwagyeman@openmv.io>
  *
  * This work is licensed under the MIT license, see the file LICENSE for details.
  *
@@ -12,57 +12,32 @@
 #define __OMV_BOARDCONFIG_H__
 
 // Architecture info
-#define OMV_ARCH_STR                          "OMV2 F4 256 JPEG" // 33 chars max
+#define OMV_BOARD_ARCH                        "OMV2 F4 256 JPEG" // 33 chars max
 #define OMV_BOARD_TYPE                        "M4"
-#define OMV_UNIQUE_ID_ADDR                    0x1FFF7A10 // Unique ID address.
-#define OMV_UNIQUE_ID_SIZE                    3 // Unique ID size in words.
-#define OMV_UNIQUE_ID_OFFSET                  4 // Bytes offset for multi-word UIDs.
+#define OMV_BOARD_UID_ADDR                    0x1FFF7A10    // Unique ID address.
+#define OMV_BOARD_UID_SIZE                    3             // Unique ID size in words.
+#define OMV_BOARD_UID_OFFSET                  4             // Bytes offset for multi-word UIDs.
 
-#define OMV_XCLK_MCO                          (0U)
-#define OMV_XCLK_TIM                          (1U)
+// JPEG configuration.
+#define OMV_JPEG_CODEC_ENABLE                 (0)
+#define OMV_JPEG_QUALITY_LOW                  (35)
+#define OMV_JPEG_QUALITY_HIGH                 (60)
+#define OMV_JPEG_QUALITY_THRESHOLD            (160 * 120 * 2)
 
-// Sensor external clock source.
-#define OMV_XCLK_SOURCE                       (OMV_XCLK_TIM)
-
-// Sensor external clock timer frequency.
-#define OMV_XCLK_FREQUENCY                    (6000000)
-
-// Sensor PLL register value.
+// Image sensor drivers configuration.
+#define OMV_OV2640_ENABLE                     (1)
+#define OMV_OV7725_ENABLE                     (1)
 #define OMV_OV7725_PLL_CONFIG                 (0x41) // x4
-
-// Sensor Banding Filter Value
 #define OMV_OV7725_BANDING                    (0x3F)
 
-// Enable sensor drivers
-#define OMV_ENABLE_OV2640                     (1)
-#define OMV_ENABLE_OV5640                     (0)
-#define OMV_ENABLE_OV7690                     (0)
-#define OMV_ENABLE_OV7725                     (1)
-#define OMV_ENABLE_OV9650                     (0)
-#define OMV_ENABLE_MT9M114                    (0)
-#define OMV_ENABLE_MT9V0XX                    (0)
-#define OMV_ENABLE_LEPTON                     (0)
-#define OMV_ENABLE_HM01B0                     (0)
-#define OMV_ENABLE_PAJ6100                    (0)
-#define OMV_ENABLE_FROGEYE2020                (0)
-#define OMV_ENABLE_FIR_MLX90621               (1)
-#define OMV_ENABLE_FIR_MLX90640               (1)
-#define OMV_ENABLE_FIR_MLX90641               (1)
-#define OMV_ENABLE_FIR_AMG8833                (1)
-#define OMV_ENABLE_FIR_LEPTON                 (1)
+// FIR sensor drivers configuration.
+#define OMV_FIR_MLX90621_ENABLE               (1)
+#define OMV_FIR_MLX90640_ENABLE               (1)
+#define OMV_FIR_MLX90641_ENABLE               (1)
+#define OMV_FIR_AMG8833_ENABLE                (1)
+#define OMV_FIR_LEPTON_ENABLE                 (1)
 
-// Enable sensor features
-#define OMV_ENABLE_OV5640_AF                  (0)
-
-// If buffer size is bigger than this threshold, the quality is reduced.
-// This is only used for JPEG images sent to the IDE not normal compression.
-#define JPEG_QUALITY_THRESH                   (160 * 120 * 2)
-
-// Low and high JPEG QS.
-#define JPEG_QUALITY_LOW                      35
-#define JPEG_QUALITY_HIGH                     60
-
-// FB Heap Block Size
+// UMM heap block size
 #define OMV_UMM_BLOCK_SIZE                    16
 
 // USB IRQn.
@@ -120,77 +95,77 @@
 #define OMV_FLASH_TXT_LENGTH                  960K
 
 // Main image sensor I2C bus
-#define ISC_I2C_ID                            (1)
-#define ISC_I2C_SPEED                         (OMV_I2C_SPEED_STANDARD)
+#define OMV_CSI_I2C_ID                        (1)
+#define OMV_CSI_I2C_SPEED                     (OMV_I2C_SPEED_STANDARD)
 
 // Thermal image sensor I2C bus
-#define FIR_I2C_ID                            (2)
-#define FIR_I2C_SPEED                         (OMV_I2C_SPEED_FULL)
+#define OMV_FIR_I2C_ID                        (2)
+#define OMV_FIR_I2C_SPEED                     (OMV_I2C_SPEED_FULL)
 
 // Soft I2C bus
-#define SOFT_I2C_SIOC_PIN                     (&omv_pin_B10_GPIO)
-#define SOFT_I2C_SIOD_PIN                     (&omv_pin_B11_GPIO)
-#define SOFT_I2C_SPIN_DELAY                   16
+#define OMV_SOFT_I2C_SIOC_PIN                 (&omv_pin_B10_GPIO)
+#define OMV_SOFT_I2C_SIOD_PIN                 (&omv_pin_B11_GPIO)
+#define OMV_SOFT_I2C_SPIN_DELAY               16
 
 // WINC SPI bus
-#define WINC_SPI_ID                           (2)
-#define WINC_SPI_BAUDRATE                     (27000000)
-#define WINC_EN_PIN                           (&omv_pin_A5_GPIO)
-#define WINC_RST_PIN                          (&omv_pin_D12_GPIO)
-#define WINC_IRQ_PIN                          (&omv_pin_D13_GPIO)
+#define OMV_WINC_SPI_ID                       (2)
+#define OMV_WINC_SPI_BAUDRATE                 (27000000)
+#define OMV_WINC_EN_PIN                       (&omv_pin_A5_GPIO)
+#define OMV_WINC_RST_PIN                      (&omv_pin_D12_GPIO)
+#define OMV_WINC_IRQ_PIN                      (&omv_pin_D13_GPIO)
 
-// DCMI pins.
-#define DCMI_TIM                              (TIM1)
-#define DCMI_TIM_PIN                          (&omv_pin_A8_TIM1)
-#define DCMI_TIM_CHANNEL                      (TIM_CHANNEL_1)
-#define DCMI_TIM_CLK_ENABLE()                 __TIM1_CLK_ENABLE()
-#define DCMI_TIM_CLK_DISABLE()                __TIM1_CLK_DISABLE()
-#define DCMI_TIM_PCLK_FREQ()                  HAL_RCC_GetPCLK2Freq()
+// Camera Interface
+#define OMV_CSI_XCLK_SOURCE                   (XCLK_SOURCE_TIM)
+#define OMV_CSI_XCLK_FREQUENCY                (6000000)
+#define OMV_CSI_TIM                           (TIM1)
+#define OMV_CSI_TIM_PIN                       (&omv_pin_A8_TIM1)
+#define OMV_CSI_TIM_CHANNEL                   (TIM_CHANNEL_1)
+#define OMV_CSI_TIM_CLK_ENABLE()              __TIM1_CLK_ENABLE()
+#define OMV_CSI_TIM_CLK_DISABLE()             __TIM1_CLK_DISABLE()
+#define OMV_CSI_TIM_PCLK_FREQ()               HAL_RCC_GetPCLK2Freq()
 
-// DCMI pins.
-#define DCMI_RESET_PIN                        (&omv_pin_A10_GPIO)
-#define DCMI_POWER_PIN                        (&omv_pin_B5_GPIO)
+#define OMV_CSI_D0_PIN                        (&omv_pin_C6_DCMI)
+#define OMV_CSI_D1_PIN                        (&omv_pin_C7_DCMI)
+#define OMV_CSI_D2_PIN                        (&omv_pin_E0_DCMI)
+#define OMV_CSI_D3_PIN                        (&omv_pin_E1_DCMI)
+#define OMV_CSI_D4_PIN                        (&omv_pin_E4_DCMI)
+#define OMV_CSI_D5_PIN                        (&omv_pin_B6_DCMI)
+#define OMV_CSI_D6_PIN                        (&omv_pin_E5_DCMI)
+#define OMV_CSI_D7_PIN                        (&omv_pin_E6_DCMI)
 
-#define DCMI_D0_PIN                           (&omv_pin_C6_DCMI)
-#define DCMI_D1_PIN                           (&omv_pin_C7_DCMI)
-#define DCMI_D2_PIN                           (&omv_pin_E0_DCMI)
-#define DCMI_D3_PIN                           (&omv_pin_E1_DCMI)
-#define DCMI_D4_PIN                           (&omv_pin_E4_DCMI)
-#define DCMI_D5_PIN                           (&omv_pin_B6_DCMI)
-#define DCMI_D6_PIN                           (&omv_pin_E5_DCMI)
-#define DCMI_D7_PIN                           (&omv_pin_E6_DCMI)
-
-#define DCMI_HSYNC_PIN                        (&omv_pin_A4_DCMI)
-#define DCMI_VSYNC_PIN                        (&omv_pin_B7_DCMI)
-#define DCMI_PXCLK_PIN                        (&omv_pin_A6_DCMI)
+#define OMV_CSI_HSYNC_PIN                     (&omv_pin_A4_DCMI)
+#define OMV_CSI_VSYNC_PIN                     (&omv_pin_B7_DCMI)
+#define OMV_CSI_PXCLK_PIN                     (&omv_pin_A6_DCMI)
+#define OMV_CSI_RESET_PIN                     (&omv_pin_A10_GPIO)
+#define OMV_CSI_POWER_PIN                     (&omv_pin_B5_GPIO)
 
 // Physical I2C buses.
 
 // I2C bus 1
-#define I2C1_ID                               (1)
-#define I2C1_SCL_PIN                          (&omv_pin_B8_I2C1)
-#define I2C1_SDA_PIN                          (&omv_pin_B9_I2C1)
+#define OMV_I2C1_ID                           (1)
+#define OMV_I2C1_SCL_PIN                      (&omv_pin_B8_I2C1)
+#define OMV_I2C1_SDA_PIN                      (&omv_pin_B9_I2C1)
 
 // I2C bus 2
-#define I2C2_ID                               (2)
-#define I2C2_SCL_PIN                          (&omv_pin_B10_I2C2)
-#define I2C2_SDA_PIN                          (&omv_pin_B11_I2C2)
+#define OMV_I2C2_ID                           (2)
+#define OMV_I2C2_SCL_PIN                      (&omv_pin_B10_I2C2)
+#define OMV_I2C2_SDA_PIN                      (&omv_pin_B11_I2C2)
 
 // Physical SPI buses.
 
 // SPI bus 2
-#define SPI2_ID                               (2)
-#define SPI2_SCLK_PIN                         (&omv_pin_B13_SPI2)
-#define SPI2_MISO_PIN                         (&omv_pin_B14_SPI2)
-#define SPI2_MOSI_PIN                         (&omv_pin_B15_SPI2)
-#define SPI2_SSEL_PIN                         (&omv_pin_B12_SPI2)
-#define SPI2_DMA_TX_CHANNEL                   (DMA1_Stream4)
-#define SPI2_DMA_RX_CHANNEL                   (DMA1_Stream3)
+#define OMV_SPI2_ID                           (2)
+#define OMV_SPI2_SCLK_PIN                     (&omv_pin_B13_SPI2)
+#define OMV_SPI2_MISO_PIN                     (&omv_pin_B14_SPI2)
+#define OMV_SPI2_MOSI_PIN                     (&omv_pin_B15_SPI2)
+#define OMV_SPI2_SSEL_PIN                     (&omv_pin_B12_SPI2)
+#define OMV_SPI2_DMA_TX_CHANNEL               (DMA1_Stream4)
+#define OMV_SPI2_DMA_RX_CHANNEL               (DMA1_Stream3)
 #define DMA_REQUEST_SPI2_TX                   (DMA_CHANNEL_0)
 #define DMA_REQUEST_SPI2_RX                   (DMA_CHANNEL_0)
 
 // SPI LCD Interface
-#define OMV_SPI_DISPLAY_CONTROLLER            (SPI2_ID)
+#define OMV_SPI_DISPLAY_CONTROLLER            (OMV_SPI2_ID)
 #define OMV_SPI_DISPLAY_MOSI_PIN              (&omv_pin_B15_SPI2)
 #define OMV_SPI_DISPLAY_MISO_PIN              (&omv_pin_B14_SPI2)
 #define OMV_SPI_DISPLAY_SCLK_PIN              (&omv_pin_B13_SPI2)
@@ -201,10 +176,10 @@
 #define OMV_SPI_DISPLAY_BL_PIN                (&omv_pin_A5_GPIO)
 
 // FIR Lepton
-#define OMV_FIR_LEPTON_I2C_BUS                (FIR_I2C_ID)
-#define OMV_FIR_LEPTON_I2C_BUS_SPEED          (FIR_I2C_SPEED)
+#define OMV_FIR_LEPTON_I2C_BUS                (OMV_FIR_I2C_ID)
+#define OMV_FIR_LEPTON_I2C_BUS_SPEED          (OMV_FIR_I2C_SPEED)
 
-#define OMV_FIR_LEPTON_SPI_BUS                (SPI2_ID)
+#define OMV_FIR_LEPTON_SPI_BUS                (OMV_SPI2_ID)
 #define OMV_FIR_LEPTON_MOSI_PIN               (&omv_pin_B15_SPI2)
 #define OMV_FIR_LEPTON_MISO_PIN               (&omv_pin_B14_SPI2)
 #define OMV_FIR_LEPTON_SCLK_PIN               (&omv_pin_B13_SPI2)

--- a/src/omv/boards/OPENMV3/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV3/omv_boardconfig.h
@@ -1,8 +1,8 @@
 /*
  * This file is part of the OpenMV project.
  *
- * Copyright (c) 2013-2021 Ibrahim Abdelkader <iabdalkader@openmv.io>
- * Copyright (c) 2013-2021 Kwabena W. Agyeman <kwagyeman@openmv.io>
+ * Copyright (c) 2013-2024 Ibrahim Abdelkader <iabdalkader@openmv.io>
+ * Copyright (c) 2013-2024 Kwabena W. Agyeman <kwagyeman@openmv.io>
  *
  * This work is licensed under the MIT license, see the file LICENSE for details.
  *
@@ -12,57 +12,31 @@
 #define __OMV_BOARDCONFIG_H__
 
 // Architecture info
-#define OMV_ARCH_STR                          "OMV3 F7 512" // 33 chars max
+#define OMV_BOARD_ARCH                        "OMV3 F7 512" // 33 chars max
 #define OMV_BOARD_TYPE                        "M7"
-#define OMV_UNIQUE_ID_ADDR                    0x1FF0F420 // Unique ID address.
-#define OMV_UNIQUE_ID_SIZE                    3 // Unique ID size in words.
-#define OMV_UNIQUE_ID_OFFSET                  4 // Bytes offset for multi-word UIDs.
+#define OMV_BOARD_UID_ADDR                    0x1FF0F420    // Unique ID address.
+#define OMV_BOARD_UID_SIZE                    3             // Unique ID size in words.
+#define OMV_BOARD_UID_OFFSET                  4             // Bytes offset for multi-word UIDs.
 
-#define OMV_XCLK_MCO                          (0U)
-#define OMV_XCLK_TIM                          (1U)
+// JPEG configuration.
+#define OMV_JPEG_CODEC_ENABLE                 (0)
+#define OMV_JPEG_QUALITY_LOW                  (35)
+#define OMV_JPEG_QUALITY_HIGH                 (60)
+#define OMV_JPEG_QUALITY_THRESHOLD            (160 * 120 * 2)
 
-// Sensor external clock source.
-#define OMV_XCLK_SOURCE                       (OMV_XCLK_TIM)
-
-// Sensor external clock timer frequency.
-#define OMV_XCLK_FREQUENCY                    (9000000)
-
-// Sensor PLL register value.
+// Image sensor drivers configuration.
+#define OMV_OV7725_ENABLE                     (1)
 #define OMV_OV7725_PLL_CONFIG                 (0x81) // x6
-
-// Sensor Banding Filter Value
 #define OMV_OV7725_BANDING                    (0x8F)
 
-// Enable sensor drivers
-#define OMV_ENABLE_OV2640                     (0)
-#define OMV_ENABLE_OV5640                     (0)
-#define OMV_ENABLE_OV7690                     (0)
-#define OMV_ENABLE_OV7725                     (1)
-#define OMV_ENABLE_OV9650                     (0)
-#define OMV_ENABLE_MT9M114                    (0)
-#define OMV_ENABLE_MT9V0XX                    (0)
-#define OMV_ENABLE_LEPTON                     (0)
-#define OMV_ENABLE_HM01B0                     (0)
-#define OMV_ENABLE_PAJ6100                    (0)
-#define OMV_ENABLE_FROGEYE2020                (0)
-#define OMV_ENABLE_FIR_MLX90621               (1)
-#define OMV_ENABLE_FIR_MLX90640               (1)
-#define OMV_ENABLE_FIR_MLX90641               (1)
-#define OMV_ENABLE_FIR_AMG8833                (1)
-#define OMV_ENABLE_FIR_LEPTON                 (1)
+// FIR sensor drivers configuration.
+#define OMV_FIR_MLX90621_ENABLE               (1)
+#define OMV_FIR_MLX90640_ENABLE               (1)
+#define OMV_FIR_MLX90641_ENABLE               (1)
+#define OMV_FIR_AMG8833_ENABLE                (1)
+#define OMV_FIR_LEPTON_ENABLE                 (1)
 
-// Enable sensor features
-#define OMV_ENABLE_OV5640_AF                  (0)
-
-// If buffer size is bigger than this threshold, the quality is reduced.
-// This is only used for JPEG images sent to the IDE not normal compression.
-#define JPEG_QUALITY_THRESH                   (160 * 120 * 2)
-
-// Low and high JPEG QS.
-#define JPEG_QUALITY_LOW                      35
-#define JPEG_QUALITY_HIGH                     60
-
-// FB Heap Block Size
+// UMM heap block size
 #define OMV_UMM_BLOCK_SIZE                    16
 
 // USB IRQn.
@@ -120,77 +94,77 @@
 #define OMV_FLASH_TXT_LENGTH                  1920K
 
 // Main image sensor I2C bus
-#define ISC_I2C_ID                            (1)
-#define ISC_I2C_SPEED                         (OMV_I2C_SPEED_STANDARD)
+#define OMV_CSI_I2C_ID                        (1)
+#define OMV_CSI_I2C_SPEED                     (OMV_I2C_SPEED_STANDARD)
 
 // FIR I2C bus
-#define FIR_I2C_ID                            (2)
-#define FIR_I2C_SPEED                         (OMV_I2C_SPEED_FULL)
+#define OMV_FIR_I2C_ID                        (2)
+#define OMV_FIR_I2C_SPEED                     (OMV_I2C_SPEED_FULL)
 
 // Soft I2C bus
-#define SOFT_I2C_SIOC_PIN                     (&omv_pin_B10_GPIO)
-#define SOFT_I2C_SIOD_PIN                     (&omv_pin_B11_GPIO)
-#define SOFT_I2C_SPIN_DELAY                   24
+#define OMV_SOFT_I2C_SIOC_PIN                 (&omv_pin_B10_GPIO)
+#define OMV_SOFT_I2C_SIOD_PIN                 (&omv_pin_B11_GPIO)
+#define OMV_SOFT_I2C_SPIN_DELAY               24
 
 // WINC SPI bus
-#define WINC_SPI_ID                           (2)
-#define WINC_SPI_BAUDRATE                     (27000000)
-#define WINC_EN_PIN                           (&omv_pin_A5_GPIO)
-#define WINC_RST_PIN                          (&omv_pin_D12_GPIO)
-#define WINC_IRQ_PIN                          (&omv_pin_D13_GPIO)
+#define OMV_WINC_SPI_ID                       (2)
+#define OMV_WINC_SPI_BAUDRATE                 (27000000)
+#define OMV_WINC_EN_PIN                       (&omv_pin_A5_GPIO)
+#define OMV_WINC_RST_PIN                      (&omv_pin_D12_GPIO)
+#define OMV_WINC_IRQ_PIN                      (&omv_pin_D13_GPIO)
 
-// DCMI timer
-#define DCMI_TIM                              (TIM1)
-#define DCMI_TIM_PIN                          (&omv_pin_A8_TIM1)
-#define DCMI_TIM_CHANNEL                      (TIM_CHANNEL_1)
-#define DCMI_TIM_CLK_ENABLE()                 __TIM1_CLK_ENABLE()
-#define DCMI_TIM_CLK_DISABLE()                __TIM1_CLK_DISABLE()
-#define DCMI_TIM_PCLK_FREQ()                  HAL_RCC_GetPCLK2Freq()
+// Camera Interface
+#define OMV_CSI_XCLK_SOURCE                   (XCLK_SOURCE_TIM)
+#define OMV_CSI_XCLK_FREQUENCY                (9000000)
+#define OMV_CSI_TIM                           (TIM1)
+#define OMV_CSI_TIM_PIN                       (&omv_pin_A8_TIM1)
+#define OMV_CSI_TIM_CHANNEL                   (TIM_CHANNEL_1)
+#define OMV_CSI_TIM_CLK_ENABLE()              __TIM1_CLK_ENABLE()
+#define OMV_CSI_TIM_CLK_DISABLE()             __TIM1_CLK_DISABLE()
+#define OMV_CSI_TIM_PCLK_FREQ()               HAL_RCC_GetPCLK2Freq()
 
-// DCMI pins
-#define DCMI_RESET_PIN                        (&omv_pin_A10_GPIO)
-#define DCMI_POWER_PIN                        (&omv_pin_B5_GPIO)
+#define OMV_CSI_D0_PIN                        (&omv_pin_C6_DCMI)
+#define OMV_CSI_D1_PIN                        (&omv_pin_C7_DCMI)
+#define OMV_CSI_D2_PIN                        (&omv_pin_E0_DCMI)
+#define OMV_CSI_D3_PIN                        (&omv_pin_E1_DCMI)
+#define OMV_CSI_D4_PIN                        (&omv_pin_E4_DCMI)
+#define OMV_CSI_D5_PIN                        (&omv_pin_B6_DCMI)
+#define OMV_CSI_D6_PIN                        (&omv_pin_E5_DCMI)
+#define OMV_CSI_D7_PIN                        (&omv_pin_E6_DCMI)
 
-#define DCMI_D0_PIN                           (&omv_pin_C6_DCMI)
-#define DCMI_D1_PIN                           (&omv_pin_C7_DCMI)
-#define DCMI_D2_PIN                           (&omv_pin_E0_DCMI)
-#define DCMI_D3_PIN                           (&omv_pin_E1_DCMI)
-#define DCMI_D4_PIN                           (&omv_pin_E4_DCMI)
-#define DCMI_D5_PIN                           (&omv_pin_B6_DCMI)
-#define DCMI_D6_PIN                           (&omv_pin_E5_DCMI)
-#define DCMI_D7_PIN                           (&omv_pin_E6_DCMI)
-
-#define DCMI_HSYNC_PIN                        (&omv_pin_A4_DCMI)
-#define DCMI_VSYNC_PIN                        (&omv_pin_B7_DCMI)
-#define DCMI_PXCLK_PIN                        (&omv_pin_A6_DCMI)
+#define OMV_CSI_HSYNC_PIN                     (&omv_pin_A4_DCMI)
+#define OMV_CSI_VSYNC_PIN                     (&omv_pin_B7_DCMI)
+#define OMV_CSI_PXCLK_PIN                     (&omv_pin_A6_DCMI)
+#define OMV_CSI_RESET_PIN                     (&omv_pin_A10_GPIO)
+#define OMV_CSI_POWER_PIN                     (&omv_pin_B5_GPIO)
 
 // Physical I2C buses.
 
 // I2C bus 1
-#define I2C1_ID                               (1)
-#define I2C1_SCL_PIN                          (&omv_pin_B8_I2C1)
-#define I2C1_SDA_PIN                          (&omv_pin_B9_I2C1)
+#define OMV_I2C1_ID                           (1)
+#define OMV_I2C1_SCL_PIN                      (&omv_pin_B8_I2C1)
+#define OMV_I2C1_SDA_PIN                      (&omv_pin_B9_I2C1)
 
 // I2C bus 2
-#define I2C2_ID                               (2)
-#define I2C2_SCL_PIN                          (&omv_pin_B10_I2C2)
-#define I2C2_SDA_PIN                          (&omv_pin_B11_I2C2)
+#define OMV_I2C2_ID                           (2)
+#define OMV_I2C2_SCL_PIN                      (&omv_pin_B10_I2C2)
+#define OMV_I2C2_SDA_PIN                      (&omv_pin_B11_I2C2)
 
 // Physical SPI buses.
 
 // SPI bus 2
-#define SPI2_ID                               (2)
-#define SPI2_SCLK_PIN                         (&omv_pin_B13_SPI2)
-#define SPI2_MISO_PIN                         (&omv_pin_B14_SPI2)
-#define SPI2_MOSI_PIN                         (&omv_pin_B15_SPI2)
-#define SPI2_SSEL_PIN                         (&omv_pin_B12_SPI2)
-#define SPI2_DMA_TX_CHANNEL                   (DMA1_Stream4)
-#define SPI2_DMA_RX_CHANNEL                   (DMA1_Stream3)
+#define OMV_SPI2_ID                           (2)
+#define OMV_SPI2_SCLK_PIN                     (&omv_pin_B13_SPI2)
+#define OMV_SPI2_MISO_PIN                     (&omv_pin_B14_SPI2)
+#define OMV_SPI2_MOSI_PIN                     (&omv_pin_B15_SPI2)
+#define OMV_SPI2_SSEL_PIN                     (&omv_pin_B12_SPI2)
+#define OMV_SPI2_DMA_TX_CHANNEL               (DMA1_Stream4)
+#define OMV_SPI2_DMA_RX_CHANNEL               (DMA1_Stream3)
 #define DMA_REQUEST_SPI2_TX                   (DMA_CHANNEL_0)
 #define DMA_REQUEST_SPI2_RX                   (DMA_CHANNEL_0)
 
 // SPI LCD Interface
-#define OMV_SPI_DISPLAY_CONTROLLER            (SPI2_ID)
+#define OMV_SPI_DISPLAY_CONTROLLER            (OMV_SPI2_ID)
 #define OMV_SPI_DISPLAY_MOSI_PIN              (&omv_pin_B15_SPI2)
 #define OMV_SPI_DISPLAY_MISO_PIN              (&omv_pin_B14_SPI2)
 #define OMV_SPI_DISPLAY_SCLK_PIN              (&omv_pin_B13_SPI2)
@@ -201,10 +175,10 @@
 #define OMV_SPI_DISPLAY_BL_PIN                (&omv_pin_A5_GPIO)
 
 // FIR Lepton
-#define OMV_FIR_LEPTON_I2C_BUS                (FIR_I2C_ID)
-#define OMV_FIR_LEPTON_I2C_BUS_SPEED          (FIR_I2C_SPEED)
+#define OMV_FIR_LEPTON_I2C_BUS                (OMV_FIR_I2C_ID)
+#define OMV_FIR_LEPTON_I2C_BUS_SPEED          (OMV_FIR_I2C_SPEED)
 
-#define OMV_FIR_LEPTON_SPI_BUS                (SPI2_ID)
+#define OMV_FIR_LEPTON_SPI_BUS                (OMV_SPI2_ID)
 #define OMV_FIR_LEPTON_MOSI_PIN               (&omv_pin_B15_SPI2)
 #define OMV_FIR_LEPTON_MISO_PIN               (&omv_pin_B14_SPI2)
 #define OMV_FIR_LEPTON_SCLK_PIN               (&omv_pin_B13_SPI2)

--- a/src/omv/boards/OPENMV4/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4/omv_boardconfig.h
@@ -1,8 +1,8 @@
 /*
  * This file is part of the OpenMV project.
  *
- * Copyright (c) 2013-2021 Ibrahim Abdelkader <iabdalkader@openmv.io>
- * Copyright (c) 2013-2021 Kwabena W. Agyeman <kwagyeman@openmv.io>
+ * Copyright (c) 2013-2024 Ibrahim Abdelkader <iabdalkader@openmv.io>
+ * Copyright (c) 2013-2024 Kwabena W. Agyeman <kwagyeman@openmv.io>
  *
  * This work is licensed under the MIT license, see the file LICENSE for details.
  *
@@ -12,28 +12,22 @@
 #define __OMV_BOARDCONFIG_H__
 
 // Architecture info
-#define OMV_ARCH_STR                          "OMV4 H7 1024" // 33 chars max
+#define OMV_BOARD_ARCH                        "OMV4 H7 1024" // 33 chars max
 #define OMV_BOARD_TYPE                        "H7"
-#define OMV_UNIQUE_ID_ADDR                    0x1FF1E800 // Unique ID address.
-#define OMV_UNIQUE_ID_SIZE                    3 // Unique ID size in words.
-#define OMV_UNIQUE_ID_OFFSET                  4 // Bytes offset for multi-word UIDs.
+#define OMV_BOARD_UID_ADDR                    0x1FF1E800    // Unique ID address.
+#define OMV_BOARD_UID_SIZE                    3             // Unique ID size in words.
+#define OMV_BOARD_UID_OFFSET                  4             // Bytes offset for multi-word UIDs.
 
-#define OMV_XCLK_MCO                          (0U)
-#define OMV_XCLK_TIM                          (1U)
+// JPEG configuration.
+#define OMV_JPEG_CODEC_ENABLE                 (1)
+#define OMV_JPEG_QUALITY_LOW                  (50)
+#define OMV_JPEG_QUALITY_HIGH                 (90)
+#define OMV_JPEG_QUALITY_THRESHOLD            (320 * 240 * 2)
 
-// Sensor external clock source.
-#define OMV_XCLK_SOURCE                       (OMV_XCLK_TIM)
-
-// Sensor external clock timer frequency.
-#define OMV_XCLK_FREQUENCY                    (12000000)
-
-// Sensor PLL register value.
-#define OMV_OV7725_PLL_CONFIG                 (0x41) // x4
-
-// Sensor Banding Filter Value
-#define OMV_OV7725_BANDING                    (0x7F)
-
-// OV5640 Sensor Settings
+// Image sensor drivers configuration.
+#define OMV_OV2640_ENABLE                     (1)
+#define OMV_OV5640_ENABLE                     (1)
+#define OMV_OV5640_AF_ENABLE                  (1)
 #define OMV_OV5640_XCLK_FREQ                  (24000000)
 #define OMV_OV5640_PLL_CTRL2                  (0x64)
 #define OMV_OV5640_PLL_CTRL3                  (0x13)
@@ -42,58 +36,28 @@
 #define OMV_OV5640_REV_Y_CTRL2                (0x54)
 #define OMV_OV5640_REV_Y_CTRL3                (0x13)
 
-// Enable hardware JPEG
-#define OMV_HARDWARE_JPEG                     (1)
+#define OMV_OV7725_ENABLE                     (1)
+#define OMV_OV7725_PLL_CONFIG                 (0x41) // x4
+#define OMV_OV7725_BANDING                    (0x7F)
 
-// Enable fast line transfer with DMA.
-#define OMA_ENABLE_DMA_MEMCPY                 (1)
+#define OMV_OV9650_ENABLE                     (1)
+#define OMV_MT9M114_ENABLE                    (1)
+#define OMV_MT9V0XX_ENABLE                    (1)
+#define OMV_LEPTON_ENABLE                     (1)
+#define OMV_PAJ6100_ENABLE                    (1)
+#define OMV_FROGEYE2020_ENABLE                (1)
 
-// MDMA configuration
-#define OMV_MDMA_CHANNEL_DCMI_0               (0)
-#define OMV_MDMA_CHANNEL_DCMI_1               (1)
-#define OMV_MDMA_CHANNEL_JPEG_IN              (7) // in has a lower pri than out
-#define OMV_MDMA_CHANNEL_JPEG_OUT             (6) // out has a higher pri than in
+// FIR sensor drivers configuration.
+#define OMV_FIR_MLX90621_ENABLE               (1)
+#define OMV_FIR_MLX90640_ENABLE               (1)
+#define OMV_FIR_MLX90641_ENABLE               (1)
+#define OMV_FIR_AMG8833_ENABLE                (1)
+#define OMV_FIR_LEPTON_ENABLE                 (1)
 
-// Enable sensor drivers
-#define OMV_ENABLE_OV2640                     (1)
-#define OMV_ENABLE_OV5640                     (1)
-#define OMV_ENABLE_OV7670                     (0)
-#define OMV_ENABLE_OV7690                     (1)
-#define OMV_ENABLE_OV7725                     (1)
-#define OMV_ENABLE_OV9650                     (1)
-#define OMV_ENABLE_MT9M114                    (1)
-#define OMV_ENABLE_MT9V0XX                    (1)
-#define OMV_ENABLE_LEPTON                     (1)
-#define OMV_ENABLE_HM01B0                     (0)
-#define OMV_ENABLE_PAJ6100                    (1)
-#define OMV_ENABLE_FROGEYE2020                (1)
-#define OMV_ENABLE_FIR_MLX90621               (1)
-#define OMV_ENABLE_FIR_MLX90640               (1)
-#define OMV_ENABLE_FIR_MLX90641               (1)
-#define OMV_ENABLE_FIR_AMG8833                (1)
-#define OMV_ENABLE_FIR_LEPTON                 (1)
+// Debugging configuration.
+#define OMV_WIFIDBG_ENABLE                    (1)
 
-// Set which OV767x sensor is used
-#define OMV_OV7670_VERSION                    (70)
-
-// OV7670 clock divider
-#define OMV_OV7670_CLKRC                      (0)
-
-// Enable sensor features
-#define OMV_ENABLE_OV5640_AF                  (1)
-
-// Enable WiFi debug
-#define OMV_ENABLE_WIFIDBG                    (1)
-
-// If buffer size is bigger than this threshold, the quality is reduced.
-// This is only used for JPEG images sent to the IDE not normal compression.
-#define JPEG_QUALITY_THRESH                   (320 * 240 * 2)
-
-// Low and high JPEG QS.
-#define JPEG_QUALITY_LOW                      50
-#define JPEG_QUALITY_HIGH                     90
-
-// FB Heap Block Size
+// UMM heap block size
 #define OMV_UMM_BLOCK_SIZE                    16
 
 // USB IRQn.
@@ -208,93 +172,100 @@
 //#define OMV_DMA_REGION_D3_BASE  (OMV_SRAM4_ORIGIN+(0*1024))
 //#define OMV_DMA_REGION_D3_SIZE  MPU_REGION_SIZE_64KB
 
+// MDMA configuration
+#define OMV_MDMA_CHANNEL_DCMI_0               (0)
+#define OMV_MDMA_CHANNEL_DCMI_1               (1)
+#define OMV_MDMA_CHANNEL_JPEG_IN              (7) // in has a lower pri than out
+#define OMV_MDMA_CHANNEL_JPEG_OUT             (6) // out has a higher pri than in
+
 // AXI QoS - Low-High (0:15) - default 0
 #define OMV_AXI_QOS_MDMA_R_PRI                15 // Max pri to move data.
 #define OMV_AXI_QOS_MDMA_W_PRI                15 // Max pri to move data.
 
 // Main image sensor I2C bus
-#define ISC_I2C_ID                            (1)
-#define ISC_I2C_SPEED                         (OMV_I2C_SPEED_STANDARD)
+#define OMV_CSI_I2C_ID                        (1)
+#define OMV_CSI_I2C_SPEED                     (OMV_I2C_SPEED_STANDARD)
 
 // Thermal image sensor I2C bus
-#define FIR_I2C_ID                            (2)
-#define FIR_I2C_SPEED                         (OMV_I2C_SPEED_FULL)
+#define OMV_FIR_I2C_ID                        (2)
+#define OMV_FIR_I2C_SPEED                     (OMV_I2C_SPEED_FULL)
 
 // Soft I2C bus
-#define SOFT_I2C_SIOC_PIN                     (&omv_pin_B10_GPIO)
-#define SOFT_I2C_SIOD_PIN                     (&omv_pin_B11_GPIO)
-#define SOFT_I2C_SPIN_DELAY                   64
+#define OMV_SOFT_I2C_SIOC_PIN                 (&omv_pin_B10_GPIO)
+#define OMV_SOFT_I2C_SIOD_PIN                 (&omv_pin_B11_GPIO)
+#define OMV_SOFT_I2C_SPIN_DELAY               64
 
 // Main image sensor SPI bus
-#define ISC_SPI_ID                            (3)
+#define OMV_CSI_SPI_ID                        (3)
 
 // WINC1500 WiFi module SPI bus
-#define WINC_SPI_ID                           (2)
-#define WINC_SPI_BAUDRATE                     (40000000)
-#define WINC_EN_PIN                           (&omv_pin_A5_GPIO)
-#define WINC_RST_PIN                          (&omv_pin_D12_GPIO)
-#define WINC_IRQ_PIN                          (&omv_pin_D13_GPIO)
+#define OMV_WINC_SPI_ID                       (2)
+#define OMV_WINC_SPI_BAUDRATE                 (40000000)
+#define OMV_WINC_EN_PIN                       (&omv_pin_A5_GPIO)
+#define OMV_WINC_RST_PIN                      (&omv_pin_D12_GPIO)
+#define OMV_WINC_IRQ_PIN                      (&omv_pin_D13_GPIO)
 
-// DCMI timer.
-#define DCMI_TIM                              (TIM1)
-#define DCMI_TIM_PIN                          (&omv_pin_A8_TIM1)
-#define DCMI_TIM_CHANNEL                      (TIM_CHANNEL_1)
-#define DCMI_TIM_CLK_ENABLE()                 __TIM1_CLK_ENABLE()
-#define DCMI_TIM_CLK_DISABLE()                __TIM1_CLK_DISABLE()
-#define DCMI_TIM_PCLK_FREQ()                  HAL_RCC_GetPCLK2Freq()
+// Camera Interface
+#define OMV_CSI_XCLK_SOURCE                   (XCLK_SOURCE_TIM)
+#define OMV_CSI_XCLK_FREQUENCY                (12000000)
+#define OMV_CSI_TIM                           (TIM1)
+#define OMV_CSI_TIM_PIN                       (&omv_pin_A8_TIM1)
+#define OMV_CSI_TIM_CHANNEL                   (TIM_CHANNEL_1)
+#define OMV_CSI_TIM_CLK_ENABLE()              __TIM1_CLK_ENABLE()
+#define OMV_CSI_TIM_CLK_DISABLE()             __TIM1_CLK_DISABLE()
+#define OMV_CSI_TIM_PCLK_FREQ()               HAL_RCC_GetPCLK2Freq()
+#define OMV_CSI_DMA_MEMCPY_ENABLE             (1)
 
-// DCMI pins.
-#define DCMI_RESET_PIN                        (&omv_pin_A10_GPIO)
-#define DCMI_POWER_PIN                        (&omv_pin_D7_GPIO)
-#define DCMI_FSYNC_PIN                        (&omv_pin_B4_GPIO)
+#define OMV_CSI_D0_PIN                        (&omv_pin_C6_DCMI)
+#define OMV_CSI_D1_PIN                        (&omv_pin_C7_DCMI)
+#define OMV_CSI_D2_PIN                        (&omv_pin_E0_DCMI)
+#define OMV_CSI_D3_PIN                        (&omv_pin_E1_DCMI)
+#define OMV_CSI_D4_PIN                        (&omv_pin_E4_DCMI)
+#define OMV_CSI_D5_PIN                        (&omv_pin_B6_DCMI)
+#define OMV_CSI_D6_PIN                        (&omv_pin_E5_DCMI)
+#define OMV_CSI_D7_PIN                        (&omv_pin_E6_DCMI)
 
-#define DCMI_D0_PIN                           (&omv_pin_C6_DCMI)
-#define DCMI_D1_PIN                           (&omv_pin_C7_DCMI)
-#define DCMI_D2_PIN                           (&omv_pin_E0_DCMI)
-#define DCMI_D3_PIN                           (&omv_pin_E1_DCMI)
-#define DCMI_D4_PIN                           (&omv_pin_E4_DCMI)
-#define DCMI_D5_PIN                           (&omv_pin_B6_DCMI)
-#define DCMI_D6_PIN                           (&omv_pin_E5_DCMI)
-#define DCMI_D7_PIN                           (&omv_pin_E6_DCMI)
-
-#define DCMI_HSYNC_PIN                        (&omv_pin_A4_DCMI)
-#define DCMI_VSYNC_PIN                        (&omv_pin_B7_DCMI)
-#define DCMI_PXCLK_PIN                        (&omv_pin_A6_DCMI)
+#define OMV_CSI_HSYNC_PIN                     (&omv_pin_A4_DCMI)
+#define OMV_CSI_VSYNC_PIN                     (&omv_pin_B7_DCMI)
+#define OMV_CSI_PXCLK_PIN                     (&omv_pin_A6_DCMI)
+#define OMV_CSI_RESET_PIN                     (&omv_pin_A10_GPIO)
+#define OMV_CSI_POWER_PIN                     (&omv_pin_D7_GPIO)
+#define OMV_CSI_FSYNC_PIN                     (&omv_pin_B4_GPIO)
 
 // Physical I2C buses.
 
 // I2C bus 1
-#define I2C1_ID                               (1)
-#define I2C1_SCL_PIN                          (&omv_pin_B8_I2C1)
-#define I2C1_SDA_PIN                          (&omv_pin_B9_I2C1)
+#define OMV_I2C1_ID                           (1)
+#define OMV_I2C1_SCL_PIN                      (&omv_pin_B8_I2C1)
+#define OMV_I2C1_SDA_PIN                      (&omv_pin_B9_I2C1)
 
 // I2C bus 2
-#define I2C2_ID                               (2)
-#define I2C2_SCL_PIN                          (&omv_pin_B10_I2C2)
-#define I2C2_SDA_PIN                          (&omv_pin_B11_I2C2)
+#define OMV_I2C2_ID                           (2)
+#define OMV_I2C2_SCL_PIN                      (&omv_pin_B10_I2C2)
+#define OMV_I2C2_SDA_PIN                      (&omv_pin_B11_I2C2)
 
 // Physical SPI buses.
 
 // SPI bus 2
-#define SPI2_ID                               (2)
-#define SPI2_SCLK_PIN                         (&omv_pin_B13_SPI2)
-#define SPI2_MISO_PIN                         (&omv_pin_B14_SPI2)
-#define SPI2_MOSI_PIN                         (&omv_pin_B15_SPI2)
-#define SPI2_SSEL_PIN                         (&omv_pin_B12_SPI2)
-#define SPI2_DMA_TX_CHANNEL                   (DMA1_Stream4)
-#define SPI2_DMA_RX_CHANNEL                   (DMA1_Stream3)
+#define OMV_SPI2_ID                           (2)
+#define OMV_SPI2_SCLK_PIN                     (&omv_pin_B13_SPI2)
+#define OMV_SPI2_MISO_PIN                     (&omv_pin_B14_SPI2)
+#define OMV_SPI2_MOSI_PIN                     (&omv_pin_B15_SPI2)
+#define OMV_SPI2_SSEL_PIN                     (&omv_pin_B12_SPI2)
+#define OMV_SPI2_DMA_TX_CHANNEL               (DMA1_Stream4)
+#define OMV_SPI2_DMA_RX_CHANNEL               (DMA1_Stream3)
 
 // SPI bus 3
-#define SPI3_ID                               (3)
-#define SPI3_SCLK_PIN                         (&omv_pin_B3_SPI3)
-#define SPI3_MISO_PIN                         (&omv_pin_B4_SPI3)
-#define SPI3_MOSI_PIN                         (&omv_pin_B5_SPI3)
-#define SPI3_SSEL_PIN                         (&omv_pin_A15_SPI3)
-#define SPI3_DMA_TX_CHANNEL                   (DMA1_Stream7)
-#define SPI3_DMA_RX_CHANNEL                   (DMA1_Stream2)
+#define OMV_SPI3_ID                           (3)
+#define OMV_SPI3_SCLK_PIN                     (&omv_pin_B3_SPI3)
+#define OMV_SPI3_MISO_PIN                     (&omv_pin_B4_SPI3)
+#define OMV_SPI3_MOSI_PIN                     (&omv_pin_B5_SPI3)
+#define OMV_SPI3_SSEL_PIN                     (&omv_pin_A15_SPI3)
+#define OMV_SPI3_DMA_TX_CHANNEL               (DMA1_Stream7)
+#define OMV_SPI3_DMA_RX_CHANNEL               (DMA1_Stream2)
 
 // SPI LCD Interface
-#define OMV_SPI_DISPLAY_CONTROLLER            (SPI2_ID)
+#define OMV_SPI_DISPLAY_CONTROLLER            (OMV_SPI2_ID)
 #define OMV_SPI_DISPLAY_MOSI_PIN              (&omv_pin_B15_SPI2)
 #define OMV_SPI_DISPLAY_MISO_PIN              (&omv_pin_B14_SPI2)
 #define OMV_SPI_DISPLAY_SCLK_PIN              (&omv_pin_B13_SPI2)
@@ -305,10 +276,10 @@
 #define OMV_SPI_DISPLAY_BL_PIN                (&omv_pin_A5_GPIO)
 
 // FIR Lepton
-#define OMV_FIR_LEPTON_I2C_BUS                (FIR_I2C_ID)
-#define OMV_FIR_LEPTON_I2C_BUS_SPEED          (FIR_I2C_SPEED)
+#define OMV_FIR_LEPTON_I2C_BUS                (OMV_FIR_I2C_ID)
+#define OMV_FIR_LEPTON_I2C_BUS_SPEED          (OMV_FIR_I2C_SPEED)
 
-#define OMV_FIR_LEPTON_SPI_BUS                (SPI2_ID)
+#define OMV_FIR_LEPTON_SPI_BUS                (OMV_SPI2_ID)
 #define OMV_FIR_LEPTON_MOSI_PIN               (&omv_pin_B15_SPI2)
 #define OMV_FIR_LEPTON_MISO_PIN               (&omv_pin_B14_SPI2)
 #define OMV_FIR_LEPTON_SCLK_PIN               (&omv_pin_B13_SPI2)

--- a/src/omv/boards/OPENMV4P/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4P/omv_boardconfig.h
@@ -1,8 +1,8 @@
 /*
  * This file is part of the OpenMV project.
  *
- * Copyright (c) 2013-2021 Ibrahim Abdelkader <iabdalkader@openmv.io>
- * Copyright (c) 2013-2021 Kwabena W. Agyeman <kwagyeman@openmv.io>
+ * Copyright (c) 2013-2024 Ibrahim Abdelkader <iabdalkader@openmv.io>
+ * Copyright (c) 2013-2024 Kwabena W. Agyeman <kwagyeman@openmv.io>
  *
  * This work is licensed under the MIT license, see the file LICENSE for details.
  *
@@ -12,28 +12,23 @@
 #define __OMV_BOARDCONFIG_H__
 
 // Architecture info
-#define OMV_ARCH_STR                          "OMV4P H7 32768 SDRAM" // 33 chars max
+#define OMV_BOARD_ARCH                        "OMV4P H7 32768 SDRAM" // 33 chars max
 #define OMV_BOARD_TYPE                        "H7"
-#define OMV_UNIQUE_ID_ADDR                    0x1FF1E800 // Unique ID address.
-#define OMV_UNIQUE_ID_SIZE                    3 // Unique ID size in words.
-#define OMV_UNIQUE_ID_OFFSET                  4 // Bytes offset for multi-word UIDs.
+#define OMV_BOARD_UID_ADDR                    0x1FF1E800    // Unique ID address.
+#define OMV_BOARD_UID_SIZE                    3             // Unique ID size in words.
+#define OMV_BOARD_UID_OFFSET                  4             // Bytes offset for multi-word UIDs.
 
-#define OMV_XCLK_MCO                          (0U)
-#define OMV_XCLK_TIM                          (1U)
+// JPEG compression settings.
+#define OMV_JPEG_CODEC_ENABLE                 (1)
+#define OMV_JPEG_QUALITY_LOW                  (50)
+#define OMV_JPEG_QUALITY_HIGH                 (90)
+#define OMV_JPEG_QUALITY_THRESHOLD            (1920 * 1080 * 2)
 
-// Sensor external clock source.
-#define OMV_XCLK_SOURCE                       (OMV_XCLK_TIM)
+// Image sensor drivers configuration.
+#define OMV_OV2640_ENABLE                     (1)
 
-// Sensor external clock timer frequency.
-#define OMV_XCLK_FREQUENCY                    (12000000)
-
-// Sensor PLL register value.
-#define OMV_OV7725_PLL_CONFIG                 (0x41) // x4
-
-// Sensor Banding Filter Value
-#define OMV_OV7725_BANDING                    (0x7F)
-
-// OV5640 Sensor Settings
+#define OMV_OV5640_ENABLE                     (1)
+#define OMV_OV5640_AF_ENABLE                  (1)
 #define OMV_OV5640_XCLK_FREQ                  (24000000)
 #define OMV_OV5640_PLL_CTRL2                  (0x64)
 #define OMV_OV5640_PLL_CTRL3                  (0x13)
@@ -42,57 +37,28 @@
 #define OMV_OV5640_REV_Y_CTRL2                (0x54)
 #define OMV_OV5640_REV_Y_CTRL3                (0x13)
 
-// Enable hardware JPEG
-#define OMV_HARDWARE_JPEG                     (1)
+#define OMV_OV7725_ENABLE                     (1)
+#define OMV_OV7725_PLL_CONFIG                 (0x41) // x4
+#define OMV_OV7725_BANDING                    (0x7F)
 
-// Enable fast line transfer with DMA.
-#define OMA_ENABLE_DMA_MEMCPY                 (1)
+#define OMV_OV9650_ENABLE                     (1)
+#define OMV_MT9M114_ENABLE                    (1)
+#define OMV_MT9V0XX_ENABLE                    (1)
+#define OMV_LEPTON_ENABLE                     (1)
+#define OMV_PAJ6100_ENABLE                    (1)
+#define OMV_FROGEYE2020_ENABLE                (1)
 
-// MDMA configuration
-#define OMV_MDMA_CHANNEL_DCMI_0               (0)
-#define OMV_MDMA_CHANNEL_DCMI_1               (1)
-#define OMV_MDMA_CHANNEL_JPEG_IN              (7) // in has a lower pri than out
-#define OMV_MDMA_CHANNEL_JPEG_OUT             (6) // out has a higher pri than in
+// FIR sensor drivers configuration.
+#define OMV_FIR_MLX90621_ENABLE               (1)
+#define OMV_FIR_MLX90640_ENABLE               (1)
+#define OMV_FIR_MLX90641_ENABLE               (1)
+#define OMV_FIR_AMG8833_ENABLE                (1)
+#define OMV_FIR_LEPTON_ENABLE                 (1)
 
-// Enable sensor drivers
-#define OMV_ENABLE_OV2640                     (1)
-#define OMV_ENABLE_OV5640                     (1)
-#define OMV_ENABLE_OV7690                     (0)
-#define OMV_ENABLE_OV7725                     (1)
-#define OMV_ENABLE_OV9650                     (1)
-#define OMV_ENABLE_MT9M114                    (1)
-#define OMV_ENABLE_MT9V0XX                    (1)
-#define OMV_ENABLE_LEPTON                     (1)
-#define OMV_ENABLE_HM01B0                     (0)
-#define OMV_ENABLE_PAJ6100                    (1)
-#define OMV_ENABLE_FROGEYE2020                (1)
-#define OMV_ENABLE_FIR_MLX90621               (1)
-#define OMV_ENABLE_FIR_MLX90640               (1)
-#define OMV_ENABLE_FIR_MLX90641               (1)
-#define OMV_ENABLE_FIR_AMG8833                (1)
-#define OMV_ENABLE_FIR_LEPTON                 (1)
+// Debugging configuration.
+#define OMV_WIFIDBG_ENABLE                    (1)
 
-// Enable additional GPIO banks.
-#define OMV_ENABLE_GPIO_BANK_F                (1)
-#define OMV_ENABLE_GPIO_BANK_G                (1)
-#define OMV_ENABLE_GPIO_BANK_H                (1)
-#define OMV_ENABLE_GPIO_BANK_I                (1)
-
-// Enable sensor features
-#define OMV_ENABLE_OV5640_AF                  (1)
-
-// Enable WiFi debug
-#define OMV_ENABLE_WIFIDBG                    (1)
-
-// If buffer size is bigger than this threshold, the quality is reduced.
-// This is only used for JPEG images sent to the IDE not normal compression.
-#define JPEG_QUALITY_THRESH                   (1920 * 1080 * 2)
-
-// Low and high JPEG QS.
-#define JPEG_QUALITY_LOW                      50
-#define JPEG_QUALITY_HIGH                     90
-
-// FB Heap Block Size
+// UMM heap block size
 #define OMV_UMM_BLOCK_SIZE                    256
 
 // USB IRQn.
@@ -211,93 +177,106 @@
 #define OMV_DMA_REGION_D3_BASE                (OMV_SRAM4_ORIGIN + (0 * 1024))
 #define OMV_DMA_REGION_D3_SIZE                MPU_REGION_SIZE_64KB
 
+// MDMA configuration
+#define OMV_MDMA_CHANNEL_DCMI_0               (0)
+#define OMV_MDMA_CHANNEL_DCMI_1               (1)
+#define OMV_MDMA_CHANNEL_JPEG_IN              (7) // in has a lower pri than out
+#define OMV_MDMA_CHANNEL_JPEG_OUT             (6) // out has a higher pri than in
+
 // AXI QoS - Low-High (0:15) - default 0
 #define OMV_AXI_QOS_MDMA_R_PRI                15 // Max pri to move data.
 #define OMV_AXI_QOS_MDMA_W_PRI                15 // Max pri to move data.
 
+// Enable additional GPIO ports.
+#define OMV_GPIO_PORT_F_ENABLE                (1)
+#define OMV_GPIO_PORT_G_ENABLE                (1)
+#define OMV_GPIO_PORT_H_ENABLE                (1)
+#define OMV_GPIO_PORT_I_ENABLE                (1)
+
 // Main image sensor I2C bus
-#define ISC_I2C_ID                            (1)
-#define ISC_I2C_SPEED                         (OMV_I2C_SPEED_STANDARD)
+#define OMV_CSI_I2C_ID                        (1)
+#define OMV_CSI_I2C_SPEED                     (OMV_I2C_SPEED_STANDARD)
 
 // Thermal image sensor I2C bus
-#define FIR_I2C_ID                            (2)
-#define FIR_I2C_SPEED                         (OMV_I2C_SPEED_FULL)
+#define OMV_FIR_I2C_ID                        (2)
+#define OMV_FIR_I2C_SPEED                     (OMV_I2C_SPEED_FULL)
 
 // Soft I2C bus.
-#define SOFT_I2C_SIOC_PIN                     (&omv_pin_B10_GPIO)
-#define SOFT_I2C_SIOD_PIN                     (&omv_pin_B11_GPIO)
-#define SOFT_I2C_SPIN_DELAY                   64
+#define OMV_SOFT_I2C_SIOC_PIN                 (&omv_pin_B10_GPIO)
+#define OMV_SOFT_I2C_SIOD_PIN                 (&omv_pin_B11_GPIO)
+#define OMV_SOFT_I2C_SPIN_DELAY               64
 
 // Main image sensor SPI bus
-#define ISC_SPI_ID                            (3)
+#define OMV_CSI_SPI_ID                        (3)
 
 // WINC1500 WiFi module SPI bus
-#define WINC_SPI_ID                           (2)
-#define WINC_SPI_BAUDRATE                     (40000000)
-#define WINC_EN_PIN                           (&omv_pin_A5_GPIO)
-#define WINC_RST_PIN                          (&omv_pin_D12_GPIO)
-#define WINC_IRQ_PIN                          (&omv_pin_D13_GPIO)
+#define OMV_WINC_SPI_ID                       (2)
+#define OMV_WINC_SPI_BAUDRATE                 (40000000)
+#define OMV_WINC_EN_PIN                       (&omv_pin_A5_GPIO)
+#define OMV_WINC_RST_PIN                      (&omv_pin_D12_GPIO)
+#define OMV_WINC_IRQ_PIN                      (&omv_pin_D13_GPIO)
 
-// DCMI timer.
-#define DCMI_TIM                              (TIM1)
-#define DCMI_TIM_PIN                          (&omv_pin_A8_TIM1)
-#define DCMI_TIM_CHANNEL                      (TIM_CHANNEL_1)
-#define DCMI_TIM_CLK_ENABLE()                 __TIM1_CLK_ENABLE()
-#define DCMI_TIM_CLK_DISABLE()                __TIM1_CLK_DISABLE()
-#define DCMI_TIM_PCLK_FREQ()                  HAL_RCC_GetPCLK2Freq()
+// Camera Interface
+#define OMV_CSI_XCLK_SOURCE                   (XCLK_SOURCE_TIM)
+#define OMV_CSI_XCLK_FREQUENCY                (12000000)
+#define OMV_CSI_TIM                           (TIM1)
+#define OMV_CSI_TIM_PIN                       (&omv_pin_A8_TIM1)
+#define OMV_CSI_TIM_CHANNEL                   (TIM_CHANNEL_1)
+#define OMV_CSI_TIM_CLK_ENABLE()              __TIM1_CLK_ENABLE()
+#define OMV_CSI_TIM_CLK_DISABLE()             __TIM1_CLK_DISABLE()
+#define OMV_CSI_TIM_PCLK_FREQ()               HAL_RCC_GetPCLK2Freq()
+#define OMV_CSI_DMA_MEMCPY_ENABLE             (1)
 
-// DCMI pins.
-#define DCMI_RESET_PIN                        (&omv_pin_A10_GPIO)
-#define DCMI_POWER_PIN                        (&omv_pin_D7_GPIO)
-#define DCMI_FSYNC_PIN                        (&omv_pin_B4_GPIO)
+#define OMV_CSI_D0_PIN                        (&omv_pin_C6_DCMI)
+#define OMV_CSI_D1_PIN                        (&omv_pin_C7_DCMI)
+#define OMV_CSI_D2_PIN                        (&omv_pin_G10_DCMI)
+#define OMV_CSI_D3_PIN                        (&omv_pin_G11_DCMI)
+#define OMV_CSI_D4_PIN                        (&omv_pin_E4_DCMI)
+#define OMV_CSI_D5_PIN                        (&omv_pin_B6_DCMI)
+#define OMV_CSI_D6_PIN                        (&omv_pin_E5_DCMI)
+#define OMV_CSI_D7_PIN                        (&omv_pin_E6_DCMI)
 
-#define DCMI_D0_PIN                           (&omv_pin_C6_DCMI)
-#define DCMI_D1_PIN                           (&omv_pin_C7_DCMI)
-#define DCMI_D2_PIN                           (&omv_pin_G10_DCMI)
-#define DCMI_D3_PIN                           (&omv_pin_G11_DCMI)
-#define DCMI_D4_PIN                           (&omv_pin_E4_DCMI)
-#define DCMI_D5_PIN                           (&omv_pin_B6_DCMI)
-#define DCMI_D6_PIN                           (&omv_pin_E5_DCMI)
-#define DCMI_D7_PIN                           (&omv_pin_E6_DCMI)
-
-#define DCMI_HSYNC_PIN                        (&omv_pin_A4_DCMI)
-#define DCMI_VSYNC_PIN                        (&omv_pin_B7_DCMI)
-#define DCMI_PXCLK_PIN                        (&omv_pin_A6_DCMI)
+#define OMV_CSI_HSYNC_PIN                     (&omv_pin_A4_DCMI)
+#define OMV_CSI_VSYNC_PIN                     (&omv_pin_B7_DCMI)
+#define OMV_CSI_PXCLK_PIN                     (&omv_pin_A6_DCMI)
+#define OMV_CSI_RESET_PIN                     (&omv_pin_A10_GPIO)
+#define OMV_CSI_POWER_PIN                     (&omv_pin_D7_GPIO)
+#define OMV_CSI_FSYNC_PIN                     (&omv_pin_B4_GPIO)
 
 // Physical I2C buses.
 
 // I2C bus 1
-#define I2C1_ID                               (1)
-#define I2C1_SCL_PIN                          (&omv_pin_B8_I2C1)
-#define I2C1_SDA_PIN                          (&omv_pin_B9_I2C1)
+#define OMV_I2C1_ID                           (1)
+#define OMV_I2C1_SCL_PIN                      (&omv_pin_B8_I2C1)
+#define OMV_I2C1_SDA_PIN                      (&omv_pin_B9_I2C1)
 
 // I2C bus 2
-#define I2C2_ID                               (2)
-#define I2C2_SCL_PIN                          (&omv_pin_B10_I2C2)
-#define I2C2_SDA_PIN                          (&omv_pin_B11_I2C2)
+#define OMV_I2C2_ID                           (2)
+#define OMV_I2C2_SCL_PIN                      (&omv_pin_B10_I2C2)
+#define OMV_I2C2_SDA_PIN                      (&omv_pin_B11_I2C2)
 
 // Physical SPI buses.
 
 // SPI bus 2
-#define SPI2_ID                               (2)
-#define SPI2_SCLK_PIN                         (&omv_pin_B13_SPI2)
-#define SPI2_MISO_PIN                         (&omv_pin_B14_SPI2)
-#define SPI2_MOSI_PIN                         (&omv_pin_B15_SPI2)
-#define SPI2_SSEL_PIN                         (&omv_pin_B12_SPI2)
-#define SPI2_DMA_TX_CHANNEL                   (DMA1_Stream4)
-#define SPI2_DMA_RX_CHANNEL                   (DMA1_Stream3)
+#define OMV_SPI2_ID                           (2)
+#define OMV_SPI2_SCLK_PIN                     (&omv_pin_B13_SPI2)
+#define OMV_SPI2_MISO_PIN                     (&omv_pin_B14_SPI2)
+#define OMV_SPI2_MOSI_PIN                     (&omv_pin_B15_SPI2)
+#define OMV_SPI2_SSEL_PIN                     (&omv_pin_B12_SPI2)
+#define OMV_SPI2_DMA_TX_CHANNEL               (DMA1_Stream4)
+#define OMV_SPI2_DMA_RX_CHANNEL               (DMA1_Stream3)
 
 // SPI bus 3
-#define SPI3_ID                               (3)
-#define SPI3_SCLK_PIN                         (&omv_pin_B3_SPI3)
-#define SPI3_MISO_PIN                         (&omv_pin_B4_SPI3)
-#define SPI3_MOSI_PIN                         (&omv_pin_B5_SPI3)
-#define SPI3_SSEL_PIN                         (&omv_pin_A15_SPI3)
-#define SPI3_DMA_TX_CHANNEL                   (DMA1_Stream7)
-#define SPI3_DMA_RX_CHANNEL                   (DMA1_Stream2)
+#define OMV_SPI3_ID                           (3)
+#define OMV_SPI3_SCLK_PIN                     (&omv_pin_B3_SPI3)
+#define OMV_SPI3_MISO_PIN                     (&omv_pin_B4_SPI3)
+#define OMV_SPI3_MOSI_PIN                     (&omv_pin_B5_SPI3)
+#define OMV_SPI3_SSEL_PIN                     (&omv_pin_A15_SPI3)
+#define OMV_SPI3_DMA_TX_CHANNEL               (DMA1_Stream7)
+#define OMV_SPI3_DMA_RX_CHANNEL               (DMA1_Stream2)
 
 // SPI LCD Interface
-#define OMV_SPI_DISPLAY_CONTROLLER            (SPI2_ID)
+#define OMV_SPI_DISPLAY_CONTROLLER            (OMV_SPI2_ID)
 #define OMV_SPI_DISPLAY_MOSI_PIN              (&omv_pin_B15_SPI2)
 #define OMV_SPI_DISPLAY_MISO_PIN              (&omv_pin_B14_SPI2)
 #define OMV_SPI_DISPLAY_SCLK_PIN              (&omv_pin_B13_SPI2)
@@ -309,10 +288,10 @@
 #define OMV_SPI_DISPLAY_TRIPLE_BUFFER         (1)
 
 // FIR Lepton
-#define OMV_FIR_LEPTON_I2C_BUS                (FIR_I2C_ID)
-#define OMV_FIR_LEPTON_I2C_BUS_SPEED          (FIR_I2C_SPEED)
+#define OMV_FIR_LEPTON_I2C_BUS                (OMV_FIR_I2C_ID)
+#define OMV_FIR_LEPTON_I2C_BUS_SPEED          (OMV_FIR_I2C_SPEED)
 
-#define OMV_FIR_LEPTON_SPI_BUS                (SPI2_ID)
+#define OMV_FIR_LEPTON_SPI_BUS                (OMV_SPI2_ID)
 #define OMV_FIR_LEPTON_MOSI_PIN               (&omv_pin_B15_SPI2)
 #define OMV_FIR_LEPTON_MISO_PIN               (&omv_pin_B14_SPI2)
 #define OMV_FIR_LEPTON_SCLK_PIN               (&omv_pin_B13_SPI2)

--- a/src/omv/boards/OPENMV4_PRO/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4_PRO/omv_boardconfig.h
@@ -1,8 +1,8 @@
 /*
  * This file is part of the OpenMV project.
  *
- * Copyright (c) 2013-2021 Ibrahim Abdelkader <iabdalkader@openmv.io>
- * Copyright (c) 2013-2021 Kwabena W. Agyeman <kwagyeman@openmv.io>
+ * Copyright (c) 2013-2024 Ibrahim Abdelkader <iabdalkader@openmv.io>
+ * Copyright (c) 2013-2024 Kwabena W. Agyeman <kwagyeman@openmv.io>
  *
  * This work is licensed under the MIT license, see the file LICENSE for details.
  *
@@ -12,67 +12,22 @@
 #define __OMV_BOARDCONFIG_H__
 
 // Architecture info
-#define OMV_ARCH_STR                          "OMV4 H7 PRO 32768 SDRAM" // 33 chars max
+#define OMV_BOARD_ARCH                        "OMV4 H7 PRO 32768 SDRAM" // 33 chars max
 #define OMV_BOARD_TYPE                        "H7"
-#define OMV_UNIQUE_ID_ADDR                    0x1FF1E800 // Unique ID address.
-#define OMV_UNIQUE_ID_SIZE                    3 // Unique ID size in words.
-#define OMV_UNIQUE_ID_OFFSET                  4 // Bytes offset for multi-word UIDs.
+#define OMV_BOARD_UID_ADDR                    0x1FF1E800    // Unique ID address.
+#define OMV_BOARD_UID_SIZE                    3             // Unique ID size in words.
+#define OMV_BOARD_UID_OFFSET                  4             // Bytes offset for multi-word UIDs.
 
-#define OMV_XCLK_MCO                          (0U)
-#define OMV_XCLK_TIM                          (1U)
+// JPEG configuration.
+#define OMV_JPEG_CODEC_ENABLE                 (1)
+#define OMV_JPEG_QUALITY_LOW                  (50)
+#define OMV_JPEG_QUALITY_HIGH                 (90)
+#define OMV_JPEG_QUALITY_THRESHOLD            (1920 * 1080 * 2)
 
-// Sensor external clock source.
-#define OMV_XCLK_SOURCE                       (OMV_XCLK_TIM)
+// Image sensor drivers configuration.
+#define OMV_OV2640_ENABLE                     (1)
 
-// Sensor external clock timer frequency.
-#define OMV_XCLK_FREQUENCY                    (24000000)
-
-// Enable hardware JPEG
-#define OMV_HARDWARE_JPEG                     (1)
-
-// Enable fast line transfer with DMA.
-#define OMA_ENABLE_DMA_MEMCPY                 (1)
-
-// MDMA configuration
-#define OMV_MDMA_CHANNEL_DCMI_0               (0)
-#define OMV_MDMA_CHANNEL_DCMI_1               (1)
-#define OMV_MDMA_CHANNEL_JPEG_IN              (7) // in has a lower pri than out
-#define OMV_MDMA_CHANNEL_JPEG_OUT             (6) // out has a higher pri than in
-
-// Enable additional GPIO banks
-#define OMV_ENABLE_GPIO_BANK_F                (1)
-#define OMV_ENABLE_GPIO_BANK_G                (1)
-#define OMV_ENABLE_GPIO_BANK_H                (1)
-#define OMV_ENABLE_GPIO_BANK_I                (1)
-#define OMV_ENABLE_GPIO_BANK_J                (1)
-#define OMV_ENABLE_GPIO_BANK_K                (1)
-
-// Configure image sensor drivers
-#define OMV_ENABLE_OV2640                     (1)
-#define OMV_ENABLE_OV5640                     (1)
-#define OMV_ENABLE_OV7690                     (0)
-#define OMV_ENABLE_OV7725                     (1)
-#define OMV_ENABLE_OV9650                     (1)
-#define OMV_ENABLE_MT9M114                    (1)
-#define OMV_ENABLE_MT9V0XX                    (1)
-#define OMV_ENABLE_LEPTON                     (1)
-#define OMV_ENABLE_HM01B0                     (0)
-#define OMV_ENABLE_PAJ6100                    (1)
-#define OMV_ENABLE_FROGEYE2020                (1)
-
-// Configure FIR sensors drivers
-#define OMV_ENABLE_FIR_MLX90621               (1)
-#define OMV_ENABLE_FIR_MLX90640               (1)
-#define OMV_ENABLE_FIR_MLX90641               (1)
-#define OMV_ENABLE_FIR_AMG8833                (1)
-#define OMV_ENABLE_FIR_LEPTON                 (0)
-#define OMV_ENABLE_TOF_VL53L5CX               (1)
-
-// OV7725 sensor settings
-#define OMV_OV7725_PLL_CONFIG                 (0x41) // x4
-#define OMV_OV7725_BANDING                    (0x7F)
-
-// OV5640 sensor settings
+#define OMV_OV5640_ENABLE                     (1)
 #define OMV_OV5640_XCLK_FREQ                  (24000000)
 #define OMV_OV5640_PLL_CTRL2                  (0x64)
 #define OMV_OV5640_PLL_CTRL3                  (0x13)
@@ -80,20 +35,32 @@
 #define OMV_OV5640_REV_Y_FREQ                 (25000000)
 #define OMV_OV5640_REV_Y_CTRL2                (0x54)
 #define OMV_OV5640_REV_Y_CTRL3                (0x13)
-#define OMV_ENABLE_OV5640_AF                  (0)
+#define OMV_OV5640_AF_ENABLE                  (0)
 
-// Enable WiFi debug
-#define OMV_ENABLE_WIFIDBG                    (0)
+#define OMV_OV7725_ENABLE                     (1)
+#define OMV_OV7725_PLL_CONFIG                 (0x41) // x4
+#define OMV_OV7725_BANDING                    (0x7F)
+#define OMV_OV9650_ENABLE                     (1)
 
-// If buffer size is bigger than this threshold, the quality is reduced.
-// This is only used for JPEG images sent to the IDE not normal compression.
-#define JPEG_QUALITY_THRESH                   (1920 * 1080 * 2)
+#define OMV_MT9M114_ENABLE                    (1)
+#define OMV_MT9V0XX_ENABLE                    (1)
+#define OMV_LEPTON_ENABLE                     (1)
+#define OMV_HM01B0_ENABLE                     (0)
+#define OMV_PAJ6100_ENABLE                    (1)
+#define OMV_FROGEYE2020_ENABLE                (1)
 
-// Low and high JPEG QS.
-#define JPEG_QUALITY_LOW                      50
-#define JPEG_QUALITY_HIGH                     90
+// FIR sensor drivers configuration.
+#define OMV_FIR_MLX90621_ENABLE               (1)
+#define OMV_FIR_MLX90640_ENABLE               (1)
+#define OMV_FIR_MLX90641_ENABLE               (1)
+#define OMV_FIR_AMG8833_ENABLE                (1)
+#define OMV_FIR_LEPTON_ENABLE                 (0)
+#define OMV_TOF_VL53L5CX_ENABLE               (1)
 
-// FB Heap Block Size
+// Debugging configuration.
+#define OMV_WIFIDBG_ENABLE                    (1)
+
+// UMM heap block size
 #define OMV_UMM_BLOCK_SIZE                    256
 
 // USB IRQn.
@@ -226,17 +193,31 @@
 #define OMV_DMA_REGION_D3_BASE                (OMV_SRAM4_ORIGIN + (0 * 1024))
 #define OMV_DMA_REGION_D3_SIZE                MPU_REGION_SIZE_4KB
 
+// MDMA configuration
+#define OMV_MDMA_CHANNEL_DCMI_0               (0)
+#define OMV_MDMA_CHANNEL_DCMI_1               (1)
+#define OMV_MDMA_CHANNEL_JPEG_IN              (7) // in has a lower pri than out
+#define OMV_MDMA_CHANNEL_JPEG_OUT             (6) // out has a higher pri than in
+
 // AXI QoS - Low-High (0:15) - default 0
 #define OMV_AXI_QOS_MDMA_R_PRI                15 // Max pri to move data.
 #define OMV_AXI_QOS_MDMA_W_PRI                15 // Max pri to move data.
 
+// Enable additional GPIO ports
+#define OMV_GPIO_PORT_F_ENABLE                (1)
+#define OMV_GPIO_PORT_G_ENABLE                (1)
+#define OMV_GPIO_PORT_H_ENABLE                (1)
+#define OMV_GPIO_PORT_I_ENABLE                (1)
+#define OMV_GPIO_PORT_J_ENABLE                (1)
+#define OMV_GPIO_PORT_K_ENABLE                (1)
+
 // Image sensor I2C configuration
-#define ISC_I2C_ID                            (2)
-#define ISC_I2C_SPEED                         (OMV_I2C_SPEED_STANDARD)
+#define OMV_CSI_I2C_ID                        (2)
+#define OMV_CSI_I2C_SPEED                     (OMV_I2C_SPEED_STANDARD)
 
 // FIR sensor I2C configuration
-#define FIR_I2C_ID                            (1)
-#define FIR_I2C_SPEED                         (OMV_I2C_SPEED_STANDARD)
+#define OMV_FIR_I2C_ID                        (1)
+#define OMV_FIR_I2C_SPEED                     (OMV_I2C_SPEED_STANDARD)
 
 // TOF sensor I2C configuration
 #define TOF_I2C_ID                            (4)
@@ -249,92 +230,44 @@
 #define OMV_IMU_X_Y_ROTATION_DEGREES          (0)
 #define OMV_IMU_MOUNTING_Z_DIRECTION          (-1)
 
-// DCMI timer configuration
-#define DCMI_TIM                              (TIM1)
-#define DCMI_TIM_PIN                          (&omv_pin_A8_TIM1)
-#define DCMI_TIM_CHANNEL                      (TIM_CHANNEL_1)
-#define DCMI_TIM_CLK_ENABLE()                 __TIM1_CLK_ENABLE()
-#define DCMI_TIM_CLK_DISABLE()                __TIM1_CLK_DISABLE()
-#define DCMI_TIM_PCLK_FREQ()                  HAL_RCC_GetPCLK2Freq()
+// Camera interface configuration
+#define OMV_CSI_XCLK_SOURCE                   (XCLK_SOURCE_TIM)
+#define OMV_CSI_XCLK_FREQUENCY                (24000000)
+#define OMV_CSI_TIM                           (TIM1)
+#define OMV_CSI_TIM_PIN                       (&omv_pin_A8_TIM1)
+#define OMV_CSI_TIM_CHANNEL                   (TIM_CHANNEL_1)
+#define OMV_CSI_TIM_CLK_ENABLE()              __TIM1_CLK_ENABLE()
+#define OMV_CSI_TIM_CLK_DISABLE()             __TIM1_CLK_DISABLE()
+#define OMV_CSI_TIM_PCLK_FREQ()               HAL_RCC_GetPCLK2Freq()
+#define OMV_CSI_DMA_MEMCPY_ENABLE             (1)
 
-// DCMI pins configuration
-#define DCMI_RESET_PIN                        (&omv_pin_C13_GPIO)
-#define DCMI_POWER_PIN                        (&omv_pin_I8_GPIO)
-#define DCMI_FSYNC_PIN                        (&omv_pin_D5_GPIO)
+#define OMV_CSI_D0_PIN                        (&omv_pin_A9_DCMI)
+#define OMV_CSI_D1_PIN                        (&omv_pin_A10_DCMI)
+#define OMV_CSI_D2_PIN                        (&omv_pin_G10_DCMI)
+#define OMV_CSI_D3_PIN                        (&omv_pin_G11_DCMI)
+#define OMV_CSI_D4_PIN                        (&omv_pin_E4_DCMI)
+#define OMV_CSI_D5_PIN                        (&omv_pin_D3_DCMI)
+#define OMV_CSI_D6_PIN                        (&omv_pin_E5_DCMI)
+#define OMV_CSI_D7_PIN                        (&omv_pin_E6_DCMI)
 
-#define DCMI_D0_PIN                           (&omv_pin_A9_DCMI)
-#define DCMI_D1_PIN                           (&omv_pin_A10_DCMI)
-#define DCMI_D2_PIN                           (&omv_pin_G10_DCMI)
-#define DCMI_D3_PIN                           (&omv_pin_G11_DCMI)
-#define DCMI_D4_PIN                           (&omv_pin_E4_DCMI)
-#define DCMI_D5_PIN                           (&omv_pin_D3_DCMI)
-#define DCMI_D6_PIN                           (&omv_pin_E5_DCMI)
-#define DCMI_D7_PIN                           (&omv_pin_E6_DCMI)
-
-#define DCMI_VSYNC_PIN                        (&omv_pin_G9_DCMI)
-#define DCMI_HSYNC_PIN                        (&omv_pin_A4_DCMI)
-#define DCMI_PXCLK_PIN                        (&omv_pin_A6_DCMI)
+#define OMV_CSI_VSYNC_PIN                     (&omv_pin_G9_DCMI)
+#define OMV_CSI_HSYNC_PIN                     (&omv_pin_A4_DCMI)
+#define OMV_CSI_PXCLK_PIN                     (&omv_pin_A6_DCMI)
+#define OMV_CSI_RESET_PIN                     (&omv_pin_C13_GPIO)
+#define OMV_CSI_POWER_PIN                     (&omv_pin_I8_GPIO)
+#define OMV_CSI_FSYNC_PIN                     (&omv_pin_D5_GPIO)
 
 // Physical I2C buses.
 // I2C bus 1
-#define I2C1_ID                               (1)
-#define I2C1_SCL_PIN                          (&omv_pin_B8_I2C1)
-#define I2C1_SDA_PIN                          (&omv_pin_B9_I2C1)
+#define OMV_I2C1_ID                           (1)
+#define OMV_I2C1_SCL_PIN                      (&omv_pin_B8_I2C1)
+#define OMV_I2C1_SDA_PIN                      (&omv_pin_B9_I2C1)
 // I2C bus 2
-#define I2C2_ID                               (2)
-#define I2C2_SCL_PIN                          (&omv_pin_H4_I2C2)
-#define I2C2_SDA_PIN                          (&omv_pin_H5_I2C2)
+#define OMV_I2C2_ID                           (2)
+#define OMV_I2C2_SCL_PIN                      (&omv_pin_H4_I2C2)
+#define OMV_I2C2_SDA_PIN                      (&omv_pin_H5_I2C2)
 // I2C bus 4
-#define I2C4_ID                               (4)
-#define I2C4_SCL_PIN                          (&omv_pin_B6_I2C4)
-#define I2C4_SDA_PIN                          (&omv_pin_B7_I2C4)
-
-#define ISC_SPI                               (SPI6)
-// SPI6 clock source is PLL3Q (80MHz/4 == 20MHz) - Minimum (164*240*8*27 = 8,501,760Hz)
-#define ISC_SPI_PRESCALER                     (SPI_BAUDRATEPRESCALER_4)
-
-#define ISC_SPI_IRQn                          (SPI6_IRQn)
-#define ISC_SPI_IRQHandler                    (SPI6_IRQHandler)
-
-#define ISC_SPI_DMA_IRQn                      (BDMA_Channel1_IRQn)
-#define ISC_SPI_DMA_STREAM                    (BDMA_Channel1)
-
-#define ISC_SPI_DMA_REQUEST                   (BDMA_REQUEST_SPI6_RX)
-#define ISC_SPI_DMA_IRQHandler                (BDMA_Channel1_IRQHandler)
-
-#define ISC_SPI_RESET()                       __HAL_RCC_SPI6_FORCE_RESET()
-#define ISC_SPI_RELEASE()                     __HAL_RCC_SPI6_RELEASE_RESET()
-
-#define ISC_SPI_CLK_ENABLE()                  __HAL_RCC_SPI6_CLK_ENABLE()
-#define ISC_SPI_CLK_DISABLE()                 __HAL_RCC_SPI6_CLK_DISABLE()
-#define ISC_SPI_DMA_CLK_ENABLE()              __HAL_RCC_BDMA_CLK_ENABLE()
-
-#define ISC_SPI_SCLK_PIN                      (&omv_pin_G13_SPI6)
-#define ISC_SPI_MISO_PIN                      (&omv_pin_G12_SPI6)
-#define ISC_SPI_MOSI_PIN                      (&omv_pin_G14_SPI6)
-#define ISC_SPI_SSEL_PIN                      (&omv_pin_A15_SPI6)
-
-#if 0
-// SPI LCD Interface
-#define OMV_SPI_DISPLAY_CONTROLLER            (&spi_obj[1])
-#define OMV_SPI_DISPLAY_MOSI_PIN              (&omv_pin_C1_SPI2)
-#define OMV_SPI_DISPLAY_MISO_PIN              (&omv_pin_C2_SPI2)
-#define OMV_SPI_DISPLAY_SCLK_PIN              (&omv_pin_A12_SPI2)
-#define OMV_SPI_DISPLAY_SSEL_PIN              (&omv_pin_A11_GPIO)
-
-#define OMV_SPI_DISPLAY_RST_PIN               (&omv_pin_C6_GPIO)
-#define OMV_SPI_DISPLAY_RS_PIN                (&omv_pin_C7_GPIO)
-#define OMV_SPI_DISPLAY_BL_PIN                (&omv_pin_C5_GPIO)
-
-// FIR Lepton
-#define OMV_FIR_LEPTON_I2C_BUS                (FIR_I2C_ID)
-#define OMV_FIR_LEPTON_I2C_BUS_SPEED          (FIR_I2C_SPEED)
-#define OMV_FIR_LEPTON_CONTROLLER             (&spi_obj[1])
-#define OMV_FIR_LEPTON_CONTROLLER_INSTANCE    (SPI2)
-
-#define OMV_FIR_LEPTON_MOSI_PORT              (&omv_pin_C1_SPI2)
-#define OMV_FIR_LEPTON_MISO_PORT              (&omv_pin_C2_SPI2)
-#define OMV_FIR_LEPTON_SCLK_PORT              (&omv_pin_A12_SPI2)
-#define OMV_FIR_LEPTON_CS_PORT                (&omv_pin_A11_GPIO)
-#endif
+#define OMV_I2C4_ID                           (4)
+#define OMV_I2C4_SCL_PIN                      (&omv_pin_B6_I2C4)
+#define OMV_I2C4_SDA_PIN                      (&omv_pin_B7_I2C4)
 #endif //__OMV_BOARDCONFIG_H__

--- a/src/omv/boards/OPENMVPT/omv_boardconfig.h
+++ b/src/omv/boards/OPENMVPT/omv_boardconfig.h
@@ -1,8 +1,8 @@
 /*
  * This file is part of the OpenMV project.
  *
- * Copyright (c) 2013-2021 Ibrahim Abdelkader <iabdalkader@openmv.io>
- * Copyright (c) 2013-2021 Kwabena W. Agyeman <kwagyeman@openmv.io>
+ * Copyright (c) 2013-2024 Ibrahim Abdelkader <iabdalkader@openmv.io>
+ * Copyright (c) 2013-2024 Kwabena W. Agyeman <kwagyeman@openmv.io>
  *
  * This work is licensed under the MIT license, see the file LICENSE for details.
  *
@@ -12,414 +12,381 @@
 #define __OMV_BOARDCONFIG_H__
 
 // Architecture info
-#define OMV_ARCH_STR                               "OPENMVPT 65536 SDRAM" // 33 chars max
-#define OMV_BOARD_TYPE                             "H7"
-#define OMV_UNIQUE_ID_ADDR                         0x1FF1E800 // Unique ID address.
-#define OMV_UNIQUE_ID_SIZE                         3 // Unique ID size in words.
-#define OMV_UNIQUE_ID_OFFSET                       4 // Bytes offset for multi-word UIDs.
+#define OMV_BOARD_ARCH                          "OPENMVPT 65536 SDRAM" // 33 chars max
+#define OMV_BOARD_TYPE                          "H7"
+#define OMV_BOARD_UID_ADDR                      0x1FF1E800   // Unique ID address.
+#define OMV_BOARD_UID_SIZE                      3            // Unique ID size in words.
+#define OMV_BOARD_UID_OFFSET                    4            // Bytes offset for multi-word UIDs.
 
-#define OMV_XCLK_MCO                               (0U)
-#define OMV_XCLK_TIM                               (1U)
+// JPEG configuration.
+#define OMV_JPEG_CODEC_ENABLE                   (1)
+#define OMV_JPEG_QUALITY_LOW                    (50)
+#define OMV_JPEG_QUALITY_HIGH                   (90)
+#define OMV_JPEG_QUALITY_THRESHOLD              (1920 * 1080 * 2)
 
-// Sensor external clock source.
-#define OMV_XCLK_SOURCE                            (OMV_XCLK_TIM)
+// Image sensor drivers configuration.
+#define OMV_OV5640_ENABLE                       (1)
+#define OMV_OV5640_AF_ENABLE                    (1)
+#define OMV_OV5640_XCLK_FREQ                    (24000000)
+#define OMV_OV5640_PLL_CTRL2                    (0x64)
+#define OMV_OV5640_PLL_CTRL3                    (0x13)
+#define OMV_OV5640_REV_Y_CHECK                  (1)
+#define OMV_OV5640_REV_Y_FREQ                   (25000000)
+#define OMV_OV5640_REV_Y_CTRL2                  (0x54)
+#define OMV_OV5640_REV_Y_CTRL3                  (0x13)
 
-// Sensor external clock timer frequency.
-#define OMV_XCLK_FREQUENCY                         (12000000)
+// FIR sensor drivers configuration.
+#define OMV_FIR_MLX90621_ENABLE                 (1)
+#define OMV_FIR_MLX90640_ENABLE                 (1)
+#define OMV_FIR_MLX90641_ENABLE                 (1)
+#define OMV_FIR_AMG8833_ENABLE                  (1)
+#define OMV_FIR_LEPTON_ENABLE                   (1)
 
-// Sensor PLL register value.
-#define OMV_OV7725_PLL_CONFIG                      (0x41) // x4
+// Debugging configuration.
+#define OMV_WIFIDBG_ENABLE                      (1)
 
-// Sensor Banding Filter Value
-#define OMV_OV7725_BANDING                         (0x7F)
-
-// OV5640 Sensor Settings
-#define OMV_OV5640_XCLK_FREQ                       (24000000)
-#define OMV_OV5640_PLL_CTRL2                       (0x64)
-#define OMV_OV5640_PLL_CTRL3                       (0x13)
-#define OMV_OV5640_REV_Y_CHECK                     (1)
-#define OMV_OV5640_REV_Y_FREQ                      (25000000)
-#define OMV_OV5640_REV_Y_CTRL2                     (0x54)
-#define OMV_OV5640_REV_Y_CTRL3                     (0x13)
-
-// Enable hardware JPEG
-#define OMV_HARDWARE_JPEG                          (1)
-
-// Enable fast line transfer with DMA.
-#define OMA_ENABLE_DMA_MEMCPY                      (1)
-
-// MDMA configuration
-#define OMV_MDMA_CHANNEL_DCMI_0                    (0)
-#define OMV_MDMA_CHANNEL_DCMI_1                    (1)
-#define OMV_MDMA_CHANNEL_JPEG_IN                   (7) // in has a lower pri than out
-#define OMV_MDMA_CHANNEL_JPEG_OUT                  (6) // out has a higher pri than in
-
-// Enable sensor drivers
-#define OMV_ENABLE_OV2640                          (0)
-#define OMV_ENABLE_OV5640                          (1)
-#define OMV_ENABLE_OV7690                          (0)
-#define OMV_ENABLE_OV7725                          (0)
-#define OMV_ENABLE_OV9650                          (0)
-#define OMV_ENABLE_MT9M114                         (0)
-#define OMV_ENABLE_MT9V0XX                         (0)
-#define OMV_ENABLE_LEPTON                          (0)
-#define OMV_ENABLE_HM01B0                          (0)
-#define OMV_ENABLE_PAJ6100                         (0)
-#define OMV_ENABLE_FROGEYE2020                     (0)
-#define OMV_ENABLE_FIR_MLX90621                    (1)
-#define OMV_ENABLE_FIR_MLX90640                    (1)
-#define OMV_ENABLE_FIR_MLX90641                    (1)
-#define OMV_ENABLE_FIR_AMG8833                     (1)
-#define OMV_ENABLE_FIR_LEPTON                      (1)
-
-// Enable additional GPIO banks.
-#define OMV_ENABLE_GPIO_BANK_F                     (1)
-#define OMV_ENABLE_GPIO_BANK_G                     (1)
-#define OMV_ENABLE_GPIO_BANK_H                     (1)
-#define OMV_ENABLE_GPIO_BANK_I                     (1)
-#define OMV_ENABLE_GPIO_BANK_J                     (1)
-#define OMV_ENABLE_GPIO_BANK_K                     (1)
-
-// Enable sensor features
-#define OMV_ENABLE_OV5640_AF                       (1)
-
-// Enable WiFi debug
-#define OMV_ENABLE_WIFIDBG                         (1)
-
-// If buffer size is bigger than this threshold, the quality is reduced.
-// This is only used for JPEG images sent to the IDE not normal compression.
-#define JPEG_QUALITY_THRESH                        (1920 * 1080 * 2)
-
-// Low and high JPEG QS.
-#define JPEG_QUALITY_LOW                           50
-#define JPEG_QUALITY_HIGH                          90
-
-// FB Heap Block Size
-#define OMV_UMM_BLOCK_SIZE                         256
+// UMM heap block size
+#define OMV_UMM_BLOCK_SIZE                      256
 
 // USB IRQn.
-#define OMV_USB_IRQN                               (OTG_FS_IRQn)
+#define OMV_USB_IRQN                            (OTG_FS_IRQn)
 
 //PLL1 48MHz for USB, SDMMC and FDCAN
-#define OMV_OSC_PLL1M                              (3)
-#define OMV_OSC_PLL1N                              (240)
-#define OMV_OSC_PLL1P                              (2)
-#define OMV_OSC_PLL1Q                              (20)
-#define OMV_OSC_PLL1R                              (2)
-#define OMV_OSC_PLL1VCI                            (RCC_PLL1VCIRANGE_2)
-#define OMV_OSC_PLL1VCO                            (RCC_PLL1VCOWIDE)
-#define OMV_OSC_PLL1FRAC                           (0)
+#define OMV_OSC_PLL1M                           (3)
+#define OMV_OSC_PLL1N                           (240)
+#define OMV_OSC_PLL1P                           (2)
+#define OMV_OSC_PLL1Q                           (20)
+#define OMV_OSC_PLL1R                           (2)
+#define OMV_OSC_PLL1VCI                         (RCC_PLL1VCIRANGE_2)
+#define OMV_OSC_PLL1VCO                         (RCC_PLL1VCOWIDE)
+#define OMV_OSC_PLL1FRAC                        (0)
 
 // PLL2 200MHz for FMC and QSPI.
-#define OMV_OSC_PLL2M                              (3)
-#define OMV_OSC_PLL2N                              (100)
-#define OMV_OSC_PLL2P                              (2)
-#define OMV_OSC_PLL2Q                              (2)
-#define OMV_OSC_PLL2R                              (2)
-#define OMV_OSC_PLL2VCI                            (RCC_PLL2VCIRANGE_2)
-#define OMV_OSC_PLL2VCO                            (RCC_PLL2VCOWIDE)
-#define OMV_OSC_PLL2FRAC                           (0)
+#define OMV_OSC_PLL2M                           (3)
+#define OMV_OSC_PLL2N                           (100)
+#define OMV_OSC_PLL2P                           (2)
+#define OMV_OSC_PLL2Q                           (2)
+#define OMV_OSC_PLL2R                           (2)
+#define OMV_OSC_PLL2VCI                         (RCC_PLL2VCIRANGE_2)
+#define OMV_OSC_PLL2VCO                         (RCC_PLL2VCOWIDE)
+#define OMV_OSC_PLL2FRAC                        (0)
 
 // PLL3 160MHz for ADC and SPI123
-#define OMV_OSC_PLL3M                              (3)
-#define OMV_OSC_PLL3N                              (80)
-#define OMV_OSC_PLL3P                              (2)
-#define OMV_OSC_PLL3Q                              (2)
-#define OMV_OSC_PLL3R                              (2)
-#define OMV_OSC_PLL3VCI                            (RCC_PLL3VCIRANGE_2)
-#define OMV_OSC_PLL3VCO                            (RCC_PLL3VCOWIDE)
-#define OMV_OSC_PLL3FRAC                           (0)
+#define OMV_OSC_PLL3M                           (3)
+#define OMV_OSC_PLL3N                           (80)
+#define OMV_OSC_PLL3P                           (2)
+#define OMV_OSC_PLL3Q                           (2)
+#define OMV_OSC_PLL3R                           (2)
+#define OMV_OSC_PLL3VCI                         (RCC_PLL3VCIRANGE_2)
+#define OMV_OSC_PLL3VCO                         (RCC_PLL3VCOWIDE)
+#define OMV_OSC_PLL3FRAC                        (0)
 
 // Clock Sources
-#define OMV_OSC_PLL_CLKSOURCE                      RCC_PLLSOURCE_HSE
-#define OMV_OSC_USB_CLKSOURCE                      RCC_USBCLKSOURCE_PLL
-#define OMV_OSC_RNG_CLKSOURCE                      RCC_RNGCLKSOURCE_HSI48
-#define OMV_OSC_ADC_CLKSOURCE                      RCC_ADCCLKSOURCE_PLL2
-//#define OMV_OSC_RTC_CLKSOURCE           RCC_RTCCLKSOURCE_LSE
-#define OMV_OSC_SPI123_CLKSOURCE                   RCC_SPI123CLKSOURCE_PLL2
+#define OMV_OSC_PLL_CLKSOURCE                   RCC_PLLSOURCE_HSE
+#define OMV_OSC_USB_CLKSOURCE                   RCC_USBCLKSOURCE_PLL
+#define OMV_OSC_RNG_CLKSOURCE                   RCC_RNGCLKSOURCE_HSI48
+#define OMV_OSC_ADC_CLKSOURCE                   RCC_ADCCLKSOURCE_PLL2
+//#define OMV_OSC_RTC_CLKSOURCE                   RCC_RTCCLKSOURCE_LSE
+#define OMV_OSC_SPI123_CLKSOURCE                RCC_SPI123CLKSOURCE_PLL2
 
 // HSE/HSI/CSI State
 // The LSE/LSI and RTC are managed by micropython's rtc.c.
-// #define OMV_OSC_LSE_STATE               (RCC_LSE_ON)
-// #define OMV_OSC_LSE_DRIVE               (RCC_LSEDRIVE_HIGH)
-#define OMV_OSC_HSE_STATE                          (RCC_HSE_ON)
-#define OMV_OSC_HSI48_STATE                        (RCC_HSI48_ON)
+// #define OMV_OSC_LSE_STATE                      (RCC_LSE_ON)
+// #define OMV_OSC_LSE_DRIVE                      (RCC_LSEDRIVE_HIGH)
+#define OMV_OSC_HSE_STATE                       (RCC_HSE_ON)
+#define OMV_OSC_HSI48_STATE                     (RCC_HSI48_ON)
 // Errata
-#define OMV_OMVPT_ERRATA_RTC                       (1)
+#define OMV_OMVPT_ERRATA_RTC                    (1)
 
 // Flash Latency
-#define OMV_FLASH_LATENCY                          (FLASH_LATENCY_2)
+#define OMV_FLASH_LATENCY                       (FLASH_LATENCY_2)
 
 // Power supply configuration
-#define OMV_PWR_SUPPLY                             (PWR_LDO_SUPPLY)
+#define OMV_PWR_SUPPLY                          (PWR_LDO_SUPPLY)
 
 // Linker script constants (see the linker script template stm32fxxx.ld.S).
 // Note: fb_alloc is a stack-based, dynamically allocated memory on FB.
 // The maximum available fb_alloc memory = FB_ALLOC_SIZE + FB_SIZE - (w*h*bpp).
-#define OMV_MAIN_MEMORY                            SRAM1 // data, bss and heap
-#define OMV_STACK_MEMORY                           ITCM // stack memory
-#define OMV_DMA_MEMORY                             SRAM3 // DMA buffers memory.
-#define OMV_FB_MEMORY                              DRAM // Framebuffer, fb_alloc
-#define OMV_JPEG_MEMORY                            DRAM // JPEG buffer memory buffer.
-#define OMV_JPEG_MEMORY_OFFSET                     (63M) // JPEG buffer is placed after FB/fballoc memory.
-#define OMV_VOSPI_MEMORY                           SRAM4 // VoSPI buffer memory.
-#define OMV_FB_OVERLAY_MEMORY                      AXI_SRAM // Fast fb_alloc memory.
+#define OMV_MAIN_MEMORY                         SRAM1 // data, bss and heap
+#define OMV_STACK_MEMORY                        ITCM // stack memory
+#define OMV_DMA_MEMORY                          SRAM3 // DMA buffers memory.
+#define OMV_FB_MEMORY                           DRAM // Framebuffer, fb_alloc
+#define OMV_JPEG_MEMORY                         DRAM // JPEG buffer memory buffer.
+#define OMV_JPEG_MEMORY_OFFSET                  (63M) // JPEG buffer is placed after FB/fballoc memory.
+#define OMV_VOSPI_MEMORY                        SRAM4 // VoSPI buffer memory.
+#define OMV_FB_OVERLAY_MEMORY                   AXI_SRAM // Fast fb_alloc memory.
 
-#define OMV_FB_SIZE                                (32M) // FB memory: header + VGA/GS image
-#define OMV_FB_ALLOC_SIZE                          (31M) // minimum fb alloc size
-#define OMV_FB_OVERLAY_SIZE                        (496 * 1024) // Fast fb_alloc memory size.
-#define OMV_STACK_SIZE                             (64K)
-#define OMV_HEAP_SIZE                              (250K)
-#define OMV_SDRAM_SIZE                             (64 * 1024 * 1024) // This needs to be here for UVC firmware.
+#define OMV_FB_SIZE                             (32M) // FB memory: header + VGA/GS image
+#define OMV_FB_ALLOC_SIZE                       (31M) // minimum fb alloc size
+#define OMV_FB_OVERLAY_SIZE                     (496 * 1024) // Fast fb_alloc memory size.
+#define OMV_STACK_SIZE                          (64K)
+#define OMV_HEAP_SIZE                           (250K)
+#define OMV_SDRAM_SIZE                          (64 * 1024 * 1024) // This needs to be here for UVC firmware.
 
-#define OMV_LINE_BUF_SIZE                          (11 * 1024) // Image line buffer round(2592 * 2BPP * 2 buffers).
-#define OMV_MSC_BUF_SIZE                           (2K) // USB MSC bot data
-#define OMV_VFS_BUF_SIZE                           (1K) // VFS struct + FATFS file buffer (624 bytes)
-#define OMV_JPEG_BUF_SIZE                          (1024 * 1024) // IDE JPEG buffer (header + data).
+#define OMV_LINE_BUF_SIZE                       (11 * 1024) // Image line buffer round(2592 * 2BPP * 2 buffers).
+#define OMV_MSC_BUF_SIZE                        (2K) // USB MSC bot data
+#define OMV_VFS_BUF_SIZE                        (1K) // VFS struct + FATFS file buffer (624 bytes)
+#define OMV_JPEG_BUF_SIZE                       (1024 * 1024) // IDE JPEG buffer (header + data).
 
 // Memory map.
-#define OMV_FLASH_ORIGIN                           0x08000000
-#define OMV_FLASH_LENGTH                           2048K
-#define OMV_DTCM_ORIGIN                            0x20000000 // Note accessible by CPU and MDMA only.
-#define OMV_DTCM_LENGTH                            128K
-#define OMV_ITCM_ORIGIN                            0x00000000
-#define OMV_ITCM_LENGTH                            64K
-#define OMV_SRAM1_ORIGIN                           0x30000000
-#define OMV_SRAM1_LENGTH                           272K // SRAM1 + SRAM2 + 1/2 SRAM3
-#define OMV_SRAM3_ORIGIN                           0x30044000
-#define OMV_SRAM3_LENGTH                           16K
-#define OMV_SRAM4_ORIGIN                           0x38000000
-#define OMV_SRAM4_LENGTH                           64K
-#define OMV_AXI_SRAM_ORIGIN                        0x24000000
-#define OMV_AXI_SRAM_LENGTH                        512K
-#define OMV_DRAM_ORIGIN                            0xC0000000
-#define OMV_DRAM_LENGTH                            64M
+#define OMV_FLASH_ORIGIN                        0x08000000
+#define OMV_FLASH_LENGTH                        2048K
+#define OMV_DTCM_ORIGIN                         0x20000000 // Note accessible by CPU and MDMA only.
+#define OMV_DTCM_LENGTH                         128K
+#define OMV_ITCM_ORIGIN                         0x00000000
+#define OMV_ITCM_LENGTH                         64K
+#define OMV_SRAM1_ORIGIN                        0x30000000
+#define OMV_SRAM1_LENGTH                        272K // SRAM1 + SRAM2 + 1/2 SRAM3
+#define OMV_SRAM3_ORIGIN                        0x30044000
+#define OMV_SRAM3_LENGTH                        16K
+#define OMV_SRAM4_ORIGIN                        0x38000000
+#define OMV_SRAM4_LENGTH                        64K
+#define OMV_AXI_SRAM_ORIGIN                     0x24000000
+#define OMV_AXI_SRAM_LENGTH                     512K
+#define OMV_DRAM_ORIGIN                         0xC0000000
+#define OMV_DRAM_LENGTH                         64M
 
 // Flash configuration.
-#define OMV_FLASH_FFS_ORIGIN                       0x08020000
-#define OMV_FLASH_FFS_LENGTH                       128K
-#define OMV_FLASH_TXT_ORIGIN                       0x08040000
-#define OMV_FLASH_TXT_LENGTH                       1792K
+#define OMV_FLASH_FFS_ORIGIN                    0x08020000
+#define OMV_FLASH_FFS_LENGTH                    128K
+#define OMV_FLASH_TXT_ORIGIN                    0x08040000
+#define OMV_FLASH_TXT_LENGTH                    1792K
 
 // Domain 1 DMA buffers region.
-#define OMV_DMA_MEMORY_D1                          AXI_SRAM
-#define OMV_DMA_MEMORY_D1_SIZE                     (16 * 1024) // Reserved memory for DMA buffers
-#define OMV_DMA_REGION_D1_BASE                     (OMV_AXI_SRAM_ORIGIN + OMV_FB_OVERLAY_SIZE)
-#define OMV_DMA_REGION_D1_SIZE                     MPU_REGION_SIZE_16KB
+#define OMV_DMA_MEMORY_D1                       AXI_SRAM
+#define OMV_DMA_MEMORY_D1_SIZE                  (16 * 1024) // Reserved memory for DMA buffers
+#define OMV_DMA_REGION_D1_BASE                  (OMV_AXI_SRAM_ORIGIN + OMV_FB_OVERLAY_SIZE)
+#define OMV_DMA_REGION_D1_SIZE                  MPU_REGION_SIZE_16KB
 
 // Domain 2 DMA buffers region.
-#define OMV_DMA_MEMORY_D2                          SRAM3
-#define OMV_DMA_MEMORY_D2_SIZE                     (1 * 1024) // Reserved memory for DMA buffers
-#define OMV_DMA_REGION_D2_BASE                     (OMV_SRAM3_ORIGIN + (0 * 1024))
-#define OMV_DMA_REGION_D2_SIZE                     MPU_REGION_SIZE_16KB
+#define OMV_DMA_MEMORY_D2                       SRAM3
+#define OMV_DMA_MEMORY_D2_SIZE                  (1 * 1024) // Reserved memory for DMA buffers
+#define OMV_DMA_REGION_D2_BASE                  (OMV_SRAM3_ORIGIN + (0 * 1024))
+#define OMV_DMA_REGION_D2_SIZE                  MPU_REGION_SIZE_16KB
 
 // Domain 3 DMA buffers region.
-#define OMV_DMA_MEMORY_D3                          SRAM4
-#define OMV_DMA_MEMORY_D3_SIZE                     (64 * 1024) // Reserved memory for DMA buffers
-#define OMV_DMA_REGION_D3_BASE                     (OMV_SRAM4_ORIGIN + (0 * 1024))
-#define OMV_DMA_REGION_D3_SIZE                     MPU_REGION_SIZE_64KB
+#define OMV_DMA_MEMORY_D3                       SRAM4
+#define OMV_DMA_MEMORY_D3_SIZE                  (64 * 1024) // Reserved memory for DMA buffers
+#define OMV_DMA_REGION_D3_BASE                  (OMV_SRAM4_ORIGIN + (0 * 1024))
+#define OMV_DMA_REGION_D3_SIZE                  MPU_REGION_SIZE_64KB
+
+// MDMA configuration
+#define OMV_MDMA_CHANNEL_DCMI_0                 (0)
+#define OMV_MDMA_CHANNEL_DCMI_1                 (1)
+#define OMV_MDMA_CHANNEL_JPEG_IN                (7) // in has a lower pri than out
+#define OMV_MDMA_CHANNEL_JPEG_OUT               (6) // out has a higher pri than in
 
 // AXI QoS - Low-High (0:15) - default 0
-#define OMV_AXI_QOS_MDMA_R_PRI                     14 // Max pri to move data.
-#define OMV_AXI_QOS_MDMA_W_PRI                     15 // Max pri to move data.
-#define OMV_AXI_QOS_LTDC_R_PRI                     15 // Max pri to read out the frame buffer.
+#define OMV_AXI_QOS_MDMA_R_PRI                  14 // Max pri to move data.
+#define OMV_AXI_QOS_MDMA_W_PRI                  15 // Max pri to move data.
+#define OMV_AXI_QOS_LTDC_R_PRI                  15 // Max pri to read out the frame buffer.
+
+// Enable additional GPIO ports.
+#define OMV_GPIO_PORT_F_ENABLE                  (1)
+#define OMV_GPIO_PORT_G_ENABLE                  (1)
+#define OMV_GPIO_PORT_H_ENABLE                  (1)
+#define OMV_GPIO_PORT_I_ENABLE                  (1)
+#define OMV_GPIO_PORT_J_ENABLE                  (1)
+#define OMV_GPIO_PORT_K_ENABLE                  (1)
 
 // Main image sensor I2C bus
-#define ISC_I2C_ID                                 (1)
-#define ISC_I2C_SPEED                              (OMV_I2C_SPEED_STANDARD)
+#define OMV_CSI_I2C_ID                          (1)
+#define OMV_CSI_I2C_SPEED                       (OMV_I2C_SPEED_STANDARD)
 
 // Thermal image sensor I2C bus
-#define FIR_I2C_ID                                 (2)
-#define FIR_I2C_SPEED                              (OMV_I2C_SPEED_FULL)
+#define OMV_FIR_I2C_ID                          (2)
+#define OMV_FIR_I2C_SPEED                       (OMV_I2C_SPEED_FULL)
 
 // Soft I2C bus.
-#define SOFT_I2C_SIOC_PIN                          (&omv_pin_B10_GPIO)
-#define SOFT_I2C_SIOD_PIN                          (&omv_pin_B11_GPIO)
-#define SOFT_I2C_SPIN_DELAY                        64
+#define OMV_SOFT_I2C_SIOC_PIN                   (&omv_pin_B10_GPIO)
+#define OMV_SOFT_I2C_SIOD_PIN                   (&omv_pin_B11_GPIO)
+#define OMV_SOFT_I2C_SPIN_DELAY                 64
 
 // WINC1500 WiFi module SPI bus
-#define WINC_SPI_ID                                (5)
-#define WINC_SPI_BAUDRATE                          (50000000)
-#define WINC_EN_PIN                                (&omv_pin_A0_GPIO)
-#define WINC_RST_PIN                               (&omv_pin_C3_GPIO)
-#define WINC_WAKE_PIN                              (&omv_pin_A1_GPIO)
-#define WINC_CFG_PIN                               (&omv_pin_I15_GPIO)
-#define WINC_IRQ_PIN                               (&omv_pin_H5_GPIO)
+#define OMV_WINC_SPI_ID                         (5)
+#define OMV_WINC_SPI_BAUDRATE                   (50000000)
+#define OMV_WINC_EN_PIN                         (&omv_pin_A0_GPIO)
+#define OMV_WINC_RST_PIN                        (&omv_pin_C3_GPIO)
+#define OMV_WINC_WAKE_PIN                       (&omv_pin_A1_GPIO)
+#define OMV_WINC_CFG_PIN                        (&omv_pin_I15_GPIO)
+#define OMV_WINC_IRQ_PIN                        (&omv_pin_H5_GPIO)
 
-/* DCMI */
-#define DCMI_TIM                                   (TIM1)
-#define DCMI_TIM_PIN                               (&omv_pin_A8_TIM1)
-#define DCMI_TIM_CHANNEL                           (TIM_CHANNEL_1)
-#define DCMI_TIM_CLK_ENABLE()                      __TIM1_CLK_ENABLE()
-#define DCMI_TIM_CLK_DISABLE()                     __TIM1_CLK_DISABLE()
-#define DCMI_TIM_PCLK_FREQ()                       HAL_RCC_GetPCLK2Freq()
+// Camera interface
+#define OMV_CSI_XCLK_SOURCE                     (XCLK_SOURCE_TIM)
+#define OMV_CSI_XCLK_FREQUENCY                  (12000000)
+#define OMV_CSI_TIM                             (TIM1)
+#define OMV_CSI_TIM_PIN                         (&omv_pin_A8_TIM1)
+#define OMV_CSI_TIM_CHANNEL                     (TIM_CHANNEL_1)
+#define OMV_CSI_TIM_CLK_ENABLE()                __TIM1_CLK_ENABLE()
+#define OMV_CSI_TIM_CLK_DISABLE()               __TIM1_CLK_DISABLE()
+#define OMV_CSI_TIM_PCLK_FREQ()                 HAL_RCC_GetPCLK2Freq()
+#define OMV_CSI_DMA_MEMCPY_ENABLE               (1)
 
-#define DCMI_RESET_PIN                             (&omv_pin_A10_GPIO)
-#define DCMI_POWER_PIN                             (&omv_pin_D7_GPIO)
+#define OMV_CSI_D0_PIN                          (&omv_pin_C6_DCMI)
+#define OMV_CSI_D1_PIN                          (&omv_pin_C7_DCMI)
+#define OMV_CSI_D2_PIN                          (&omv_pin_G10_DCMI)
+#define OMV_CSI_D3_PIN                          (&omv_pin_G11_DCMI)
+#define OMV_CSI_D4_PIN                          (&omv_pin_E4_DCMI)
+#define OMV_CSI_D5_PIN                          (&omv_pin_B6_DCMI)
+#define OMV_CSI_D6_PIN                          (&omv_pin_E5_DCMI)
+#define OMV_CSI_D7_PIN                          (&omv_pin_E6_DCMI)
 
-#define DCMI_D0_PIN                                (&omv_pin_C6_DCMI)
-#define DCMI_D1_PIN                                (&omv_pin_C7_DCMI)
-#define DCMI_D2_PIN                                (&omv_pin_G10_DCMI)
-#define DCMI_D3_PIN                                (&omv_pin_G11_DCMI)
-#define DCMI_D4_PIN                                (&omv_pin_E4_DCMI)
-#define DCMI_D5_PIN                                (&omv_pin_B6_DCMI)
-#define DCMI_D6_PIN                                (&omv_pin_E5_DCMI)
-#define DCMI_D7_PIN                                (&omv_pin_E6_DCMI)
-
-#define DCMI_HSYNC_PIN                             (&omv_pin_A4_DCMI)
-#define DCMI_VSYNC_PIN                             (&omv_pin_B7_DCMI)
-#define DCMI_PXCLK_PIN                             (&omv_pin_A6_DCMI)
+#define OMV_CSI_HSYNC_PIN                       (&omv_pin_A4_DCMI)
+#define OMV_CSI_VSYNC_PIN                       (&omv_pin_B7_DCMI)
+#define OMV_CSI_PXCLK_PIN                       (&omv_pin_A6_DCMI)
+#define OMV_CSI_RESET_PIN                       (&omv_pin_A10_GPIO)
+#define OMV_CSI_POWER_PIN                       (&omv_pin_D7_GPIO)
 
 // Physical I2C buses.
 
 // I2C bus 1
-#define I2C1_ID                                    (1)
-#define I2C1_SCL_PIN                               (&omv_pin_B8_I2C1)
-#define I2C1_SDA_PIN                               (&omv_pin_B9_I2C1)
+#define OMV_I2C1_ID                             (1)
+#define OMV_I2C1_SCL_PIN                        (&omv_pin_B8_I2C1)
+#define OMV_I2C1_SDA_PIN                        (&omv_pin_B9_I2C1)
 
 // I2C bus 2
-#define I2C2_ID                                    (2)
-#define I2C2_SCL_PIN                               (&omv_pin_B10_I2C2)
-#define I2C2_SDA_PIN                               (&omv_pin_B11_I2C2)
+#define OMV_I2C2_ID                             (2)
+#define OMV_I2C2_SCL_PIN                        (&omv_pin_B10_I2C2)
+#define OMV_I2C2_SDA_PIN                        (&omv_pin_B11_I2C2)
 
 // Physical SPI buses.
 
 // SPI bus 2
-#define SPI2_ID                                    (2)
-#define SPI2_SCLK_PIN                              (&omv_pin_B13_SPI2)
-#define SPI2_MISO_PIN                              (&omv_pin_B14_SPI2)
-#define SPI2_MOSI_PIN                              (&omv_pin_B15_SPI2)
-#define SPI2_SSEL_PIN                              (&omv_pin_B12_GPIO)
-#define SPI2_DMA_TX_CHANNEL                        (DMA1_Stream4)
-#define SPI2_DMA_RX_CHANNEL                        (DMA1_Stream3)
+#define OMV_SPI2_ID                             (2)
+#define OMV_SPI2_SCLK_PIN                       (&omv_pin_B13_SPI2)
+#define OMV_SPI2_MISO_PIN                       (&omv_pin_B14_SPI2)
+#define OMV_SPI2_MOSI_PIN                       (&omv_pin_B15_SPI2)
+#define OMV_SPI2_SSEL_PIN                       (&omv_pin_B12_GPIO)
+#define OMV_SPI2_DMA_TX_CHANNEL                 (DMA1_Stream4)
+#define OMV_SPI2_DMA_RX_CHANNEL                 (DMA1_Stream3)
 
 // SPI bus 3
-#define SPI3_ID                                    (3)
-#define SPI3_SCLK_PIN                              (&omv_pin_B3_SPI3)
-#define SPI3_MISO_PIN                              (&omv_pin_B4_SPI3)
-#define SPI3_MOSI_PIN                              (&omv_pin_B5_SPI3)
-#define SPI3_SSEL_PIN                              (&omv_pin_A15_GPIO)
-#define SPI3_DMA_TX_CHANNEL                        (DMA1_Stream7)
-#define SPI3_DMA_RX_CHANNEL                        (DMA1_Stream2)
+#define OMV_SPI3_ID                             (3)
+#define OMV_SPI3_SCLK_PIN                       (&omv_pin_B3_SPI3)
+#define OMV_SPI3_MISO_PIN                       (&omv_pin_B4_SPI3)
+#define OMV_SPI3_MOSI_PIN                       (&omv_pin_B5_SPI3)
+#define OMV_SPI3_SSEL_PIN                       (&omv_pin_A15_GPIO)
+#define OMV_SPI3_DMA_TX_CHANNEL                 (DMA1_Stream7)
+#define OMV_SPI3_DMA_RX_CHANNEL                 (DMA1_Stream2)
 
 // SPI bus 5
-#define SPI5_ID                                    (5)
-#define SPI5_SCLK_PIN                              (&omv_pin_H6_SPI5)
-#define SPI5_MISO_PIN                              (&omv_pin_H7_SPI5)
-#define SPI5_MOSI_PIN                              (&omv_pin_J10_SPI5)
-#define SPI5_SSEL_PIN                              (&omv_pin_K1_GPIO)
-#define SPI5_DMA_TX_CHANNEL                        (DMA2_Stream4)
-#define SPI5_DMA_RX_CHANNEL                        (DMA2_Stream3)
+#define OMV_SPI5_ID                             (5)
+#define OMV_SPI5_SCLK_PIN                       (&omv_pin_H6_SPI5)
+#define OMV_SPI5_MISO_PIN                       (&omv_pin_H7_SPI5)
+#define OMV_SPI5_MOSI_PIN                       (&omv_pin_J10_SPI5)
+#define OMV_SPI5_SSEL_PIN                       (&omv_pin_K1_GPIO)
+#define OMV_SPI5_DMA_TX_CHANNEL                 (DMA2_Stream4)
+#define OMV_SPI5_DMA_RX_CHANNEL                 (DMA2_Stream3)
 
 // LCD Interface
-#define OMV_RGB_DISPLAY_CONTROLLER                 (LTDC)
-#define OMV_RGB_DISPLAY_CLK_ENABLE()               __HAL_RCC_LTDC_CLK_ENABLE()
-#define OMV_RGB_DISPLAY_CLK_DISABLE()              __HAL_RCC_LTDC_CLK_DISABLE()
-#define OMV_RGB_DISPLAY_FORCE_RESET()              __HAL_RCC_LTDC_FORCE_RESET()
-#define OMV_RGB_DISPLAY_RELEASE_RESET()            __HAL_RCC_LTDC_RELEASE_RESET()
+#define OMV_RGB_DISPLAY_CONTROLLER              (LTDC)
+#define OMV_RGB_DISPLAY_CLK_ENABLE()            __HAL_RCC_LTDC_CLK_ENABLE()
+#define OMV_RGB_DISPLAY_CLK_DISABLE()           __HAL_RCC_LTDC_CLK_DISABLE()
+#define OMV_RGB_DISPLAY_FORCE_RESET()           __HAL_RCC_LTDC_FORCE_RESET()
+#define OMV_RGB_DISPLAY_RELEASE_RESET()         __HAL_RCC_LTDC_RELEASE_RESET()
 
-#define OMV_RGB_DISPLAY_R0_PIN                     (&omv_pin_G13_LTDC)
-#define OMV_RGB_DISPLAY_R1_PIN                     (&omv_pin_A2_LTDC)
-#define OMV_RGB_DISPLAY_R2_PIN                     (&omv_pin_J1_LTDC)
-#define OMV_RGB_DISPLAY_R3_PIN                     (&omv_pin_J2_LTDC)
-#define OMV_RGB_DISPLAY_R4_PIN                     (&omv_pin_J3_LTDC)
-#define OMV_RGB_DISPLAY_R5_PIN                     (&omv_pin_J4_LTDC)
-#define OMV_RGB_DISPLAY_R6_PIN                     (&omv_pin_J5_LTDC)
-#define OMV_RGB_DISPLAY_R7_PIN                     (&omv_pin_J0_LTDC)
+#define OMV_RGB_DISPLAY_R0_PIN                  (&omv_pin_G13_LTDC)
+#define OMV_RGB_DISPLAY_R1_PIN                  (&omv_pin_A2_LTDC)
+#define OMV_RGB_DISPLAY_R2_PIN                  (&omv_pin_J1_LTDC)
+#define OMV_RGB_DISPLAY_R3_PIN                  (&omv_pin_J2_LTDC)
+#define OMV_RGB_DISPLAY_R4_PIN                  (&omv_pin_J3_LTDC)
+#define OMV_RGB_DISPLAY_R5_PIN                  (&omv_pin_J4_LTDC)
+#define OMV_RGB_DISPLAY_R6_PIN                  (&omv_pin_J5_LTDC)
+#define OMV_RGB_DISPLAY_R7_PIN                  (&omv_pin_J0_LTDC)
 
-#define OMV_RGB_DISPLAY_G0_PIN                     (&omv_pin_J7_LTDC)
-#define OMV_RGB_DISPLAY_G1_PIN                     (&omv_pin_J8_LTDC)
-#define OMV_RGB_DISPLAY_G2_PIN                     (&omv_pin_J9_LTDC)
-#define OMV_RGB_DISPLAY_G3_PIN                     (&omv_pin_J12_LTDC)
-#define OMV_RGB_DISPLAY_G4_PIN                     (&omv_pin_J11_LTDC)
-#define OMV_RGB_DISPLAY_G5_PIN                     (&omv_pin_K0_LTDC)
-#define OMV_RGB_DISPLAY_G6_PIN                     (&omv_pin_I11_LTDC)
-#define OMV_RGB_DISPLAY_G7_PIN                     (&omv_pin_D3_LTDC)
+#define OMV_RGB_DISPLAY_G0_PIN                  (&omv_pin_J7_LTDC)
+#define OMV_RGB_DISPLAY_G1_PIN                  (&omv_pin_J8_LTDC)
+#define OMV_RGB_DISPLAY_G2_PIN                  (&omv_pin_J9_LTDC)
+#define OMV_RGB_DISPLAY_G3_PIN                  (&omv_pin_J12_LTDC)
+#define OMV_RGB_DISPLAY_G4_PIN                  (&omv_pin_J11_LTDC)
+#define OMV_RGB_DISPLAY_G5_PIN                  (&omv_pin_K0_LTDC)
+#define OMV_RGB_DISPLAY_G6_PIN                  (&omv_pin_I11_LTDC)
+#define OMV_RGB_DISPLAY_G7_PIN                  (&omv_pin_D3_LTDC)
 
-#define OMV_RGB_DISPLAY_B0_PIN                     (&omv_pin_G14_LTDC)
-#define OMV_RGB_DISPLAY_B1_PIN                     (&omv_pin_G12_LTDC)
-#define OMV_RGB_DISPLAY_B2_PIN                     (&omv_pin_D6_LTDC)
-#define OMV_RGB_DISPLAY_B3_PIN                     (&omv_pin_J15_LTDC)
-#define OMV_RGB_DISPLAY_B4_PIN                     (&omv_pin_K3_LTDC)
-#define OMV_RGB_DISPLAY_B5_PIN                     (&omv_pin_K4_LTDC)
-#define OMV_RGB_DISPLAY_B6_PIN                     (&omv_pin_K5_LTDC)
-#define OMV_RGB_DISPLAY_B7_PIN                     (&omv_pin_K6_LTDC)
+#define OMV_RGB_DISPLAY_B0_PIN                  (&omv_pin_G14_LTDC)
+#define OMV_RGB_DISPLAY_B1_PIN                  (&omv_pin_G12_LTDC)
+#define OMV_RGB_DISPLAY_B2_PIN                  (&omv_pin_D6_LTDC)
+#define OMV_RGB_DISPLAY_B3_PIN                  (&omv_pin_J15_LTDC)
+#define OMV_RGB_DISPLAY_B4_PIN                  (&omv_pin_K3_LTDC)
+#define OMV_RGB_DISPLAY_B5_PIN                  (&omv_pin_K4_LTDC)
+#define OMV_RGB_DISPLAY_B6_PIN                  (&omv_pin_K5_LTDC)
+#define OMV_RGB_DISPLAY_B7_PIN                  (&omv_pin_K6_LTDC)
 
-#define OMV_RGB_DISPLAY_CLK_PIN                    (&omv_pin_I14_LTDC)
-#define OMV_RGB_DISPLAY_DE_PIN                     (&omv_pin_K7_LTDC)
-#define OMV_RGB_DISPLAY_HSYNC_PIN                  (&omv_pin_I12_LTDC)
-#define OMV_RGB_DISPLAY_VSYNC_PIN                  (&omv_pin_I13_LTDC)
-#define OMV_RGB_DISPLAY_DISP_PIN                   (&omv_pin_G9_GPIO)
-#define OMV_RGB_DISPLAY_BL_PIN                     (&omv_pin_B0_TIM3)
+#define OMV_RGB_DISPLAY_CLK_PIN                 (&omv_pin_I14_LTDC)
+#define OMV_RGB_DISPLAY_DE_PIN                  (&omv_pin_K7_LTDC)
+#define OMV_RGB_DISPLAY_HSYNC_PIN               (&omv_pin_I12_LTDC)
+#define OMV_RGB_DISPLAY_VSYNC_PIN               (&omv_pin_I13_LTDC)
+#define OMV_RGB_DISPLAY_DISP_PIN                (&omv_pin_G9_GPIO)
+#define OMV_RGB_DISPLAY_BL_PIN                  (&omv_pin_B0_TIM3)
 
 // SPI LCD Interface
-#define OMV_SPI_DISPLAY_CONTROLLER                 (SPI2_ID)
-#define OMV_SPI_DISPLAY_MOSI_PIN                   (&omv_pin_B15_SPI2)
-#define OMV_SPI_DISPLAY_MISO_PIN                   (&omv_pin_B14_SPI2)
-#define OMV_SPI_DISPLAY_SCLK_PIN                   (&omv_pin_B13_SPI2)
-#define OMV_SPI_DISPLAY_SSEL_PIN                   (&omv_pin_B12_GPIO)
+#define OMV_SPI_DISPLAY_CONTROLLER              (OMV_SPI2_ID)
+#define OMV_SPI_DISPLAY_MOSI_PIN                (&omv_pin_B15_SPI2)
+#define OMV_SPI_DISPLAY_MISO_PIN                (&omv_pin_B14_SPI2)
+#define OMV_SPI_DISPLAY_SCLK_PIN                (&omv_pin_B13_SPI2)
+#define OMV_SPI_DISPLAY_SSEL_PIN                (&omv_pin_B12_GPIO)
 
-#define OMV_SPI_DISPLAY_RS_PIN                     (&omv_pin_D13_GPIO)
-#define OMV_SPI_DISPLAY_RST_PIN                    (&omv_pin_D12_GPIO)
-#define OMV_SPI_DISPLAY_BL_PIN                     (&omv_pin_A5_GPIO)
-#define OMV_SPI_DISPLAY_TRIPLE_BUFFER              (1)
+#define OMV_SPI_DISPLAY_RS_PIN                  (&omv_pin_D13_GPIO)
+#define OMV_SPI_DISPLAY_RST_PIN                 (&omv_pin_D12_GPIO)
+#define OMV_SPI_DISPLAY_BL_PIN                  (&omv_pin_A5_GPIO)
+#define OMV_SPI_DISPLAY_TRIPLE_BUFFER           (1)
 
 // HDMI CEC/DDC I/O
-#define OMV_DISPLAY_CEC_ENABLE                     (1)
-#define OMV_DISPLAY_DDC_ENABLE                     (1)
-#define OMV_CEC_PIN                                (&omv_pin_H2_GPIO)
-#define OMV_DDC_SCL_PIN                            (pin_H3)
-#define OMV_DDC_SDA_PIN                            (pin_H4)
+#define OMV_DISPLAY_CEC_ENABLE                  (1)
+#define OMV_DISPLAY_DDC_ENABLE                  (1)
+#define OMV_CEC_PIN                             (&omv_pin_H2_GPIO)
+#define OMV_DDC_SCL_PIN                         (pin_H3)
+#define OMV_DDC_SDA_PIN                         (pin_H4)
 
 // TFP410 DVI serializer
-#define OMV_TFP410_ENABLE                          (1)
-#define OMV_TFP410_RESET_PIN                       (&omv_pin_D11_GPIO)
-#define OMV_TFP410_SCL_PIN                         (pin_B1)
-#define OMV_TFP410_SDA_PIN                         (pin_B2)
-#define OMV_TFP410_INT_PIN                         (&omv_pin_I8_GPIO)
+#define OMV_TFP410_ENABLE                       (1)
+#define OMV_TFP410_RESET_PIN                    (&omv_pin_D11_GPIO)
+#define OMV_TFP410_SCL_PIN                      (pin_B1)
+#define OMV_TFP410_SDA_PIN                      (pin_B2)
+#define OMV_TFP410_INT_PIN                      (&omv_pin_I8_GPIO)
 
 // FT5X06 Touch Screen
-#define OMV_FT5X06_ENABLE                          (1)
-#define OMV_FT5X06_RESET_PIN                       (&omv_pin_K2_GPIO)
-#define OMV_FT5X06_SCL_PIN                         (pin_J13)
-#define OMV_FT5X06_SDA_PIN                         (pin_J14)
-#define OMV_FT5X06_INT_PIN                         (&omv_pin_J6_GPIO)
+#define OMV_FT5X06_ENABLE                       (1)
+#define OMV_FT5X06_RESET_PIN                    (&omv_pin_K2_GPIO)
+#define OMV_FT5X06_SCL_PIN                      (pin_J13)
+#define OMV_FT5X06_SDA_PIN                      (pin_J14)
+#define OMV_FT5X06_INT_PIN                      (&omv_pin_J6_GPIO)
 
 // FIR Lepton
-#define OMV_FIR_LEPTON_I2C_BUS                     (ISC_I2C_ID)
-#define OMV_FIR_LEPTON_I2C_BUS_SPEED               (ISC_I2C_SPEED)
+#define OMV_FIR_LEPTON_I2C_BUS                  (OMV_CSI_I2C_ID)
+#define OMV_FIR_LEPTON_I2C_BUS_SPEED            (OMV_CSI_I2C_SPEED)
 
-#define OMV_FIR_LEPTON_SPI_BUS                     (SPI3_ID)
-#define OMV_FIR_LEPTON_MOSI_PIN                    (&omv_pin_B5_SPI3)
-#define OMV_FIR_LEPTON_MISO_PIN                    (&omv_pin_B4_SPI3)
-#define OMV_FIR_LEPTON_SCLK_PIN                    (&omv_pin_B3_SPI3)
-#define OMV_FIR_LEPTON_SSEL_PIN                    (&omv_pin_A15_GPIO)
+#define OMV_FIR_LEPTON_SPI_BUS                  (OMV_SPI3_ID)
+#define OMV_FIR_LEPTON_MOSI_PIN                 (&omv_pin_B5_SPI3)
+#define OMV_FIR_LEPTON_MISO_PIN                 (&omv_pin_B4_SPI3)
+#define OMV_FIR_LEPTON_SCLK_PIN                 (&omv_pin_B3_SPI3)
+#define OMV_FIR_LEPTON_SSEL_PIN                 (&omv_pin_A15_GPIO)
 
-#define OMV_FIR_LEPTON_RESET_PIN                   (&omv_pin_D5_GPIO)
-#define OMV_FIR_LEPTON_POWER_PIN                   (&omv_pin_D4_GPIO)
-#define OMV_FIR_LEPTON_VSYNC_PIN                   (&omv_pin_E3_GPIO)
+#define OMV_FIR_LEPTON_RESET_PIN                (&omv_pin_D5_GPIO)
+#define OMV_FIR_LEPTON_POWER_PIN                (&omv_pin_D4_GPIO)
+#define OMV_FIR_LEPTON_VSYNC_PIN                (&omv_pin_E3_GPIO)
 
-#define OMV_FIR_LEPTON_MCLK_PIN                    (&omv_pin_A3_TIM15)
-#define OMV_FIR_LEPTON_MCLK_FREQ                   (24000000)
+#define OMV_FIR_LEPTON_MCLK_PIN                 (&omv_pin_A3_TIM15)
+#define OMV_FIR_LEPTON_MCLK_FREQ                (24000000)
 
-#define OMV_FIR_LEPTON_MCLK_TIM                    (TIM15)
-#define OMV_FIR_LEPTON_MCLK_TIM_CHANNEL            (TIM_CHANNEL_2)
-#define OMV_FIR_LEPTON_MCLK_TIM_CLK_ENABLE()       __HAL_RCC_TIM15_CLK_ENABLE()
-#define OMV_FIR_LEPTON_MCLK_TIM_CLK_DISABLE()      __HAL_RCC_TIM15_CLK_DISABLE()
-#define OMV_FIR_LEPTON_MCLK_TIM_FORCE_RESET()      __HAL_RCC_TIM15_FORCE_RESET()
-#define OMV_FIR_LEPTON_MCLK_TIM_RELEASE_RESET()    __HAL_RCC_TIM15_RELEASE_RESET()
-#define OMV_FIR_LEPTON_MCLK_TIM_PCLK_FREQ()        HAL_RCC_GetPCLK2Freq()
+#define OMV_FIR_LEPTON_MCLK_TIM                 (TIM15)
+#define OMV_FIR_LEPTON_MCLK_TIM_CHANNEL         (TIM_CHANNEL_2)
+#define OMV_FIR_LEPTON_MCLK_TIM_CLK_ENABLE()    __HAL_RCC_TIM15_CLK_ENABLE()
+#define OMV_FIR_LEPTON_MCLK_TIM_CLK_DISABLE()   __HAL_RCC_TIM15_CLK_DISABLE()
+#define OMV_FIR_LEPTON_MCLK_TIM_FORCE_RESET()   __HAL_RCC_TIM15_FORCE_RESET()
+#define OMV_FIR_LEPTON_MCLK_TIM_RELEASE_RESET() __HAL_RCC_TIM15_RELEASE_RESET()
+#define OMV_FIR_LEPTON_MCLK_TIM_PCLK_FREQ()     HAL_RCC_GetPCLK2Freq()
 
 // Buzzer
-#define OMV_BUZZER_PIN                             (&omv_pin_A1_TIM2)
-#define OMV_BUZZER_FREQ                            (4000)
+#define OMV_BUZZER_PIN                          (&omv_pin_A1_TIM2)
+#define OMV_BUZZER_FREQ                         (4000)
 
-#define OMV_BUZZER_TIM                             (TIM2)
-#define OMV_BUZZER_TIM_CHANNEL                     (TIM_CHANNEL_2)
-#define OMV_BUZZER_TIM_CLK_ENABLE()                __HAL_RCC_TIM2_CLK_ENABLE()
-#define OMV_BUZZER_TIM_CLK_DISABLE()               __HAL_RCC_TIM2_CLK_DISABLE()
-#define OMV_BUZZER_TIM_FORCE_RESET()               __HAL_RCC_TIM2_FORCE_RESET()
-#define OMV_BUZZER_TIM_RELEASE_RESET()             __HAL_RCC_TIM2_RELEASE_RESET()
-#define OMV_BUZZER_TIM_PCLK_FREQ()                 HAL_RCC_GetPCLK1Freq()
+#define OMV_BUZZER_TIM                          (TIM2)
+#define OMV_BUZZER_TIM_CHANNEL                  (TIM_CHANNEL_2)
+#define OMV_BUZZER_TIM_CLK_ENABLE()             __HAL_RCC_TIM2_CLK_ENABLE()
+#define OMV_BUZZER_TIM_CLK_DISABLE()            __HAL_RCC_TIM2_CLK_DISABLE()
+#define OMV_BUZZER_TIM_FORCE_RESET()            __HAL_RCC_TIM2_FORCE_RESET()
+#define OMV_BUZZER_TIM_RELEASE_RESET()          __HAL_RCC_TIM2_RELEASE_RESET()
+#define OMV_BUZZER_TIM_PCLK_FREQ()              HAL_RCC_GetPCLK1Freq()
 
 #endif //__OMV_BOARDCONFIG_H__

--- a/src/omv/boards/OPENMV_RT1060/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV_RT1060/omv_boardconfig.h
@@ -1,8 +1,8 @@
 /*
  * This file is part of the OpenMV project.
  *
- * Copyright (c) 2013-2023 Ibrahim Abdelkader <iabdalkader@openmv.io>
- * Copyright (c) 2013-2023 Kwabena W. Agyeman <kwagyeman@openmv.io>
+ * Copyright (c) 2013-2024 Ibrahim Abdelkader <iabdalkader@openmv.io>
+ * Copyright (c) 2013-2024 Kwabena W. Agyeman <kwagyeman@openmv.io>
  *
  * This work is licensed under the MIT license, see the file LICENSE for details.
  *
@@ -12,25 +12,21 @@
 #define __OMV_BOARDCONFIG_H__
 
 // Architecture info
-#define OMV_ARCH_STR                    "OMVRT1060 32768 SDRAM"    // 33 chars max
+#define OMV_BOARD_ARCH                  "OMVRT1060 32768 SDRAM"    // 33 chars max
 #define OMV_BOARD_TYPE                  "IMXRT1060"
-#define OMV_UNIQUE_ID_ADDR              0x401f4410   // Unique ID address.
-#define OMV_UNIQUE_ID_SIZE              3            // Unique ID size in words.
-#define OMV_UNIQUE_ID_OFFSET            12           // Bytes offset for multi-word UIDs.
+#define OMV_BOARD_UID_ADDR              0x401f4410   // Unique ID address.
+#define OMV_BOARD_UID_SIZE              3            // Unique ID size in words.
+#define OMV_BOARD_UID_OFFSET            12           // Bytes offset for multi-word UIDs.
 
-// Sensor external clock timer frequency.
-#define OMV_XCLK_FREQUENCY              (12000000)
+// JPEG configuration.
+#define OMV_JPEG_CODEC_ENABLE           (0)
+#define OMV_JPEG_QUALITY_LOW            (50)
+#define OMV_JPEG_QUALITY_HIGH           (90)
+#define OMV_JPEG_QUALITY_THRESHOLD      (320 * 240 * 2)
 
-// OV767x sensor configuration.
-#define OMV_OV7670_VERSION              (70)
-#define OMV_OV7670_CLKRC                (0)
-
-// OV7725 sensor configuration.
-#define OMV_OV7725_PLL_CONFIG           (0x41)   // x4
-#define OMV_OV7725_BANDING              (0x7F)
-
-// OV5640 Sensor Settings
-#define OMV_ENABLE_OV5640_AF            (1)
+// Image sensor drivers configuration.
+#define OMV_OV5640_ENABLE               (1)
+#define OMV_OV5640_AF_ENABLE            (1)
 #define OMV_OV5640_XCLK_FREQ            (24000000)
 #define OMV_OV5640_PLL_CTRL2            (0x64)
 #define OMV_OV5640_PLL_CTRL3            (0x13)
@@ -39,42 +35,28 @@
 #define OMV_OV5640_REV_Y_CTRL2          (0x54)
 #define OMV_OV5640_REV_Y_CTRL3          (0x13)
 
-// Enable hardware JPEG
-#define OMV_HARDWARE_JPEG               (0)
+#define OMV_OV7725_ENABLE               (1)
+#define OMV_OV7725_PLL_CONFIG           (0x41)   // x4
+#define OMV_OV7725_BANDING              (0x7F)
 
-// Enable sensor drivers
-#define OMV_ENABLE_OV2640               (0)
-#define OMV_ENABLE_OV5640               (1)
-#define OMV_ENABLE_OV7670               (0)
-#define OMV_ENABLE_OV7690               (0)
-#define OMV_ENABLE_OV7725               (1)
-#define OMV_ENABLE_OV9650               (0)
-#define OMV_ENABLE_MT9M114              (1)
-#define OMV_ENABLE_MT9V0XX              (1)
-#define OMV_ENABLE_LEPTON               (1)
-#define OMV_ENABLE_HM01B0               (0)
-#define OMV_ENABLE_PAJ6100              (1)
-#define OMV_ENABLE_FROGEYE2020          (1)
-#define OMV_ENABLE_FIR_MLX90621         (1)
-#define OMV_ENABLE_FIR_MLX90640         (1)
-#define OMV_ENABLE_FIR_MLX90641         (1)
-#define OMV_ENABLE_FIR_AMG8833          (1)
-#define OMV_ENABLE_FIR_LEPTON           (1)
+#define OMV_MT9M114_ENABLE              (1)
+#define OMV_MT9V0XX_ENABLE              (1)
+#define OMV_LEPTON_ENABLE               (1)
+#define OMV_PAJ6100_ENABLE              (1)
+#define OMV_FROGEYE2020_ENABLE          (1)
 
-// Enable WiFi debug
-#define OMV_ENABLE_WIFIDBG              (0)
-#define OMV_ENABLE_TUSBDBG              (1)
+// FIR sensor drivers configuration.
+#define OMV_FIR_MLX90621_ENABLE         (1)
+#define OMV_FIR_MLX90640_ENABLE         (1)
+#define OMV_FIR_MLX90641_ENABLE         (1)
+#define OMV_FIR_AMG8833_ENABLE          (1)
+#define OMV_FIR_LEPTON_ENABLE           (1)
+
+// Debugging configuration.
+#define OMV_TUSBDBG_ENABLE              (1)
 #define OMV_TUSBDBG_PACKET              (512)
 
-// If buffer size is bigger than this threshold, the quality is reduced.
-// This is only used for JPEG images sent to the IDE not normal compression.
-#define JPEG_QUALITY_THRESH             (320 * 240 * 2)
-
-// Low and high JPEG QS.
-#define JPEG_QUALITY_LOW                50
-#define JPEG_QUALITY_HIGH               90
-
-// FB Heap Block Size
+// UMM heap block size
 #define OMV_UMM_BLOCK_SIZE              256
 
 // USB config.
@@ -90,8 +72,6 @@
 // Linker script constants (see the linker script template mimxrt10xx.ld.S).
 // Note: fb_alloc is a stack-based, dynamically allocated memory on FB.
 // The maximum available fb_alloc memory = FB_ALLOC_SIZE + FB_SIZE - (w*h*bpp).
-
-//#define OMV_FFS_MEMORY                  DTCM        // Flash filesystem cache memory
 #define OMV_MAIN_MEMORY                 DTCM         // data, bss and heap memory
 #define OMV_STACK_MEMORY                ITCM1        // stack memory
 #define OMV_RAMFUNC_MEMORY              ITCM2        // RAM code memory.
@@ -106,13 +86,9 @@
 #define OMV_FB_ALLOC_SIZE               (11M)         // minimum fb alloc size
 #define OMV_FB_OVERLAY_SIZE             (512K)
 #define OMV_STACK_SIZE                  (32K)
-#define OMV_HEAP_SIZE                   (280K)
+#define OMV_HEAP_SIZE                   (284K)
 #define OMV_SDRAM_SIZE                  (32 * 1024 * 1024)  // This needs to be here for UVC firmware.
-
 #define OMV_LINE_BUF_SIZE               (11 * 1024)  // Image line buffer.
-// TODO remove
-#define OMV_MSC_BUF_SIZE                (2K)         // USB MSC bot data
-#define OMV_VFS_BUF_SIZE                (1K)         // VFS struct + FATFS file buffer (624 bytes)
 #define OMV_JPEG_BUF_SIZE               (1024 * 1024)  // IDE JPEG buffer (header + data).
 
 // Memory configuration.
@@ -133,70 +109,65 @@
 // Flash configuration.
 #define OMV_FLASH_ORIGIN                0x60000000
 #define OMV_FLASH_LENGTH                0x00800000
-
 #define OMV_FLASH_APP_ORIGIN            0x60040000   // 256K reserved for bootloader
 #define OMV_FLASH_APP_LENGTH            0x007C0000
-
 #define OMV_FLASH_TXT_ORIGIN            0x60043000
 #define OMV_FLASH_TXT_LENGTH            0x00380000
-
 #define OMV_FLASH_FFS_ORIGIN            0x60400000
 #define OMV_FLASH_FFS_LENGTH            0x00400000
 
 // Main image sensor I2C bus
-#define ISC_I2C_ID                      (1)
-#define ISC_I2C_SPEED                   (OMV_I2C_SPEED_STANDARD)
+#define OMV_CSI_I2C_ID                  (1)
+#define OMV_CSI_I2C_SPEED               (OMV_I2C_SPEED_STANDARD)
 
 // Thermal image sensor I2C bus
-#define FIR_I2C_ID                      (4)
-#define FIR_I2C_SPEED                   (OMV_I2C_SPEED_FULL)
+#define OMV_FIR_I2C_ID                  (4)
+#define OMV_FIR_I2C_SPEED               (OMV_I2C_SPEED_FULL)
 
 // Main image sensor SPI bus
-#define ISC_SPI_ID                      (4)
+#define OMV_CSI_SPI_ID                  (4)
 
 // Physical I2C buses.
-
 // LPI2C1
-#define LPI2C1_ID                       (1)
-#define LPI2C1_SCL_PIN                  (&omv_pin_LPI2C1_SCL)
-#define LPI2C1_SDA_PIN                  (&omv_pin_LPI2C1_SDA)
+#define OMV_I2C1_ID                     (1)
+#define OMV_I2C1_SCL_PIN                (&omv_pin_LPI2C1_SCL)
+#define OMV_I2C1_SDA_PIN                (&omv_pin_LPI2C1_SDA)
 
 // LPI2C2
-#define LPI2C2_ID                       (2)
-#define LPI2C2_SCL_PIN                  (&omv_pin_LPI2C2_SCL)
-#define LPI2C2_SDA_PIN                  (&omv_pin_LPI2C2_SDA)
+#define OMV_I2C2_ID                     (2)
+#define OMV_I2C2_SCL_PIN                (&omv_pin_LPI2C2_SCL)
+#define OMV_I2C2_SDA_PIN                (&omv_pin_LPI2C2_SDA)
 
 // LPI2C4
-#define LPI2C4_ID                       (4)
-#define LPI2C4_SCL_PIN                  (&omv_pin_LPI2C4_SCL)
-#define LPI2C4_SDA_PIN                  (&omv_pin_LPI2C4_SDA)
+#define OMV_I2C4_ID                     (4)
+#define OMV_I2C4_SCL_PIN                (&omv_pin_LPI2C4_SCL)
+#define OMV_I2C4_SDA_PIN                (&omv_pin_LPI2C4_SDA)
 
 // Physical SPI buses.
-
 // LPSPI3
-#define LPSPI3_ID                       (3)
-#define LPSPI3_SCLK_PIN                 (&omv_pin_LPSPI3_SCLK)
-#define LPSPI3_MISO_PIN                 (&omv_pin_LPSPI3_MISO)
-#define LPSPI3_MOSI_PIN                 (&omv_pin_LPSPI3_MOSI)
-#define LPSPI3_SSEL_PIN                 (&omv_pin_LPSPI3_SSEL)
-#define LPSPI3_DMA                      (DMA0)
-#define LPSPI3_DMA_MUX                  (DMAMUX)
-#define LPSPI3_DMA_TX_CHANNEL           (3U)
-#define LPSPI3_DMA_RX_CHANNEL           (2U)
+#define OMV_SPI3_ID                     (3)
+#define OMV_SPI3_SCLK_PIN               (&omv_pin_LPSPI3_SCLK)
+#define OMV_SPI3_MISO_PIN               (&omv_pin_LPSPI3_MISO)
+#define OMV_SPI3_MOSI_PIN               (&omv_pin_LPSPI3_MOSI)
+#define OMV_SPI3_SSEL_PIN               (&omv_pin_LPSPI3_SSEL)
+#define OMV_SPI3_DMA                    (DMA0)
+#define OMV_SPI3_DMA_MUX                (DMAMUX)
+#define OMV_SPI3_DMA_TX_CHANNEL         (3U)
+#define OMV_SPI3_DMA_RX_CHANNEL         (2U)
 
 // LPSPI4
-#define LPSPI4_ID                       (4)
-#define LPSPI4_SCLK_PIN                 (&omv_pin_LPSPI4_SCLK)
-#define LPSPI4_MISO_PIN                 (&omv_pin_LPSPI4_MISO)
-#define LPSPI4_MOSI_PIN                 (&omv_pin_LPSPI4_MOSI)
-#define LPSPI4_SSEL_PIN                 (&omv_pin_LPSPI4_SSEL)
-#define LPSPI4_DMA                      (DMA0)
-#define LPSPI4_DMA_MUX                  (DMAMUX)
-#define LPSPI4_DMA_TX_CHANNEL           (1U)
-#define LPSPI4_DMA_RX_CHANNEL           (0U)
+#define OMV_SPI4_ID                     (4)
+#define OMV_SPI4_SCLK_PIN               (&omv_pin_LPSPI4_SCLK)
+#define OMV_SPI4_MISO_PIN               (&omv_pin_LPSPI4_MISO)
+#define OMV_SPI4_MOSI_PIN               (&omv_pin_LPSPI4_MOSI)
+#define OMV_SPI4_SSEL_PIN               (&omv_pin_LPSPI4_SSEL)
+#define OMV_SPI4_DMA                    (DMA0)
+#define OMV_SPI4_DMA_MUX                (DMAMUX)
+#define OMV_SPI4_DMA_TX_CHANNEL         (1U)
+#define OMV_SPI4_DMA_RX_CHANNEL         (0U)
 
 // SPI LCD Interface
-#define OMV_SPI_DISPLAY_CONTROLLER      (LPSPI3_ID)
+#define OMV_SPI_DISPLAY_CONTROLLER      (OMV_SPI3_ID)
 #define OMV_SPI_DISPLAY_MOSI_PIN        (&omv_pin_LPSPI3_MOSI)
 #define OMV_SPI_DISPLAY_MISO_PIN        (&omv_pin_LPSPI3_MISO)
 #define OMV_SPI_DISPLAY_SCLK_PIN        (&omv_pin_LPSPI3_SCLK)
@@ -209,34 +180,35 @@
 #define OMV_SPI_DISPLAY_RX_CLK_DIV      (8)
 
 // FIR Lepton
-#define OMV_FIR_LEPTON_I2C_BUS          (FIR_I2C_ID)
-#define OMV_FIR_LEPTON_I2C_BUS_SPEED    (FIR_I2C_SPEED)
+#define OMV_FIR_LEPTON_I2C_BUS          (OMV_FIR_I2C_ID)
+#define OMV_FIR_LEPTON_I2C_BUS_SPEED    (OMV_FIR_I2C_SPEED)
+#define OMV_FIR_LEPTON_RX_CLK_DIV       (8)
 
-#define OMV_FIR_LEPTON_SPI_BUS          (LPSPI3_ID)
+#define OMV_FIR_LEPTON_SPI_BUS          (OMV_SPI3_ID)
 #define OMV_FIR_LEPTON_MOSI_PIN         (&omv_pin_LPSPI3_MOSI)
 #define OMV_FIR_LEPTON_MISO_PIN         (&omv_pin_LPSPI3_MISO)
 #define OMV_FIR_LEPTON_SCLK_PIN         (&omv_pin_LPSPI3_SCLK)
 #define OMV_FIR_LEPTON_SSEL_PIN         (&omv_pin_LPSPI3_GPIO)
 
-#define OMV_FIR_LEPTON_RX_CLK_DIV       (8)
-
 // Camera interface configuration.
 #define OMV_CSI_BASE                    (CSI)
+#define OMV_CSI_XCLK_FREQUENCY          (12000000)
 
-#define DCMI_RESET_PIN                  (&omv_pin_DCMI_RESET)
-#define DCMI_POWER_PIN                  (&omv_pin_DCMI_POWER)
-#define DCMI_FSYNC_PIN                  (&omv_pin_DCMI_FSYNC)
+#define OMV_CSI_D0_PIN                  (&omv_pin_DCMI_D0)
+#define OMV_CSI_D1_PIN                  (&omv_pin_DCMI_D1)
+#define OMV_CSI_D2_PIN                  (&omv_pin_DCMI_D2)
+#define OMV_CSI_D3_PIN                  (&omv_pin_DCMI_D3)
+#define OMV_CSI_D4_PIN                  (&omv_pin_DCMI_D4)
+#define OMV_CSI_D5_PIN                  (&omv_pin_DCMI_D5)
+#define OMV_CSI_D6_PIN                  (&omv_pin_DCMI_D6)
+#define OMV_CSI_D7_PIN                  (&omv_pin_DCMI_D7)
 
-#define DCMI_D0_PIN                     (&omv_pin_DCMI_D0)
-#define DCMI_D1_PIN                     (&omv_pin_DCMI_D1)
-#define DCMI_D2_PIN                     (&omv_pin_DCMI_D2)
-#define DCMI_D3_PIN                     (&omv_pin_DCMI_D3)
-#define DCMI_D4_PIN                     (&omv_pin_DCMI_D4)
-#define DCMI_D5_PIN                     (&omv_pin_DCMI_D5)
-#define DCMI_D6_PIN                     (&omv_pin_DCMI_D6)
-#define DCMI_D7_PIN                     (&omv_pin_DCMI_D7)
-#define DCMI_MCLK_PIN                   (&omv_pin_DCMI_MCLK)
-#define DCMI_HSYNC_PIN                  (&omv_pin_DCMI_HSYNC)
-#define DCMI_VSYNC_PIN                  (&omv_pin_DCMI_VSYNC)
-#define DCMI_PXCLK_PIN                  (&omv_pin_DCMI_PXCLK)
+#define OMV_CSI_HSYNC_PIN               (&omv_pin_DCMI_HSYNC)
+#define OMV_CSI_VSYNC_PIN               (&omv_pin_DCMI_VSYNC)
+#define OMV_CSI_PXCLK_PIN               (&omv_pin_DCMI_PXCLK)
+#define OMV_CSI_MXCLK_PIN               (&omv_pin_DCMI_MCLK)
+#define OMV_CSI_RESET_PIN               (&omv_pin_DCMI_RESET)
+#define OMV_CSI_POWER_PIN               (&omv_pin_DCMI_POWER)
+#define OMV_CSI_FSYNC_PIN               (&omv_pin_DCMI_FSYNC)
+
 #endif //__OMV_BOARDCONFIG_H__

--- a/src/omv/boards/PICO/dcmi.pio
+++ b/src/omv/boards/PICO/dcmi.pio
@@ -62,27 +62,27 @@ int sensor_dcmi_config(uint32_t pixformat)
     uint offset;
     pio_sm_config config;
 
-    pio_sm_set_enabled(DCMI_PIO, DCMI_SM, false);
-    pio_sm_clear_fifos(DCMI_PIO, DCMI_SM);
+    pio_sm_set_enabled(OMV_CSI_PIO, OMV_CSI_SM, false);
+    pio_sm_clear_fifos(OMV_CSI_PIO, OMV_CSI_SM);
 
-    for(uint i=DCMI_D0_PIN; i<DCMI_D0_PIN+8; i++) {
-        pio_gpio_init(DCMI_PIO, i);
+    for(uint i=OMV_CSI_D0_PIN; i<OMV_CSI_D0_PIN+8; i++) {
+        pio_gpio_init(OMV_CSI_PIO, i);
     }
-    pio_sm_set_consecutive_pindirs(DCMI_PIO, DCMI_SM, DCMI_D0_PIN, 8, false);
+    pio_sm_set_consecutive_pindirs(OMV_CSI_PIO, OMV_CSI_SM, OMV_CSI_D0_PIN, 8, false);
 
     if (pixformat == PIXFORMAT_GRAYSCALE) {
-        offset = pio_add_program(DCMI_PIO, &dcmi_odd_byte_program);
+        offset = pio_add_program(OMV_CSI_PIO, &dcmi_odd_byte_program);
         config = dcmi_odd_byte_program_get_default_config(offset);
     } else {
-        offset = pio_add_program(DCMI_PIO, &dcmi_default_program);
+        offset = pio_add_program(OMV_CSI_PIO, &dcmi_default_program);
         config = dcmi_default_program_get_default_config(offset);
     }
 
     sm_config_set_clkdiv(&config, 1);
-    sm_config_set_in_pins(&config, DCMI_D0_PIN);
+    sm_config_set_in_pins(&config, OMV_CSI_D0_PIN);
     sm_config_set_in_shift(&config, true, true, 32);
-    pio_sm_init(DCMI_PIO, DCMI_SM, offset, &config);
-    pio_sm_set_enabled(DCMI_PIO, DCMI_SM, true);
+    pio_sm_init(OMV_CSI_PIO, OMV_CSI_SM, offset, &config);
+    pio_sm_set_enabled(OMV_CSI_PIO, OMV_CSI_SM, true);
     return 0;
 }
 %}

--- a/src/omv/boards/PICO/omv_boardconfig.h
+++ b/src/omv/boards/PICO/omv_boardconfig.h
@@ -1,8 +1,8 @@
 /*
  * This file is part of the OpenMV project.
  *
- * Copyright (c) 2013-2021 Ibrahim Abdelkader <iabdalkader@openmv.io>
- * Copyright (c) 2013-2021 Kwabena W. Agyeman <kwagyeman@openmv.io>
+ * Copyright (c) 2013-2024 Ibrahim Abdelkader <iabdalkader@openmv.io>
+ * Copyright (c) 2013-2024 Kwabena W. Agyeman <kwagyeman@openmv.io>
  *
  * This work is licensed under the MIT license, see the file LICENSE for details.
  *
@@ -12,67 +12,33 @@
 #define __OMV_BOARDCONFIG_H__
 
 // Architecture info
-#define OMV_ARCH_STR               "PICO M0" // 33 chars max
+#define OMV_BOARD_ARCH             "PICO M0" // 33 chars max
 #define OMV_BOARD_TYPE             "PICO"
-
 #ifndef LINKER_SCRIPT
-extern unsigned char *OMV_UNIQUE_ID_ADDR;   // Unique ID address.
+extern unsigned char *OMV_BOARD_UID_ADDR;   // Unique ID address.
 #endif
-#define OMV_UNIQUE_ID_SIZE         2        // Unique ID size in words.
-#define OMV_UNIQUE_ID_OFFSET       4        // Bytes offset for multi-word UIDs.
+#define OMV_BOARD_UID_SIZE         2        // Unique ID size in words.
+#define OMV_BOARD_UID_OFFSET       4        // Bytes offset for multi-word UIDs.
 
-#define OMV_XCLK_MCO               (0U)
-#define OMV_XCLK_TIM               (1U)
+// JPEG configuration.
+#define OMV_JPEG_CODEC_ENABLE      (0)
+#define OMV_JPEG_QUALITY_LOW       (35)
+#define OMV_JPEG_QUALITY_HIGH      (60)
+#define OMV_JPEG_QUALITY_THRESHOLD (160 * 120)
 
-// Sensor external clock source.
-#define OMV_XCLK_SOURCE            (OMV_XCLK_TIM)
-
-// Sensor external clock timer frequency.
-// TODO Not actually used right now, frequency is hardcoded.
-#define OMV_XCLK_FREQUENCY         (12500000)
-
-// Enable hardware JPEG
-#define OMV_HARDWARE_JPEG          (0)
-
-// Enable sensor drivers
-#define OMV_ENABLE_OV2640          (0)
-#define OMV_ENABLE_OV5640          (0)
-#define OMV_ENABLE_OV7670          (1)
-#define OMV_ENABLE_OV7690          (0)
-#define OMV_ENABLE_OV7725          (0)
-#define OMV_ENABLE_OV9650          (0)
-#define OMV_ENABLE_MT9V0XX         (0)
-#define OMV_ENABLE_LEPTON          (0)
-#define OMV_ENABLE_HM01B0          (0)
-
-// Set which OV767x sensor is used
+// Image sensor drivers configuration.
+#define OMV_OV7670_ENABLE          (1)
 #define OMV_OV7670_VERSION         (70)
-
-// OV7670 clock divider
 #define OMV_OV7670_CLKRC           (0x00)
 
-// FIR Module
-#define OMV_ENABLE_FIR_MLX90621    (0)
-#define OMV_ENABLE_FIR_MLX90640    (0)
-#define OMV_ENABLE_FIR_MLX90641    (0)
-#define OMV_ENABLE_FIR_AMG8833     (1)
-#define OMV_ENABLE_FIR_LEPTON      (0)
+// FIR sensor drivers configuration.
+#define OMV_FIR_MLX90621_ENABLE    (0)
+#define OMV_FIR_MLX90640_ENABLE    (0)
+#define OMV_FIR_MLX90641_ENABLE    (0)
+#define OMV_FIR_AMG8833_ENABLE     (1)
+#define OMV_FIR_LEPTON_ENABLE      (0)
 
-// Enable sensor features
-#define OMV_ENABLE_OV5640_AF       (0)
-
-// Enable WiFi debug
-#define OMV_ENABLE_WIFIDBG         (0)
-
-// If buffer size is bigger than this threshold, the quality is reduced.
-// This is only used for JPEG images sent to the IDE not normal compression.
-#define JPEG_QUALITY_THRESH        (160 * 120)
-
-// Low and high JPEG QS.
-#define JPEG_QUALITY_LOW           35
-#define JPEG_QUALITY_HIGH          60
-
-// FB Heap Block Size
+// UMM heap block size
 #define OMV_UMM_BLOCK_SIZE         16
 
 // USB IRQn.
@@ -91,63 +57,57 @@ extern unsigned char *OMV_UNIQUE_ID_ADDR;   // Unique ID address.
 #define OMV_JPEG_BUF_SIZE          (20 * 1024) // IDE JPEG buffer (header + data).
 
 // GP LED
-#define LED_PIN                    (25)
+#define OMV_LED_PIN                (25)
 
 // FIR I2C
-#define FIR_I2C_ID                 (0)
-#define FIR_I2C_SCL_PIN            (21)
-#define FIR_I2C_SDA_PIN            (20)
-#define FIR_I2C_SPEED              (OMV_I2C_SPEED_FULL)
+#define OMV_FIR_I2C_ID             (0)
+#define OMV_FIR_I2C_SPEED          (OMV_I2C_SPEED_FULL)
 
 // ISC I2C
-#define ISC_I2C_ID                 (1)
-#define ISC_I2C_SCL_PIN            (15)
-#define ISC_I2C_SDA_PIN            (14)
-#define ISC_I2C_SPEED              (OMV_I2C_SPEED_STANDARD)
+#define OMV_CSI_I2C_ID             (1)
+#define OMV_CSI_I2C_SPEED          (OMV_I2C_SPEED_STANDARD)
 
 // I2C0
-#define I2C0_ID                    (0)
-#define I2C0_SCL_PIN               (21)
-#define I2C0_SDA_PIN               (20)
-#define I2C0_SPEED                 (OMV_I2C_SPEED_FULL)
+#define OMV_I2C0_ID                (0)
+#define OMV_I2C0_SCL_PIN           (21)
+#define OMV_I2C0_SDA_PIN           (20)
 
 // I2C1
-#define I2C1_ID                    (1)
-#define I2C1_SCL_PIN               (15)
-#define I2C1_SDA_PIN               (14)
-#define I2C1_SPEED                 (OMV_I2C_SPEED_FULL)
+#define OMV_I2C1_ID                (1)
+#define OMV_I2C1_SCL_PIN           (15)
+#define OMV_I2C1_SDA_PIN           (14)
 
-#define LCD_SPI                    (spi0)
-#define LCD_CS_PIN                 (17)
-#define LCD_MOSI_PIN               (19)
-#define LCD_SCLK_PIN               (18)
-#define LCD_RST_PIN                (20)
-#define LCD_RS_PIN                 (21)
+#define OMV_LCD_SPI                (spi0)
+#define OMV_LCD_CS_PIN             (17)
+#define OMV_LCD_MOSI_PIN           (19)
+#define OMV_LCD_SCLK_PIN           (18)
+#define OMV_LCD_RST_PIN            (20)
+#define OMV_LCD_RS_PIN             (21)
 
-// DCMI config.
-#define DCMI_PIO                   (pio0)
-#define DCMI_SM                    (0)
-#define DCMI_DMA                   (0)
-#define DCMI_DMA_IRQ               (DMA_IRQ_0)
-#define DCMI_DMA_CHANNEL           (0)
+// Camera interface.
+#define OMV_CSI_PIO                (pio0)
+#define OMV_CSI_SM                 (0)
+#define OMV_CSI_DMA                (0)
+#define OMV_CSI_DMA_IRQ            (DMA_IRQ_0)
+#define OMV_CSI_DMA_CHANNEL        (0)
+#define OMV_CSI_XCLK_SOURCE        (XCLK_SOURCE_TIM)
+#define OMV_CSI_XCLK_FREQUENCY     (12500000)
 
-#define DCMI_POWER_PIN             (0)
-#define DCMI_RESET_PIN             (1)
-
-#define DCMI_D0_PIN                (2)
-#define DCMI_D1_PIN                (3)
-#define DCMI_D2_PIN                (4)
-#define DCMI_D3_PIN                (5)
-#define DCMI_D4_PIN                (6)
-#define DCMI_D5_PIN                (7)
-#define DCMI_D6_PIN                (8)
-#define DCMI_D7_PIN                (9)
-
-#define DCMI_XCLK_PIN              (10)
+#define OMV_CSI_D0_PIN             (2)
+#define OMV_CSI_D1_PIN             (3)
+#define OMV_CSI_D2_PIN             (4)
+#define OMV_CSI_D3_PIN             (5)
+#define OMV_CSI_D4_PIN             (6)
+#define OMV_CSI_D5_PIN             (7)
+#define OMV_CSI_D6_PIN             (8)
+#define OMV_CSI_D7_PIN             (9)
 
 // Must match the pins defined in dcmi.pio.
-#define DCMI_PXCLK_PIN             (11)
-#define DCMI_HSYNC_PIN             (12)
-#define DCMI_VSYNC_PIN             (13)
+#define OMV_CSI_HSYNC_PIN          (12)
+#define OMV_CSI_VSYNC_PIN          (13)
+#define OMV_CSI_PXCLK_PIN          (11)
+#define OMV_CSI_MXCLK_PIN          (10)
+#define OMV_CSI_POWER_PIN          (0)
+#define OMV_CSI_RESET_PIN          (1)
 
 #endif //__OMV_BOARDCONFIG_H__

--- a/src/omv/common/boot_utils.c
+++ b/src/omv/common/boot_utils.c
@@ -23,7 +23,7 @@
 #endif
 #include "omv_boardconfig.h"
 #include "usbdbg.h"
-#if OMV_ENABLE_WIFIDBG
+#if OMV_WIFIDBG_ENABLE
 #include "wifidbg.h"
 #endif
 #include "file_utils.h"
@@ -68,7 +68,7 @@ bool bootutils_exec_bootscript(const char *path, bool interruptible, bool wifidb
         if (interruptible) {
             usbdbg_set_irq_enabled(true);
             usbdbg_set_script_running(true);
-            #if OMV_ENABLE_WIFIDBG
+            #if OMV_WIFIDBG_ENABLE
             wifidbg_set_irq_enabled(wifidbg_enabled);
             #endif
         }
@@ -83,7 +83,7 @@ bool bootutils_exec_bootscript(const char *path, bool interruptible, bool wifidb
     // Disable IDE interrupts
     usbdbg_set_irq_enabled(false);
     usbdbg_set_script_running(false);
-    #if OMV_ENABLE_WIFIDBG
+    #if OMV_WIFIDBG_ENABLE
     wifidbg_set_irq_enabled(false);
     #endif
 

--- a/src/omv/common/sensor.h
+++ b/src/omv/common/sensor.h
@@ -133,6 +133,12 @@ typedef enum {
 } polarity_t;
 
 typedef enum {
+    XCLK_SOURCE_MCO = 0U,
+    XCLK_SOURCE_TIM = 1U,
+    XCLK_SOURCE_OSC = 2U,
+} xclk_source_t;
+
+typedef enum {
     IOCTL_SET_READOUT_WINDOW,
     IOCTL_GET_READOUT_WINDOW,
     IOCTL_SET_TRIGGERED_MODE,

--- a/src/omv/common/sensor_utils.c
+++ b/src/omv/common/sensor_utils.c
@@ -142,16 +142,16 @@ __weak int sensor_reset() {
     // Disable the bus before reset.
     omv_i2c_enable(&sensor.i2c_bus, false);
 
-    #if defined(DCMI_RESET_PIN)
+    #if defined(OMV_CSI_RESET_PIN)
     // Hard-reset the sensor
     if (sensor.reset_pol == ACTIVE_HIGH) {
-        omv_gpio_write(DCMI_RESET_PIN, 1);
+        omv_gpio_write(OMV_CSI_RESET_PIN, 1);
         mp_hal_delay_ms(10);
-        omv_gpio_write(DCMI_RESET_PIN, 0);
+        omv_gpio_write(OMV_CSI_RESET_PIN, 0);
     } else {
-        omv_gpio_write(DCMI_RESET_PIN, 0);
+        omv_gpio_write(OMV_CSI_RESET_PIN, 0);
         mp_hal_delay_ms(10);
-        omv_gpio_write(DCMI_RESET_PIN, 1);
+        omv_gpio_write(OMV_CSI_RESET_PIN, 1);
     }
     #endif
 
@@ -179,59 +179,59 @@ static int sensor_detect() {
     for (int i = 0; i < OMV_MIN(n_devs, OMV_ISC_MAX_DEVICES); i++) {
         uint8_t slv_addr = devs_list[i];
         switch (slv_addr) {
-            #if (OMV_ENABLE_OV2640 == 1)
+            #if (OMV_OV2640_ENABLE == 1)
             case OV2640_SLV_ADDR: // Or OV9650.
                 omv_i2c_readb(&sensor.i2c_bus, slv_addr, OV_CHIP_ID, &sensor.chip_id);
                 return slv_addr;
-            #endif // (OMV_ENABLE_OV2640 == 1)
+            #endif // (OMV_OV2640_ENABLE == 1)
 
-            #if (OMV_ENABLE_OV5640 == 1)
+            #if (OMV_OV5640_ENABLE == 1)
             case OV5640_SLV_ADDR:
                 omv_i2c_readb2(&sensor.i2c_bus, slv_addr, OV5640_CHIP_ID, &sensor.chip_id);
                 return slv_addr;
-            #endif // (OMV_ENABLE_OV5640 == 1)
+            #endif // (OMV_OV5640_ENABLE == 1)
 
-            #if (OMV_ENABLE_OV7725 == 1) || (OMV_ENABLE_OV7670 == 1) || (OMV_ENABLE_OV7690 == 1)
+            #if (OMV_OV7725_ENABLE == 1) || (OMV_OV7670_ENABLE == 1) || (OMV_OV7690_ENABLE == 1)
             case OV7725_SLV_ADDR: // Or OV7690 or OV7670.
                 omv_i2c_readb(&sensor.i2c_bus, slv_addr, OV_CHIP_ID, &sensor.chip_id);
                 return slv_addr;
-            #endif //(OMV_ENABLE_OV7725 == 1) || (OMV_ENABLE_OV7670 == 1) || (OMV_ENABLE_OV7690 == 1)
+            #endif //(OMV_OV7725_ENABLE == 1) || (OMV_OV7670_ENABLE == 1) || (OMV_OV7690_ENABLE == 1)
 
-            #if (OMV_ENABLE_MT9V0XX == 1)
+            #if (OMV_MT9V0XX_ENABLE == 1)
             case MT9V0XX_SLV_ADDR:
                 omv_i2c_readw(&sensor.i2c_bus, slv_addr, ON_CHIP_ID, &sensor.chip_id_w);
                 return slv_addr;
-            #endif //(OMV_ENABLE_MT9V0XX == 1)
+            #endif //(OMV_MT9V0XX_ENABLE == 1)
 
-            #if (OMV_ENABLE_MT9M114 == 1)
+            #if (OMV_MT9M114_ENABLE == 1)
             case MT9M114_SLV_ADDR:
                 omv_i2c_readw2(&sensor.i2c_bus, slv_addr, ON_CHIP_ID, &sensor.chip_id_w);
                 return slv_addr;
-            #endif // (OMV_ENABLE_MT9M114 == 1)
+            #endif // (OMV_MT9M114_ENABLE == 1)
 
-            #if (OMV_ENABLE_LEPTON == 1)
+            #if (OMV_LEPTON_ENABLE == 1)
             case LEPTON_SLV_ADDR:
                 sensor.chip_id = LEPTON_ID;
                 return slv_addr;
-            #endif // (OMV_ENABLE_LEPTON == 1)
+            #endif // (OMV_LEPTON_ENABLE == 1)
 
-            #if (OMV_ENABLE_HM01B0 == 1) || (OMV_ENABLE_HM0360 == 1)
+            #if (OMV_HM01B0_ENABLE == 1) || (OMV_HM0360_ENABLE == 1)
             case HM0XX0_SLV_ADDR:
                 omv_i2c_readb2(&sensor.i2c_bus, slv_addr, HIMAX_CHIP_ID, &sensor.chip_id);
                 return slv_addr;
-            #endif // (OMV_ENABLE_HM01B0 == 1) || (OMV_ENABLE_HM0360 == 1)
+            #endif // (OMV_HM01B0_ENABLE == 1) || (OMV_HM0360_ENABLE == 1)
 
-            #if (OMV_ENABLE_GC2145 == 1)
+            #if (OMV_GC2145_ENABLE == 1)
             case GC2145_SLV_ADDR:
                 omv_i2c_readb(&sensor.i2c_bus, slv_addr, GC_CHIP_ID, &sensor.chip_id);
                 return slv_addr;
-            #endif //(OMV_ENABLE_GC2145 == 1)
+            #endif //(OMV_GC2145_ENABLE == 1)
 
-            #if (OMV_ENABLE_FROGEYE2020 == 1)
+            #if (OMV_FROGEYE2020_ENABLE == 1)
             case FROGEYE2020_SLV_ADDR:
                 sensor.chip_id_w = FROGEYE2020_ID;
                 return slv_addr;
-            #endif // (OMV_ENABLE_FROGEYE2020 == 1)
+            #endif // (OMV_FROGEYE2020_ENABLE == 1)
         }
     }
 
@@ -241,23 +241,23 @@ static int sensor_detect() {
 int sensor_probe_init(uint32_t bus_id, uint32_t bus_speed) {
     int init_ret = 0;
 
-    #if defined(DCMI_POWER_PIN)
+    #if defined(OMV_CSI_POWER_PIN)
     sensor.pwdn_pol = ACTIVE_HIGH;
     // Do a power cycle
-    omv_gpio_write(DCMI_POWER_PIN, 1);
+    omv_gpio_write(OMV_CSI_POWER_PIN, 1);
     mp_hal_delay_ms(10);
 
-    omv_gpio_write(DCMI_POWER_PIN, 0);
+    omv_gpio_write(OMV_CSI_POWER_PIN, 0);
     mp_hal_delay_ms(10);
     #endif
 
-    #if defined(DCMI_RESET_PIN)
+    #if defined(OMV_CSI_RESET_PIN)
     sensor.reset_pol = ACTIVE_HIGH;
     // Reset the sensor
-    omv_gpio_write(DCMI_RESET_PIN, 1);
+    omv_gpio_write(OMV_CSI_RESET_PIN, 1);
     mp_hal_delay_ms(10);
 
-    omv_gpio_write(DCMI_RESET_PIN, 0);
+    omv_gpio_write(OMV_CSI_RESET_PIN, 0);
     mp_hal_delay_ms(10);
     #endif
 
@@ -270,23 +270,23 @@ int sensor_probe_init(uint32_t bus_id, uint32_t bus_speed) {
     if ((sensor.slv_addr = sensor_detect()) == 0) {
         // No devices were detected, try scanning the bus
         // again with different reset/power-down polarities.
-        #if defined(DCMI_RESET_PIN)
+        #if defined(OMV_CSI_RESET_PIN)
         sensor.reset_pol = ACTIVE_LOW;
-        omv_gpio_write(DCMI_RESET_PIN, 1);
+        omv_gpio_write(OMV_CSI_RESET_PIN, 1);
         mp_hal_delay_ms(10);
         #endif
 
         if ((sensor.slv_addr = sensor_detect()) == 0) {
-            #if defined(DCMI_POWER_PIN)
+            #if defined(OMV_CSI_POWER_PIN)
             sensor.pwdn_pol = ACTIVE_LOW;
-            omv_gpio_write(DCMI_POWER_PIN, 1);
+            omv_gpio_write(OMV_CSI_POWER_PIN, 1);
             mp_hal_delay_ms(10);
             #endif
 
             if ((sensor.slv_addr = sensor_detect()) == 0) {
-                #if defined(DCMI_RESET_PIN)
+                #if defined(OMV_CSI_RESET_PIN)
                 sensor.reset_pol = ACTIVE_HIGH;
-                omv_gpio_write(DCMI_RESET_PIN, 0);
+                omv_gpio_write(OMV_CSI_RESET_PIN, 0);
                 mp_hal_delay_ms(10);
                 #endif
                 sensor.slv_addr = sensor_detect();
@@ -296,7 +296,7 @@ int sensor_probe_init(uint32_t bus_id, uint32_t bus_speed) {
         // If no devices were detected on the I2C bus, try the SPI bus.
         if (sensor.slv_addr == 0) {
             if (0) {
-            #if (OMV_ENABLE_PAJ6100 == 1)
+            #if (OMV_PAJ6100_ENABLE == 1)
             } else if (paj6100_detect(&sensor)) {
                 // Found PixArt PAJ6100
                 sensor.chip_id_w = PAJ6100_ID;
@@ -311,16 +311,16 @@ int sensor_probe_init(uint32_t bus_id, uint32_t bus_speed) {
 
     // A supported sensor was detected, try to initialize it.
     switch (sensor.chip_id_w) {
-        #if (OMV_ENABLE_OV2640 == 1)
+        #if (OMV_OV2640_ENABLE == 1)
         case OV2640_ID:
-            if (sensor_set_xclk_frequency(OV2640_XCLK_FREQ) != 0) {
+            if (sensor_set_xclk_frequency(OMV_OV2640_XCLK_FREQ) != 0) {
                 return SENSOR_ERROR_TIM_INIT_FAILED;
             }
             init_ret = ov2640_init(&sensor);
             break;
-        #endif // (OMV_ENABLE_OV2640 == 1)
+        #endif // (OMV_OV2640_ENABLE == 1)
 
-        #if (OMV_ENABLE_OV5640 == 1)
+        #if (OMV_OV5640_ENABLE == 1)
         case OV5640_ID: {
             int freq = OMV_OV5640_XCLK_FREQ;
             #if (OMV_OV5640_REV_Y_CHECK == 1)
@@ -335,114 +335,114 @@ int sensor_probe_init(uint32_t bus_id, uint32_t bus_speed) {
             init_ret = ov5640_init(&sensor);
             break;
         }
-        #endif // (OMV_ENABLE_OV5640 == 1)
+        #endif // (OMV_OV5640_ENABLE == 1)
 
-        #if (OMV_ENABLE_OV7670 == 1)
+        #if (OMV_OV7670_ENABLE == 1)
         case OV7670_ID:
-            if (sensor_set_xclk_frequency(OV7670_XCLK_FREQ) != 0) {
+            if (sensor_set_xclk_frequency(OMV_OV7670_XCLK_FREQ) != 0) {
                 return SENSOR_ERROR_TIM_INIT_FAILED;
             }
             init_ret = ov7670_init(&sensor);
             break;
-        #endif // (OMV_ENABLE_OV7670 == 1)
+        #endif // (OMV_OV7670_ENABLE == 1)
 
-        #if (OMV_ENABLE_OV7690 == 1)
+        #if (OMV_OV7690_ENABLE == 1)
         case OV7690_ID:
-            if (sensor_set_xclk_frequency(OV7690_XCLK_FREQ) != 0) {
+            if (sensor_set_xclk_frequency(OMV_OV7690_XCLK_FREQ) != 0) {
                 return SENSOR_ERROR_TIM_INIT_FAILED;
             }
             init_ret = ov7690_init(&sensor);
             break;
-        #endif // (OMV_ENABLE_OV7690 == 1)
+        #endif // (OMV_OV7690_ENABLE == 1)
 
-        #if (OMV_ENABLE_OV7725 == 1)
+        #if (OMV_OV7725_ENABLE == 1)
         case OV7725_ID:
             init_ret = ov7725_init(&sensor);
             break;
-        #endif // (OMV_ENABLE_OV7725 == 1)
+        #endif // (OMV_OV7725_ENABLE == 1)
 
-        #if (OMV_ENABLE_OV9650 == 1)
+        #if (OMV_OV9650_ENABLE == 1)
         case OV9650_ID:
             init_ret = ov9650_init(&sensor);
             break;
-        #endif // (OMV_ENABLE_OV9650 == 1)
+        #endif // (OMV_OV9650_ENABLE == 1)
 
-        #if (OMV_ENABLE_MT9V0XX == 1)
+        #if (OMV_MT9V0XX_ENABLE == 1)
         case MT9V0X2_ID_V_1:
         case MT9V0X2_ID_V_2:
             // Force old versions to the newest.
             sensor.chip_id_w = MT9V0X2_ID;
         case MT9V0X2_ID:
         case MT9V0X4_ID:
-            if (sensor_set_xclk_frequency(MT9V0XX_XCLK_FREQ) != 0) {
+            if (sensor_set_xclk_frequency(OMV_MT9V0XX_XCLK_FREQ) != 0) {
                 return SENSOR_ERROR_TIM_INIT_FAILED;
             }
             init_ret = mt9v0xx_init(&sensor);
             break;
-        #endif //(OMV_ENABLE_MT9V0XX == 1)
+        #endif //(OMV_MT9V0XX_ENABLE == 1)
 
-        #if (OMV_ENABLE_MT9M114 == 1)
+        #if (OMV_MT9M114_ENABLE == 1)
         case MT9M114_ID:
-            if (sensor_set_xclk_frequency(MT9M114_XCLK_FREQ) != 0) {
+            if (sensor_set_xclk_frequency(OMV_MT9M114_XCLK_FREQ) != 0) {
                 return SENSOR_ERROR_TIM_INIT_FAILED;
             }
             init_ret = mt9m114_init(&sensor);
             break;
-        #endif //(OMV_ENABLE_MT9M114 == 1)
+        #endif //(OMV_MT9M114_ENABLE == 1)
 
-        #if (OMV_ENABLE_LEPTON == 1)
+        #if (OMV_LEPTON_ENABLE == 1)
         case LEPTON_ID:
-            if (sensor_set_xclk_frequency(LEPTON_XCLK_FREQ) != 0) {
+            if (sensor_set_xclk_frequency(OMV_LEPTON_XCLK_FREQ) != 0) {
                 return SENSOR_ERROR_TIM_INIT_FAILED;
             }
             init_ret = lepton_init(&sensor);
             break;
-        #endif // (OMV_ENABLE_LEPTON == 1)
+        #endif // (OMV_LEPTON_ENABLE == 1)
 
-        #if (OMV_ENABLE_HM01B0 == 1)
+        #if (OMV_HM01B0_ENABLE == 1)
         case HM01B0_ID:
-            if (sensor_set_xclk_frequency(HM01B0_XCLK_FREQ) != 0) {
+            if (sensor_set_xclk_frequency(OMV_HM01B0_XCLK_FREQ) != 0) {
                 return SENSOR_ERROR_TIM_INIT_FAILED;
             }
             init_ret = hm01b0_init(&sensor);
             break;
-        #endif //(OMV_ENABLE_HM01B0 == 1)
+        #endif //(OMV_HM01B0_ENABLE == 1)
 
-        #if (OMV_ENABLE_HM0360 == 1)
+        #if (OMV_HM0360_ENABLE == 1)
         case HM0360_ID:
-            if (sensor_set_xclk_frequency(HM0360_XCLK_FREQ) != 0) {
+            if (sensor_set_xclk_frequency(OMV_HM0360_XCLK_FREQ) != 0) {
                 return SENSOR_ERROR_TIM_INIT_FAILED;
             }
             init_ret = hm0360_init(&sensor);
             break;
-        #endif //(OMV_ENABLE_HM0360 == 1)
+        #endif //(OMV_HM0360_ENABLE == 1)
 
-        #if (OMV_ENABLE_GC2145 == 1)
+        #if (OMV_GC2145_ENABLE == 1)
         case GC2145_ID:
-            if (sensor_set_xclk_frequency(GC2145_XCLK_FREQ) != 0) {
+            if (sensor_set_xclk_frequency(OMV_GC2145_XCLK_FREQ) != 0) {
                 return SENSOR_ERROR_TIM_INIT_FAILED;
             }
             init_ret = gc2145_init(&sensor);
             break;
-        #endif //(OMV_ENABLE_GC2145 == 1)
+        #endif //(OMV_GC2145_ENABLE == 1)
 
-        #if (OMV_ENABLE_PAJ6100 == 1)
+        #if (OMV_PAJ6100_ENABLE == 1)
         case PAJ6100_ID:
-            if (sensor_set_xclk_frequency(PAJ6100_XCLK_FREQ) != 0) {
+            if (sensor_set_xclk_frequency(OMV_PAJ6100_XCLK_FREQ) != 0) {
                 return SENSOR_ERROR_TIM_INIT_FAILED;
             }
             init_ret = paj6100_init(&sensor);
             break;
-        #endif // (OMV_ENABLE_PAJ6100 == 1)
+        #endif // (OMV_PAJ6100_ENABLE == 1)
 
-        #if (OMV_ENABLE_FROGEYE2020 == 1)
+        #if (OMV_FROGEYE2020_ENABLE == 1)
         case FROGEYE2020_ID:
-            if (sensor_set_xclk_frequency(FROGEYE2020_XCLK_FREQ) != 0) {
+            if (sensor_set_xclk_frequency(OMV_FROGEYE2020_XCLK_FREQ) != 0) {
                 return SENSOR_ERROR_TIM_INIT_FAILED;
             }
             init_ret = frogeye2020_init(&sensor);
             break;
-        #endif // (OMV_ENABLE_FROGEYE2020 == 1)
+        #endif // (OMV_FROGEYE2020_ENABLE == 1)
 
         default:
             return SENSOR_ERROR_ISC_UNSUPPORTED;
@@ -496,18 +496,18 @@ __weak int sensor_shutdown(int enable) {
     // Disable any ongoing frame capture.
     sensor_abort(true, false);
 
-    #if defined(DCMI_POWER_PIN)
+    #if defined(OMV_CSI_POWER_PIN)
     if (enable) {
         if (sensor.pwdn_pol == ACTIVE_HIGH) {
-            omv_gpio_write(DCMI_POWER_PIN, 1);
+            omv_gpio_write(OMV_CSI_POWER_PIN, 1);
         } else {
-            omv_gpio_write(DCMI_POWER_PIN, 0);
+            omv_gpio_write(OMV_CSI_POWER_PIN, 0);
         }
     } else {
         if (sensor.pwdn_pol == ACTIVE_HIGH) {
-            omv_gpio_write(DCMI_POWER_PIN, 0);
+            omv_gpio_write(OMV_CSI_POWER_PIN, 0);
         } else {
-            omv_gpio_write(DCMI_POWER_PIN, 1);
+            omv_gpio_write(OMV_CSI_POWER_PIN, 1);
         }
     }
     #endif
@@ -1265,13 +1265,13 @@ __weak int sensor_auto_crop_framebuffer() {
 __weak int sensor_copy_line(void *dma, uint8_t *src, uint8_t *dst) {
     uint16_t *src16 = (uint16_t *) src;
     uint16_t *dst16 = (uint16_t *) dst;
-    #if OMA_ENABLE_DMA_MEMCPY
+    #if OMV_CSI_DMA_MEMCPY_ENABLE
     extern int sensor_dma_memcpy(void *dma, void *dst, void *src, int bpp, bool transposed);
     #endif
 
     switch (sensor.pixformat) {
         case PIXFORMAT_BAYER:
-            #if OMA_ENABLE_DMA_MEMCPY
+            #if OMV_CSI_DMA_MEMCPY_ENABLE
             sensor_dma_memcpy(dma, dst, src, sizeof(uint8_t), sensor.transpose);
             #else
             if (!sensor.transpose) {
@@ -1282,7 +1282,7 @@ __weak int sensor_copy_line(void *dma, uint8_t *src, uint8_t *dst) {
             #endif
             break;
         case PIXFORMAT_GRAYSCALE:
-            #if OMA_ENABLE_DMA_MEMCPY
+            #if OMV_CSI_DMA_MEMCPY_ENABLE
             sensor_dma_memcpy(dma, dst, src, sizeof(uint8_t), sensor.transpose);
             #else
             if (sensor.hw_flags.gs_bpp == 1) {
@@ -1304,7 +1304,7 @@ __weak int sensor_copy_line(void *dma, uint8_t *src, uint8_t *dst) {
             break;
         case PIXFORMAT_RGB565:
         case PIXFORMAT_YUV422:
-            #if OMA_ENABLE_DMA_MEMCPY
+            #if OMV_CSI_DMA_MEMCPY_ENABLE
             sensor_dma_memcpy(dma, dst16, src16, sizeof(uint16_t), sensor.transpose);
             #else
             if ((sensor.pixformat == PIXFORMAT_RGB565 && sensor.hw_flags.rgb_swap)

--- a/src/omv/common/tinyusb_debug.c
+++ b/src/omv/common/tinyusb_debug.c
@@ -10,7 +10,7 @@
  */
 
 #include "omv_boardconfig.h"
-#if (OMV_ENABLE_TUSBDBG == 1)
+#if (OMV_TUSBDBG_ENABLE == 1)
 #include "py/runtime.h"
 #include "py/stream.h"
 #include "py/mphal.h"

--- a/src/omv/common/usbdbg.c
+++ b/src/omv/common/usbdbg.c
@@ -200,16 +200,16 @@ void usbdbg_data_in(void *buffer, int length) {
 
         case USBDBG_ARCH_STR: {
             unsigned int uid[3] = {
-                #if (OMV_UNIQUE_ID_SIZE == 2)
+                #if (OMV_BOARD_UID_SIZE == 2)
                 0U,
                 #else
-                *((unsigned int *) (OMV_UNIQUE_ID_ADDR + OMV_UNIQUE_ID_OFFSET * 2)),
+                *((unsigned int *) (OMV_BOARD_UID_ADDR + OMV_BOARD_UID_OFFSET * 2)),
                 #endif
-                *((unsigned int *) (OMV_UNIQUE_ID_ADDR + OMV_UNIQUE_ID_OFFSET * 1)),
-                *((unsigned int *) (OMV_UNIQUE_ID_ADDR + OMV_UNIQUE_ID_OFFSET * 0)),
+                *((unsigned int *) (OMV_BOARD_UID_ADDR + OMV_BOARD_UID_OFFSET * 1)),
+                *((unsigned int *) (OMV_BOARD_UID_ADDR + OMV_BOARD_UID_OFFSET * 0)),
             };
             snprintf((char *) buffer, 64, "%s [%s:%08X%08X%08X]",
-                     OMV_ARCH_STR, OMV_BOARD_TYPE, uid[0], uid[1], uid[2]);
+                     OMV_BOARD_ARCH, OMV_BOARD_TYPE, uid[0], uid[1], uid[2]);
             cmd = USBDBG_NONE;
             break;
         }

--- a/src/omv/common/vospi.c
+++ b/src/omv/common/vospi.c
@@ -9,7 +9,7 @@
  * VOSPI driver.
  */
 #include "omv_boardconfig.h"
-#if OMV_ENABLE_VOSPI || OMV_ENABLE_LEPTON
+#if OMV_ENABLE_VOSPI || OMV_LEPTON_ENABLE
 
 #include <stdint.h>
 #include <string.h>
@@ -159,7 +159,7 @@ int vospi_init(uint32_t n_packets, void *buffer) {
     vospi.flags = VOSPI_FLAGS_RESYNC;
 
     omv_spi_config_t spi_config;
-    omv_spi_default_config(&spi_config, ISC_SPI_ID);
+    omv_spi_default_config(&spi_config, OMV_CSI_SPI_ID);
 
     spi_config.bus_mode = OMV_SPI_BUS_RX;
     spi_config.datasize = 16;

--- a/src/omv/imlib/framebuffer.c
+++ b/src/omv/imlib/framebuffer.c
@@ -85,7 +85,7 @@ void framebuffer_init0() {
     MAIN_FB()->streaming_enabled = true; // controlled by the OpenMV Cam.
 
     // Set default quality
-    JPEG_FB()->quality = ((JPEG_QUALITY_HIGH - JPEG_QUALITY_LOW) / 2) + JPEG_QUALITY_LOW;
+    JPEG_FB()->quality = ((OMV_JPEG_QUALITY_HIGH - OMV_JPEG_QUALITY_LOW) / 2) + OMV_JPEG_QUALITY_LOW;
 
     // Set fb_enabled
     JPEG_FB()->enabled = fb_enabled; // controlled by the IDE.
@@ -184,8 +184,8 @@ void framebuffer_update_jpeg_buffer() {
                     }
 
                     // Dynamically adjust our quality if the image is huge.
-                    bool big_frame_buffer = image_size(src) > JPEG_QUALITY_THRESH;
-                    int jpeg_quality_max = big_frame_buffer ? JPEG_QUALITY_LOW : JPEG_QUALITY_HIGH;
+                    bool big_frame_buffer = image_size(src) > OMV_JPEG_QUALITY_THRESHOLD;
+                    int jpeg_quality_max = big_frame_buffer ? OMV_JPEG_QUALITY_LOW : OMV_JPEG_QUALITY_HIGH;
 
                     // No buffer overflow, increase quality up to max quality based on frame size...
                     if ((!overflow_count) && (jpeg_framebuffer->quality < jpeg_quality_max)) {

--- a/src/omv/imlib/imlib.c
+++ b/src/omv/imlib/imlib.c
@@ -20,7 +20,7 @@
 #include "omv_boardconfig.h"
 
 void imlib_init_all() {
-    #if (OMV_HARDWARE_JPEG == 1)
+    #if (OMV_JPEG_CODEC_ENABLE == 1)
     imlib_hardware_jpeg_init();
     #endif
 }
@@ -29,7 +29,7 @@ void imlib_deinit_all() {
     #ifdef IMLIB_ENABLE_DMA2D
     imlib_draw_row_deinit_all();
     #endif
-    #if (OMV_HARDWARE_JPEG == 1)
+    #if (OMV_JPEG_CODEC_ENABLE == 1)
     imlib_hardware_jpeg_deinit();
     #endif
 }

--- a/src/omv/imlib/imlib.h
+++ b/src/omv/imlib/imlib.h
@@ -1162,7 +1162,7 @@ bool bmp_read_geometry(FIL *fp, image_t *img, const char *path, bmp_read_setting
 void bmp_read_pixels(FIL *fp, image_t *img, int n_lines, bmp_read_settings_t *rs);
 void bmp_read(image_t *img, const char *path);
 void bmp_write_subimg(image_t *img, const char *path, rectangle_t *r);
-#if (OMV_HARDWARE_JPEG == 1)
+#if (OMV_JPEG_CODEC_ENABLE == 1)
 void imlib_hardware_jpeg_init();
 void imlib_hardware_jpeg_deinit();
 #endif

--- a/src/omv/imlib/jpegd.c
+++ b/src/omv/imlib/jpegd.c
@@ -20,7 +20,7 @@
 #include <stdio.h>
 #endif
 
-#if (OMV_HARDWARE_JPEG == 0)
+#if (OMV_JPEG_CODEC_ENABLE == 0)
 /* Software JPEG decoder */
 #define FILE_HIGHWATER         1536
 #define JPEG_FILE_BUF_SIZE     2048

--- a/src/omv/imlib/jpege.c
+++ b/src/omv/imlib/jpege.c
@@ -19,7 +19,7 @@
 #endif
 
 // Expand 4 bits to 32 for binary to grayscale - process 4 pixels at a time
-#if (OMV_HARDWARE_JPEG == 1)
+#if (OMV_JPEG_CODEC_ENABLE == 1)
 #define JPEG_BINARY_0              0x00
 #define JPEG_BINARY_1              0xFF
 static const uint32_t jpeg_expand[16] = {
@@ -90,7 +90,7 @@ void jpeg_get_mcu(image_t *src, int x_offset, int y_offset, int dx, int dy,
             for (int y = y_offset, yy = y + dy; y < yy; y++) {
                 uint8_t *rp = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(src, y) + x_offset;
 
-                #if (OMV_HARDWARE_JPEG == 0)
+                #if (OMV_JPEG_CODEC_ENABLE == 0)
                 if (dx == JPEG_MCU_W) {
                     *((uint32_t *) Y0) = *((uint32_t *) rp) ^ 0x80808080;
                     *(((uint32_t *) Y0) + 1) = *(((uint32_t *) rp) + 1) ^ 0x80808080;
@@ -165,7 +165,7 @@ void jpeg_get_mcu(image_t *src, int x_offset, int y_offset, int dx, int dy,
 
                     int y = ((r_pixels * 38) + (g_pixels * 75) + (b_pixels * 15)) >> 7;
 
-                    #if (OMV_HARDWARE_JPEG == 0)
+                    #if (OMV_JPEG_CODEC_ENABLE == 0)
                     y ^= 0x800080;
                     #endif
 
@@ -173,7 +173,7 @@ void jpeg_get_mcu(image_t *src, int x_offset, int y_offset, int dx, int dy,
 
                     int u = __SSUB16(b_pixels * 64, (r_pixels * 21) + (g_pixels * 43)) >> 7;
 
-                    #if (OMV_HARDWARE_JPEG == 1)
+                    #if (OMV_JPEG_CODEC_ENABLE == 1)
                     u ^= 0x800080;
                     #endif
 
@@ -181,7 +181,7 @@ void jpeg_get_mcu(image_t *src, int x_offset, int y_offset, int dx, int dy,
 
                     int v = __SSUB16(r_pixels * 64, (g_pixels * 54) + (b_pixels * 10)) >> 7;
 
-                    #if (OMV_HARDWARE_JPEG == 1)
+                    #if (OMV_JPEG_CODEC_ENABLE == 1)
                     v ^= 0x800080;
                     #endif
 
@@ -196,7 +196,7 @@ void jpeg_get_mcu(image_t *src, int x_offset, int y_offset, int dx, int dy,
 
                     int y0 = COLOR_RGB888_TO_Y(r, g, b);
 
-                    #if (OMV_HARDWARE_JPEG == 0)
+                    #if (OMV_JPEG_CODEC_ENABLE == 0)
                     y0 ^= 0x80;
                     #endif
 
@@ -204,7 +204,7 @@ void jpeg_get_mcu(image_t *src, int x_offset, int y_offset, int dx, int dy,
 
                     int cb = COLOR_RGB888_TO_U(r, g, b);
 
-                    #if (OMV_HARDWARE_JPEG == 1)
+                    #if (OMV_JPEG_CODEC_ENABLE == 1)
                     cb ^= 0x80;
                     #endif
 
@@ -212,7 +212,7 @@ void jpeg_get_mcu(image_t *src, int x_offset, int y_offset, int dx, int dy,
 
                     int cr = COLOR_RGB888_TO_V(r, g, b);
 
-                    #if (OMV_HARDWARE_JPEG == 1)
+                    #if (OMV_JPEG_CODEC_ENABLE == 1)
                     cr ^= 0x80;
                     #endif
 
@@ -239,7 +239,7 @@ void jpeg_get_mcu(image_t *src, int x_offset, int y_offset, int dx, int dy,
                 for (int x = 0, xx = dx - 1; x < xx; x += 2, index += 2) {
                     int pixels = *rp++;
 
-                    #if (OMV_HARDWARE_JPEG == 0)
+                    #if (OMV_JPEG_CODEC_ENABLE == 0)
                     pixels ^= 0x80808080;
                     #endif
 
@@ -255,7 +255,7 @@ void jpeg_get_mcu(image_t *src, int x_offset, int y_offset, int dx, int dy,
                 if (dx & 1) {
                     int pixel = *((uint16_t *) rp);
 
-                    #if (OMV_HARDWARE_JPEG == 0)
+                    #if (OMV_JPEG_CODEC_ENABLE == 0)
                     pixel ^= 0x8080;
                     #endif
 
@@ -272,13 +272,13 @@ void jpeg_get_mcu(image_t *src, int x_offset, int y_offset, int dx, int dy,
                     } else {
                         if (shift == 8) {
                             CB[index] = pixel >> 8;
-                            #if (OMV_HARDWARE_JPEG == 0)
+                            #if (OMV_JPEG_CODEC_ENABLE == 0)
                             CR[index++] = 0;
                             #else
                             CR[index++] = 0x80;
                             #endif
                         } else {
-                            #if (OMV_HARDWARE_JPEG == 0)
+                            #if (OMV_JPEG_CODEC_ENABLE == 0)
                             CB[index] = 0;
                             #else
                             CB[index] = 0x80;
@@ -431,7 +431,7 @@ void jpeg_get_mcu(image_t *src, int x_offset, int y_offset, int dx, int dy,
 
                         int y0 = ((r_pixels_0 * 38) + (g_pixels_0 * 75) + (b_pixels_0 * 15)) >> 7;
 
-                        #if (OMV_HARDWARE_JPEG == 0)
+                        #if (OMV_JPEG_CODEC_ENABLE == 0)
                         y0 ^= 0x800080;
                         #endif
 
@@ -439,7 +439,7 @@ void jpeg_get_mcu(image_t *src, int x_offset, int y_offset, int dx, int dy,
 
                         int u0 = __SSUB16(b_pixels_0 * 64, (r_pixels_0 * 21) + (g_pixels_0 * 43)) >> 7;
 
-                        #if (OMV_HARDWARE_JPEG == 1)
+                        #if (OMV_JPEG_CODEC_ENABLE == 1)
                         u0 ^= 0x800080;
                         #endif
 
@@ -447,7 +447,7 @@ void jpeg_get_mcu(image_t *src, int x_offset, int y_offset, int dx, int dy,
 
                         int v0 = __SSUB16(r_pixels_0 * 64, (g_pixels_0 * 54) + (b_pixels_0 * 10)) >> 7;
 
-                        #if (OMV_HARDWARE_JPEG == 1)
+                        #if (OMV_JPEG_CODEC_ENABLE == 1)
                         v0 ^= 0x800080;
                         #endif
 
@@ -566,7 +566,7 @@ void jpeg_get_mcu(image_t *src, int x_offset, int y_offset, int dx, int dy,
 
                         int y1 = ((r_pixels_1 * 38) + (g_pixels_1 * 75) + (b_pixels_1 * 15)) >> 7;
 
-                        #if (OMV_HARDWARE_JPEG == 0)
+                        #if (OMV_JPEG_CODEC_ENABLE == 0)
                         y1 ^= 0x800080;
                         #endif
 
@@ -574,7 +574,7 @@ void jpeg_get_mcu(image_t *src, int x_offset, int y_offset, int dx, int dy,
 
                         int u1 = __SSUB16(b_pixels_1 * 64, (r_pixels_1 * 21) + (g_pixels_1 * 43)) >> 7;
 
-                        #if (OMV_HARDWARE_JPEG == 1)
+                        #if (OMV_JPEG_CODEC_ENABLE == 1)
                         u1 ^= 0x800080;
                         #endif
 
@@ -582,7 +582,7 @@ void jpeg_get_mcu(image_t *src, int x_offset, int y_offset, int dx, int dy,
 
                         int v1 = __SSUB16(r_pixels_1 * 64, (g_pixels_1 * 54) + (b_pixels_1 * 10)) >> 7;
 
-                        #if (OMV_HARDWARE_JPEG == 1)
+                        #if (OMV_JPEG_CODEC_ENABLE == 1)
                         v1 ^= 0x800080;
                         #endif
 
@@ -796,7 +796,7 @@ void jpeg_get_mcu(image_t *src, int x_offset, int y_offset, int dx, int dy,
 
                         int y0 = ((r_pixels_0 * 38) + (g_pixels_0 * 75) + (b_pixels_0 * 15)) >> 7;
 
-                        #if (OMV_HARDWARE_JPEG == 0)
+                        #if (OMV_JPEG_CODEC_ENABLE == 0)
                         y0 ^= 0x800080;
                         #endif
 
@@ -804,7 +804,7 @@ void jpeg_get_mcu(image_t *src, int x_offset, int y_offset, int dx, int dy,
 
                         int u0 = __SSUB16(b_pixels_0 * 64, (r_pixels_0 * 21) + (g_pixels_0 * 43)) >> 7;
 
-                        #if (OMV_HARDWARE_JPEG == 1)
+                        #if (OMV_JPEG_CODEC_ENABLE == 1)
                         u0 ^= 0x800080;
                         #endif
 
@@ -812,7 +812,7 @@ void jpeg_get_mcu(image_t *src, int x_offset, int y_offset, int dx, int dy,
 
                         int v0 = __SSUB16(r_pixels_0 * 64, (g_pixels_0 * 54) + (b_pixels_0 * 10)) >> 7;
 
-                        #if (OMV_HARDWARE_JPEG == 1)
+                        #if (OMV_JPEG_CODEC_ENABLE == 1)
                         v0 ^= 0x800080;
                         #endif
 
@@ -931,7 +931,7 @@ void jpeg_get_mcu(image_t *src, int x_offset, int y_offset, int dx, int dy,
 
                         int y1 = ((r_pixels_1 * 38) + (g_pixels_1 * 75) + (b_pixels_1 * 15)) >> 7;
 
-                        #if (OMV_HARDWARE_JPEG == 0)
+                        #if (OMV_JPEG_CODEC_ENABLE == 0)
                         y1 ^= 0x800080;
                         #endif
 
@@ -939,7 +939,7 @@ void jpeg_get_mcu(image_t *src, int x_offset, int y_offset, int dx, int dy,
 
                         int u1 = __SSUB16(b_pixels_1 * 64, (r_pixels_1 * 21) + (g_pixels_1 * 43)) >> 7;
 
-                        #if (OMV_HARDWARE_JPEG == 1)
+                        #if (OMV_JPEG_CODEC_ENABLE == 1)
                         u1 ^= 0x800080;
                         #endif
 
@@ -947,7 +947,7 @@ void jpeg_get_mcu(image_t *src, int x_offset, int y_offset, int dx, int dy,
 
                         int v1 = __SSUB16(r_pixels_1 * 64, (g_pixels_1 * 54) + (b_pixels_1 * 10)) >> 7;
 
-                        #if (OMV_HARDWARE_JPEG == 1)
+                        #if (OMV_JPEG_CODEC_ENABLE == 1)
                         v1 ^= 0x800080;
                         #endif
 
@@ -964,7 +964,7 @@ void jpeg_get_mcu(image_t *src, int x_offset, int y_offset, int dx, int dy,
     }
 }
 
-#if (OMV_HARDWARE_JPEG == 0)
+#if (OMV_JPEG_CODEC_ENABLE == 0)
 
 // Software JPEG implementation.
 #define FIX_0_382683433    ((int32_t) 98)
@@ -1849,7 +1849,7 @@ bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc) {
     return false;
 }
 
-#endif // (OMV_HARDWARE_JPEG == 0)
+#endif // (OMV_JPEG_CODEC_ENABLE == 0)
 
 bool jpeg_is_valid(image_t *img) {
     uint8_t *p = img->data, *p_end = img->data + img->size;

--- a/src/omv/modules/py_fir.c
+++ b/src/omv/modules/py_fir.c
@@ -12,21 +12,21 @@
 #include "py/objlist.h"
 #include "omv_boardconfig.h"
 
-#if OMV_ENABLE_FIR_MLX90621 || \
-    OMV_ENABLE_FIR_MLX90640 || \
-    OMV_ENABLE_FIR_MLX90641 || \
-    OMV_ENABLE_FIR_AMG8833 ||  \
-    OMV_ENABLE_FIR_LEPTON
+#if OMV_FIR_MLX90621_ENABLE || \
+    OMV_FIR_MLX90640_ENABLE || \
+    OMV_FIR_MLX90641_ENABLE || \
+    OMV_FIR_AMG8833_ENABLE ||  \
+    OMV_FIR_LEPTON_ENABLE
 #include "omv_i2c.h"
-#if (OMV_ENABLE_FIR_MLX90621 == 1)
+#if (OMV_FIR_MLX90621_ENABLE == 1)
 #include "MLX90621_API.h"
 #include "MLX90621_I2C_Driver.h"
 #endif
-#if (OMV_ENABLE_FIR_MLX90640 == 1)
+#if (OMV_FIR_MLX90640_ENABLE == 1)
 #include "MLX90640_API.h"
 #include "MLX90640_I2C_Driver.h"
 #endif
-#if (OMV_ENABLE_FIR_MLX90641 == 1)
+#if (OMV_FIR_MLX90641_ENABLE == 1)
 #include "MLX90641_API.h"
 #include "MLX90641_I2C_Driver.h"
 #endif
@@ -36,7 +36,7 @@
 #include "py_helper.h"
 #include "py_image.h"
 
-#if (OMV_ENABLE_FIR_LEPTON == 1)
+#if (OMV_FIR_LEPTON_ENABLE == 1)
 #include "py_fir_lepton.h"
 #endif
 
@@ -78,25 +78,25 @@
     })
 
 static omv_i2c_t fir_bus = {};
-#if ((OMV_ENABLE_FIR_MLX90621 == 1) || (OMV_ENABLE_FIR_MLX90640 == 1) || (OMV_ENABLE_FIR_MLX90641 == 1))
+#if ((OMV_FIR_MLX90621_ENABLE == 1) || (OMV_FIR_MLX90640_ENABLE == 1) || (OMV_FIR_MLX90641_ENABLE == 1))
 static void *fir_mlx_data = NULL;
 #endif
 
 typedef enum fir_sensor_type {
     FIR_NONE,
-    #if (OMV_ENABLE_FIR_MLX90621 == 1)
+    #if (OMV_FIR_MLX90621_ENABLE == 1)
     FIR_MLX90621,
     #endif
-    #if (OMV_ENABLE_FIR_MLX90640 == 1)
+    #if (OMV_FIR_MLX90640_ENABLE == 1)
     FIR_MLX90640,
     #endif
-    #if (OMV_ENABLE_FIR_MLX90641 == 1)
+    #if (OMV_FIR_MLX90641_ENABLE == 1)
     FIR_MLX90641,
     #endif
-    #if (OMV_ENABLE_FIR_AMG8833 == 1)
+    #if (OMV_FIR_AMG8833_ENABLE == 1)
     FIR_AMG8833,
     #endif
-    #if (OMV_ENABLE_FIR_LEPTON == 1)
+    #if (OMV_FIR_LEPTON_ENABLE == 1)
     FIR_LEPTON
     #endif
 } fir_sensor_type_t;
@@ -138,7 +138,7 @@ static void fir_fill_image_float_obj(image_t *img, mp_obj_t *data, float min, fl
     }
 }
 
-#if (OMV_ENABLE_FIR_MLX90621 == 1)
+#if (OMV_FIR_MLX90621_ENABLE == 1)
 static void fir_MLX90621_get_frame(float *Ta, float *To) {
     uint16_t *data = fb_alloc(MLX90621_FRAME_DATA_SIZE * sizeof(uint16_t), FB_ALLOC_NO_HINT);
 
@@ -151,7 +151,7 @@ static void fir_MLX90621_get_frame(float *Ta, float *To) {
 }
 #endif
 
-#if (OMV_ENABLE_FIR_MLX90640 == 1)
+#if (OMV_FIR_MLX90640_ENABLE == 1)
 static void fir_MLX90640_get_frame(float *Ta, float *To) {
     uint16_t *data = fb_alloc(MLX90640_FRAME_DATA_SIZE * sizeof(uint16_t), FB_ALLOC_NO_HINT);
 
@@ -174,7 +174,7 @@ static void fir_MLX90640_get_frame(float *Ta, float *To) {
 }
 #endif
 
-#if (OMV_ENABLE_FIR_MLX90641 == 1)
+#if (OMV_FIR_MLX90641_ENABLE == 1)
 static void fir_MLX90641_get_frame(float *Ta, float *To) {
     uint16_t *data = fb_alloc(MLX90641_FRAME_DATA_SIZE * sizeof(uint16_t), FB_ALLOC_NO_HINT);
 
@@ -190,7 +190,7 @@ static void fir_MLX90641_get_frame(float *Ta, float *To) {
 }
 #endif
 
-#if (OMV_ENABLE_FIR_AMG8833 == 1)
+#if (OMV_FIR_AMG8833_ENABLE == 1)
 static void fir_AMG8833_get_frame(float *Ta, float *To) {
     int16_t temp;
     int error = 0;
@@ -296,7 +296,7 @@ static mp_obj_t fir_get_ir(int w, int h, float Ta, float *To, bool mirror,
 }
 
 static mp_obj_t py_fir_deinit() {
-    #if (OMV_ENABLE_FIR_LEPTON == 1)
+    #if (OMV_FIR_LEPTON_ENABLE == 1)
     if (fir_sensor == FIR_LEPTON) {
         fir_lepton_deinit();
     }
@@ -307,7 +307,7 @@ static mp_obj_t py_fir_deinit() {
         fir_sensor = FIR_NONE;
     }
 
-    #if ((OMV_ENABLE_FIR_MLX90621 == 1) || (OMV_ENABLE_FIR_MLX90640 == 1) || (OMV_ENABLE_FIR_MLX90641 == 1))
+    #if ((OMV_FIR_MLX90621_ENABLE == 1) || (OMV_FIR_MLX90640_ENABLE == 1) || (OMV_FIR_MLX90641_ENABLE == 1))
     if (fir_mlx_data != NULL) {
         fir_mlx_data = NULL;
     }
@@ -339,38 +339,38 @@ mp_obj_t py_fir_init(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     int type = args[ARG_type].u_int;
     if (type == -1) {
         FIR_SCAN_RETRY:
-        omv_i2c_init(&fir_bus, FIR_I2C_ID, OMV_I2C_SPEED_STANDARD);
+        omv_i2c_init(&fir_bus, OMV_FIR_I2C_ID, OMV_I2C_SPEED_STANDARD);
         // Scan and detect any supported sensor.
         uint8_t dev_list[10];
         int dev_size = omv_i2c_scan(&fir_bus, dev_list, sizeof(dev_list));
         for (int i = 0; i < dev_size && type == -1; i++) {
             switch (dev_list[i]) {
-                #if (OMV_ENABLE_FIR_MLX90621 == 1)
+                #if (OMV_FIR_MLX90621_ENABLE == 1)
                 case (MLX90621_ADDR << 1): {
                     type = FIR_MLX90621;
                     break;
                 }
                 #endif
-                #if (OMV_ENABLE_FIR_MLX90640 == 1)
+                #if (OMV_FIR_MLX90640_ENABLE == 1)
                 case (MLX90640_ADDR << 1): {
                     type = FIR_MLX90640;
                     break;
                 }
                 #endif
-                #if (OMV_ENABLE_FIR_MLX90640 == 0) \
-                && (OMV_ENABLE_FIR_MLX90641 == 1)
+                #if (OMV_FIR_MLX90640_ENABLE == 0) \
+                && (OMV_FIR_MLX90641_ENABLE == 1)
                 case (MLX90641_ADDR << 1): {
                     type = FIR_MLX90641;
                     break;
                 }
                 #endif
-                #if (OMV_ENABLE_FIR_AMG8833 == 1)
+                #if (OMV_FIR_AMG8833_ENABLE == 1)
                 case AMG8833_ADDR: {
                     type = FIR_AMG8833;
                     break;
                 }
                 #endif
-                #if (OMV_ENABLE_FIR_LEPTON == 1)
+                #if (OMV_FIR_LEPTON_ENABLE == 1)
                 case LEPTON_ADDR: {
                     type = FIR_LEPTON;
                     break;
@@ -394,7 +394,7 @@ mp_obj_t py_fir_init(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     // Initialize the detected sensor.
     first_init = true;
     switch (type) {
-        #if (OMV_ENABLE_FIR_MLX90621 == 1)
+        #if (OMV_FIR_MLX90621_ENABLE == 1)
         case FIR_MLX90621: {
             // Set refresh rate and ADC resolution
             uint32_t ir_fresh_rate = args[ARG_refresh].u_int != -1 ? args[ARG_refresh].u_int : 64;
@@ -408,7 +408,7 @@ mp_obj_t py_fir_init(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
 
             fir_sensor = FIR_MLX90621;
             FIR_MLX90621_RETRY:
-            omv_i2c_init(&fir_bus, FIR_I2C_ID, OMV_I2C_SPEED_FULL); // The EEPROM must be read at <= 400KHz.
+            omv_i2c_init(&fir_bus, OMV_FIR_I2C_ID, OMV_I2C_SPEED_FULL); // The EEPROM must be read at <= 400KHz.
             MLX90621_I2CInit(&fir_bus);
 
             fb_alloc_mark();
@@ -433,7 +433,7 @@ mp_obj_t py_fir_init(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
 
             // Switch to FAST speed
             omv_i2c_deinit(&fir_bus);
-            omv_i2c_init(&fir_bus, FIR_I2C_ID, OMV_I2C_SPEED_FAST);
+            omv_i2c_init(&fir_bus, OMV_FIR_I2C_ID, OMV_I2C_SPEED_FAST);
             fir_width = MLX90621_WIDTH;
             fir_height = MLX90621_HEIGHT;
             fir_ir_fresh_rate = ir_fresh_rate;
@@ -441,7 +441,7 @@ mp_obj_t py_fir_init(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
             return mp_const_none;
         }
         #endif
-        #if (OMV_ENABLE_FIR_MLX90640 == 1)
+        #if (OMV_FIR_MLX90640_ENABLE == 1)
         case FIR_MLX90640: {
             // Set refresh rate and ADC resolution
             uint32_t ir_fresh_rate = args[ARG_refresh].u_int != -1 ? args[ARG_refresh].u_int : 32;
@@ -455,7 +455,7 @@ mp_obj_t py_fir_init(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
 
             fir_sensor = FIR_MLX90640;
             FIR_MLX90640_RETRY:
-            omv_i2c_init(&fir_bus, FIR_I2C_ID, OMV_I2C_SPEED_FULL); // The EEPROM must be read at <= 400KHz.
+            omv_i2c_init(&fir_bus, OMV_FIR_I2C_ID, OMV_I2C_SPEED_FULL); // The EEPROM must be read at <= 400KHz.
             MLX90640_I2CInit(&fir_bus);
 
             fb_alloc_mark();
@@ -479,7 +479,7 @@ mp_obj_t py_fir_init(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
 
             // Switch to FAST speed
             omv_i2c_deinit(&fir_bus);
-            omv_i2c_init(&fir_bus, FIR_I2C_ID, OMV_I2C_SPEED_FAST);
+            omv_i2c_init(&fir_bus, OMV_FIR_I2C_ID, OMV_I2C_SPEED_FAST);
             fir_width = MLX90640_WIDTH;
             fir_height = MLX90640_HEIGHT;
             fir_ir_fresh_rate = ir_fresh_rate;
@@ -487,7 +487,7 @@ mp_obj_t py_fir_init(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
             return mp_const_none;
         }
         #endif
-        #if (OMV_ENABLE_FIR_MLX90641 == 1)
+        #if (OMV_FIR_MLX90641_ENABLE == 1)
         case FIR_MLX90641: {
             // Set refresh rate and ADC resolution
             uint32_t ir_fresh_rate = args[ARG_refresh].u_int != -1 ? args[ARG_refresh].u_int : 32;
@@ -501,7 +501,7 @@ mp_obj_t py_fir_init(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
 
             fir_sensor = FIR_MLX90641;
             FIR_MLX90641_RETRY:
-            omv_i2c_init(&fir_bus, FIR_I2C_ID, OMV_I2C_SPEED_FULL); // The EEPROM must be read at <= 400KHz.
+            omv_i2c_init(&fir_bus, OMV_FIR_I2C_ID, OMV_I2C_SPEED_FULL); // The EEPROM must be read at <= 400KHz.
             MLX90641_I2CInit(&fir_bus);
 
             fb_alloc_mark();
@@ -525,7 +525,7 @@ mp_obj_t py_fir_init(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
 
             // Switch to FAST speed
             omv_i2c_deinit(&fir_bus);
-            omv_i2c_init(&fir_bus, FIR_I2C_ID, OMV_I2C_SPEED_FAST);
+            omv_i2c_init(&fir_bus, OMV_FIR_I2C_ID, OMV_I2C_SPEED_FAST);
             fir_width = MLX90641_WIDTH;
             fir_height = MLX90641_HEIGHT;
             fir_ir_fresh_rate = ir_fresh_rate;
@@ -533,11 +533,11 @@ mp_obj_t py_fir_init(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
             return mp_const_none;
         }
         #endif
-        #if (OMV_ENABLE_FIR_AMG8833 == 1)
+        #if (OMV_FIR_AMG8833_ENABLE == 1)
         case FIR_AMG8833: {
             fir_sensor = FIR_AMG8833;
             FIR_AMG8833_RETRY:
-            omv_i2c_init(&fir_bus, FIR_I2C_ID, OMV_I2C_SPEED_STANDARD);
+            omv_i2c_init(&fir_bus, OMV_FIR_I2C_ID, OMV_I2C_SPEED_STANDARD);
 
             int error = omv_i2c_write_bytes(&fir_bus, AMG8833_ADDR,
                                             (uint8_t [2]) {AMG8833_RESET_REGISTER, AMG8833_INITIAL_RESET_VALUE}, 2, 0);
@@ -559,7 +559,7 @@ mp_obj_t py_fir_init(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
             return mp_const_none;
         }
         #endif
-        #if (OMV_ENABLE_FIR_LEPTON == 1)
+        #if (OMV_FIR_LEPTON_ENABLE == 1)
         case FIR_LEPTON: {
             fir_sensor = FIR_LEPTON;
             FIR_LEPTON_RETRY:
@@ -615,30 +615,30 @@ static mp_obj_t py_fir_height() {
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_fir_height_obj, py_fir_height);
 
 static mp_obj_t py_fir_refresh() {
-    #if (OMV_ENABLE_FIR_MLX90621 == 1)
+    #if (OMV_FIR_MLX90621_ENABLE == 1)
     const int mlx_90621_refresh_rates[16] = {512, 512, 512, 512, 512, 512, 256, 128, 64, 32, 16, 8, 4, 2, 1, 0};
     #endif
-    #if (OMV_ENABLE_FIR_MLX90640 == 1) || (OMV_ENABLE_FIR_MLX90641 == 1)
+    #if (OMV_FIR_MLX90640_ENABLE == 1) || (OMV_FIR_MLX90641_ENABLE == 1)
     const int mlx_90640_1_refresh_rates[8] = {0, 1, 2, 4, 8, 16, 32, 64};
     #endif
     switch (fir_sensor) {
-        #if (OMV_ENABLE_FIR_MLX90621 == 1)
+        #if (OMV_FIR_MLX90621_ENABLE == 1)
         case FIR_MLX90621:
             return mp_obj_new_int(mlx_90621_refresh_rates[fir_ir_fresh_rate]);
         #endif
-        #if (OMV_ENABLE_FIR_MLX90640 == 1)
+        #if (OMV_FIR_MLX90640_ENABLE == 1)
         case FIR_MLX90640:
             return mp_obj_new_int(mlx_90640_1_refresh_rates[fir_ir_fresh_rate]);
         #endif
-        #if (OMV_ENABLE_FIR_MLX90641 == 1)
+        #if (OMV_FIR_MLX90641_ENABLE == 1)
         case FIR_MLX90641:
             return mp_obj_new_int(mlx_90640_1_refresh_rates[fir_ir_fresh_rate]);
         #endif
-        #if (OMV_ENABLE_FIR_AMG8833 == 1)
+        #if (OMV_FIR_AMG8833_ENABLE == 1)
         case FIR_AMG8833:
             return mp_obj_new_int(fir_ir_fresh_rate);
         #endif
-        #if (OMV_ENABLE_FIR_LEPTON == 1)
+        #if (OMV_FIR_LEPTON_ENABLE == 1)
         case FIR_LEPTON:
             return mp_obj_new_int(fir_ir_fresh_rate);
         #endif
@@ -650,23 +650,23 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_fir_refresh_obj, py_fir_refresh);
 
 static mp_obj_t py_fir_resolution() {
     switch (fir_sensor) {
-        #if (OMV_ENABLE_FIR_MLX90621 == 1)
+        #if (OMV_FIR_MLX90621_ENABLE == 1)
         case FIR_MLX90621:
             return mp_obj_new_int(fir_adc_resolution + 15);
         #endif
-        #if (OMV_ENABLE_FIR_MLX90640 == 1)
+        #if (OMV_FIR_MLX90640_ENABLE == 1)
         case FIR_MLX90640:
             return mp_obj_new_int(fir_adc_resolution + 16);
         #endif
-        #if (OMV_ENABLE_FIR_MLX90641 == 1)
+        #if (OMV_FIR_MLX90641_ENABLE == 1)
         case FIR_MLX90641:
             return mp_obj_new_int(fir_adc_resolution + 16);
         #endif
-        #if (OMV_ENABLE_FIR_AMG8833 == 1)
+        #if (OMV_FIR_AMG8833_ENABLE == 1)
         case FIR_AMG8833:
             return mp_obj_new_int(fir_adc_resolution);
         #endif
-        #if (OMV_ENABLE_FIR_LEPTON == 1)
+        #if (OMV_FIR_LEPTON_ENABLE == 1)
         case FIR_LEPTON:
             return mp_obj_new_int(fir_adc_resolution);
         #endif
@@ -676,7 +676,7 @@ static mp_obj_t py_fir_resolution() {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_fir_resolution_obj, py_fir_resolution);
 
-#if (OMV_ENABLE_FIR_LEPTON == 1)
+#if (OMV_FIR_LEPTON_ENABLE == 1)
 static mp_obj_t py_fir_radiometric() {
     if (fir_sensor == FIR_LEPTON) {
         return fir_lepton_get_radiometry();
@@ -739,7 +739,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_fir_trigger_ffc_obj, 0, py_fir_trigger_ffc)
 
 mp_obj_t py_fir_read_ta() {
     switch (fir_sensor) {
-        #if (OMV_ENABLE_FIR_MLX90621 == 1)
+        #if (OMV_FIR_MLX90621_ENABLE == 1)
         case FIR_MLX90621: {
             fb_alloc_mark();
             uint16_t *data = fb_alloc(MLX90621_FRAME_DATA_SIZE * sizeof(uint16_t), FB_ALLOC_NO_HINT);
@@ -750,7 +750,7 @@ mp_obj_t py_fir_read_ta() {
             return result;
         }
         #endif
-        #if (OMV_ENABLE_FIR_MLX90640 == 1)
+        #if (OMV_FIR_MLX90640_ENABLE == 1)
         case FIR_MLX90640: {
             fb_alloc_mark();
             uint16_t *data = fb_alloc(MLX90640_FRAME_DATA_SIZE * sizeof(uint16_t), FB_ALLOC_NO_HINT);
@@ -761,7 +761,7 @@ mp_obj_t py_fir_read_ta() {
             return result;
         }
         #endif
-        #if (OMV_ENABLE_FIR_MLX90641 == 1)
+        #if (OMV_FIR_MLX90641_ENABLE == 1)
         case FIR_MLX90641: {
             fb_alloc_mark();
             uint16_t *data = fb_alloc(MLX90641_FRAME_DATA_SIZE * sizeof(uint16_t), FB_ALLOC_NO_HINT);
@@ -772,7 +772,7 @@ mp_obj_t py_fir_read_ta() {
             return result;
         }
         #endif
-        #if (OMV_ENABLE_FIR_AMG8833 == 1)
+        #if (OMV_FIR_AMG8833_ENABLE == 1)
         case FIR_AMG8833: {
             int16_t temp;
             int error = 0;
@@ -786,7 +786,7 @@ mp_obj_t py_fir_read_ta() {
             return mp_obj_new_float(AMG8833_12_TO_16(temp) * 0.0625f);
         }
         #endif
-        #if (OMV_ENABLE_FIR_LEPTON == 1)
+        #if (OMV_FIR_LEPTON_ENABLE == 1)
         case FIR_LEPTON: {
             return fir_lepton_read_ta();
         }
@@ -816,7 +816,7 @@ mp_obj_t py_fir_read_ir(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_args
     fir_transposed = args[ARG_transpose].u_bool;
 
     switch (fir_sensor) {
-        #if (OMV_ENABLE_FIR_MLX90621 == 1)
+        #if (OMV_FIR_MLX90621_ENABLE == 1)
         case FIR_MLX90621: {
             fb_alloc_mark();
             float Ta, *To = fb_alloc(MLX90621_WIDTH * MLX90621_HEIGHT * sizeof(float), FB_ALLOC_NO_HINT);
@@ -827,7 +827,7 @@ mp_obj_t py_fir_read_ir(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_args
             return result;
         }
         #endif
-        #if (OMV_ENABLE_FIR_MLX90640 == 1)
+        #if (OMV_FIR_MLX90640_ENABLE == 1)
         case FIR_MLX90640: {
             fb_alloc_mark();
             float Ta, *To = fb_alloc(MLX90640_WIDTH * MLX90640_HEIGHT * sizeof(float), FB_ALLOC_NO_HINT);
@@ -838,7 +838,7 @@ mp_obj_t py_fir_read_ir(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_args
             return result;
         }
         #endif
-        #if (OMV_ENABLE_FIR_MLX90641 == 1)
+        #if (OMV_FIR_MLX90641_ENABLE == 1)
         case FIR_MLX90641: {
             fb_alloc_mark();
             float Ta, *To = fb_alloc(MLX90641_WIDTH * MLX90641_HEIGHT * sizeof(float), FB_ALLOC_NO_HINT);
@@ -849,7 +849,7 @@ mp_obj_t py_fir_read_ir(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_args
             return result;
         }
         #endif
-        #if (OMV_ENABLE_FIR_AMG8833 == 1)
+        #if (OMV_FIR_AMG8833_ENABLE == 1)
         case FIR_AMG8833: {
             fb_alloc_mark();
             float Ta, *To = fb_alloc(AMG8833_WIDTH * AMG8833_HEIGHT * sizeof(float), FB_ALLOC_NO_HINT);
@@ -860,7 +860,7 @@ mp_obj_t py_fir_read_ir(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_args
             return result;
         }
         #endif
-        #if (OMV_ENABLE_FIR_LEPTON == 1)
+        #if (OMV_FIR_LEPTON_ENABLE == 1)
         case FIR_LEPTON: {
             return fir_lepton_read_ir(fir_width, fir_height, args[ARG_hmirror].u_bool,
                                       args[ARG_vflip].u_bool, args[ARG_transpose].u_bool, args[ARG_timeout].u_int);
@@ -1026,7 +1026,7 @@ mp_obj_t py_fir_snapshot(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_arg
     src_img.data = fb_alloc(src_img.w * src_img.h * sizeof(uint8_t), FB_ALLOC_NO_HINT);
 
     switch (fir_sensor) {
-        #if (OMV_ENABLE_FIR_MLX90621 == 1)
+        #if (OMV_FIR_MLX90621_ENABLE == 1)
         case FIR_MLX90621: {
             float Ta, *To = fb_alloc(MLX90621_WIDTH * MLX90621_HEIGHT * sizeof(float), FB_ALLOC_NO_HINT);
             fir_MLX90621_get_frame(&Ta, To);
@@ -1038,7 +1038,7 @@ mp_obj_t py_fir_snapshot(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_arg
             break;
         }
         #endif
-        #if (OMV_ENABLE_FIR_MLX90640 == 1)
+        #if (OMV_FIR_MLX90640_ENABLE == 1)
         case FIR_MLX90640: {
             float Ta, *To = fb_alloc(MLX90640_WIDTH * MLX90640_HEIGHT * sizeof(float), FB_ALLOC_NO_HINT);
             fir_MLX90640_get_frame(&Ta, To);
@@ -1050,7 +1050,7 @@ mp_obj_t py_fir_snapshot(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_arg
             break;
         }
         #endif
-        #if (OMV_ENABLE_FIR_MLX90641 == 1)
+        #if (OMV_FIR_MLX90641_ENABLE == 1)
         case FIR_MLX90641: {
             float Ta, *To = fb_alloc(MLX90641_WIDTH * MLX90641_HEIGHT * sizeof(float), FB_ALLOC_NO_HINT);
             fir_MLX90641_get_frame(&Ta, To);
@@ -1062,7 +1062,7 @@ mp_obj_t py_fir_snapshot(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_arg
             break;
         }
         #endif
-        #if (OMV_ENABLE_FIR_AMG8833 == 1)
+        #if (OMV_FIR_AMG8833_ENABLE == 1)
         case FIR_AMG8833: {
             float Ta, *To = fb_alloc(AMG8833_WIDTH * AMG8833_HEIGHT * sizeof(float), FB_ALLOC_NO_HINT);
             fir_AMG8833_get_frame(&Ta, To);
@@ -1074,7 +1074,7 @@ mp_obj_t py_fir_snapshot(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_arg
             break;
         }
         #endif
-        #if (OMV_ENABLE_FIR_LEPTON == 1)
+        #if (OMV_FIR_LEPTON_ENABLE == 1)
         case FIR_LEPTON: {
             bool auto_range = args[ARG_scale].u_obj == mp_const_none;
             fir_lepton_fill_image(&src_img, fir_width, fir_height, auto_range, min, max,
@@ -1103,20 +1103,20 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_fir_snapshot_obj, 0, py_fir_snapshot);
 
 STATIC const mp_rom_map_elem_t globals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),            MP_ROM_QSTR(MP_QSTR_fir)                    },
-    #if (OMV_ENABLE_FIR_MLX90621 == 1)
+    #if (OMV_FIR_MLX90621_ENABLE == 1)
     { MP_ROM_QSTR(MP_QSTR_FIR_SHIELD),          MP_ROM_INT(FIR_MLX90621)                    },
     { MP_ROM_QSTR(MP_QSTR_FIR_MLX90621),        MP_ROM_INT(FIR_MLX90621)                    },
     #endif
-    #if (OMV_ENABLE_FIR_MLX90640 == 1)
+    #if (OMV_FIR_MLX90640_ENABLE == 1)
     { MP_ROM_QSTR(MP_QSTR_FIR_MLX90640),        MP_ROM_INT(FIR_MLX90640)                    },
     #endif
-    #if (OMV_ENABLE_FIR_MLX90641 == 1)
+    #if (OMV_FIR_MLX90641_ENABLE == 1)
     { MP_ROM_QSTR(MP_QSTR_FIR_MLX90641),        MP_ROM_INT(FIR_MLX90641)                    },
     #endif
-    #if (OMV_ENABLE_FIR_AMG8833 == 1)
+    #if (OMV_FIR_AMG8833_ENABLE == 1)
     { MP_ROM_QSTR(MP_QSTR_FIR_AMG8833),         MP_ROM_INT(FIR_AMG8833)                     },
     #endif
-    #if (OMV_ENABLE_FIR_LEPTON == 1)
+    #if (OMV_FIR_LEPTON_ENABLE == 1)
     { MP_ROM_QSTR(MP_QSTR_FIR_LEPTON),          MP_ROM_INT(FIR_LEPTON)                      },
     #endif
     { MP_ROM_QSTR(MP_QSTR_init),                MP_ROM_PTR(&py_fir_init_obj)                },
@@ -1126,7 +1126,7 @@ STATIC const mp_rom_map_elem_t globals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_height),              MP_ROM_PTR(&py_fir_height_obj)              },
     { MP_ROM_QSTR(MP_QSTR_refresh),             MP_ROM_PTR(&py_fir_refresh_obj)             },
     { MP_ROM_QSTR(MP_QSTR_resolution),          MP_ROM_PTR(&py_fir_resolution_obj)          },
-    #if (OMV_ENABLE_FIR_LEPTON == 1)
+    #if (OMV_FIR_LEPTON_ENABLE == 1)
     { MP_ROM_QSTR(MP_QSTR_radiometric),         MP_ROM_PTR(&py_fir_radiometric_obj)         },
     #if defined(OMV_FIR_LEPTON_VSYNC_PRESENT)
     { MP_ROM_QSTR(MP_QSTR_register_vsync_cb),   MP_ROM_PTR(&py_fir_register_vsync_cb_obj)   },
@@ -1160,7 +1160,7 @@ void py_fir_init0() {
     py_fir_deinit();
 }
 
-#if ((OMV_ENABLE_FIR_MLX90621 == 1) || (OMV_ENABLE_FIR_MLX90640 == 1) || (OMV_ENABLE_FIR_MLX90641 == 1))
+#if ((OMV_FIR_MLX90621_ENABLE == 1) || (OMV_FIR_MLX90640_ENABLE == 1) || (OMV_FIR_MLX90641_ENABLE == 1))
 MP_REGISTER_ROOT_POINTER(void *fir_mlx_data);
 #endif
 MP_REGISTER_MODULE(MP_QSTR_fir, fir_module);

--- a/src/omv/modules/py_fir_lepton.c
+++ b/src/omv/modules/py_fir_lepton.c
@@ -9,7 +9,7 @@
  * FIR Python module.
  */
 #include "omv_boardconfig.h"
-#if (OMV_ENABLE_FIR_LEPTON == 1)
+#if (OMV_FIR_LEPTON_ENABLE == 1)
 #include "py/nlr.h"
 #include "py/runtime.h"
 #include "py/obj.h"
@@ -614,4 +614,4 @@ void fir_lepton_trigger_ffc(int timeout) {
     }
 }
 
-#endif // OMV_ENABLE_FIR_LEPTON
+#endif // OMV_FIR_LEPTON_ENABLE

--- a/src/omv/modules/py_omv.c
+++ b/src/omv/modules/py_omv.c
@@ -27,7 +27,7 @@ static mp_obj_t py_omv_version_string() {
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_omv_version_string_obj, py_omv_version_string);
 
 static mp_obj_t py_omv_arch() {
-    char *str = OMV_ARCH_STR;
+    char *str = OMV_BOARD_ARCH;
     return mp_obj_new_str(str, strlen(str));
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_omv_arch_obj, py_omv_arch);
@@ -41,9 +41,9 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_omv_board_type_obj, py_omv_board_type);
 static mp_obj_t py_omv_board_id() {
     char str[25];
     snprintf(str, 25, "%08X%08X%08X",
-             *((unsigned int *) (OMV_UNIQUE_ID_ADDR + 8)),
-             *((unsigned int *) (OMV_UNIQUE_ID_ADDR + 4)),
-             *((unsigned int *) (OMV_UNIQUE_ID_ADDR + 0)));
+             *((unsigned int *) (OMV_BOARD_UID_ADDR + 8)),
+             *((unsigned int *) (OMV_BOARD_UID_ADDR + 4)),
+             *((unsigned int *) (OMV_BOARD_UID_ADDR + 0)));
     return mp_obj_new_str(str, strlen(str));
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_omv_board_id_obj, py_omv_board_id);

--- a/src/omv/modules/py_sensor.c
+++ b/src/omv/modules/py_sensor.c
@@ -792,7 +792,7 @@ static mp_obj_t py_sensor_ioctl(uint n_args, const mp_obj_t *args) {
             break;
         }
 
-        #if (OMV_ENABLE_OV5640_AF == 1)
+        #if (OMV_OV5640_AF_ENABLE == 1)
         case IOCTL_TRIGGER_AUTO_FOCUS:
         case IOCTL_PAUSE_AUTO_FOCUS:
         case IOCTL_RESET_AUTO_FOCUS: {
@@ -926,7 +926,7 @@ static mp_obj_t py_sensor_ioctl(uint n_args, const mp_obj_t *args) {
             break;
         }
 
-        #if (OMV_ENABLE_HM01B0 == 1)
+        #if (OMV_HM01B0_ENABLE == 1)
         case IOCTL_HIMAX_MD_ENABLE: {
             if (n_args >= 2) {
                 error = sensor_ioctl(request, mp_obj_get_int(args[1]));
@@ -979,7 +979,7 @@ static mp_obj_t py_sensor_ioctl(uint n_args, const mp_obj_t *args) {
             }
             break;
         }
-        #endif // (OMV_ENABLE_HM01B0 == 1)
+        #endif // (OMV_HM01B0_ENABLE == 1)
 
         default: {
             sensor_raise_error(SENSOR_ERROR_CTL_UNSUPPORTED);
@@ -1124,7 +1124,7 @@ STATIC const mp_rom_map_elem_t globals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_IOCTL_GET_TRIGGERED_MODE),            MP_ROM_INT(IOCTL_GET_TRIGGERED_MODE)},
     { MP_ROM_QSTR(MP_QSTR_IOCTL_SET_FOV_WIDE),                  MP_ROM_INT(IOCTL_SET_FOV_WIDE)},
     { MP_ROM_QSTR(MP_QSTR_IOCTL_GET_FOV_WIDE),                  MP_ROM_INT(IOCTL_GET_FOV_WIDE)},
-    #if (OMV_ENABLE_OV5640_AF == 1)
+    #if (OMV_OV5640_AF_ENABLE == 1)
     { MP_ROM_QSTR(MP_QSTR_IOCTL_TRIGGER_AUTO_FOCUS),            MP_ROM_INT(IOCTL_TRIGGER_AUTO_FOCUS)},
     { MP_ROM_QSTR(MP_QSTR_IOCTL_PAUSE_AUTO_FOCUS),              MP_ROM_INT(IOCTL_PAUSE_AUTO_FOCUS)},
     { MP_ROM_QSTR(MP_QSTR_IOCTL_RESET_AUTO_FOCUS),              MP_ROM_INT(IOCTL_RESET_AUTO_FOCUS)},
@@ -1146,7 +1146,7 @@ STATIC const mp_rom_map_elem_t globals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_IOCTL_LEPTON_GET_MEASUREMENT_MODE),   MP_ROM_INT(IOCTL_LEPTON_GET_MEASUREMENT_MODE)},
     { MP_ROM_QSTR(MP_QSTR_IOCTL_LEPTON_SET_MEASUREMENT_RANGE),  MP_ROM_INT(IOCTL_LEPTON_SET_MEASUREMENT_RANGE)},
     { MP_ROM_QSTR(MP_QSTR_IOCTL_LEPTON_GET_MEASUREMENT_RANGE),  MP_ROM_INT(IOCTL_LEPTON_GET_MEASUREMENT_RANGE)},
-    #if (OMV_ENABLE_HM01B0 == 1)
+    #if (OMV_HM01B0_ENABLE == 1)
     { MP_ROM_QSTR(MP_QSTR_IOCTL_HIMAX_MD_ENABLE),       MP_ROM_INT(IOCTL_HIMAX_MD_ENABLE)},
     { MP_ROM_QSTR(MP_QSTR_IOCTL_HIMAX_MD_WINDOW),       MP_ROM_INT(IOCTL_HIMAX_MD_WINDOW)},
     { MP_ROM_QSTR(MP_QSTR_IOCTL_HIMAX_MD_THRESHOLD),    MP_ROM_INT(IOCTL_HIMAX_MD_THRESHOLD)},

--- a/src/omv/modules/py_tof.c
+++ b/src/omv/modules/py_tof.c
@@ -21,7 +21,7 @@
 #include "py_image.h"
 #include "framebuffer.h"
 
-#if (OMV_ENABLE_TOF_VL53L5CX == 1)
+#if (OMV_TOF_VL53L5CX_ENABLE == 1)
 #include "vl53l5cx_api.h"
 #endif
 
@@ -34,7 +34,7 @@ static omv_i2c_t tof_bus = {};
 
 typedef enum tof_type {
     TOF_NONE,
-    #if (OMV_ENABLE_TOF_VL53L5CX == 1)
+    #if (OMV_TOF_VL53L5CX_ENABLE == 1)
     TOF_VL53L5CX,
     #endif
 } tof_type_t;
@@ -44,7 +44,7 @@ static int tof_height = 0;
 static bool tof_transposed = false;
 static tof_type_t tof_sensor = TOF_NONE;
 
-#if (OMV_ENABLE_TOF_VL53L5CX == 1)
+#if (OMV_TOF_VL53L5CX_ENABLE == 1)
 static VL53L5CX_Configuration vl53l5cx_dev = {
     .platform = {
         .bus = &tof_bus,
@@ -83,7 +83,7 @@ static void tof_fill_image_float_obj(image_t *img, mp_obj_t *data, float min, fl
     }
 }
 
-#if (OMV_ENABLE_TOF_VL53L5CX == 1)
+#if (OMV_TOF_VL53L5CX_ENABLE == 1)
 static void tof_vl53l5cx_get_depth(VL53L5CX_Configuration *vl53l5cx_dev, float *frame, uint32_t timeout) {
     uint8_t frame_ready = 0;
     // Note depending on the config in platform.h, this struct can be too big to alloc on the stack.
@@ -188,7 +188,7 @@ static mp_obj_t py_tof_deinit() {
     tof_transposed = false;
 
     if (tof_sensor != TOF_NONE) {
-        #if (OMV_ENABLE_TOF_VL53L5CX == 1)
+        #if (OMV_TOF_VL53L5CX_ENABLE == 1)
         if (tof_sensor == TOF_VL53L5CX) {
             vl53l5cx_stop_ranging(&vl53l5cx_dev);
         }
@@ -223,7 +223,7 @@ mp_obj_t py_tof_init(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
         int dev_size = omv_i2c_scan(&tof_bus, dev_list, sizeof(dev_list));
         for (int i = 0; i < dev_size && type == -1; i++) {
             switch (dev_list[i]) {
-                #if (OMV_ENABLE_TOF_VL53L5CX == 1)
+                #if (OMV_TOF_VL53L5CX_ENABLE == 1)
                 case (VL53L5CX_ADDR): {
                     type = TOF_VL53L5CX;
                     break;
@@ -247,7 +247,7 @@ mp_obj_t py_tof_init(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     // Initialize the detected sensor.
     first_init = true;
     switch (type) {
-        #if (OMV_ENABLE_TOF_VL53L5CX == 1)
+        #if (OMV_TOF_VL53L5CX_ENABLE == 1)
         case TOF_VL53L5CX: {
             int error = 0;
             uint8_t isAlive = 0;
@@ -329,7 +329,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(py_tof_height_obj, py_tof_height);
 
 static mp_obj_t py_tof_refresh() {
     switch (tof_sensor) {
-        #if (OMV_ENABLE_TOF_VL53L5CX == 1)
+        #if (OMV_TOF_VL53L5CX_ENABLE == 1)
         case TOF_VL53L5CX:
             return mp_obj_new_int(15);
         #endif
@@ -355,7 +355,7 @@ mp_obj_t py_tof_read_depth(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_a
     tof_transposed = args[ARG_transpose].u_bool;
 
     switch (tof_sensor) {
-        #if (OMV_ENABLE_TOF_VL53L5CX == 1)
+        #if (OMV_TOF_VL53L5CX_ENABLE == 1)
         case TOF_VL53L5CX: {
             fb_alloc_mark();
             float *frame = fb_alloc(VL53L5CX_WIDTH * VL53L5CX_HEIGHT * sizeof(float), FB_ALLOC_PREFER_SPEED);
@@ -526,7 +526,7 @@ mp_obj_t py_tof_snapshot(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_arg
     src_img.data = fb_alloc(src_img.w * src_img.h * sizeof(uint8_t), FB_ALLOC_NO_HINT);
 
     switch (tof_sensor) {
-        #if (OMV_ENABLE_TOF_VL53L5CX == 1)
+        #if (OMV_TOF_VL53L5CX_ENABLE == 1)
         case TOF_VL53L5CX: {
             float *frame = fb_alloc(VL53L5CX_WIDTH * VL53L5CX_HEIGHT * sizeof(float), FB_ALLOC_PREFER_SPEED);
             tof_vl53l5cx_get_depth(&vl53l5cx_dev, frame, args[ARG_timeout].u_int);
@@ -559,7 +559,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_tof_snapshot_obj, 0, py_tof_snapshot);
 STATIC const mp_rom_map_elem_t globals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),            MP_ROM_QSTR(MP_QSTR_tof)                },
     { MP_ROM_QSTR(MP_QSTR_TOF_NONE),            MP_ROM_INT(TOF_NONE)                    },
-    #if (OMV_ENABLE_TOF_VL53L5CX == 1)
+    #if (OMV_TOF_VL53L5CX_ENABLE == 1)
     { MP_ROM_QSTR(MP_QSTR_TOF_VL53L5CX),        MP_ROM_INT(TOF_VL53L5CX)                },
     #endif
     { MP_ROM_QSTR(MP_QSTR_PALETTE_RAINBOW),     MP_ROM_INT(COLOR_PALETTE_RAINBOW)       },

--- a/src/omv/ports/mimxrt/mimxrt.ld.S
+++ b/src/omv/ports/mimxrt/mimxrt.ld.S
@@ -226,14 +226,6 @@ SECTIONS
     _line_buf = .;      // Image line buffer.
     . = . + OMV_LINE_BUF_SIZE;
 
-    . = ALIGN(16);
-    _msc_buf  = .;      // USB MSC bot data (2K)
-    . = . + OMV_MSC_BUF_SIZE;
-
-    . = ALIGN(16);
-    _vfs_buf  = .;      // VFS struct + FATFS file buffer  (around 624 bytes)
-    . = . + OMV_VFS_BUF_SIZE;
-
     #if !defined(OMV_JPEG_MEMORY)
     . = ALIGN(16);
     _jpeg_buf = .;      // IDE JPEG buffer

--- a/src/omv/ports/mimxrt/mimxrt_hal.c
+++ b/src/omv/ports/mimxrt/mimxrt_hal.c
@@ -106,29 +106,29 @@ int mimxrt_hal_csi_init(CSI_Type *inst) {
     CLOCK_EnableClock(kCLOCK_Csi);
 
     // Configure DCMI pins.
-    omv_gpio_config(DCMI_D0_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
-    omv_gpio_config(DCMI_D1_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
-    omv_gpio_config(DCMI_D2_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
-    omv_gpio_config(DCMI_D3_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
-    omv_gpio_config(DCMI_D4_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
-    omv_gpio_config(DCMI_D5_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
-    omv_gpio_config(DCMI_D6_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
-    omv_gpio_config(DCMI_D7_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
+    omv_gpio_config(OMV_CSI_D0_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
+    omv_gpio_config(OMV_CSI_D1_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
+    omv_gpio_config(OMV_CSI_D2_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
+    omv_gpio_config(OMV_CSI_D3_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
+    omv_gpio_config(OMV_CSI_D4_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
+    omv_gpio_config(OMV_CSI_D5_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
+    omv_gpio_config(OMV_CSI_D6_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
+    omv_gpio_config(OMV_CSI_D7_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
 
-    omv_gpio_config(DCMI_MCLK_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
-    omv_gpio_config(DCMI_HSYNC_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
-    omv_gpio_config(DCMI_VSYNC_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
-    omv_gpio_config(DCMI_PXCLK_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
+    omv_gpio_config(OMV_CSI_MXCLK_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
+    omv_gpio_config(OMV_CSI_HSYNC_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
+    omv_gpio_config(OMV_CSI_VSYNC_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
+    omv_gpio_config(OMV_CSI_PXCLK_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
 
     // Configure DCMI GPIOs
-    #if defined(DCMI_RESET_PIN)
-    omv_gpio_config(DCMI_RESET_PIN, OMV_GPIO_MODE_OUTPUT, OMV_GPIO_PULL_DOWN, OMV_GPIO_SPEED_LOW, -1);
+    #if defined(OMV_CSI_RESET_PIN)
+    omv_gpio_config(OMV_CSI_RESET_PIN, OMV_GPIO_MODE_OUTPUT, OMV_GPIO_PULL_DOWN, OMV_GPIO_SPEED_LOW, -1);
     #endif
-    #if defined(DCMI_FSYNC_PIN)
-    omv_gpio_config(DCMI_FSYNC_PIN, OMV_GPIO_MODE_OUTPUT, OMV_GPIO_PULL_DOWN, OMV_GPIO_SPEED_LOW, -1);
+    #if defined(OMV_CSI_FSYNC_PIN)
+    omv_gpio_config(OMV_CSI_FSYNC_PIN, OMV_GPIO_MODE_OUTPUT, OMV_GPIO_PULL_DOWN, OMV_GPIO_SPEED_LOW, -1);
     #endif
-    #if defined(DCMI_POWER_PIN)
-    omv_gpio_config(DCMI_POWER_PIN, OMV_GPIO_MODE_OUTPUT, OMV_GPIO_PULL_UP, OMV_GPIO_SPEED_LOW, -1);
+    #if defined(OMV_CSI_POWER_PIN)
+    omv_gpio_config(OMV_CSI_POWER_PIN, OMV_GPIO_MODE_OUTPUT, OMV_GPIO_PULL_UP, OMV_GPIO_SPEED_LOW, -1);
     #endif
 
     // Configure IRQ priority.
@@ -142,31 +142,31 @@ int mimxrt_hal_i2c_init(uint32_t bus_id) {
     omv_gpio_t sda_pin = NULL;
 
     switch (bus_id) {
-        #if defined(LPI2C1_ID)
-        case LPI2C1_ID: {
-            scl_pin = LPI2C1_SCL_PIN;
-            sda_pin = LPI2C1_SDA_PIN;
+        #if defined(OMV_I2C1_ID)
+        case OMV_I2C1_ID: {
+            scl_pin = OMV_I2C1_SCL_PIN;
+            sda_pin = OMV_I2C1_SDA_PIN;
             break;
         }
         #endif
-        #if defined(LPI2C2_ID)
-        case LPI2C2_ID: {
-            scl_pin = LPI2C2_SCL_PIN;
-            sda_pin = LPI2C2_SDA_PIN;
+        #if defined(OMV_I2C2_ID)
+        case OMV_I2C2_ID: {
+            scl_pin = OMV_I2C2_SCL_PIN;
+            sda_pin = OMV_I2C2_SDA_PIN;
             break;
         }
         #endif
-        #if defined(LPI2C3_ID)
-        case LPI2C3_ID: {
-            scl_pin = LPI2C3_SCL_PIN;
-            sda_pin = LPI2C3_SDA_PIN;
+        #if defined(OMV_I2C3_ID)
+        case OMV_I2C3_ID: {
+            scl_pin = OMV_I2C3_SCL_PIN;
+            sda_pin = OMV_I2C3_SDA_PIN;
             break;
         }
         #endif
-        #if defined(LPI2C4_ID)
-        case LPI2C4_ID: {
-            scl_pin = LPI2C4_SCL_PIN;
-            sda_pin = LPI2C4_SDA_PIN;
+        #if defined(OMV_I2C4_ID)
+        case OMV_I2C4_ID: {
+            scl_pin = OMV_I2C4_SCL_PIN;
+            sda_pin = OMV_I2C4_SDA_PIN;
             break;
         }
         #endif
@@ -191,34 +191,34 @@ int mimxrt_hal_spi_init(uint32_t bus_id, bool nss_enable, uint32_t nss_pol) {
     spi_pins_t spi_pins = { NULL, NULL, NULL, NULL };
 
     switch (bus_id) {
-        #if defined(LPSPI1_ID)
-        case LPSPI1_ID: {
+        #if defined(OMV_SPI1_ID)
+        case OMV_SPI1_ID: {
             spi_pins = (spi_pins_t) {
-                LPSPI1_SCLK_PIN, LPSPI1_MISO_PIN, LPSPI1_MOSI_PIN, LPSPI1_SSEL_PIN
+                OMV_SPI1_SCLK_PIN, OMV_SPI1_MISO_PIN, OMV_SPI1_MOSI_PIN, OMV_SPI1_SSEL_PIN
             };
             break;
         }
         #endif
-        #if defined(LPSPI2_ID)
-        case LPSPI2_ID: {
+        #if defined(OMV_SPI2_ID)
+        case OMV_SPI2_ID: {
             spi_pins = (spi_pins_t) {
-                LPSPI2_SCLK_PIN, LPSPI2_MISO_PIN, LPSPI2_MOSI_PIN, LPSPI2_SSEL_PIN
+                OMV_SPI2_SCLK_PIN, OMV_SPI2_MISO_PIN, OMV_SPI2_MOSI_PIN, OMV_SPI2_SSEL_PIN
             };
             break;
         }
         #endif
-        #if defined(LPSPI3_ID)
-        case LPSPI3_ID: {
+        #if defined(OMV_SPI3_ID)
+        case OMV_SPI3_ID: {
             spi_pins = (spi_pins_t) {
-                LPSPI3_SCLK_PIN, LPSPI3_MISO_PIN, LPSPI3_MOSI_PIN, LPSPI3_SSEL_PIN
+                OMV_SPI3_SCLK_PIN, OMV_SPI3_MISO_PIN, OMV_SPI3_MOSI_PIN, OMV_SPI3_SSEL_PIN
             };
             break;
         }
         #endif
-        #if defined(LPSPI4_ID)
-        case LPSPI4_ID: {
+        #if defined(OMV_SPI4_ID)
+        case OMV_SPI4_ID: {
             spi_pins = (spi_pins_t) {
-                LPSPI4_SCLK_PIN, LPSPI4_MISO_PIN, LPSPI4_MOSI_PIN, LPSPI4_SSEL_PIN
+                OMV_SPI4_SCLK_PIN, OMV_SPI4_MISO_PIN, OMV_SPI4_MOSI_PIN, OMV_SPI4_SSEL_PIN
             };
             break;
         }
@@ -254,34 +254,34 @@ int mimxrt_hal_spi_deinit(uint32_t bus_id) {
     spi_pins_t spi_pins = { NULL, NULL, NULL, NULL };
 
     switch (bus_id) {
-        #if defined(LPSPI1_ID)
-        case LPSPI1_ID: {
+        #if defined(OMV_SPI1_ID)
+        case OMV_SPI1_ID: {
             spi_pins = (spi_pins_t) {
-                LPSPI1_SCLK_PIN, LPSPI1_MISO_PIN, LPSPI1_MOSI_PIN, LPSPI1_SSEL_PIN
+                OMV_SPI1_SCLK_PIN, OMV_SPI1_MISO_PIN, OMV_SPI1_MOSI_PIN, OMV_SPI1_SSEL_PIN
             };
             break;
         }
         #endif
-        #if defined(LPSPI2_ID)
-        case LPSPI2_ID: {
+        #if defined(OMV_SPI2_ID)
+        case OMV_SPI2_ID: {
             spi_pins = (spi_pins_t) {
-                LPSPI2_SCLK_PIN, LPSPI2_MISO_PIN, LPSPI2_MOSI_PIN, LPSPI2_SSEL_PIN
+                OMV_SPI2_SCLK_PIN, OMV_SPI2_MISO_PIN, OMV_SPI2_MOSI_PIN, OMV_SPI2_SSEL_PIN
             };
             break;
         }
         #endif
-        #if defined(LPSPI3_ID)
-        case LPSPI3_ID: {
+        #if defined(OMV_SPI3_ID)
+        case OMV_SPI3_ID: {
             spi_pins = (spi_pins_t) {
-                LPSPI3_SCLK_PIN, LPSPI3_MISO_PIN, LPSPI3_MOSI_PIN, LPSPI3_SSEL_PIN
+                OMV_SPI3_SCLK_PIN, OMV_SPI3_MISO_PIN, OMV_SPI3_MOSI_PIN, OMV_SPI3_SSEL_PIN
             };
             break;
         }
         #endif
-        #if defined(LPSPI4_ID)
-        case LPSPI4_ID: {
+        #if defined(OMV_SPI4_ID)
+        case OMV_SPI4_ID: {
             spi_pins = (spi_pins_t) {
-                LPSPI4_SCLK_PIN, LPSPI4_MISO_PIN, LPSPI4_MOSI_PIN, LPSPI4_SSEL_PIN
+                OMV_SPI4_SCLK_PIN, OMV_SPI4_MISO_PIN, OMV_SPI4_MOSI_PIN, OMV_SPI4_SSEL_PIN
             };
             break;
         }

--- a/src/omv/ports/mimxrt/omv_i2c.c
+++ b/src/omv/ports/mimxrt/omv_i2c.c
@@ -56,33 +56,33 @@ int omv_i2c_init(omv_i2c_t *i2c, uint32_t bus_id, uint32_t speed) {
     }
 
     switch (bus_id) {
-        case LPI2C1_ID: {
+        case OMV_I2C1_ID: {
             i2c->inst = LPI2C1;
-            i2c->scl_pin = LPI2C1_SCL_PIN;
-            i2c->sda_pin = LPI2C1_SDA_PIN;
+            i2c->scl_pin = OMV_I2C1_SCL_PIN;
+            i2c->sda_pin = OMV_I2C1_SDA_PIN;
             break;
         }
-        #if defined(LPI2C2_ID)
-        case LPI2C2_ID: {
+        #if defined(OMV_I2C2_ID)
+        case OMV_I2C2_ID: {
             i2c->inst = LPI2C2;
-            i2c->scl_pin = LPI2C2_SCL_PIN;
-            i2c->sda_pin = LPI2C2_SDA_PIN;
+            i2c->scl_pin = OMV_I2C2_SCL_PIN;
+            i2c->sda_pin = OMV_I2C2_SDA_PIN;
             break;
         }
         #endif
-        #if defined(LPI2C3_ID)
-        case LPI2C3_ID: {
+        #if defined(OMV_I2C3_ID)
+        case OMV_I2C3_ID: {
             i2c->inst = LPI2C3;
-            i2c->scl_pin = LPI2C3_SCL_PIN;
-            i2c->sda_pin = LPI2C3_SDA_PIN;
+            i2c->scl_pin = OMV_I2C3_SCL_PIN;
+            i2c->sda_pin = OMV_I2C3_SDA_PIN;
             break;
         }
         #endif
-        #if defined(LPI2C4_ID)
-        case LPI2C4_ID: {
+        #if defined(OMV_I2C4_ID)
+        case OMV_I2C4_ID: {
             i2c->inst = LPI2C4;
-            i2c->scl_pin = LPI2C4_SCL_PIN;
-            i2c->sda_pin = LPI2C4_SDA_PIN;
+            i2c->scl_pin = OMV_I2C4_SCL_PIN;
+            i2c->sda_pin = OMV_I2C4_SDA_PIN;
             break;
         }
         #endif

--- a/src/omv/ports/mimxrt/omv_spi.c
+++ b/src/omv/ports/mimxrt/omv_spi.c
@@ -37,34 +37,34 @@ typedef struct omv_spi_descr {
 } omv_spi_descr_t;
 
 static const omv_spi_descr_t omv_spi_descr_all[] = {
-    #if defined(LPSPI1_ID)
-    { LPSPI1, LPSPI1_SSEL_PIN,
-      { LPSPI1_DMA, LPSPI1_DMA_MUX, LPSPI1_DMA_TX_CHANNEL, kDmaRequestMuxLPSPI1Tx },
-      { LPSPI1_DMA, LPSPI1_DMA_MUX, LPSPI1_DMA_RX_CHANNEL, kDmaRequestMuxLPSPI1Rx } },
+    #if defined(OMV_SPI1_ID)
+    { LPSPI1, OMV_SPI1_SSEL_PIN,
+      { OMV_SPI1_DMA, OMV_SPI1_DMA_MUX, OMV_SPI1_DMA_TX_CHANNEL, kDmaRequestMuxLPSPI1Tx },
+      { OMV_SPI1_DMA, OMV_SPI1_DMA_MUX, OMV_SPI1_DMA_RX_CHANNEL, kDmaRequestMuxLPSPI1Rx } },
     #else
     { NULL, NULL, { NULL, NULL, 0, 0 }, { NULL, NULL, 0, 0 } },
     #endif
 
-    #if defined(LPSPI2_ID)
-    { LPSPI2, LPSPI2_SSEL_PIN,
-      { LPSPI2_DMA, LPSPI2_DMA_MUX, LPSPI2_DMA_TX_CHANNEL, kDmaRequestMuxLPSPI2Tx },
-      { LPSPI2_DMA, LPSPI2_DMA_MUX, LPSPI2_DMA_RX_CHANNEL, kDmaRequestMuxLPSPI2Rx } },
+    #if defined(OMV_SPI2_ID)
+    { LPSPI2, OMV_SPI2_SSEL_PIN,
+      { OMV_SPI2_DMA, OMV_SPI2_DMA_MUX, OMV_SPI2_DMA_TX_CHANNEL, kDmaRequestMuxLPSPI2Tx },
+      { OMV_SPI2_DMA, OMV_SPI2_DMA_MUX, OMV_SPI2_DMA_RX_CHANNEL, kDmaRequestMuxLPSPI2Rx } },
     #else
     { NULL, NULL, { NULL, NULL, 0, 0 }, { NULL, NULL, 0, 0 } },
     #endif
 
-    #if defined(LPSPI3_ID)
-    { LPSPI3, LPSPI3_SSEL_PIN,
-      { LPSPI3_DMA, LPSPI3_DMA_MUX, LPSPI3_DMA_TX_CHANNEL, kDmaRequestMuxLPSPI3Tx },
-      { LPSPI3_DMA, LPSPI3_DMA_MUX, LPSPI3_DMA_RX_CHANNEL, kDmaRequestMuxLPSPI3Rx } },
+    #if defined(OMV_SPI3_ID)
+    { LPSPI3, OMV_SPI3_SSEL_PIN,
+      { OMV_SPI3_DMA, OMV_SPI3_DMA_MUX, OMV_SPI3_DMA_TX_CHANNEL, kDmaRequestMuxLPSPI3Tx },
+      { OMV_SPI3_DMA, OMV_SPI3_DMA_MUX, OMV_SPI3_DMA_RX_CHANNEL, kDmaRequestMuxLPSPI3Rx } },
     #else
     { NULL, NULL, { NULL, NULL, 0, 0 }, { NULL, NULL, 0, 0 } },
     #endif
 
-    #if defined(LPSPI4_ID)
-    { LPSPI4, LPSPI4_SSEL_PIN,
-      { LPSPI4_DMA, LPSPI4_DMA_MUX, LPSPI4_DMA_TX_CHANNEL, kDmaRequestMuxLPSPI4Tx },
-      { LPSPI4_DMA, LPSPI4_DMA_MUX, LPSPI4_DMA_RX_CHANNEL, kDmaRequestMuxLPSPI4Rx } },
+    #if defined(OMV_SPI4_ID)
+    { LPSPI4, OMV_SPI4_SSEL_PIN,
+      { OMV_SPI4_DMA, OMV_SPI4_DMA_MUX, OMV_SPI4_DMA_TX_CHANNEL, kDmaRequestMuxLPSPI4Tx },
+      { OMV_SPI4_DMA, OMV_SPI4_DMA_MUX, OMV_SPI4_DMA_RX_CHANNEL, kDmaRequestMuxLPSPI4Rx } },
     #else
     { NULL, NULL, { NULL, NULL, 0, 0 }, { NULL, NULL, 0, 0 } },
     #endif

--- a/src/omv/ports/mimxrt/sensor.c
+++ b/src/omv/ports/mimxrt/sensor.c
@@ -57,12 +57,12 @@ int sensor_init() {
 
     mimxrt_hal_csi_init(CSI);
 
-    #if defined(DCMI_POWER_PIN)
-    omv_gpio_write(DCMI_POWER_PIN, 1);
+    #if defined(OMV_CSI_POWER_PIN)
+    omv_gpio_write(OMV_CSI_POWER_PIN, 1);
     #endif
 
-    #if defined(DCMI_RESET_PIN)
-    omv_gpio_write(DCMI_RESET_PIN, 1);
+    #if defined(OMV_CSI_RESET_PIN)
+    omv_gpio_write(OMV_CSI_RESET_PIN, 1);
     #endif
 
     // Reset the sensor state
@@ -73,13 +73,13 @@ int sensor_init() {
     sensor.snapshot = sensor_snapshot;
 
     // Configure the sensor external clock (XCLK).
-    if (sensor_set_xclk_frequency(OMV_XCLK_FREQUENCY) != 0) {
+    if (sensor_set_xclk_frequency(OMV_CSI_XCLK_FREQUENCY) != 0) {
         // Failed to initialize the sensor clock.
         return SENSOR_ERROR_TIM_INIT_FAILED;
     }
 
     // Detect and initialize the image sensor.
-    if ((init_ret = sensor_probe_init(ISC_I2C_ID, ISC_I2C_SPEED)) != 0) {
+    if ((init_ret = sensor_probe_init(OMV_CSI_I2C_ID, OMV_CSI_I2C_SPEED)) != 0) {
         // Sensor probe/init failed.
         return init_ret;
     }
@@ -335,9 +335,9 @@ int sensor_snapshot(sensor_t *sensor, image_t *image, uint32_t flags) {
     }
 
     // Let the camera know we want to trigger it now.
-    #if defined(DCMI_FSYNC_PIN)
+    #if defined(OMV_CSI_FSYNC_PIN)
     if (sensor->hw_flags.fsync) {
-        omv_gpio_write(DCMI_FSYNC_PIN, 1);
+        omv_gpio_write(OMV_CSI_FSYNC_PIN, 1);
     }
     #endif
 
@@ -348,9 +348,9 @@ int sensor_snapshot(sensor_t *sensor, image_t *image, uint32_t flags) {
         if ((mp_hal_ticks_ms() - ticks) > 3000) {
             sensor_abort(true, false);
 
-            #if defined(DCMI_FSYNC_PIN)
+            #if defined(OMV_CSI_FSYNC_PIN)
             if (sensor->hw_flags.fsync) {
-                omv_gpio_write(DCMI_FSYNC_PIN, 0);
+                omv_gpio_write(OMV_CSI_FSYNC_PIN, 0);
             }
             #endif
 
@@ -360,9 +360,9 @@ int sensor_snapshot(sensor_t *sensor, image_t *image, uint32_t flags) {
     }
 
     // We're done receiving data.
-    #if defined(DCMI_FSYNC_PIN)
+    #if defined(OMV_CSI_FSYNC_PIN)
     if (sensor->hw_flags.fsync) {
-        omv_gpio_write(DCMI_FSYNC_PIN, 0);
+        omv_gpio_write(OMV_CSI_FSYNC_PIN, 0);
     }
     #endif
 

--- a/src/omv/ports/nrf/modules/py_audio.c
+++ b/src/omv/ports/nrf/modules/py_audio.c
@@ -81,8 +81,8 @@ static mp_obj_t py_audio_init(uint n_args, const mp_obj_t *pos_args, mp_map_t *k
     int gain_db = args[ARG_gain_db].u_int;
 
     nrfx_pdm_config_t nrfx_pdm_config = {
-        .pin_clk = PDM_CLK_PIN,
-        .pin_din = PDM_DIN_PIN,
+        .pin_clk = OMV_PDM_CLK_PIN,
+        .pin_din = OMV_PDM_DIN_PIN,
         .gain_l = gain_db,
         .gain_r = gain_db,
         .interrupt_priority = PDM_IRQ_PRIORITY,
@@ -124,8 +124,8 @@ static mp_obj_t py_audio_init(uint n_args, const mp_obj_t *pos_args, mp_map_t *k
     }
 
     // Power the mic on.
-    nrf_gpio_cfg_output(PDM_PWR_PIN);
-    nrf_gpio_pin_set(PDM_PWR_PIN);
+    nrf_gpio_cfg_output(OMV_PDM_PWR_PIN);
+    nrf_gpio_pin_set(OMV_PDM_PWR_PIN);
 
     // Allocate global PCM buffer.
     g_pcmbuf = mp_obj_new_bytearray_by_ref(PDM_BUFFER_SIZE * sizeof(int16_t), m_new(int16_t, PDM_BUFFER_SIZE));
@@ -140,9 +140,9 @@ void py_audio_deinit() {
     nrfx_pdm_uninit();
 
     // Power the mic off
-    nrf_gpio_cfg_output(PDM_PWR_PIN);
-    nrf_gpio_pin_clear(PDM_PWR_PIN);
-    nrf_gpio_cfg_input(PDM_PWR_PIN, NRF_GPIO_PIN_PULLDOWN);
+    nrf_gpio_cfg_output(OMV_PDM_PWR_PIN);
+    nrf_gpio_pin_clear(OMV_PDM_PWR_PIN);
+    nrf_gpio_cfg_input(OMV_PDM_PWR_PIN, NRF_GPIO_PIN_PULLDOWN);
 
     g_channels = 0;
     g_pcmbuf = NULL;

--- a/src/omv/ports/nrf/omv_i2c.c
+++ b/src/omv/ports/nrf/omv_i2c.c
@@ -39,14 +39,14 @@ int omv_i2c_init(omv_i2c_t *i2c, uint32_t bus_id, uint32_t speed) {
 
     switch (bus_id) {
         case 0: {
-            i2c->scl_pin = TWI0_SCL_PIN;
-            i2c->sda_pin = TWI0_SDA_PIN;
+            i2c->scl_pin = OMV_I2C0_SCL_PIN;
+            i2c->sda_pin = OMV_I2C0_SDA_PIN;
             i2c->inst = (nrfx_twi_t) NRFX_TWI_INSTANCE(0);
             break;
         }
         case 1: {
-            i2c->scl_pin = TWI1_SCL_PIN;
-            i2c->sda_pin = TWI1_SDA_PIN;
+            i2c->scl_pin = OMV_I2C1_SCL_PIN;
+            i2c->sda_pin = OMV_I2C1_SDA_PIN;
             i2c->inst = (nrfx_twi_t) NRFX_TWI_INSTANCE(1);
             break;
         }

--- a/src/omv/ports/nrf/sensor.c
+++ b/src/omv/ports/nrf/sensor.c
@@ -53,14 +53,14 @@ extern void __fatal_error(const char *msg);
 int sensor_init() {
     int init_ret = 0;
 
-    #if defined(DCMI_POWER_PIN)
-    nrf_gpio_cfg_output(DCMI_POWER_PIN);
-    nrf_gpio_pin_write(DCMI_POWER_PIN, 1);
+    #if defined(OMV_CSI_POWER_PIN)
+    nrf_gpio_cfg_output(OMV_CSI_POWER_PIN);
+    nrf_gpio_pin_write(OMV_CSI_POWER_PIN, 1);
     #endif
 
-    #if defined(DCMI_RESET_PIN)
-    nrf_gpio_cfg_output(DCMI_RESET_PIN);
-    nrf_gpio_pin_write(DCMI_RESET_PIN, 1);
+    #if defined(OMV_CSI_RESET_PIN)
+    nrf_gpio_cfg_output(OMV_CSI_RESET_PIN);
+    nrf_gpio_pin_write(OMV_CSI_RESET_PIN, 1);
     #endif
 
     // Reset the sensor state
@@ -71,13 +71,13 @@ int sensor_init() {
     sensor.snapshot = sensor_snapshot;
 
     // Configure the sensor external clock (XCLK).
-    if (sensor_set_xclk_frequency(OMV_XCLK_FREQUENCY) != 0) {
+    if (sensor_set_xclk_frequency(OMV_CSI_XCLK_FREQUENCY) != 0) {
         // Failed to initialize the sensor clock.
         return SENSOR_ERROR_TIM_INIT_FAILED;
     }
 
     // Detect and initialize the image sensor.
-    if ((init_ret = sensor_probe_init(ISC_I2C_ID, ISC_I2C_SPEED)) != 0) {
+    if ((init_ret = sensor_probe_init(OMV_CSI_I2C_ID, OMV_CSI_I2C_SPEED)) != 0) {
         // Sensor probe/init failed.
         return init_ret;
     }
@@ -107,17 +107,17 @@ int sensor_init() {
 
 int sensor_dcmi_config(uint32_t pixformat) {
     uint32_t dcmi_pins[] = {
-        DCMI_D0_PIN,
-        DCMI_D1_PIN,
-        DCMI_D2_PIN,
-        DCMI_D3_PIN,
-        DCMI_D4_PIN,
-        DCMI_D5_PIN,
-        DCMI_D6_PIN,
-        DCMI_D7_PIN,
-        DCMI_VSYNC_PIN,
-        DCMI_HSYNC_PIN,
-        DCMI_PXCLK_PIN,
+        OMV_CSI_D0_PIN,
+        OMV_CSI_D1_PIN,
+        OMV_CSI_D2_PIN,
+        OMV_CSI_D3_PIN,
+        OMV_CSI_D4_PIN,
+        OMV_CSI_D5_PIN,
+        OMV_CSI_D6_PIN,
+        OMV_CSI_D7_PIN,
+        OMV_CSI_VSYNC_PIN,
+        OMV_CSI_HSYNC_PIN,
+        OMV_CSI_PXCLK_PIN,
     };
 
     // Configure DCMI input pins
@@ -125,30 +125,30 @@ int sensor_dcmi_config(uint32_t pixformat) {
         nrf_gpio_cfg_input(dcmi_pins[i], NRF_GPIO_PIN_PULLUP);
     }
 
-    _vsyncMask = digitalPinToBitMask(DCMI_VSYNC_PIN);
-    _hrefMask = digitalPinToBitMask(DCMI_HSYNC_PIN);
-    _pclkMask = digitalPinToBitMask(DCMI_PXCLK_PIN);
+    _vsyncMask = digitalPinToBitMask(OMV_CSI_VSYNC_PIN);
+    _hrefMask = digitalPinToBitMask(OMV_CSI_HSYNC_PIN);
+    _pclkMask = digitalPinToBitMask(OMV_CSI_PXCLK_PIN);
 
-    _vsyncPort = portInputRegister(digitalPinToPort(DCMI_VSYNC_PIN));
-    _hrefPort = portInputRegister(digitalPinToPort(DCMI_HSYNC_PIN));
-    _pclkPort = portInputRegister(digitalPinToPort(DCMI_PXCLK_PIN));
+    _vsyncPort = portInputRegister(digitalPinToPort(OMV_CSI_VSYNC_PIN));
+    _hrefPort = portInputRegister(digitalPinToPort(OMV_CSI_HSYNC_PIN));
+    _pclkPort = portInputRegister(digitalPinToPort(OMV_CSI_PXCLK_PIN));
 
     return 0;
 }
 
 uint32_t sensor_get_xclk_frequency() {
-    return OMV_XCLK_FREQUENCY;
+    return OMV_CSI_XCLK_FREQUENCY;
 }
 
 int sensor_set_xclk_frequency(uint32_t frequency) {
-    nrf_gpio_cfg_output(DCMI_XCLK_PIN);
+    nrf_gpio_cfg_output(OMV_CSI_MXCLK_PIN);
 
     // Generates 16 MHz signal using I2S peripheral
     NRF_I2S->CONFIG.MCKEN = (I2S_CONFIG_MCKEN_MCKEN_ENABLE << I2S_CONFIG_MCKEN_MCKEN_Pos);
     NRF_I2S->CONFIG.MCKFREQ = I2S_CONFIG_MCKFREQ_MCKFREQ_32MDIV2 << I2S_CONFIG_MCKFREQ_MCKFREQ_Pos;
     NRF_I2S->CONFIG.MODE = I2S_CONFIG_MODE_MODE_MASTER << I2S_CONFIG_MODE_MODE_Pos;
 
-    NRF_I2S->PSEL.MCK = (DCMI_XCLK_PIN << I2S_PSEL_MCK_PIN_Pos);
+    NRF_I2S->PSEL.MCK = (OMV_CSI_MXCLK_PIN << I2S_PSEL_MCK_PIN_Pos);
 
     NRF_I2S->ENABLE = 1;
     NRF_I2S->TASKS_START = 1;

--- a/src/omv/ports/rp2/main.c
+++ b/src/omv/ports/rp2/main.c
@@ -76,7 +76,7 @@ extern void pendsv_init(void);
 extern uint8_t __StackTop, __StackBottom;
 static char OMV_ATTR_SECTION(OMV_ATTR_ALIGNED(gc_heap[OMV_HEAP_SIZE], 4), ".heap");
 
-uint8_t *OMV_UNIQUE_ID_ADDR;
+uint8_t *OMV_BOARD_UID_ADDR;
 static pico_unique_board_id_t OMV_ATTR_ALIGNED(pico_unique_id, 4);
 
 // Embed version info in the binary in machine readable form
@@ -89,13 +89,13 @@ bi_decl(bi_program_feature_group_with_flags(BINARY_INFO_TAG_MICROPYTHON,
                                             BI_NAMED_GROUP_SEPARATE_COMMAS | BI_NAMED_GROUP_SORT_ALPHA));
 
 void __fatal_error() {
-    gpio_init(LED_PIN);
-    gpio_set_dir(LED_PIN, GPIO_OUT);
+    gpio_init(OMV_LED_PIN);
+    gpio_set_dir(OMV_LED_PIN, GPIO_OUT);
 
     while (true) {
-        gpio_put(LED_PIN, 1);
+        gpio_put(OMV_LED_PIN, 1);
         sleep_ms(100);
-        gpio_put(LED_PIN, 0);
+        gpio_put(OMV_LED_PIN, 0);
         sleep_ms(100);
     }
 }
@@ -141,7 +141,7 @@ int main(int argc, char **argv) {
     mp_hal_time_ns_set_from_rtc();
 
     // Set board unique ID from flash for USB debugging.
-    OMV_UNIQUE_ID_ADDR = pico_unique_id.id;
+    OMV_BOARD_UID_ADDR = pico_unique_id.id;
     pico_get_unique_board_id(&pico_unique_id);
 
 soft_reset:

--- a/src/omv/ports/rp2/omv_i2c.c
+++ b/src/omv/ports/rp2/omv_i2c.c
@@ -43,14 +43,14 @@ int omv_i2c_init(omv_i2c_t *i2c, uint32_t bus_id, uint32_t speed) {
     switch (bus_id) {
         case 0: {
             i2c->inst = i2c0;
-            i2c->scl_pin = I2C0_SCL_PIN;
-            i2c->sda_pin = I2C0_SDA_PIN;
+            i2c->scl_pin = OMV_I2C0_SCL_PIN;
+            i2c->sda_pin = OMV_I2C0_SDA_PIN;
             break;
         }
         case 1: {
             i2c->inst = i2c1;
-            i2c->scl_pin = I2C1_SCL_PIN;
-            i2c->sda_pin = I2C1_SDA_PIN;
+            i2c->scl_pin = OMV_I2C1_SCL_PIN;
+            i2c->sda_pin = OMV_I2C1_SDA_PIN;
             break;
         }
         default:

--- a/src/omv/ports/stm32/jpeg.c
+++ b/src/omv/ports/stm32/jpeg.c
@@ -9,7 +9,7 @@
  * Hardware Accelerated JPEG Encoder and Decoder
  */
 #include "omv_boardconfig.h"
-#if (OMV_HARDWARE_JPEG == 1)
+#if (OMV_JPEG_CODEC_ENABLE == 1)
 #include "imlib.h"
 
 #include "py/mphal.h"

--- a/src/omv/ports/stm32/main.c
+++ b/src/omv/ports/stm32/main.c
@@ -448,7 +448,7 @@ else {
     ini_parse(&vfs_fat->fatfs, "/openmv.config", ini_handler_callback, &openmv_config);
 
     // Init wifi debugging if enabled and on first soft-reset only.
-    #if OMV_ENABLE_WIFIDBG && MICROPY_PY_WINC1500
+    #if OMV_WIFIDBG_ENABLE && MICROPY_PY_WINC1500
     if (openmv_config.wifidbg == true &&
         wifidbg_init(&openmv_config.wifidbg_config) != 0) {
         openmv_config.wifidbg = false;
@@ -503,7 +503,7 @@ else {
             if (nlr_push(&nlr) == 0) {
                 // enable IDE interrupt
                 usbdbg_set_irq_enabled(true);
-                #if OMV_ENABLE_WIFIDBG && MICROPY_PY_WINC1500
+                #if OMV_WIFIDBG_ENABLE && MICROPY_PY_WINC1500
                 wifidbg_set_irq_enabled(openmv_config.wifidbg);
                 #endif
 
@@ -527,7 +527,7 @@ else {
             if (nlr_push(&nlr) == 0) {
                 // Enable IDE interrupts
                 usbdbg_set_irq_enabled(true);
-                #if OMV_ENABLE_WIFIDBG && MICROPY_PY_WINC1500
+                #if OMV_WIFIDBG_ENABLE && MICROPY_PY_WINC1500
                 wifidbg_set_irq_enabled(openmv_config.wifidbg);
                 #endif
                 // Execute the script.
@@ -542,7 +542,7 @@ else {
             if (usbdbg_is_busy() && nlr_push(&nlr) == 0) {
                 // Enable IDE interrupt
                 usbdbg_set_irq_enabled(true);
-                #if OMV_ENABLE_WIFIDBG && MICROPY_PY_WINC1500
+                #if OMV_WIFIDBG_ENABLE && MICROPY_PY_WINC1500
                 wifidbg_set_irq_enabled(openmv_config.wifidbg);
                 #endif
                 // Wait for the current command to finish.

--- a/src/omv/ports/stm32/omv_i2c.c
+++ b/src/omv/ports/stm32/omv_i2c.c
@@ -100,39 +100,39 @@ int omv_i2c_init(omv_i2c_t *i2c, uint32_t bus_id, uint32_t speed) {
     i2c->sda_pin = NULL;
 
     switch (bus_id) {
-        #if defined(I2C1_ID)
+        #if defined(OMV_I2C1_ID)
         case 1: {
             i2c->inst = &I2CHandle1;
             i2c->inst->Instance = I2C1;
-            i2c->scl_pin = I2C1_SCL_PIN;
-            i2c->sda_pin = I2C1_SDA_PIN;
+            i2c->scl_pin = OMV_I2C1_SCL_PIN;
+            i2c->sda_pin = OMV_I2C1_SDA_PIN;
             break;
         }
         #endif
-        #if defined(I2C2_ID)
+        #if defined(OMV_I2C2_ID)
         case 2: {
             i2c->inst = &I2CHandle2;
             i2c->inst->Instance = I2C2;
-            i2c->scl_pin = I2C2_SCL_PIN;
-            i2c->sda_pin = I2C2_SDA_PIN;
+            i2c->scl_pin = OMV_I2C2_SCL_PIN;
+            i2c->sda_pin = OMV_I2C2_SDA_PIN;
             break;
         }
         #endif
-        #if defined(I2C3_ID)
+        #if defined(OMV_I2C3_ID)
         case 3: {
             i2c->inst = &I2CHandle3;
             i2c->inst->Instance = I2C3;
-            i2c->scl_pin = I2C3_SCL_PIN;
-            i2c->sda_pin = I2C3_SDA_PIN;
+            i2c->scl_pin = OMV_I2C3_SCL_PIN;
+            i2c->sda_pin = OMV_I2C3_SDA_PIN;
             break;
         }
         #endif
-        #if defined(I2C4_ID)
+        #if defined(OMV_I2C4_ID)
         case 4: {
             i2c->inst = &I2CHandle4;
             i2c->inst->Instance = I2C4;
-            i2c->scl_pin = I2C4_SCL_PIN;
-            i2c->sda_pin = I2C4_SDA_PIN;
+            i2c->scl_pin = OMV_I2C4_SCL_PIN;
+            i2c->sda_pin = OMV_I2C4_SDA_PIN;
             break;
         }
         #endif
@@ -203,28 +203,28 @@ static int omv_i2c_set_irq_state(omv_i2c_t *i2c, bool enabled) {
     IRQn_Type ev_irqn;
     IRQn_Type er_irqn;
     switch (i2c->id) {
-        #if defined(I2C1_ID)
+        #if defined(OMV_I2C1_ID)
         case 1: {
             ev_irqn = I2C1_EV_IRQn;
             er_irqn = I2C1_ER_IRQn;
             break;
         }
         #endif
-        #if defined(I2C2_ID)
+        #if defined(OMV_I2C2_ID)
         case 2: {
             ev_irqn = I2C2_EV_IRQn;
             er_irqn = I2C2_ER_IRQn;
             break;
         }
         #endif
-        #if defined(I2C3_ID)
+        #if defined(OMV_I2C3_ID)
         case 3: {
             ev_irqn = I2C3_EV_IRQn;
             er_irqn = I2C3_ER_IRQn;
             break;
         }
         #endif
-        #if defined(I2C4_ID)
+        #if defined(OMV_I2C4_ID)
         case 4: {
             ev_irqn = I2C4_EV_IRQn;
             er_irqn = I2C4_ER_IRQn;

--- a/src/omv/ports/stm32/omv_spi.c
+++ b/src/omv/ports/stm32/omv_spi.c
@@ -28,33 +28,33 @@
     static SPI_HandleTypeDef SPIHandle##n; \
     void SPI##n##_IRQHandler(void) { HAL_SPI_IRQHandler(&SPIHandle##n); }
 
-#if defined(SPI1_ID) && defined(MICROPY_HW_SPI1_SCK)
+#if defined(OMV_SPI1_ID) && defined(MICROPY_HW_SPI1_SCK)
 extern SPI_HandleTypeDef SPIHandle1;
-#elif defined(SPI1_ID)
+#elif defined(OMV_SPI1_ID)
 DEFINE_SPI_INSTANCE(1)
 #endif
 
-#if defined(SPI2_ID) && defined(MICROPY_HW_SPI2_SCK)
+#if defined(OMV_SPI2_ID) && defined(MICROPY_HW_SPI2_SCK)
 extern SPI_HandleTypeDef SPIHandle2;
-#elif defined(SPI2_ID)
+#elif defined(OMV_SPI2_ID)
 DEFINE_SPI_INSTANCE(2)
 #endif
 
-#if defined(SPI3_ID) && defined(MICROPY_HW_SPI3_SCK)
+#if defined(OMV_SPI3_ID) && defined(MICROPY_HW_SPI3_SCK)
 extern SPI_HandleTypeDef SPIHandle3;
-#elif defined(SPI3_ID)
+#elif defined(OMV_SPI3_ID)
 DEFINE_SPI_INSTANCE(3)
 #endif
 
-#if defined(SPI4_ID) && defined(MICROPY_HW_SPI4_SCK)
+#if defined(OMV_SPI4_ID) && defined(MICROPY_HW_SPI4_SCK)
 extern SPI_HandleTypeDef SPIHandle4;
-#elif defined(SPI4_ID)
+#elif defined(OMV_SPI4_ID)
 DEFINE_SPI_INSTANCE(4)
 #endif
 
-#if defined(SPI5_ID) && defined(MICROPY_HW_SPI5_SCK)
+#if defined(OMV_SPI5_ID) && defined(MICROPY_HW_SPI5_SCK)
 extern SPI_HandleTypeDef SPIHandle5;
-#elif defined(SPI5_ID)
+#elif defined(OMV_SPI5_ID)
 DEFINE_SPI_INSTANCE(5)
 #endif
 
@@ -64,17 +64,17 @@ extern SPI_HandleTypeDef SPIHandle6;
 DEFINE_SPI_INSTANCE(6)
 #endif
 
-#define INITIALIZE_SPI_DESCR(spi, spi_number)                                   \
-    do {                                                                        \
-        (spi)->id = spi_number;                                                 \
-        (spi)->irqn = SPI##spi_number##_IRQn;                                   \
-        (spi)->cs = SPI##spi_number##_SSEL_PIN;                                 \
-        (spi)->descr = &SPIHandle##spi_number;                                  \
-        (spi)->descr->Instance = SPI##spi_number;                               \
-        (spi)->dma_descr_tx = (DMA_HandleTypeDef)                               \
-        {SPI##spi_number##_DMA_TX_CHANNEL, {DMA_REQUEST_SPI##spi_number##_TX}}; \
-        (spi)->dma_descr_rx = (DMA_HandleTypeDef)                               \
-        {SPI##spi_number##_DMA_RX_CHANNEL, {DMA_REQUEST_SPI##spi_number##_RX}}; \
+#define INITIALIZE_SPI_DESCR(spi, spi_number)                                       \
+    do {                                                                            \
+        (spi)->id = spi_number;                                                     \
+        (spi)->irqn = SPI##spi_number##_IRQn;                                       \
+        (spi)->cs = OMV_SPI##spi_number##_SSEL_PIN;                                 \
+        (spi)->descr = &SPIHandle##spi_number;                                      \
+        (spi)->descr->Instance = SPI##spi_number;                                   \
+        (spi)->dma_descr_tx = (DMA_HandleTypeDef)                                   \
+        {OMV_SPI##spi_number##_DMA_TX_CHANNEL, {DMA_REQUEST_SPI##spi_number##_TX}}; \
+        (spi)->dma_descr_rx = (DMA_HandleTypeDef)                                   \
+        {OMV_SPI##spi_number##_DMA_RX_CHANNEL, {DMA_REQUEST_SPI##spi_number##_RX}}; \
     } while (0)
 
 static omv_spi_t *omv_spi_descr_all[6] = { NULL };
@@ -129,23 +129,23 @@ static int omv_spi_prescaler(SPI_TypeDef *spi, uint32_t baudrate) {
 static void omv_spi_callback(SPI_HandleTypeDef *hspi) {
     omv_spi_t *spi = NULL;
     if (0) {
-    #if defined(SPI1_ID)
+    #if defined(OMV_SPI1_ID)
     } else if (hspi->Instance == SPI1) {
         spi = omv_spi_descr_all[0];
     #endif
-    #if defined(SPI2_ID)
+    #if defined(OMV_SPI2_ID)
     } else if (hspi->Instance == SPI2) {
         spi = omv_spi_descr_all[1];
     #endif
-    #if defined(SPI3_ID)
+    #if defined(OMV_SPI3_ID)
     } else if (hspi->Instance == SPI3) {
         spi = omv_spi_descr_all[2];
     #endif
-    #if defined(SPI4_ID)
+    #if defined(OMV_SPI4_ID)
     } else if (hspi->Instance == SPI4) {
         spi = omv_spi_descr_all[3];
     #endif
-    #if defined(SPI5_ID)
+    #if defined(OMV_SPI5_ID)
     } else if (hspi->Instance == SPI5) {
         spi = omv_spi_descr_all[4];
     #endif
@@ -359,23 +359,23 @@ int omv_spi_init(omv_spi_t *spi, omv_spi_config_t *config) {
     memset(spi, 0, sizeof(omv_spi_t));
 
     if (0) {
-    #if defined(SPI1_ID)
+    #if defined(OMV_SPI1_ID)
     } else if (config->id == 1) {
         INITIALIZE_SPI_DESCR(spi, 1);
     #endif
-    #if defined(SPI2_ID)
+    #if defined(OMV_SPI2_ID)
     } else if (config->id == 2) {
         INITIALIZE_SPI_DESCR(spi, 2);
     #endif
-    #if defined(SPI3_ID)
+    #if defined(OMV_SPI3_ID)
     } else if (config->id == 3) {
         INITIALIZE_SPI_DESCR(spi, 3);
     #endif
-    #if defined(SPI4_ID)
+    #if defined(OMV_SPI4_ID)
     } else if (config->id == 4) {
         INITIALIZE_SPI_DESCR(spi, 4);
     #endif
-    #if defined(SPI5_ID)
+    #if defined(OMV_SPI5_ID)
     } else if (config->id == 5) {
         INITIALIZE_SPI_DESCR(spi, 5);
     #endif

--- a/src/omv/ports/stm32/soft_i2c.c
+++ b/src/omv/ports/stm32/soft_i2c.c
@@ -17,12 +17,12 @@
 #include "omv_boardconfig.h"
 #include "omv_gpio.h"
 
-#if defined(SOFT_I2C_SIOC_PIN)
+#if defined(OMV_SOFT_I2C_SIOC_PIN)
 #define ACK     0
 #define NACK    1
 
 static void delay(void) {
-    for (volatile int i = 0; i < SOFT_I2C_SPIN_DELAY; i++) {
+    for (volatile int i = 0; i < OMV_SOFT_I2C_SPIN_DELAY; i++) {
         ;
     }
 }
@@ -30,47 +30,47 @@ static void delay(void) {
 static void i2c_start(void) {
     /* The start of data transmission occurs when
        SIO_D is driven low while SIO_C is high */
-    omv_gpio_write(SOFT_I2C_SIOD_PIN, 0);
+    omv_gpio_write(OMV_SOFT_I2C_SIOD_PIN, 0);
     delay();
-    omv_gpio_write(SOFT_I2C_SIOC_PIN, 0);
+    omv_gpio_write(OMV_SOFT_I2C_SIOC_PIN, 0);
     delay();
 }
 
 static void i2c_stop(void) {
     /* The stop of data transmission occurs when
        SIO_D is driven high while SIO_C is high */
-    omv_gpio_write(SOFT_I2C_SIOC_PIN, 1);
+    omv_gpio_write(OMV_SOFT_I2C_SIOC_PIN, 1);
     delay();
-    omv_gpio_write(SOFT_I2C_SIOD_PIN, 1);
+    omv_gpio_write(OMV_SOFT_I2C_SIOD_PIN, 1);
     delay();
 }
 
 static uint8_t i2c_read_byte(char ack) {
     uint8_t data = 0;
 
-    omv_gpio_write(SOFT_I2C_SIOD_PIN, 1);
+    omv_gpio_write(OMV_SOFT_I2C_SIOD_PIN, 1);
     delay();
 
     for (char i = 0; i < 8; i++) {
-        omv_gpio_write(SOFT_I2C_SIOC_PIN, 1);
+        omv_gpio_write(OMV_SOFT_I2C_SIOC_PIN, 1);
         delay();
-        data += data + omv_gpio_read(SOFT_I2C_SIOD_PIN);
+        data += data + omv_gpio_read(OMV_SOFT_I2C_SIOD_PIN);
         delay();
-        omv_gpio_write(SOFT_I2C_SIOC_PIN, 0);
+        omv_gpio_write(OMV_SOFT_I2C_SIOC_PIN, 0);
         delay();
     }
 
     /* Write ACK */
-    omv_gpio_write(SOFT_I2C_SIOD_PIN, ack);
+    omv_gpio_write(OMV_SOFT_I2C_SIOD_PIN, ack);
     delay();
 
-    omv_gpio_write(SOFT_I2C_SIOC_PIN, 1);
+    omv_gpio_write(OMV_SOFT_I2C_SIOC_PIN, 1);
     delay();
 
-    omv_gpio_write(SOFT_I2C_SIOC_PIN, 0);
+    omv_gpio_write(OMV_SOFT_I2C_SIOC_PIN, 0);
     delay();
 
-    omv_gpio_write(SOFT_I2C_SIOD_PIN, 0);
+    omv_gpio_write(OMV_SOFT_I2C_SIOD_PIN, 0);
     delay();
     return data;
 }
@@ -79,28 +79,28 @@ static char i2c_write_byte(uint8_t data) {
     char i;
 
     for (i = 0; i < 8; i++) {
-        omv_gpio_write(SOFT_I2C_SIOD_PIN, (data >> (7 - i)) & 1);
+        omv_gpio_write(OMV_SOFT_I2C_SIOD_PIN, (data >> (7 - i)) & 1);
         delay();
-        omv_gpio_write(SOFT_I2C_SIOC_PIN, 1);
+        omv_gpio_write(OMV_SOFT_I2C_SIOC_PIN, 1);
         delay();
-        omv_gpio_write(SOFT_I2C_SIOC_PIN, 0);
+        omv_gpio_write(OMV_SOFT_I2C_SIOC_PIN, 0);
         delay();
     }
 
-    omv_gpio_write(SOFT_I2C_SIOD_PIN, 1);
+    omv_gpio_write(OMV_SOFT_I2C_SIOD_PIN, 1);
     delay();
 
-    omv_gpio_write(SOFT_I2C_SIOC_PIN, 1);
+    omv_gpio_write(OMV_SOFT_I2C_SIOC_PIN, 1);
     delay();
 
     /* Read ACK */
-    i = omv_gpio_read(SOFT_I2C_SIOD_PIN);
+    i = omv_gpio_read(OMV_SOFT_I2C_SIOD_PIN);
     delay();
 
-    omv_gpio_write(SOFT_I2C_SIOC_PIN, 0);
+    omv_gpio_write(OMV_SOFT_I2C_SIOC_PIN, 0);
     delay();
 
-    omv_gpio_write(SOFT_I2C_SIOD_PIN, 0);
+    omv_gpio_write(OMV_SOFT_I2C_SIOD_PIN, 0);
     delay();
     return i;
 }
@@ -116,9 +116,9 @@ int soft_i2c_read_bytes(uint8_t slv_addr, uint8_t *buf, int len, bool stop) {
     if (stop) {
         i2c_stop();
     } else {
-        omv_gpio_write(SOFT_I2C_SIOD_PIN, 1);
+        omv_gpio_write(OMV_SOFT_I2C_SIOD_PIN, 1);
         delay();
-        omv_gpio_write(SOFT_I2C_SIOC_PIN, 1);
+        omv_gpio_write(OMV_SOFT_I2C_SIOC_PIN, 1);
         delay();
     }
     MICROPY_END_ATOMIC_SECTION(atomic_state);
@@ -136,9 +136,9 @@ int soft_i2c_write_bytes(uint8_t slv_addr, uint8_t *buf, int len, bool stop) {
     if (stop) {
         i2c_stop();
     } else {
-        omv_gpio_write(SOFT_I2C_SIOD_PIN, 1);
+        omv_gpio_write(OMV_SOFT_I2C_SIOD_PIN, 1);
         delay();
-        omv_gpio_write(SOFT_I2C_SIOC_PIN, 1);
+        omv_gpio_write(OMV_SOFT_I2C_SIOC_PIN, 1);
         delay();
     }
     MICROPY_END_ATOMIC_SECTION(atomic_state);
@@ -146,11 +146,11 @@ int soft_i2c_write_bytes(uint8_t slv_addr, uint8_t *buf, int len, bool stop) {
 }
 
 void soft_i2c_init() {
-    omv_gpio_write(SOFT_I2C_SIOC_PIN, 1); // Set first to prevent glitches.
-    omv_gpio_config(SOFT_I2C_SIOC_PIN, OMV_GPIO_MODE_OUTPUT_OD, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_LOW, -1);
+    omv_gpio_write(OMV_SOFT_I2C_SIOC_PIN, 1); // Set first to prevent glitches.
+    omv_gpio_config(OMV_SOFT_I2C_SIOC_PIN, OMV_GPIO_MODE_OUTPUT_OD, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_LOW, -1);
 
-    omv_gpio_write(SOFT_I2C_SIOD_PIN, 1); // Set first to prevent glitches.
-    omv_gpio_config(SOFT_I2C_SIOD_PIN, OMV_GPIO_MODE_OUTPUT_OD, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_LOW, -1);
+    omv_gpio_write(OMV_SOFT_I2C_SIOD_PIN, 1); // Set first to prevent glitches.
+    omv_gpio_config(OMV_SOFT_I2C_SIOD_PIN, OMV_GPIO_MODE_OUTPUT_OD, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_LOW, -1);
 
     for (volatile int i = 0; i < 1000; i++) {
         ;
@@ -166,7 +166,7 @@ void soft_i2c_deinit() {
     for (volatile int i = 0; i < 1000; i++) {
         ;
     }
-    omv_gpio_deinit(SOFT_I2C_SIOC_PIN);
-    omv_gpio_deinit(SOFT_I2C_SIOD_PIN);
+    omv_gpio_deinit(OMV_SOFT_I2C_SIOC_PIN);
+    omv_gpio_deinit(OMV_SOFT_I2C_SIOD_PIN);
 }
-#endif // defined(SOFT_I2C_SIOC_PIN)
+#endif // defined(OMV_SOFT_I2C_SIOC_PIN)

--- a/src/omv/ports/stm32/soft_i2c.h
+++ b/src/omv/ports/stm32/soft_i2c.h
@@ -8,11 +8,11 @@
  *
  * Software I2C implementation.
  */
-#ifndef __SOFT_I2C_H__
-#define __SOFT_I2C_H__
+#ifndef __OMV_SOFT_I2C_H__
+#define __OMV_SOFT_I2C_H__
 #include <stdint.h>
 int soft_i2c_read_bytes(uint8_t slv_addr, uint8_t *buf, int len, bool stop);
 int soft_i2c_write_bytes(uint8_t slv_addr, uint8_t *buf, int len, bool stop);
 void soft_i2c_init();
 void soft_i2c_deinit();
-#endif // __SOFT_I2C_H__
+#endif // __OMV_SOFT_I2C_H__

--- a/src/omv/ports/stm32/stm32fxxx_hal_msp.c
+++ b/src/omv/ports/stm32/stm32fxxx_hal_msp.c
@@ -108,22 +108,22 @@ void HAL_MspInit(void) {
     __GPIOC_CLK_ENABLE();
     __GPIOD_CLK_ENABLE();
     __GPIOE_CLK_ENABLE();
-    #if OMV_ENABLE_GPIO_BANK_F
+    #if OMV_GPIO_PORT_F_ENABLE
     __GPIOF_CLK_ENABLE();
     #endif
-    #if OMV_ENABLE_GPIO_BANK_G
+    #if OMV_GPIO_PORT_G_ENABLE
     __GPIOG_CLK_ENABLE();
     #endif
-    #if OMV_ENABLE_GPIO_BANK_H
+    #if OMV_GPIO_PORT_H_ENABLE
     __GPIOH_CLK_ENABLE();
     #endif
-    #if OMV_ENABLE_GPIO_BANK_I
+    #if OMV_GPIO_PORT_I_ENABLE
     __GPIOI_CLK_ENABLE();
     #endif
-    #if OMV_ENABLE_GPIO_BANK_J
+    #if OMV_GPIO_PORT_J_ENABLE
     __GPIOJ_CLK_ENABLE();
     #endif
-    #if OMV_ENABLE_GPIO_BANK_K
+    #if OMV_GPIO_PORT_K_ENABLE
     __GPIOK_CLK_ENABLE();
     #endif
 
@@ -176,14 +176,14 @@ void HAL_MspInit(void) {
     OMV_AXI_QOS_LTDC_W_SET(OMV_AXI_QOS_LTDC_W_PRI);
     #endif
 
-    #if defined(DCMI_RESET_PIN)
-    omv_gpio_config(DCMI_RESET_PIN, OMV_GPIO_MODE_OUTPUT, OMV_GPIO_PULL_DOWN, OMV_GPIO_SPEED_LOW, -1);
+    #if defined(OMV_CSI_RESET_PIN)
+    omv_gpio_config(OMV_CSI_RESET_PIN, OMV_GPIO_MODE_OUTPUT, OMV_GPIO_PULL_DOWN, OMV_GPIO_SPEED_LOW, -1);
     #endif
-    #if defined(DCMI_FSYNC_PIN)
-    omv_gpio_config(DCMI_FSYNC_PIN, OMV_GPIO_MODE_OUTPUT, OMV_GPIO_PULL_DOWN, OMV_GPIO_SPEED_LOW, -1);
+    #if defined(OMV_CSI_FSYNC_PIN)
+    omv_gpio_config(OMV_CSI_FSYNC_PIN, OMV_GPIO_MODE_OUTPUT, OMV_GPIO_PULL_DOWN, OMV_GPIO_SPEED_LOW, -1);
     #endif
-    #if defined(DCMI_POWER_PIN)
-    omv_gpio_config(DCMI_POWER_PIN, OMV_GPIO_MODE_OUTPUT, OMV_GPIO_PULL_UP, OMV_GPIO_SPEED_LOW, -1);
+    #if defined(OMV_CSI_POWER_PIN)
+    omv_gpio_config(OMV_CSI_POWER_PIN, OMV_GPIO_MODE_OUTPUT, OMV_GPIO_PULL_UP, OMV_GPIO_SPEED_LOW, -1);
     #endif
 
     #if defined(OMV_FIR_LEPTON_RESET_PIN)
@@ -215,29 +215,29 @@ void HAL_I2C_MspInit(I2C_HandleTypeDef *hi2c) {
     omv_gpio_t sda_pin = NULL;
 
     if (0) {
-    #if defined(I2C1_ID)
+    #if defined(OMV_I2C1_ID)
     } else if (hi2c->Instance == I2C1) {
         __HAL_RCC_I2C1_CLK_ENABLE();
-        scl_pin = I2C1_SCL_PIN;
-        sda_pin = I2C1_SDA_PIN;
+        scl_pin = OMV_I2C1_SCL_PIN;
+        sda_pin = OMV_I2C1_SDA_PIN;
     #endif
-    #if defined(I2C2_ID)
+    #if defined(OMV_I2C2_ID)
     } else if (hi2c->Instance == I2C2) {
         __HAL_RCC_I2C2_CLK_ENABLE();
-        scl_pin = I2C2_SCL_PIN;
-        sda_pin = I2C2_SDA_PIN;
+        scl_pin = OMV_I2C2_SCL_PIN;
+        sda_pin = OMV_I2C2_SDA_PIN;
     #endif
-    #if defined(I2C3_ID)
+    #if defined(OMV_I2C3_ID)
     } else if (hi2c->Instance == I2C3) {
         __HAL_RCC_I2C3_CLK_ENABLE();
-        scl_pin = I2C3_SCL_PIN;
-        sda_pin = I2C3_SDA_PIN;
+        scl_pin = OMV_I2C3_SCL_PIN;
+        sda_pin = OMV_I2C3_SDA_PIN;
     #endif
-    #if defined(I2C4_ID)
+    #if defined(OMV_I2C4_ID)
     } else if (hi2c->Instance == I2C4) {
         __HAL_RCC_I2C4_CLK_ENABLE();
-        scl_pin = I2C4_SCL_PIN;
-        sda_pin = I2C4_SDA_PIN;
+        scl_pin = OMV_I2C4_SCL_PIN;
+        sda_pin = OMV_I2C4_SDA_PIN;
     #endif
     }
 
@@ -249,25 +249,25 @@ void HAL_I2C_MspInit(I2C_HandleTypeDef *hi2c) {
 
 void HAL_I2C_MspDeInit(I2C_HandleTypeDef *hi2c) {
     if (0) {
-    #if defined(I2C1_ID)
+    #if defined(OMV_I2C1_ID)
     } else if (hi2c->Instance == I2C1) {
         __HAL_RCC_I2C1_FORCE_RESET();
         __HAL_RCC_I2C1_RELEASE_RESET();
         __HAL_RCC_I2C1_CLK_DISABLE();
     #endif
-    #if defined(I2C2_ID)
+    #if defined(OMV_I2C2_ID)
     } else if (hi2c->Instance == I2C2) {
         __HAL_RCC_I2C2_FORCE_RESET();
         __HAL_RCC_I2C2_RELEASE_RESET();
         __HAL_RCC_I2C2_CLK_DISABLE();
     #endif
-    #if defined(I2C3_ID)
+    #if defined(OMV_I2C3_ID)
     } else if (hi2c->Instance == I2C3) {
         __HAL_RCC_I2C3_FORCE_RESET();
         __HAL_RCC_I2C3_RELEASE_RESET();
         __HAL_RCC_I2C3_CLK_DISABLE();
     #endif
-    #if defined(I2C4_ID)
+    #if defined(OMV_I2C4_ID)
     } else if (hi2c->Instance == I2C4) {
         __HAL_RCC_I2C4_FORCE_RESET();
         __HAL_RCC_I2C4_RELEASE_RESET();
@@ -277,17 +277,17 @@ void HAL_I2C_MspDeInit(I2C_HandleTypeDef *hi2c) {
 }
 
 void HAL_TIM_PWM_MspInit(TIM_HandleTypeDef *htim) {
-    #if (OMV_XCLK_SOURCE == OMV_XCLK_TIM)
-    if (htim->Instance == DCMI_TIM) {
+    #if (OMV_CSI_XCLK_SOURCE == XCLK_SOURCE_TIM)
+    if (htim->Instance == OMV_CSI_TIM) {
         // Enable DCMI timer clock.
-        DCMI_TIM_CLK_ENABLE();
+        OMV_CSI_TIM_CLK_ENABLE();
         // Timer GPIO configuration.
-        omv_gpio_config(DCMI_TIM_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_UP, OMV_GPIO_SPEED_HIGH, -1);
-        #if defined(DCMI_TIM_EXT_PIN)
-        omv_gpio_config(DCMI_TIM_EXT_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_UP, OMV_GPIO_SPEED_HIGH, -1);
+        omv_gpio_config(OMV_CSI_TIM_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_UP, OMV_GPIO_SPEED_HIGH, -1);
+        #if defined(OMV_CSI_TIM_EXT_PIN)
+        omv_gpio_config(OMV_CSI_TIM_EXT_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_UP, OMV_GPIO_SPEED_HIGH, -1);
         #endif
     }
-    #endif // (OMV_XCLK_SOURCE == OMV_XCLK_TIM)
+    #endif // (OMV_CSI_XCLK_SOURCE == XCLK_SOURCE_TIM)
 
     #if defined(OMV_BUZZER_TIM)
     if (htim->Instance == OMV_BUZZER_TIM) {
@@ -308,17 +308,17 @@ void HAL_TIM_PWM_MspDeInit(TIM_HandleTypeDef *htim) {
 
 void HAL_DCMI_MspInit(DCMI_HandleTypeDef *hdcmi) {
     const omv_gpio_t dcmi_pins[] = {
-        DCMI_D0_PIN,
-        DCMI_D1_PIN,
-        DCMI_D2_PIN,
-        DCMI_D3_PIN,
-        DCMI_D4_PIN,
-        DCMI_D5_PIN,
-        DCMI_D6_PIN,
-        DCMI_D7_PIN,
-        DCMI_HSYNC_PIN,
-        DCMI_VSYNC_PIN,
-        DCMI_PXCLK_PIN,
+        OMV_CSI_D0_PIN,
+        OMV_CSI_D1_PIN,
+        OMV_CSI_D2_PIN,
+        OMV_CSI_D3_PIN,
+        OMV_CSI_D4_PIN,
+        OMV_CSI_D5_PIN,
+        OMV_CSI_D6_PIN,
+        OMV_CSI_D7_PIN,
+        OMV_CSI_HSYNC_PIN,
+        OMV_CSI_VSYNC_PIN,
+        OMV_CSI_PXCLK_PIN,
     };
 
     // DCMI clock enable
@@ -329,7 +329,7 @@ void HAL_DCMI_MspInit(DCMI_HandleTypeDef *hdcmi) {
     if (exti_gpio == 0)
     #endif
     {
-        omv_gpio_config(DCMI_VSYNC_PIN, OMV_GPIO_MODE_IT_BOTH, OMV_GPIO_PULL_UP, OMV_GPIO_SPEED_MAX, -1);
+        omv_gpio_config(OMV_CSI_VSYNC_PIN, OMV_GPIO_MODE_IT_BOTH, OMV_GPIO_PULL_UP, OMV_GPIO_SPEED_MAX, -1);
     }
 
     // Configure DCMI pins.
@@ -340,17 +340,17 @@ void HAL_DCMI_MspInit(DCMI_HandleTypeDef *hdcmi) {
 
 void HAL_DCMI_MspDeInit(DCMI_HandleTypeDef *hdcmi) {
     const omv_gpio_t dcmi_pins[] = {
-        DCMI_D0_PIN,
-        DCMI_D1_PIN,
-        DCMI_D2_PIN,
-        DCMI_D3_PIN,
-        DCMI_D4_PIN,
-        DCMI_D5_PIN,
-        DCMI_D6_PIN,
-        DCMI_D7_PIN,
-        DCMI_HSYNC_PIN,
-        DCMI_VSYNC_PIN,
-        DCMI_PXCLK_PIN,
+        OMV_CSI_D0_PIN,
+        OMV_CSI_D1_PIN,
+        OMV_CSI_D2_PIN,
+        OMV_CSI_D3_PIN,
+        OMV_CSI_D4_PIN,
+        OMV_CSI_D5_PIN,
+        OMV_CSI_D6_PIN,
+        OMV_CSI_D7_PIN,
+        OMV_CSI_HSYNC_PIN,
+        OMV_CSI_VSYNC_PIN,
+        OMV_CSI_PXCLK_PIN,
     };
 
     // Disable DCMI clock.
@@ -373,39 +373,39 @@ void HAL_SPI_MspInit(SPI_HandleTypeDef *hspi) {
     spi_pins_t spi_pins = { NULL, NULL, NULL, NULL };
 
     if (0) {
-    #if defined(SPI1_ID)
+    #if defined(OMV_SPI1_ID)
     } else if (hspi->Instance == SPI1) {
         __HAL_RCC_SPI1_CLK_ENABLE();
         spi_pins = (spi_pins_t) {
-            SPI1_SCLK_PIN, SPI1_MISO_PIN, SPI1_MOSI_PIN, SPI1_SSEL_PIN
+            OMV_SPI1_SCLK_PIN, OMV_SPI1_MISO_PIN, OMV_SPI1_MOSI_PIN, OMV_SPI1_SSEL_PIN
         };
     #endif
-    #if defined(SPI2_ID)
+    #if defined(OMV_SPI2_ID)
     } else if (hspi->Instance == SPI2) {
         __HAL_RCC_SPI2_CLK_ENABLE();
         spi_pins = (spi_pins_t) {
-            SPI2_SCLK_PIN, SPI2_MISO_PIN, SPI2_MOSI_PIN, SPI2_SSEL_PIN
+            OMV_SPI2_SCLK_PIN, OMV_SPI2_MISO_PIN, OMV_SPI2_MOSI_PIN, OMV_SPI2_SSEL_PIN
         };
     #endif
-    #if defined(SPI3_ID)
+    #if defined(OMV_SPI3_ID)
     } else if (hspi->Instance == SPI3) {
         __HAL_RCC_SPI3_CLK_ENABLE();
         spi_pins = (spi_pins_t) {
-            SPI3_SCLK_PIN, SPI3_MISO_PIN, SPI3_MOSI_PIN, SPI3_SSEL_PIN
+            OMV_SPI3_SCLK_PIN, OMV_SPI3_MISO_PIN, OMV_SPI3_MOSI_PIN, OMV_SPI3_SSEL_PIN
         };
     #endif
-    #if defined(SPI4_ID)
+    #if defined(OMV_SPI4_ID)
     } else if (hspi->Instance == SPI4) {
         __HAL_RCC_SPI4_CLK_ENABLE();
         spi_pins = (spi_pins_t) {
-            SPI4_SCLK_PIN, SPI4_MISO_PIN, SPI4_MOSI_PIN, SPI4_SSEL_PIN
+            OMV_SPI4_SCLK_PIN, OMV_SPI4_MISO_PIN, OMV_SPI4_MOSI_PIN, OMV_SPI4_SSEL_PIN
         };
     #endif
-    #if defined(SPI5_ID)
+    #if defined(OMV_SPI5_ID)
     } else if (hspi->Instance == SPI5) {
         __HAL_RCC_SPI5_CLK_ENABLE();
         spi_pins = (spi_pins_t) {
-            SPI5_SCLK_PIN, SPI5_MISO_PIN, SPI5_MOSI_PIN, SPI5_SSEL_PIN
+            OMV_SPI5_SCLK_PIN, OMV_SPI5_MISO_PIN, OMV_SPI5_MOSI_PIN, OMV_SPI5_SSEL_PIN
         };
     #endif
     #if defined(SPI6_ID)
@@ -459,49 +459,49 @@ void HAL_SPI_MspDeInit(SPI_HandleTypeDef *hspi) {
     spi_pins_t spi_pins = { NULL, NULL, NULL, NULL };
 
     if (0) {
-    #if defined(SPI1_ID)
+    #if defined(OMV_SPI1_ID)
     } else if (hspi->Instance == SPI1) {
         __HAL_RCC_SPI1_FORCE_RESET();
         __HAL_RCC_SPI1_RELEASE_RESET();
         __HAL_RCC_SPI1_CLK_DISABLE();
         spi_pins = (spi_pins_t) {
-            SPI1_SCLK_PIN, SPI1_MISO_PIN, SPI1_MOSI_PIN, SPI1_SSEL_PIN
+            OMV_SPI1_SCLK_PIN, OMV_SPI1_MISO_PIN, OMV_SPI1_MOSI_PIN, OMV_SPI1_SSEL_PIN
         };
     #endif
-    #if defined(SPI2_ID)
+    #if defined(OMV_SPI2_ID)
     } else if (hspi->Instance == SPI2) {
         __HAL_RCC_SPI2_FORCE_RESET();
         __HAL_RCC_SPI2_RELEASE_RESET();
         __HAL_RCC_SPI2_CLK_DISABLE();
         spi_pins = (spi_pins_t) {
-            SPI2_SCLK_PIN, SPI2_MISO_PIN, SPI2_MOSI_PIN, SPI2_SSEL_PIN
+            OMV_SPI2_SCLK_PIN, OMV_SPI2_MISO_PIN, OMV_SPI2_MOSI_PIN, OMV_SPI2_SSEL_PIN
         };
     #endif
-    #if defined(SPI3_ID)
+    #if defined(OMV_SPI3_ID)
     } else if (hspi->Instance == SPI3) {
         __HAL_RCC_SPI3_FORCE_RESET();
         __HAL_RCC_SPI3_RELEASE_RESET();
         __HAL_RCC_SPI3_CLK_DISABLE();
         spi_pins = (spi_pins_t) {
-            SPI3_SCLK_PIN, SPI3_MISO_PIN, SPI3_MOSI_PIN, SPI3_SSEL_PIN
+            OMV_SPI3_SCLK_PIN, OMV_SPI3_MISO_PIN, OMV_SPI3_MOSI_PIN, OMV_SPI3_SSEL_PIN
         };
     #endif
-    #if defined(SPI4_ID)
+    #if defined(OMV_SPI4_ID)
     } else if (hspi->Instance == SPI4) {
         __HAL_RCC_SPI4_FORCE_RESET();
         __HAL_RCC_SPI4_RELEASE_RESET();
         __HAL_RCC_SPI4_CLK_DISABLE();
         spi_pins = (spi_pins_t) {
-            SPI4_SCLK_PIN, SPI4_MISO_PIN, SPI4_MOSI_PIN, SPI4_SSEL_PIN
+            OMV_SPI4_SCLK_PIN, OMV_SPI4_MISO_PIN, OMV_SPI4_MOSI_PIN, OMV_SPI4_SSEL_PIN
         };
     #endif
-    #if defined(SPI5_ID)
+    #if defined(OMV_SPI5_ID)
     } else if (hspi->Instance == SPI5) {
         __HAL_RCC_SPI5_FORCE_RESET();
         __HAL_RCC_SPI5_RELEASE_RESET();
         __HAL_RCC_SPI5_CLK_DISABLE();
         spi_pins = (spi_pins_t) {
-            SPI5_SCLK_PIN, SPI5_MISO_PIN, SPI5_MOSI_PIN, SPI5_SSEL_PIN
+            OMV_SPI5_SCLK_PIN, OMV_SPI5_MISO_PIN, OMV_SPI5_MOSI_PIN, OMV_SPI5_SSEL_PIN
         };
     #endif
     #if defined(SPI6_ID)
@@ -525,36 +525,36 @@ void HAL_SPI_MspDeInit(SPI_HandleTypeDef *hspi) {
     // omv_gpio_deinit(spi_pins.ssel_pin);
 }
 
-#if defined(AUDIO_SAI)
+#if defined(OMV_SAI)
 void HAL_SAI_MspInit(SAI_HandleTypeDef *hsai) {
-    if (hsai->Instance == AUDIO_SAI) {
-        AUDIO_SAI_CLK_ENABLE();
-        omv_gpio_config(AUDIO_SAI_CK_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_LOW, -1);
-        omv_gpio_config(AUDIO_SAI_D1_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_LOW, -1);
+    if (hsai->Instance == OMV_SAI) {
+        OMV_SAI_CLK_ENABLE();
+        omv_gpio_config(OMV_SAI_CK_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_LOW, -1);
+        omv_gpio_config(OMV_SAI_D1_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_LOW, -1);
     }
 }
 
 void HAL_SAI_MspDeInit(SAI_HandleTypeDef *hsai) {
     if (hsai->Instance == SAI4_Block_A) {
-        AUDIO_SAI_CLK_DISABLE();
-        omv_gpio_deinit(AUDIO_SAI_CK_PIN);
-        omv_gpio_deinit(AUDIO_SAI_D1_PIN);
+        OMV_SAI_CLK_DISABLE();
+        omv_gpio_deinit(OMV_SAI_CK_PIN);
+        omv_gpio_deinit(OMV_SAI_D1_PIN);
     }
 }
-#elif defined(AUDIO_DFSDM)
+#elif defined(OMV_DFSDM)
 void HAL_DFSDM_ChannelMspInit(DFSDM_Channel_HandleTypeDef *hdfsdm) {
-    if (hdfsdm->Instance == AUDIO_DFSDM) {
-        AUDIO_DFSDM_CLK_ENABLE();
-        omv_gpio_config(AUDIO_DFSDM_CK_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_LOW, -1);
-        omv_gpio_config(AUDIO_DFSDM_D1_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_LOW, -1);
+    if (hdfsdm->Instance == OMV_DFSDM) {
+        OMV_DFSDM_CLK_ENABLE();
+        omv_gpio_config(OMV_DFSDM_CK_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_LOW, -1);
+        omv_gpio_config(OMV_DFSDM_D1_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_LOW, -1);
     }
 }
 
 void HAL_DFSDM_ChannelMspDeInit(DFSDM_Channel_HandleTypeDef *hdfsdm) {
-    if (hdfsdm->Instance == AUDIO_DFSDM) {
-        AUDIO_DFSDM_CLK_DISABLE();
-        omv_gpio_deinit(AUDIO_DFSDM_CK_PIN);
-        omv_gpio_deinit(AUDIO_DFSDM_D1_PIN);
+    if (hdfsdm->Instance == OMV_DFSDM) {
+        OMV_DFSDM_CLK_DISABLE();
+        omv_gpio_deinit(OMV_DFSDM_CK_PIN);
+        omv_gpio_deinit(OMV_DFSDM_D1_PIN);
     }
 }
 #endif
@@ -577,7 +577,7 @@ void HAL_DMA2D_MspDeInit(DMA2D_HandleTypeDef *hdma2d) {
     __HAL_RCC_DMA2D_CLK_DISABLE();
 }
 
-#if (OMV_HARDWARE_JPEG == 1)
+#if (OMV_JPEG_CODEC_ENABLE == 1)
 void HAL_JPEG_MspInit(JPEG_HandleTypeDef *hjpeg) {
     __HAL_RCC_JPEG_CLK_ENABLE();
 }
@@ -706,7 +706,7 @@ void HAL_MspDeInit(void) {
 
 void MDMA_IRQHandler() {
     IRQ_ENTER(MDMA_IRQn);
-    #if (OMV_HARDWARE_JPEG == 1)
+    #if (OMV_JPEG_CODEC_ENABLE == 1)
     extern void jpeg_mdma_irq_handler(void);
     jpeg_mdma_irq_handler();
     #endif

--- a/src/omv/ports/stm32/wifidbg.c
+++ b/src/omv/ports/stm32/wifidbg.c
@@ -9,7 +9,7 @@
  * WiFi debugger.
  */
 #include "omv_boardconfig.h"
-#if OMV_ENABLE_WIFIDBG && MICROPY_PY_WINC1500
+#if OMV_WIFIDBG_ENABLE && MICROPY_PY_WINC1500
 
 #include <string.h>
 #include <stdint.h>
@@ -255,7 +255,7 @@ void wifidbg_set_irq_enabled(bool enable) {
         systick_disable_dispatch(SYSTICK_DISPATCH_WINC);
     }
 }
-#endif // OMV_ENABLE_WIFIDBG && MICROPY_PY_WINC1500
+#endif // OMV_WIFIDBG_ENABLE && MICROPY_PY_WINC1500
 
 // Old timer dispatch, will be removed.
 void wifidbg_dispatch() {

--- a/src/omv/sensors/frogeye2020.c
+++ b/src/omv/sensors/frogeye2020.c
@@ -9,7 +9,7 @@
  * FrogEye2020 driver.
  */
 #include "omv_boardconfig.h"
-#if (OMV_ENABLE_FROGEYE2020 == 1)
+#if (OMV_FROGEYE2020_ENABLE == 1)
 
 #include "sensor.h"
 
@@ -29,4 +29,4 @@ int frogeye2020_init(sensor_t *sensor) {
     return 0;
 }
 
-#endif // (OMV_ENABLE_FROGEYE2020 == 1)
+#endif // (OMV_FROGEYE2020_ENABLE == 1)

--- a/src/omv/sensors/frogeye2020.h
+++ b/src/omv/sensors/frogeye2020.h
@@ -10,6 +10,6 @@
  */
 #ifndef __FROGEYE2020_H__
 #define __FROGEYE2020_H__
-#define FROGEYE2020_XCLK_FREQ    (5000000)
+#define OMV_FROGEYE2020_XCLK_FREQ    (5000000)
 int frogeye2020_init(sensor_t *sensor);
 #endif // __FROGEYE2020_H__

--- a/src/omv/sensors/gc2145.c
+++ b/src/omv/sensors/gc2145.c
@@ -9,7 +9,7 @@
  * GC2145 driver.
  */
 #include "omv_boardconfig.h"
-#if (OMV_ENABLE_GC2145 == 1)
+#if (OMV_GC2145_ENABLE == 1)
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -1006,4 +1006,4 @@ int gc2145_init(sensor_t *sensor) {
 
     return 0;
 }
-#endif // (OMV_ENABLE_GC2145 == 1)
+#endif // (OMV_GC2145_ENABLE == 1)

--- a/src/omv/sensors/gc2145.h
+++ b/src/omv/sensors/gc2145.h
@@ -10,6 +10,6 @@
  */
 #ifndef __GC2145_H__
 #define __GC2145_H__
-#define GC2145_XCLK_FREQ    (12000000)
+#define OMV_GC2145_XCLK_FREQ    (12000000)
 int gc2145_init(sensor_t *sensor);
 #endif // __GC2145_H__

--- a/src/omv/sensors/hm01b0.c
+++ b/src/omv/sensors/hm01b0.c
@@ -9,7 +9,7 @@
  * HM01B0 driver.
  */
 #include "omv_boardconfig.h"
-#if (OMV_ENABLE_HM01B0 == 1)
+#if (OMV_HM01B0_ENABLE == 1)
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -377,7 +377,7 @@ static int get_vt_pix_clk(sensor_t *sensor, uint32_t *vt_pix_clk) {
     uint32_t vt_sys_div = 8 / (1 << (reg & 0x03));
 
     // vt_pix_clk = MCLK / vt_sys_div
-    *vt_pix_clk = OMV_XCLK_FREQUENCY / vt_sys_div;
+    *vt_pix_clk = OMV_CSI_XCLK_FREQUENCY / vt_sys_div;
     return 0;
 }
 
@@ -542,4 +542,4 @@ int hm01b0_init(sensor_t *sensor) {
 
     return 0;
 }
-#endif //(OMV_ENABLE_HM01B0 == 1)
+#endif //(OMV_HM01B0_ENABLE == 1)

--- a/src/omv/sensors/hm01b0.h
+++ b/src/omv/sensors/hm01b0.h
@@ -10,6 +10,6 @@
  */
 #ifndef __HM01B0_H__
 #define __HM01B0_H__
-#define HM01B0_XCLK_FREQ    (6000000)
+#define OMV_HM01B0_XCLK_FREQ    (6000000)
 int hm01b0_init(sensor_t *sensor);
 #endif // __HM01B0_H__

--- a/src/omv/sensors/hm0360.c
+++ b/src/omv/sensors/hm0360.c
@@ -9,7 +9,7 @@
  * HM0360 driver.
  */
 #include "omv_boardconfig.h"
-#if (OMV_ENABLE_HM0360 == 1)
+#if (OMV_HM0360_ENABLE == 1)
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -571,7 +571,7 @@ static int get_vt_pix_clk(sensor_t *sensor, uint32_t *vt_pix_clk) {
     uint32_t vt_sys_div = (1 << (reg & 0x03));
 
     // vt_pix_clk = MCLK / vt_sys_div
-    *vt_pix_clk = OMV_XCLK_FREQUENCY / vt_sys_div;
+    *vt_pix_clk = OMV_CSI_XCLK_FREQUENCY / vt_sys_div;
     return 0;
 }
 
@@ -771,4 +771,4 @@ int hm0360_init(sensor_t *sensor) {
 
     return 0;
 }
-#endif //(OMV_ENABLE_HM0360 == 1)
+#endif //(OMV_HM0360_ENABLE == 1)

--- a/src/omv/sensors/hm0360.h
+++ b/src/omv/sensors/hm0360.h
@@ -11,6 +11,6 @@
 #ifndef __HM0360_H__
 #define __HM0360_H__
 // This sensor uses an internal oscillator.
-#define HM0360_XCLK_FREQ    (0)
+#define OMV_HM0360_XCLK_FREQ    (0)
 int hm0360_init(sensor_t *sensor);
 #endif // __HM0360_H__

--- a/src/omv/sensors/lepton.c
+++ b/src/omv/sensors/lepton.c
@@ -9,7 +9,7 @@
  * Lepton driver.
  */
 #include "omv_boardconfig.h"
-#if (OMV_ENABLE_LEPTON == 1)
+#if (OMV_LEPTON_ENABLE == 1)
 
 #include <stdio.h>
 #include "sensor.h"
@@ -61,10 +61,10 @@ static int lepton_reset(sensor_t *sensor, bool measurement_mode, bool high_temp_
 
 static int sleep(sensor_t *sensor, int enable) {
     if (enable) {
-        omv_gpio_write(DCMI_POWER_PIN, 0);
+        omv_gpio_write(OMV_CSI_POWER_PIN, 0);
         mp_hal_delay_ms(100);
     } else {
-        omv_gpio_write(DCMI_POWER_PIN, 1);
+        omv_gpio_write(OMV_CSI_POWER_PIN, 1);
         mp_hal_delay_ms(100);
     }
 
@@ -266,16 +266,16 @@ static int ioctl(sensor_t *sensor, int request, va_list ap) {
 }
 
 static int lepton_reset(sensor_t *sensor, bool measurement_mode, bool high_temp_mode) {
-    omv_gpio_write(DCMI_POWER_PIN, 0);
+    omv_gpio_write(OMV_CSI_POWER_PIN, 0);
     mp_hal_delay_ms(10);
 
-    omv_gpio_write(DCMI_POWER_PIN, 1);
+    omv_gpio_write(OMV_CSI_POWER_PIN, 1);
     mp_hal_delay_ms(10);
 
-    omv_gpio_write(DCMI_RESET_PIN, 0);
+    omv_gpio_write(OMV_CSI_RESET_PIN, 0);
     mp_hal_delay_ms(10);
 
-    omv_gpio_write(DCMI_RESET_PIN, 1);
+    omv_gpio_write(OMV_CSI_RESET_PIN, 1);
     mp_hal_delay_ms(1000);
 
     LEP_RAD_ENABLE_E rad;
@@ -536,4 +536,4 @@ int lepton_init(sensor_t *sensor) {
     }
     return 0;
 }
-#endif // (OMV_ENABLE_LEPTON == 1)
+#endif // (OMV_LEPTON_ENABLE == 1)

--- a/src/omv/sensors/lepton.h
+++ b/src/omv/sensors/lepton.h
@@ -10,6 +10,6 @@
  */
 #ifndef __LEPTON_H__
 #define __LEPTON_H__
-#define LEPTON_XCLK_FREQ    24000000
+#define OMV_LEPTON_XCLK_FREQ    24000000
 int lepton_init(sensor_t *sensor);
 #endif // __LEPTON_H__

--- a/src/omv/sensors/mt9m114.c
+++ b/src/omv/sensors/mt9m114.c
@@ -9,7 +9,7 @@
  * MT9M114 driver.
  */
 #include "omv_boardconfig.h"
-#if (OMV_ENABLE_MT9M114 == 1)
+#if (OMV_MT9M114_ENABLE == 1)
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -461,7 +461,7 @@ static int reset(sensor_t *sensor) {
     ret |= omv_i2c_writew2(&sensor->i2c_bus, sensor->slv_addr, 0x301A, reg | (1 << 9));
 
     ret |= omv_i2c_writew2(&sensor->i2c_bus, sensor->slv_addr, MT9M114_REG_CAM_SYSCTL_PLL_DIVIDER_M_N,
-                           (sensor_get_xclk_frequency() == MT9M114_XCLK_FREQ)
+                           (sensor_get_xclk_frequency() == OMV_MT9M114_XCLK_FREQ)
             ? 0x120 // xclk=24MHz, m=32, n=1, sensor=48MHz, bus=76.8MHz
             : 0x448); // xclk=25MHz, m=72, n=4, sensor=45MHz, bus=72MHz
 
@@ -659,7 +659,7 @@ static int set_framesize(sensor_t *sensor, framesize_t framesize) {
     ret |= omv_i2c_writew2(&sensor->i2c_bus, sensor->slv_addr, MT9M114_REG_SENSOR_CFG_Y_ADDR_END, sensor_he);
     ret |= omv_i2c_writew2(&sensor->i2c_bus, sensor->slv_addr, MT9M114_REG_SENSOR_CFG_X_ADDR_END, sensor_we);
 
-    int pixclk = (sensor_get_xclk_frequency() == MT9M114_XCLK_FREQ) ? 48000000 : 45000000;
+    int pixclk = (sensor_get_xclk_frequency() == OMV_MT9M114_XCLK_FREQ) ? 48000000 : 45000000;
 
     ret |= omv_i2c_writew2(&sensor->i2c_bus, sensor->slv_addr, MT9M114_REG_SENSOR_CFG_PIXCLK, pixclk >> 16);
     ret |= omv_i2c_writew2(&sensor->i2c_bus, sensor->slv_addr, MT9M114_REG_SENSOR_CFG_PIXCLK + 2, pixclk);
@@ -998,4 +998,4 @@ int mt9m114_init(sensor_t *sensor) {
     return 0;
 }
 
-#endif // (OMV_ENABLE_MT9M114 == 1)
+#endif // (OMV_MT9M114_ENABLE == 1)

--- a/src/omv/sensors/mt9m114.h
+++ b/src/omv/sensors/mt9m114.h
@@ -10,6 +10,6 @@
  */
 #ifndef __MT9M114_H__
 #define __MT9M114_H__
-#define MT9M114_XCLK_FREQ    (24000000)
+#define OMV_MT9M114_XCLK_FREQ    (24000000)
 int mt9m114_init(sensor_t *sensor);
 #endif // __MT9M114_H__

--- a/src/omv/sensors/mt9v0xx.c
+++ b/src/omv/sensors/mt9v0xx.c
@@ -9,7 +9,7 @@
  * MT9V0XX driver.
  */
 #include "omv_boardconfig.h"
-#if (OMV_ENABLE_MT9V0XX == 1)
+#if (OMV_MT9V0XX_ENABLE == 1)
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -550,4 +550,4 @@ int mt9v0xx_init(sensor_t *sensor) {
     return ret;
 }
 
-#endif // (OMV_ENABLE_MT9V0XX == 1)
+#endif // (OMV_MT9V0XX_ENABLE == 1)

--- a/src/omv/sensors/mt9v0xx.h
+++ b/src/omv/sensors/mt9v0xx.h
@@ -10,8 +10,8 @@
  */
 #ifndef __MT9V0XX_H__
 #define __MT9V0XX_H__
-#ifndef MT9V0XX_XCLK_FREQ
-#define MT9V0XX_XCLK_FREQ    26666666
+#ifndef OMV_MT9V0XX_XCLK_FREQ
+#define OMV_MT9V0XX_XCLK_FREQ    26666666
 #endif
 int mt9v0xx_init(sensor_t *sensor);
 #endif // __MT9V0XX_H__

--- a/src/omv/sensors/ov2640.c
+++ b/src/omv/sensors/ov2640.c
@@ -9,7 +9,7 @@
  * OV2640 driver.
  */
 #include "omv_boardconfig.h"
-#if (OMV_ENABLE_OV2640 == 1)
+#if (OMV_OV2640_ENABLE == 1)
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -670,8 +670,8 @@ static int set_auto_exposure(sensor_t *sensor, int enable, int exposure_us) {
         }
 
         int exposure =
-            IM_MAX(IM_MIN(((exposure_us * (((OMV_XCLK_FREQUENCY / clk_rc) * pll_mult) / 1000000)) / t_pclk) / t_line, 0xFFFF),
-                   0x0000);
+            IM_MAX(IM_MIN(((exposure_us * (((OMV_CSI_XCLK_FREQUENCY / clk_rc) * pll_mult) / 1000000)) / t_pclk) / t_line,
+                          0xFFFF), 0x0000);
 
         ret |= omv_i2c_writeb(&sensor->i2c_bus, sensor->slv_addr, BANK_SEL, BANK_SEL_SENSOR);
 
@@ -741,7 +741,7 @@ static int get_exposure_us(sensor_t *sensor, int *exposure_us) {
     }
 
     uint16_t exposure = ((aec_1510 & 0x3F) << 10) + ((aec_92 & 0xFF) << 2) + ((aec_10 & 0x3) << 0);
-    *exposure_us = (exposure * t_line * t_pclk) / (((OMV_XCLK_FREQUENCY / clk_rc) * pll_mult) / 1000000);
+    *exposure_us = (exposure * t_line * t_pclk) / (((OMV_CSI_XCLK_FREQUENCY / clk_rc) * pll_mult) / 1000000);
 
     return ret;
 }
@@ -877,4 +877,4 @@ int ov2640_init(sensor_t *sensor) {
 
     return 0;
 }
-#endif // (OMV_ENABLE_OV2640 == 1)
+#endif // (OMV_OV2640_ENABLE == 1)

--- a/src/omv/sensors/ov2640.h
+++ b/src/omv/sensors/ov2640.h
@@ -10,6 +10,6 @@
  */
 #ifndef __OV2640_H__
 #define __OV2640_H__
-#define OV2640_XCLK_FREQ    24000000
+#define OMV_OV2640_XCLK_FREQ    24000000
 int ov2640_init(sensor_t *sensor);
 #endif // __OV2640_H__

--- a/src/omv/sensors/ov5640.c
+++ b/src/omv/sensors/ov5640.c
@@ -9,7 +9,7 @@
  * OV5640 driver.
  */
 #include "omv_boardconfig.h"
-#if (OMV_ENABLE_OV5640 == 1)
+#if (OMV_OV5640_ENABLE == 1)
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -344,7 +344,7 @@ static const uint8_t default_regs[][3] = {
     { 0x00, 0x00, 0x00 }
 };
 
-#if (OMV_ENABLE_OV5640_AF == 1)
+#if (OMV_OV5640_AF_ENABLE == 1)
 static const uint8_t af_firmware_regs[] = {
     0x02, 0x0f, 0xd6, 0x02, 0x0a, 0x39, 0xc2, 0x01, 0x22, 0x22, 0x00, 0x02, 0x0f, 0xb2, 0xe5, 0x1f,
     0x70, 0x72, 0xf5, 0x1e, 0xd2, 0x35, 0xff, 0xef, 0x25, 0xe0, 0x24, 0x4e, 0xf8, 0xe4, 0xf6, 0x08,
@@ -681,7 +681,7 @@ static int reset(sensor_t *sensor) {
         ret |= omv_i2c_writeb2(&sensor->i2c_bus, sensor->slv_addr, addr, data);
     }
 
-    #if (OMV_ENABLE_OV5640_AF == 1)
+    #if (OMV_OV5640_AF_ENABLE == 1)
     ret |= omv_i2c_writeb2(&sensor->i2c_bus, sensor->slv_addr, SYSTEM_RESET_00, 0x20); // force mcu reset
 
     // Write firmware
@@ -1362,7 +1362,7 @@ static int ioctl(sensor_t *sensor, int request, va_list ap) {
             *va_arg(ap, int *) = readout_h;
             break;
         }
-    #if (OMV_ENABLE_OV5640_AF == 1)
+    #if (OMV_OV5640_AF_ENABLE == 1)
         case IOCTL_TRIGGER_AUTO_FOCUS: {
             ret = omv_i2c_writeb2(&sensor->i2c_bus, sensor->slv_addr, AF_CMD_MAIN, 0x03);
             break;
@@ -1456,4 +1456,4 @@ int ov5640_init(sensor_t *sensor) {
 
     return 0;
 }
-#endif // (OMV_ENABLE_OV5640 == 1)
+#endif // (OMV_OV5640_ENABLE == 1)

--- a/src/omv/sensors/ov7670.c
+++ b/src/omv/sensors/ov7670.c
@@ -9,7 +9,7 @@
  * OV7670 driver.
  */
 #include "omv_boardconfig.h"
-#if (OMV_ENABLE_OV7670 == 1)
+#if (OMV_OV7670_ENABLE == 1)
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -460,4 +460,4 @@ int ov7670_init(sensor_t *sensor) {
 
     return 0;
 }
-#endif // (OMV_ENABLE_OV7670 == 1)
+#endif // (OMV_OV7670_ENABLE == 1)

--- a/src/omv/sensors/ov7670.h
+++ b/src/omv/sensors/ov7670.h
@@ -10,6 +10,6 @@
  */
 #ifndef __OV7670_H__
 #define __OV7670_H__
-#define OV7670_XCLK_FREQ    24000000
+#define OMV_OV7670_XCLK_FREQ    24000000
 int ov7670_init(sensor_t *sensor);
 #endif // __OV7725_H__

--- a/src/omv/sensors/ov7690.c
+++ b/src/omv/sensors/ov7690.c
@@ -9,7 +9,7 @@
  * OV7690 driver.
  */
 #include "omv_boardconfig.h"
-#if (OMV_ENABLE_OV7690 == 1)
+#if (OMV_OV7690_ENABLE == 1)
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -453,7 +453,8 @@ static int set_auto_exposure(sensor_t *sensor, int enable, int exposure_us) {
         }
 
         int exposure =
-            IM_MAX(IM_MIN(((exposure_us * ((((OV7690_XCLK_FREQ / clk_rc) * pll_mult) / pll_div) / 1000000)) / t_pclk) / t_line,
+            IM_MAX(IM_MIN(((exposure_us * ((((OMV_OV7690_XCLK_FREQ / clk_rc) * pll_mult) / pll_div) / 1000000)) / t_pclk) /
+                          t_line,
                           0xFFFF), 0x0000);
 
         ret |= omv_i2c_writeb(&sensor->i2c_bus, sensor->slv_addr, AECL, ((exposure >> 0) & 0xFF));
@@ -496,7 +497,8 @@ static int get_exposure_us(sensor_t *sensor, int *exposure_us) {
     }
 
     *exposure_us =
-        (((aec_h << 8) + (aec_l << 0)) * t_line * t_pclk) / ((((OV7690_XCLK_FREQ / clk_rc) * pll_mult) / pll_div) / 1000000);
+        (((aec_h <<
+            8) + (aec_l << 0)) * t_line * t_pclk) / ((((OMV_OV7690_XCLK_FREQ / clk_rc) * pll_mult) / pll_div) / 1000000);
 
     return ret;
 }
@@ -619,4 +621,4 @@ int ov7690_init(sensor_t *sensor) {
 
     return 0;
 }
-#endif //(OMV_ENABLE_OV7690 == 1)
+#endif //(OMV_OV7690_ENABLE == 1)

--- a/src/omv/sensors/ov7690.h
+++ b/src/omv/sensors/ov7690.h
@@ -10,6 +10,6 @@
  */
 #ifndef __OV7690_H__
 #define __OV7690_H__
-#define OV7690_XCLK_FREQ    24000000
+#define OMV_OV7690_XCLK_FREQ    24000000
 int ov7690_init(sensor_t *sensor);
 #endif // __OV7690_H__

--- a/src/omv/sensors/ov7725.c
+++ b/src/omv/sensors/ov7725.c
@@ -9,7 +9,7 @@
  * OV7725 driver.
  */
 #include "omv_boardconfig.h"
-#if (OMV_ENABLE_OV7725 == 1)
+#if (OMV_OV7725_ENABLE == 1)
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -40,7 +40,7 @@ static const uint8_t default_regs[][2] = {
     {FIXGAIN,       0x09},
     {AWB_CTRL0,     0xe0},
     {DSP_CTRL1,     0xff},
-    {DSP_CTRL2,     0x20 | DSP_CTRL2_VDCW_EN | DSP_CTRL2_HDCW_EN | DSP_CTRL2_VZOOM_EN | DSP_CTRL2_HZOOM_EN}, // {DSP_CTRL2, 0x20},
+    {DSP_CTRL2,     0x20 | DSP_CTRL2_VDCW_EN | DSP_CTRL2_HDCW_EN | DSP_CTRL2_VZOOM_EN | DSP_CTRL2_HZOOM_EN},
     {DSP_CTRL3,     0x00},
     {DSP_CTRL4,     0x48},
 
@@ -102,12 +102,10 @@ static const uint8_t default_regs[][2] = {
 
     {COM5,          0xf5}, // {COM5, 0x65},
 
-// OpenMV Custom.
-
+    // OpenMV Custom.
     {COM7,          COM7_FMT_RGB565},
 
-// End.
-
+    // End.
     {0x00,          0x00},
 };
 
@@ -429,8 +427,8 @@ static int set_auto_exposure(sensor_t *sensor, int enable, int exposure_us) {
         }
 
         int exposure =
-            IM_MAX(IM_MIN(((exposure_us * (((OMV_XCLK_FREQUENCY / clk_rc) * pll_mult) / 1000000)) / t_pclk) / t_line, 0xFFFF),
-                   0x0000);
+            IM_MAX(IM_MIN(((exposure_us * (((OMV_CSI_XCLK_FREQUENCY / clk_rc) * pll_mult) / 1000000)) / t_pclk) / t_line,
+                          0xFFFF), 0x0000);
 
         ret |= omv_i2c_writeb(&sensor->i2c_bus, sensor->slv_addr, AEC, ((exposure >> 0) & 0xFF));
         ret |= omv_i2c_writeb(&sensor->i2c_bus, sensor->slv_addr, AECH, ((exposure >> 8) & 0xFF));
@@ -488,7 +486,8 @@ static int get_exposure_us(sensor_t *sensor, int *exposure_us) {
         clk_rc = ((reg & CLKRC_PRESCALER) + 1) * 2;
     }
 
-    *exposure_us = (((aec_h << 8) + (aec_l << 0)) * t_line * t_pclk) / (((OMV_XCLK_FREQUENCY / clk_rc) * pll_mult) / 1000000);
+    *exposure_us =
+        (((aec_h << 8) + (aec_l << 0)) * t_line * t_pclk) / (((OMV_CSI_XCLK_FREQUENCY / clk_rc) * pll_mult) / 1000000);
 
     return ret;
 }
@@ -690,4 +689,4 @@ int ov7725_init(sensor_t *sensor) {
 
     return 0;
 }
-#endif // (OMV_ENABLE_OV7725 == 1)
+#endif // (OMV_OV7725_ENABLE == 1)

--- a/src/omv/sensors/ov9650.c
+++ b/src/omv/sensors/ov9650.c
@@ -9,7 +9,7 @@
  * OV9650 driver.
  */
 #include "omv_boardconfig.h"
-#if (OMV_ENABLE_OV9650 == 1)
+#if (OMV_OV9650_ENABLE == 1)
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -413,8 +413,8 @@ static int set_auto_exposure(sensor_t *sensor, int enable, int exposure_us) {
         int clk_rc = ((reg & REG_CLKRC_DIVIDER_MASK) + 1) * 2;
 
         int exposure =
-            IM_MAX(IM_MIN(((exposure_us * (((OMV_XCLK_FREQUENCY / clk_rc) * pll_mult) / 1000000)) / t_pclk) / t_line, 0xFFFF),
-                   0x0000);
+            IM_MAX(IM_MIN(((exposure_us * (((OMV_CSI_XCLK_FREQUENCY / clk_rc) * pll_mult) / 1000000)) / t_pclk) / t_line,
+                          0xFFFF), 0x0000);
 
         ret |= omv_i2c_readb(&sensor->i2c_bus, sensor->slv_addr, REG_COM1, &reg);
         ret |= omv_i2c_writeb(&sensor->i2c_bus, sensor->slv_addr, REG_COM1, (reg & 0xFC) | ((exposure >> 0) & 0x3));
@@ -470,7 +470,7 @@ static int get_exposure_us(sensor_t *sensor, int *exposure_us) {
     int clk_rc = ((reg & REG_CLKRC_DIVIDER_MASK) + 1) * 2;
 
     uint16_t exposure = ((aec_1510 & 0x3F) << 10) + ((aec_92 & 0xFF) << 2) + ((aec_10 & 0x3) << 0);
-    *exposure_us = (exposure * t_line * t_pclk) / (((OMV_XCLK_FREQUENCY / clk_rc) * pll_mult) / 1000000);
+    *exposure_us = (exposure * t_line * t_pclk) / (((OMV_CSI_XCLK_FREQUENCY / clk_rc) * pll_mult) / 1000000);
 
     return ret;
 }
@@ -569,4 +569,4 @@ int ov9650_init(sensor_t *sensor) {
 
     return 0;
 }
-#endif // (OMV_ENABLE_OV9650 == 1)
+#endif // (OMV_OV9650_ENABLE == 1)

--- a/src/omv/sensors/paj6100.c
+++ b/src/omv/sensors/paj6100.c
@@ -33,7 +33,7 @@
  * ----------	---	----------------------------------------------------------
  */
 #include "omv_boardconfig.h"
-#if (OMV_ENABLE_PAJ6100 == 1)
+#if (OMV_PAJ6100_ENABLE == 1)
 #include <stdio.h>
 #include <stdbool.h>
 #include "py/mphal.h"
@@ -139,7 +139,7 @@ static int init_sensor(sensor_t *sensor) {
 //-----------------------------------------------------------------
 static int set_exposure(sensor_t *sensor, int exp_us, bool protected) {
     // 3642T
-    static const uint32_t EXPOSURE_BASE = 3642 / (PAJ6100_XCLK_FREQ / 1000000.0f) + 0.5f;
+    static const uint32_t EXPOSURE_BASE = 3642 / (OMV_PAJ6100_XCLK_FREQ / 1000000.0f) + 0.5f;
     int ret;
     uint32_t cmd_expo /* 24-bit available */;
     uint16_t exp_offset;
@@ -162,18 +162,18 @@ static int set_exposure(sensor_t *sensor, int exp_us, bool protected) {
         }
 
         int max_cmd_expo = R_FrameTime - param;
-        cmd_expo = (exp_us - EXPOSURE_BASE) * ((float) PAJ6100_XCLK_FREQ / 1000000) + 0.5f;
+        cmd_expo = (exp_us - EXPOSURE_BASE) * ((float) OMV_PAJ6100_XCLK_FREQ / 1000000) + 0.5f;
         if (protected) {
             if (cmd_expo > max_cmd_expo) {
                 cmd_expo = max_cmd_expo;
-                exp_us = (cmd_expo + 3642) / ((float) PAJ6100_XCLK_FREQ / 1000000) + 0.5f;
+                exp_us = (cmd_expo + 3642) / ((float) OMV_PAJ6100_XCLK_FREQ / 1000000) + 0.5f;
                 printf("Exposure time overflow, reset to %dus.\n", exp_us);
             }
         }
         exp_offset = 0;
     } else {
         cmd_expo = 0;
-        exp_offset = (EXPOSURE_BASE - exp_us) * ((float) PAJ6100_XCLK_FREQ / 1000000) + 0.5;
+        exp_offset = (EXPOSURE_BASE - exp_us) * ((float) OMV_PAJ6100_XCLK_FREQ / 1000000) + 0.5;
     }
     #ifdef DEBUG_AE
     printf("target - cmd_exp: %ld, exp_offset: %d\n", cmd_expo, exp_offset);
@@ -228,9 +228,9 @@ static int get_exposure(sensor_t *sensor) {
     #endif
 
     if (exp_offset == 0) {
-        exp_us_cache = (cmd_expo + 3642) / (PAJ6100_XCLK_FREQ / 1000000);
+        exp_us_cache = (cmd_expo + 3642) / (OMV_PAJ6100_XCLK_FREQ / 1000000);
     } else {
-        exp_us_cache = (3642 - exp_offset) / (PAJ6100_XCLK_FREQ / 1000000);
+        exp_us_cache = (3642 - exp_offset) / (OMV_PAJ6100_XCLK_FREQ / 1000000);
     }
 
     return exp_us_cache;
@@ -725,7 +725,7 @@ bool paj6100_detect(sensor_t *sensor) {
     int ret = 0;
     uint8_t part_id_l, part_id_h;
 
-    omv_gpio_write(DCMI_RESET_PIN, 1);
+    omv_gpio_write(OMV_CSI_RESET_PIN, 1);
     mp_hal_delay_ms(10);
 
     if (!pixspi_init()) {
@@ -745,4 +745,4 @@ bool paj6100_detect(sensor_t *sensor) {
     pixspi_release();
     return false;
 }
-#endif //(OMV_ENABLE_PAJ6100 == 1)
+#endif //(OMV_PAJ6100_ENABLE == 1)

--- a/src/omv/sensors/paj6100.h
+++ b/src/omv/sensors/paj6100.h
@@ -9,7 +9,7 @@
 #ifndef __PAJ6100_H__
 #define __PAJ6100_H__
 
-#define PAJ6100_XCLK_FREQ    6000000
+#define OMV_PAJ6100_XCLK_FREQ    6000000
 
 bool paj6100_detect(sensor_t *sensor);
 int paj6100_init(sensor_t *sensor);


### PR DESCRIPTION
- Rename options more consistently.
- Add OMV prefix to every config option.
- Replace the ST-specific DCMI prefix with CSI.
- Remove the clock source defined in every header to a common enum.
- Remove obsolete board config options.