### PR TITLE
imlib/fmath: Fix fmath function inlining.

### DIFF
--- a/src/omv/imlib/fmath.c
+++ b/src/omv/imlib/fmath.c
@@ -9,9 +9,6 @@
  * Fast approximate math functions.
  */
 #include "fmath.h"
-#include "omv_common.h"
-#include CMSIS_MCU_H
-#include "arm_math.h"
 
 const float __atanf_lut[4] = {
     -0.0443265554792128f,    //p7
@@ -19,83 +16,6 @@ const float __atanf_lut[4] = {
     +0.1555786518463281f,    //p5
     +0.9997878412794807f     //p1
 };
-
-#if (__ARM_ARCH < 7)
-#include <math.h>
-float OMV_ATTR_ALWAYS_INLINE fast_sqrtf(float x) {
-    return sqrtf(x);
-}
-
-int OMV_ATTR_ALWAYS_INLINE fast_floorf(float x) {
-    return floorf(x);
-}
-
-int OMV_ATTR_ALWAYS_INLINE fast_ceilf(float x) {
-    return ceilf(x);
-}
-
-int OMV_ATTR_ALWAYS_INLINE fast_roundf(float x) {
-    return roundf(x);
-}
-
-float OMV_ATTR_ALWAYS_INLINE fast_fabsf(float x) {
-    return fabsf(x);
-}
-#else
-float OMV_ATTR_ALWAYS_INLINE fast_sqrtf(float x) {
-    asm volatile (
-        "vsqrt.f32  %[r], %[x]\n"
-        : [r] "=t" (x)
-        : [x] "t"  (x));
-    return x;
-}
-
-int OMV_ATTR_ALWAYS_INLINE fast_floorf(float x) {
-    int i;
-    asm volatile (
-    #if (__CORTEX_M > 4)
-        "vcvtm.S32.f32  %[r], %[x]\n"
-    #else
-        "vcvt.S32.f32  %[r], %[x]\n"
-    #endif
-        : [r] "=t" (i)
-        : [x] "t"  (x));
-    return i;
-}
-
-int OMV_ATTR_ALWAYS_INLINE fast_ceilf(float x) {
-    int i;
-    #if (__CORTEX_M > 4)
-    asm volatile (
-        "vcvtp.S32.f32  %[r], %[x]\n"
-    #else
-    uint32_t max = 0x3f7fffff;
-    x += *((float *) &max);
-    asm volatile (
-        "vcvt.S32.f32  %[r], %[x]\n"
-    #endif
-        : [r] "=t" (i)
-        : [x] "t"  (x));
-    return i;
-}
-
-int OMV_ATTR_ALWAYS_INLINE fast_roundf(float x) {
-    int i;
-    asm volatile (
-        "vcvtr.S32.F32  %[r], %[x]\n"
-        : [r] "=t" (i)
-        : [x] "t"  (x));
-    return i;
-}
-
-float OMV_ATTR_ALWAYS_INLINE fast_fabsf(float x) {
-    asm volatile (
-        "vabs.f32  %[r], %[x]\n"
-        : [r] "=t" (x)
-        : [x] "t"  (x));
-    return x;
-}
-#endif
 
 typedef union {
     uint32_t l;

--- a/src/omv/imlib/fmath.h
+++ b/src/omv/imlib/fmath.h
@@ -13,10 +13,89 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <float.h>
-float fast_sqrtf(float x);
-int fast_floorf(float x);
-int fast_ceilf(float x);
-int fast_roundf(float x);
+#include "omv_common.h"
+#include CMSIS_MCU_H
+#include "arm_math.h"
+#if (__ARM_ARCH < 7)
+#include <math.h>
+static float OMV_ATTR_ALWAYS_INLINE fast_sqrtf(float x) {
+    return sqrtf(x);
+}
+
+static int OMV_ATTR_ALWAYS_INLINE fast_floorf(float x) {
+    return floorf(x);
+}
+
+static int OMV_ATTR_ALWAYS_INLINE fast_ceilf(float x) {
+    return ceilf(x);
+}
+
+static int OMV_ATTR_ALWAYS_INLINE fast_roundf(float x) {
+    return roundf(x);
+}
+
+static float OMV_ATTR_ALWAYS_INLINE fast_fabsf(float x) {
+    return fabsf(x);
+}
+#else
+static float OMV_ATTR_ALWAYS_INLINE fast_sqrtf(float x) {
+    __asm__ volatile (
+        "vsqrt.f32  %[r], %[x]\n"
+        : [r] "=t" (x)
+        : [x] "t"  (x));
+    return x;
+}
+
+static int OMV_ATTR_ALWAYS_INLINE fast_floorf(float x) {
+    int i;
+    __asm__ volatile (
+    #if (__CORTEX_M > 4)
+        "vcvtm.S32.f32  %[r], %[x]\n"
+    #else
+        "vcvt.S32.f32  %[r], %[x]\n"
+    #endif
+        : [r] "=t" (i)
+        : [x] "t"  (x));
+    return i;
+}
+
+static int OMV_ATTR_ALWAYS_INLINE fast_ceilf(float x) {
+    int i;
+    #if (__CORTEX_M > 4)
+    __asm__ volatile (
+        "vcvtp.S32.f32  %[r], %[x]\n"
+    #else
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+    #pragma GCC diagnostic ignored "-Wuninitialized"
+    uint32_t max = 0x3f7fffff;
+    x += *((float *) &max);
+    #pragma GCC diagnostic pop
+    __asm__ volatile (
+        "vcvt.S32.f32  %[r], %[x]\n"
+    #endif
+        : [r] "=t" (i)
+        : [x] "t"  (x));
+    return i;
+}
+
+static int OMV_ATTR_ALWAYS_INLINE fast_roundf(float x) {
+    int i;
+    __asm__ volatile (
+        "vcvtr.S32.F32  %[r], %[x]\n"
+        : [r] "=t" (i)
+        : [x] "t"  (x));
+    return i;
+}
+
+static float OMV_ATTR_ALWAYS_INLINE fast_fabsf(float x) {
+    __asm__ volatile (
+        "vabs.f32  %[r], %[x]\n"
+        : [r] "=t" (x)
+        : [x] "t"  (x));
+    return x;
+}
+#endif
 float fast_atanf(float x);
 float fast_atan2f(float y, float x);
 float fast_expf(float x);


### PR DESCRIPTION
Compilier wasn't inlining them. Not sure if this is the right fix. Feel free to close the PR and create the proper fix.