### PR TITLE
ports/stm32: Add support for YUV422 hardware JPEG compression.

### DIFF
--- a/scripts/examples/08-RPC-Library/36-Web-Servers/rtsp_video_server_lan.py
+++ b/scripts/examples/08-RPC-Library/36-Web-Servers/rtsp_video_server_lan.py
@@ -7,7 +7,8 @@
 # This example shows off how to stream video over RTSP with your OpenMV Cam.
 #
 # You can use a program like VLC to view the video stream by connecting to the
-# OpenMV Cam's IP address.
+# OpenMV Cam's IP address. However, OpenMV IDE has an FFPLAY based RSTP Viewer built-in which
+# you can use by going to Tools->Video Tools->Play RSTP Stream.
 
 import network
 import omv
@@ -15,11 +16,15 @@ import rtsp
 import sensor
 import time
 
-# RTP MJPEG streaming works using JPEG images produced by the OV2640/OV5640 camera modules.
-# Not all programs (e.g. VLC) implement the full JPEG standard for decoding any JPEG image
-# in RTP packets. Images JPEG compressed by the OpenMV Cam internally may not display.
+# If you are using VLC on linux you may need to install the live555 library for RTSP support to
+# work. If you are using Ubuntu then run the following command:
+#
+# sudo apt-get install livemedia-utils
 
-# FFPLAY will correctly handle JPEGs produced by OpenMV software.
+# Regarding latency on programs like VLC, the default is typically set to buffer 1 second of video
+# before playback. To reduce this you need to reduce the network caching which can be set using
+# "show more options" when you open the network stream in VLC. You can reduce this to like 10ms
+# to make the video real-time.
 
 sensor.reset()
 

--- a/scripts/examples/08-RPC-Library/36-Web-Servers/rtsp_video_server_wlan.py
+++ b/scripts/examples/08-RPC-Library/36-Web-Servers/rtsp_video_server_wlan.py
@@ -7,7 +7,8 @@
 # This example shows off how to stream video over RTSP with your OpenMV Cam.
 #
 # You can use a program like VLC to view the video stream by connecting to the
-# OpenMV Cam's IP address.
+# OpenMV Cam's IP address. However, OpenMV IDE has an FFPLAY based RSTP Viewer built-in which
+# you can use by going to Tools->Video Tools->Play RSTP Stream.
 
 import network
 import omv
@@ -15,11 +16,15 @@ import rtsp
 import sensor
 import time
 
-# RTP MJPEG streaming works using JPEG images produced by the OV2640/OV5640 camera modules.
-# Not all programs (e.g. VLC) implement the full JPEG standard for decoding any JPEG image
-# in RTP packets. Images JPEG compressed by the OpenMV Cam internally may not display.
+# If you are using VLC on linux you may need to install the live555 library for RTSP support to
+# work. If you are using Ubuntu then run the following command:
+#
+# sudo apt-get install livemedia-utils
 
-# FFPLAY will correctly handle JPEGs produced by OpenMV software.
+# Regarding latency on programs like VLC, the default is typically set to buffer 1 second of video
+# before playback. To reduce this you need to reduce the network caching which can be set using
+# "show more options" when you open the network stream in VLC. You can reduce this to like 10ms
+# to make the video real-time.
 
 sensor.reset()
 

--- a/scripts/libraries/rtsp.py
+++ b/scripts/libraries/rtsp.py
@@ -6,6 +6,7 @@
 # This work is licensed under the MIT license, see the file LICENSE for details.
 
 import errno
+import image
 import random
 import re
 import socket
@@ -294,7 +295,8 @@ class rtsp_server:
             self.__close_udp_socket()
 
     def __send_rtp(self, image_callback, quality):  # private
-        img = image_callback(self.__pathname, self.__session).to_jpeg(quality=quality)
+        img = image_callback(self.__pathname, self.__session)
+        img = img.to_jpeg(quality=quality, subsampling=image.JPEG_SUBSAMPLING_422)
         if img.width() >= 2040:
             raise ValueError("Maximum width is 2040")
         if img.height() >= 2040:

--- a/src/omv/imlib/framebuffer.c
+++ b/src/omv/imlib/framebuffer.c
@@ -166,7 +166,7 @@ void framebuffer_update_jpeg_buffer() {
                     .pixels = jpeg_framebuffer->pixels
                 };
                 // Note: lower quality saves USB bandwidth and results in a faster IDE FPS.
-                bool overflow = jpeg_compress(src, &dst, jpeg_framebuffer->quality, false);
+                bool overflow = jpeg_compress(src, &dst, jpeg_framebuffer->quality, false, JPEG_SUBSAMPLING_AUTO);
 
                 if (overflow) {
                     // JPEG buffer overflowed, reduce JPEG quality for the next frame

--- a/src/omv/imlib/imlib.h
+++ b/src/omv/imlib/imlib.h
@@ -753,6 +753,13 @@ bool image_get_mask_pixel(image_t *ptr, int x, int y);
 #define JPEG_422_YCBCR_MCU_SIZE    ((JPEG_444_GS_MCU_SIZE) * 4)
 #define JPEG_420_YCBCR_MCU_SIZE    ((JPEG_444_GS_MCU_SIZE) * 6)
 
+typedef enum jpeg_subsampling {
+    JPEG_SUBSAMPLING_AUTO = 0,
+    JPEG_SUBSAMPLING_444  = 0x11, // Chroma subsampling 4:4:4 (No subsampling)
+    JPEG_SUBSAMPLING_422  = 0x21, // Chroma subsampling 4:2:2
+    JPEG_SUBSAMPLING_420  = 0x22, // Chroma subsampling 4:2:0
+} jpeg_subsampling_t;
+
 // Old Image Macros - Will be refactor and removed. But, only after making sure through testing new macros work.
 
 // Image kernels
@@ -964,12 +971,6 @@ typedef enum template_match {
     SEARCH_DS,  // Diamond search
 } template_match_t;
 
-typedef enum  jpeg_subsample {
-    JPEG_SUBSAMPLE_1x1 = 0x11,  // 1x1 chroma subsampling (No subsampling)
-    JPEG_SUBSAMPLE_2x1 = 0x21,  // 2x2 chroma subsampling
-    JPEG_SUBSAMPLE_2x2 = 0x22,  // 2x2 chroma subsampling
-} jpeg_subsample_t;
-
 typedef enum corner_detector_type {
     CORNER_FAST,
     CORNER_AGAST
@@ -1180,7 +1181,7 @@ void imlib_hardware_jpeg_deinit();
 void jpeg_get_mcu(image_t *src, int x_offset, int y_offset, int dx, int dy,
                   int8_t *Y0, int8_t *CB, int8_t *CR);
 void jpeg_decompress(image_t *dst, image_t *src);
-bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc);
+bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_subsampling_t subsampling);
 bool jpeg_is_valid(image_t *img);
 int jpeg_clean_trailing_bytes(int bpp, uint8_t *data);
 void jpeg_read_geometry(FIL *fp, image_t *img, const char *path, jpg_read_settings_t *rs);

--- a/src/omv/imlib/mjpeg.c
+++ b/src/omv/imlib/mjpeg.c
@@ -181,7 +181,7 @@ void mjpeg_write(FIL *fp, int width, int height, uint32_t *frames, uint32_t *byt
         // When jpeg_compress needs more memory than in currently allocated it
         // will try to realloc. MP will detect that the pointer is outside of
         // the heap and return NULL which will cause an out of memory error.
-        jpeg_compress(&temp, &dst_img, quality, true);
+        jpeg_compress(&temp, &dst_img, quality, true, JPEG_SUBSAMPLING_AUTO);
     } else {
         dst_img.size = img->size;
         dst_img.data = img->data;

--- a/src/omv/modules/py_image.c
+++ b/src/omv/modules/py_image.c
@@ -1025,6 +1025,9 @@ static mp_obj_t py_image_to(pixformat_t pixfmt, const uint16_t *default_color_pa
     bool arg_e = py_helper_keyword_int(n_args, args, 13, kw_args,
                                        MP_OBJ_NEW_QSTR(MP_QSTR_encode_for_ide), encode_for_ide_default);
 
+    jpeg_subsampling_t subsampling =
+        py_helper_keyword_int(n_args, args, 14, kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_subsampling), JPEG_SUBSAMPLING_AUTO);
+
     if (copy_obj) {
         if (mp_obj_is_integer(copy_obj)) {
             copy = mp_obj_get_int(copy_obj);
@@ -1111,7 +1114,7 @@ static mp_obj_t py_image_to(pixformat_t pixfmt, const uint16_t *default_color_pa
                                  (hint & (~IMAGE_HINT_CENTER)) | IMAGE_HINT_BLACK_BACKGROUND, NULL, NULL, NULL);
             }
 
-            if (((dst_img.pixfmt == PIXFORMAT_JPEG) && jpeg_compress(&temp, &dst_img_tmp, arg_q, false))
+            if (((dst_img.pixfmt == PIXFORMAT_JPEG) && jpeg_compress(&temp, &dst_img_tmp, arg_q, false, subsampling))
                 || ((dst_img.pixfmt == PIXFORMAT_PNG) && png_compress(&temp, &dst_img_tmp))) {
                 mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("Compression Failed!"));
             }
@@ -7246,6 +7249,10 @@ static const mp_rom_map_elem_t globals_dict_table[] = {
     {MP_ROM_QSTR(MP_QSTR_ROTATE_90),           MP_ROM_INT(IMAGE_HINT_VFLIP | IMAGE_HINT_TRANSPOSE)},
     {MP_ROM_QSTR(MP_QSTR_ROTATE_180),          MP_ROM_INT(IMAGE_HINT_HMIRROR | IMAGE_HINT_VFLIP)},
     {MP_ROM_QSTR(MP_QSTR_ROTATE_270),          MP_ROM_INT(IMAGE_HINT_HMIRROR | IMAGE_HINT_TRANSPOSE)},
+    {MP_ROM_QSTR(MP_QSTR_JPEG_SUBSAMPLING_AUTO), MP_ROM_INT(JPEG_SUBSAMPLING_AUTO)},
+    {MP_ROM_QSTR(MP_QSTR_JPEG_SUBSAMPLING_444), MP_ROM_INT(JPEG_SUBSAMPLING_444)},
+    {MP_ROM_QSTR(MP_QSTR_JPEG_SUBSAMPLING_422), MP_ROM_INT(JPEG_SUBSAMPLING_422)},
+    {MP_ROM_QSTR(MP_QSTR_JPEG_SUBSAMPLING_420), MP_ROM_INT(JPEG_SUBSAMPLING_420)},
     #ifdef IMLIB_FIND_TEMPLATE
     {MP_ROM_QSTR(MP_QSTR_SEARCH_EX),           MP_ROM_INT(SEARCH_EX)},
     {MP_ROM_QSTR(MP_QSTR_SEARCH_DS),           MP_ROM_INT(SEARCH_DS)},

--- a/src/omv/ports/stm32/jpeg.c
+++ b/src/omv/ports/stm32/jpeg.c
@@ -105,7 +105,7 @@ static void jpeg_compress_data_ready(JPEG_HandleTypeDef *hjpeg, uint8_t *pDataOu
     }
 }
 
-bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc) {
+bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_subsampling_t subsampling) {
     #if (TIME_JPEG == 1)
     mp_uint_t start = mp_hal_ticks_ms();
     #endif
@@ -132,9 +132,17 @@ bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc) {
             mcu_size = JPEG_444_YCBCR_MCU_SIZE;
             JPEG_Info.ColorSpace = JPEG_YCBCR_COLORSPACE;
             JPEG_Info.ChromaSubsampling = JPEG_444_SUBSAMPLING;
-            if (quality < 60) {
+            if (subsampling == JPEG_SUBSAMPLING_AUTO) {
+                if (quality < 60) {
+                    mcu_size = JPEG_422_YCBCR_MCU_SIZE;
+                    JPEG_Info.ChromaSubsampling = JPEG_422_SUBSAMPLING;
+                }
+            } else if (subsampling == JPEG_SUBSAMPLING_422) {
                 mcu_size = JPEG_422_YCBCR_MCU_SIZE;
                 JPEG_Info.ChromaSubsampling = JPEG_422_SUBSAMPLING;
+            } else if (subsampling == JPEG_SUBSAMPLING_420) {
+                // not supported
+                return true;
             }
             break;
         default:


### PR DESCRIPTION
This PR adds support for YUV422 compression in the hardware jpeg decoder on the STM32. YUV422 compression is slightly slower than YUV444. However, it's necessary to support as quite a lot of desktop software cannot process YUV444 JPEGs in MJPEG streams.

The second commit in this PR then changes the default compression level for YUV422 to turn on at 70 percent quality and adjusts all MJPEG streaming scripts to match that. This should fix all MJPEG streaming issues across all OpenMV Cams on most platforms.

Fixes: https://github.com/openmv/openmv/issues/2070

...

For example, the RTSP streamer to VLC doesn't work without this PR. Once you add this PR it works then like magic.