### PR TITLE
ports/mimxrt: Use hardware byteswap support.

### DIFF
--- a/src/omv/boards/OPENMV_RT1060/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV_RT1060/omv_boardconfig.h
@@ -193,6 +193,7 @@
 // Camera interface configuration.
 #define OMV_CSI_BASE                    (CSI)
 #define OMV_CSI_XCLK_FREQUENCY          (12000000)
+#define OMV_CSI_HW_SWAP_ENABLE          (1)
 
 #define OMV_CSI_D0_PIN                  (&omv_pin_DCMI_D0)
 #define OMV_CSI_D1_PIN                  (&omv_pin_DCMI_D1)

--- a/src/omv/common/sensor_utils.c
+++ b/src/omv/common/sensor_utils.c
@@ -1307,13 +1307,16 @@ __weak int sensor_copy_line(void *dma, uint8_t *src, uint8_t *dst) {
             #if OMV_CSI_DMA_MEMCPY_ENABLE
             sensor_dma_memcpy(dma, dst16, src16, sizeof(uint16_t), sensor.transpose);
             #else
-            if ((sensor.pixformat == PIXFORMAT_RGB565 && sensor.hw_flags.rgb_swap)
-                || (sensor.pixformat == PIXFORMAT_YUV422 && sensor.hw_flags.yuv_swap)) {
+            if (0) {
+            #if !OMV_CSI_HW_SWAP_ENABLE
+            } else if ((sensor.pixformat == PIXFORMAT_RGB565 && sensor.hw_flags.rgb_swap)
+                       || (sensor.pixformat == PIXFORMAT_YUV422 && sensor.hw_flags.yuv_swap)) {
                 if (!sensor.transpose) {
                     unaligned_memcpy_rev16(dst16, src16, MAIN_FB()->u);
                 } else {
                     copy_transposed_line_rev16(dst16, src16);
                 }
+            #endif
             } else {
                 if (!sensor.transpose) {
                     unaligned_memcpy(dst16, src16, MAIN_FB()->u * sizeof(uint16_t));

--- a/src/omv/ports/mimxrt/sensor.c
+++ b/src/omv/ports/mimxrt/sensor.c
@@ -322,6 +322,14 @@ int sensor_snapshot(sensor_t *sensor, image_t *image, uint32_t flags) {
         // Re/configure and re/start the CSI.
         uint32_t bytes_per_pixel = sensor_get_src_bpp();
         uint32_t dma_line_bytes = resolution[sensor->framesize][0] * bytes_per_pixel;
+
+        if ((sensor->pixformat == PIXFORMAT_RGB565 && sensor->hw_flags.rgb_swap)
+            || (sensor->pixformat == PIXFORMAT_YUV422 && sensor->hw_flags.yuv_swap)) {
+            CSI_REG_CR1(CSI) |= CSI_CR1_SWAP16_EN_MASK | CSI_CR1_PACK_DIR_MASK;
+        } else {
+            CSI_REG_CR1(CSI) &= ~(CSI_CR1_SWAP16_EN_MASK | CSI_CR1_PACK_DIR_MASK);
+        }
+
         CSI_REG_IMAG_PARA(CSI) =
             (dma_line_bytes << CSI_IMAG_PARA_IMAGE_WIDTH_SHIFT) |
             (1 << CSI_IMAG_PARA_IMAGE_HEIGHT_SHIFT);


### PR DESCRIPTION
Broken out into a PR as requested from https://github.com/openmv/openmv/pull/2123