### PR TITLE
imlib: Optimize math ops.

### DIFF
--- a/src/hal/cmsis/include/cmsis_extension.h
+++ b/src/hal/cmsis/include/cmsis_extension.h
@@ -249,5 +249,23 @@ __STATIC_FORCEINLINE uint32_t __SSUB16(uint32_t op1, uint32_t op2)
   return ((op1 & 0xFFFF0000) - (op2 & 0xFFFF0000)) | ((op1 - op2) & 0xFFFF);
 }
 
+__STATIC_FORCEINLINE uint32_t __USAD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result = abs((op1 & 0xFF) - (op2 & 0xFF));
+  result += abs(((op1 >> 8) & 0xFF) - ((op2 >> 8) & 0xFF));
+  result += abs(((op1 >> 16) & 0xFF) - ((op2 >> 16) & 0xFF));
+  result += abs(((op1 >> 24) & 0xFF) - ((op2 >> 24) & 0xFF));
+  return result;
+}
+
+__STATIC_FORCEINLINE uint32_t __USADA8(uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  op3 += abs((op1 & 0xFF) - (op2 & 0xFF));
+  op3 += abs(((op1 >> 8) & 0xFF) - ((op2 >> 8) & 0xFF));
+  op3 += abs(((op1 >> 16) & 0xFF) - ((op2 >> 16) & 0xFF));
+  op3 += abs(((op1 >> 24) & 0xFF) - ((op2 >> 24) & 0xFF));
+  return op3;
+}
+
 #endif /* (__ARM_FEATURE_DSP == 1) */
 #endif /* __CMSIS_EXTENSIONS_H */

--- a/src/omv/imlib/binary.c
+++ b/src/omv/imlib/binary.c
@@ -268,7 +268,7 @@ void imlib_invert(image_t *img) {
     }
 }
 
-static void imlib_b_and_line_op(image_t *img, int line, void *other, void *data, bool vflipped) {
+void imlib_b_and_line_op(image_t *img, int line, void *other, void *data, bool vflipped) {
     image_t *mask = (image_t *) data;
 
     switch (img->pixfmt) {
@@ -404,7 +404,7 @@ void imlib_b_nand(image_t *img, const char *path, image_t *other, int scalar, im
     imlib_image_operation(img, path, other, scalar, imlib_b_nand_line_op, mask);
 }
 
-static void imlib_b_or_line_op(image_t *img, int line, void *other, void *data, bool vflipped) {
+void imlib_b_or_line_op(image_t *img, int line, void *other, void *data, bool vflipped) {
     image_t *mask = (image_t *) data;
 
     switch (img->pixfmt) {
@@ -540,7 +540,7 @@ void imlib_b_nor(image_t *img, const char *path, image_t *other, int scalar, ima
     imlib_image_operation(img, path, other, scalar, imlib_b_nor_line_op,  mask);
 }
 
-static void imlib_b_xor_line_op(image_t *img, int line, void *other, void *data, bool vflipped) {
+void imlib_b_xor_line_op(image_t *img, int line, void *other, void *data, bool vflipped) {
     image_t *mask = (image_t *) data;
 
     switch (img->pixfmt) {

--- a/src/omv/imlib/imlib.h
+++ b/src/omv/imlib/imlib.h
@@ -1369,10 +1369,13 @@ void imlib_gamma(image_t *img, float gamma, float scale, float offset);
 // Binary Functions
 void imlib_binary(image_t *out, image_t *img, list_t *thresholds, bool invert, bool zero, image_t *mask);
 void imlib_invert(image_t *img);
+void imlib_b_and_line_op(image_t *img, int line, void *other, void *data, bool vflipped);
 void imlib_b_and(image_t *img, const char *path, image_t *other, int scalar, image_t *mask);
 void imlib_b_nand(image_t *img, const char *path, image_t *other, int scalar, image_t *mask);
+void imlib_b_or_line_op(image_t *img, int line, void *other, void *data, bool vflipped);
 void imlib_b_or(image_t *img, const char *path, image_t *other, int scalar, image_t *mask);
 void imlib_b_nor(image_t *img, const char *path, image_t *other, int scalar, image_t *mask);
+void imlib_b_xor_line_op(image_t *img, int line, void *other, void *data, bool vflipped);
 void imlib_b_xor(image_t *img, const char *path, image_t *other, int scalar, image_t *mask);
 void imlib_b_xnor(image_t *img, const char *path, image_t *other, int scalar, image_t *mask);
 void imlib_erode(image_t *img, int ksize, int threshold, image_t *mask);


### PR DESCRIPTION
Optimizes add()/sub()/min()/max()/difference() using cortex-m SIMD so that they work 32-bit at a time. Grayscale operations are faster and RGB565 are faster.

negate() is deleted by PR: https://github.com/openmv/openmv/pull/2139
replace() and blend() will be removed in the future by switching to a draw_image backend. So, they were not optimized.
mul() and div() are removed by PRs: https://github.com/openmv/openmv/pull/2143 and https://github.com/openmv/openmv/pull/2140 respectively.

To save firmware space, I call the binary line op from some of these line ops when the result is the same.

Broke up from: https://github.com/openmv/openmv/pull/2061

...

Performance Numbers (on OpenMV Cam Plus):

VGA Resolution:

add:
* Binary: N/A See b_or performance
* Grayscale: 6968.43us (previous 8225.84) - 18% faster
* RGB565: 16332.4us (previous 18264.0) - 11% faster

sub:
* Binary: 460.541us (previous 10931.5) - 2273% faster
* Grayscale: 6923.17us (previous 8224.25) - 18% faster
* RGB565: 13922.5us (previous 17192.8) - 23% faster

rsub:
* Binary: 443.577us (previous 10527.5) - 2273% faster
* Grayscale: 6899.38us (previous 8191.05) - 18% faster
* RGB565: 13888.0us (previous 15682.7) - 13% faster

min:
* Binary: N/A See b_and performance
* Grayscale: 6231.77us (previous 7560.89) - 21% faster
* RGB565: 15830.7us (previous 18376.8) - 16% faster

max:
* Binary: N/A See b_or performance
* Grayscale: 6232.52us (previous 7562.21) - 21% faster
* RGB565: 15874.9us (previous 18434.9) - 16% faster

difference:
* Binary: N/A See b_xor performance
* Grayscale: 6954.57us (previous 8238.88) - 18% faster
* RGB565: 16258.3us (previous 18605.3) - 14% faster

Grayscale and RGB565 image processing code should increase in performance on faster access to image data. I think the numbers were maxing out on the memory bus bandwidth as the code for processing grayscale images should be 4x faster and the code for processing RGB565 images should be 2x faster.