### PR TITLE
modules/py_tf: Add support for yolov3, yolov5 and yolov7.

### DIFF
--- a/src/omv/boards/ARDUINO_GIGA/imlib_config.h
+++ b/src/omv/boards/ARDUINO_GIGA/imlib_config.h
@@ -128,6 +128,7 @@
 // Enable Tensor Flow
 #if !defined(CUBEAI)
 #define IMLIB_ENABLE_TF (IMLIB_TF_DEFAULT)
+#define IMLIB_ENABLE_TF_YOLO
 #endif
 
 // Enable FAST (20+ KBs).

--- a/src/omv/boards/ARDUINO_PORTENTA_H7/imlib_config.h
+++ b/src/omv/boards/ARDUINO_PORTENTA_H7/imlib_config.h
@@ -128,6 +128,7 @@
 // Enable Tensor Flow
 #if !defined(CUBEAI)
 #define IMLIB_ENABLE_TF (IMLIB_TF_DEFAULT)
+#define IMLIB_ENABLE_TF_YOLO
 #endif
 
 // Enable FAST (20+ KBs).

--- a/src/omv/boards/OPENMV4P/imlib_config.h
+++ b/src/omv/boards/OPENMV4P/imlib_config.h
@@ -128,6 +128,7 @@
 // Enable Tensor Flow
 #if !defined(CUBEAI)
 #define IMLIB_ENABLE_TF (IMLIB_TF_DEFAULT)
+#define IMLIB_ENABLE_TF_YOLO
 #endif
 
 // Enable FAST (20+ KBs).

--- a/src/omv/boards/OPENMVPT/imlib_config.h
+++ b/src/omv/boards/OPENMVPT/imlib_config.h
@@ -128,6 +128,7 @@
 // Enable Tensor Flow
 #if !defined(CUBEAI)
 #define IMLIB_ENABLE_TF (IMLIB_TF_DEFAULT)
+#define IMLIB_ENABLE_TF_YOLO
 #endif
 
 // Enable FAST (20+ KBs).

--- a/src/omv/boards/OPENMV_RT1060/imlib_config.h
+++ b/src/omv/boards/OPENMV_RT1060/imlib_config.h
@@ -127,6 +127,7 @@
 // Enable Tensor Flow
 #if !defined(CUBEAI)
 #define IMLIB_ENABLE_TF (IMLIB_TF_FULLOPS)
+#define IMLIB_ENABLE_TF_YOLO
 #endif
 
 // Enable FAST (20+ KBs).

--- a/src/omv/imlib/imlib.h
+++ b/src/omv/imlib/imlib.h
@@ -149,6 +149,7 @@ bool rectangle_equal_fast(rectangle_t *ptr0, rectangle_t *ptr1);
 bool rectangle_overlap(rectangle_t *ptr0, rectangle_t *ptr1);
 void rectangle_intersected(rectangle_t *dst, rectangle_t *src);
 void rectangle_united(rectangle_t *dst, rectangle_t *src);
+float rectangle_iou(rectangle_t *r1, rectangle_t *r2);
 
 /////////////////
 // Color Stuff //

--- a/src/omv/imlib/rectangle.c
+++ b/src/omv/imlib/rectangle.c
@@ -116,3 +116,15 @@ void rectangle_expand(rectangle_t *r, int x, int y) {
         r->h = y;
     }
 }
+
+float rectangle_iou(rectangle_t *r1, rectangle_t *r2) {
+    int x1 = IM_MAX(r1->x, r2->x);
+    int y1 = IM_MAX(r1->y, r2->y);
+    int x2 = IM_MIN(r1->x + r1->w, r2->x + r2->w);
+    int y2 = IM_MIN(r1->y + r1->h, r2->y + r2->h);
+    int w = IM_MAX(0, x2 - x1);
+    int h = IM_MAX(0, y2 - y1);
+    int rect_intersection = w * h;
+    int rect_union = (r1->w * r1->h) + (r2->w * r2->h) - rect_intersection;
+    return ((float) rect_intersection) / ((float) rect_union);
+}

--- a/src/omv/modules/py_tf.c
+++ b/src/omv/modules/py_tf.c
@@ -276,29 +276,6 @@ STATIC void py_tf_input_callback(void *callback_data,
                                  libtf_parameters_t *params) {
     py_tf_input_callback_data_t *arg = (py_tf_input_callback_data_t *) callback_data;
 
-    // Disable checking input scaling and zero-point. Nets can be all over the place on the input
-    // scaling and zero-point but still work with the code below.
-
-    // if (params->input_datatype == LIBTF_DATATYPE_UINT8) {
-    //     if (fast_roundf(params->input_scale * GRAYSCALE_RANGE) != 1) {
-    //         mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("Expected model input scale to be 1/255!"));
-    //     }
-
-    //     if (params->input_zero_point != 0) {
-    //         mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("Expected model input zero point to be 0!"));
-    //     }
-    // }
-
-    // if (params->input_datatype == LIBTF_DATATYPE_INT8) {
-    //     if (fast_roundf(params->input_scale * GRAYSCALE_RANGE) != 1) {
-    //         mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("Expected model input scale to be 1/255!"));
-    //     }
-
-    //     if (params->input_zero_point != -GRAYSCALE_MID) {
-    //         mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("Expected model input zero point to be -128!"));
-    //     }
-    // }
-
     int shift = (params->input_datatype == LIBTF_DATATYPE_INT8) ? GRAYSCALE_MID : 0;
 
     image_t dst_img;
@@ -520,29 +497,6 @@ STATIC void py_tf_segment_output_callback(void *callback_data,
                                           void *model_output,
                                           libtf_parameters_t *params) {
     mp_obj_t *arg = (mp_obj_t *) callback_data;
-
-    // Disable checking output scaling and zero-point. Nets can be all over the place on the output
-    // scaling and zero-point but still work with the code below.
-
-    // if (params->output_datatype == LIBTF_DATATYPE_UINT8) {
-    //     if (fast_roundf(params->output_scale * GRAYSCALE_RANGE) != 1) {
-    //         mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("Expected model output scale to be 1/255!"));
-    //     }
-
-    //     if (params->output_zero_point != 0) {
-    //         mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("Expected model output zero point to be 0!"));
-    //     }
-    // }
-
-    // if (params->output_datatype == LIBTF_DATATYPE_INT8) {
-    //     if (fast_roundf(params->output_scale * GRAYSCALE_RANGE) != 1) {
-    //         mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("Expected model output scale to be 1/255!"));
-    //     }
-
-    //     if (params->output_zero_point != -GRAYSCALE_MID) {
-    //         mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("Expected model output zero point to be -128!"));
-    //     }
-    // }
 
     int shift = (params->output_datatype == LIBTF_DATATYPE_INT8) ? GRAYSCALE_MID : 0;
 


### PR DESCRIPTION
Adds support for YOLOV3, V5, V7 to detect().

Depends on https://github.com/openmv/openmv/pull/2133.

![image (18)](https://github.com/openmv/openmv/assets/5694981/68c92f34-d782-46b6-93af-810b3bb4cff6)
