### PR TITLE
ports/mimxrt: Enable full DMA offload.

### DIFF
--- a/src/omv/ports/mimxrt/mimxrt_hal.c
+++ b/src/omv/ports/mimxrt/mimxrt_hal.c
@@ -306,8 +306,6 @@ void CSI_IRQHandler(void) {
     CSI_REG_SR(CSI) = csisr;
 
     if (csisr & CSI_SR_SOF_INT_MASK) {
-        // Clear the FIFO and re/enable DMA.
-        CSI_REG_CR3(CSI) |= (CSI_CR3_DMA_REFLASH_RFF_MASK | CSI_CR3_DMA_REQ_EN_RFF_MASK);
         sensor_sof_callback();
     } else if (csisr & CSI_SR_DMA_TSF_DONE_FB1_MASK) {
         sensor_line_callback(CSI_REG_DMASA_FB1(CSI));


### PR DESCRIPTION
This change targets the embedded DMA controllers in the CSI module to transfer the image directly to the frame buffer bypassing the line buffers. By doing this you get a 7.5% performance boost. The code below goes from 9.44 FPS to 10.15 FPS.

This works by changing the address targets of the embedded CSI controllers to target the frame buffer on the SoF interrupt. The embedded CSI controllers will then generate an interrupt at the end of the frame once they transfer the full image per the line interrupt callback. So, this reduces the interrupt load on the processor to 2 per frame like the STM32 sensor driver.

```
from ulab import numpy as np
import sensor
import time
import math

# Set to 0 for a grayscale image. Set above 1.0 to pump-up the saturation.
UV_SCALE = 1.0

sensor.reset()
sensor.set_pixformat(sensor.RGB565)
sensor.set_framesize(sensor.WVGA)
sensor.skip_frames(time=2000)

# These are the standard coefficents for converting RGB to YUV.
rgb2yuv = np.array([[    0.299,     0.587,     0.114], # noqa
                    [-0.168736, -0.331264,       0.5], # noqa
                    [      0.5, -0.418688, -0.081312]], dtype=np.float) # noqa

# Now get the inverse so we can get back to RGB from YUV.
yuv2rgb = np.linalg.inv(rgb2yuv)

clock = time.clock()

# r will be the angle by which we rotate the colors on the UV plane by.
r = 0

while True:
    clock.tick()

    # Increment in a loop.
    r = (r + 1) % 360
    a = math.radians(r)

    # This is a rotation matrix which we will apply on the UV components of YUV values.
    # https://en.wikipedia.org/wiki/Rotation_matrix
    rot = np.array([[1,           0,            0], # noqa
                    [0, math.cos(a), -math.sin(a)], # noqa
                    [0, math.sin(a),  math.cos(a)]], dtype=np.float) # noqa

    # This is the scale matrix
    scale = np.array([[1,        0, 0], # noqa
                      [0, UV_SCALE, 0], # noqa
                      [0,        0, UV_SCALE]], dtype=np.float) # noqa

    # Now compute the final matrix using matrix multiplication.
    m = np.dot(yuv2rgb, np.dot(scale, np.dot(rot, rgb2yuv)))

    # Apply the color transformation (m.flatten().tolist() also works)
    img = sensor.snapshot().ccm(m.tolist())

    print(clock.fps())
```