### PR TITLE
modules/py_image: Use mp_arg_pasrse_all for erode/dilate.

### DIFF
--- a/src/omv/imlib/binary.c
+++ b/src/omv/imlib/binary.c
@@ -888,12 +888,12 @@ static void imlib_erode_dilate(image_t *img, int ksize, int threshold, int e_or_
 }
 
 void imlib_erode(image_t *img, int ksize, int threshold, image_t *mask) {
-    // Threshold should be equal to (((ksize*2)+1)*((ksize*2)+1))-1
-    // for normal operation. E.g. for ksize==3 -> threshold==8
+    // Threshold should be equal to 0
+    // for normal operation. E.g. for ksize==3 -> threshold==0
     // Basically you're adjusting the number of data that
     // must be set in the kernel (besides the center) for the output to be 1.
     // Erode normally requires all data to be 1.
-    imlib_erode_dilate(img, ksize, threshold, 0, mask);
+    imlib_erode_dilate(img, ksize, imlib_ksize_to_n(ksize) - 1 - threshold, 0, mask);
 }
 
 void imlib_dilate(image_t *img, int ksize, int threshold, image_t *mask) {
@@ -906,13 +906,13 @@ void imlib_dilate(image_t *img, int ksize, int threshold, image_t *mask) {
 }
 
 void imlib_open(image_t *img, int ksize, int threshold, image_t *mask) {
-    imlib_erode(img, ksize, imlib_ksize_to_n(ksize) - 1 - threshold, mask);
-    imlib_dilate(img, ksize, 0 + threshold, mask);
+    imlib_erode(img, ksize, threshold, mask);
+    imlib_dilate(img, ksize, threshold, mask);
 }
 
 void imlib_close(image_t *img, int ksize, int threshold, image_t *mask) {
-    imlib_dilate(img, ksize, 0 + threshold, mask);
-    imlib_erode(img, ksize, imlib_ksize_to_n(ksize) - 1 - threshold, mask);
+    imlib_dilate(img, ksize, threshold, mask);
+    imlib_erode(img, ksize, threshold, mask);
 }
 
 void imlib_top_hat(image_t *img, int ksize, int threshold, image_t *mask) {

--- a/src/omv/imlib/imlib.h
+++ b/src/omv/imlib/imlib.h
@@ -943,6 +943,7 @@ typedef struct img_read_settings {
     save_image_format_t format;
 } img_read_settings_t;
 
+typedef void (*binary_morph_op_t) (image_t *, int, int, image_t *);
 typedef void (*line_op_t) (image_t *, int, void *, void *, bool);
 typedef void (*flood_fill_call_back_t) (image_t *, int, int, int, void *);
 


### PR DESCRIPTION
Update erode/dilate/close/open/black_hat/top_hat to use mp_arg_pasrse_all().

Also, the meaning of the optional threshold value for erode has been changed to match how dilate's threshold works.

Broke out from: https://github.com/openmv/openmv/pull/2061