### PR TITLE
imlib/binary: Improve erode/dilate performance using SIMD.

### DIFF
--- a/src/omv/imlib/binary.c
+++ b/src/omv/imlib/binary.c
@@ -939,18 +939,19 @@ static void imlib_erode_dilate(image_t *img, int ksize, int threshold, int e_or_
         case PIXFORMAT_BINARY: {
             buf.data = fb_alloc(IMAGE_BINARY_LINE_LEN_BYTES(img) * brows, FB_ALLOC_NO_HINT);
 
-            for (int y = 0, yy = img->h; y < yy; y++) {
+            for (int y = 0; y < img->h; y++) {
                 uint32_t *row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(img, y);
                 uint32_t *buf_row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(&buf, (y % brows));
                 int acc = 0;
 
-                for (int x = 0, xx = img->w; x < xx; x++) {
+                for (int x = 0; x < img->w; x++) {
                     int pixel = IMAGE_GET_BINARY_PIXEL_FAST(row_ptr, x);
                     IMAGE_PUT_BINARY_PIXEL_FAST(buf_row_ptr, x, pixel);
 
                     if (mask && (!image_get_mask_pixel(mask, x, y))) {
                         continue; // Short circuit.
                     }
+
                     if (x > ksize && x < img->w - ksize && y >= ksize && y < img->h - ksize) {
                         // faster
                         for (int j = -ksize; j <= ksize; j++) {
@@ -995,7 +996,7 @@ static void imlib_erode_dilate(image_t *img, int ksize, int threshold, int e_or_
             }
 
             // Copy any remaining lines from the buffer image...
-            for (int y = IM_MAX(img->h - ksize, 0), yy = img->h; y < yy; y++) {
+            for (int y = IM_MAX(img->h - ksize, 0); y < img->h; y++) {
                 memcpy(IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(img, y),
                        IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(&buf, (y % brows)),
                        IMAGE_BINARY_LINE_LEN_BYTES(img));
@@ -1007,12 +1008,17 @@ static void imlib_erode_dilate(image_t *img, int ksize, int threshold, int e_or_
         case PIXFORMAT_GRAYSCALE: {
             buf.data = fb_alloc(IMAGE_GRAYSCALE_LINE_LEN_BYTES(img) * brows, FB_ALLOC_NO_HINT);
 
-            for (int y = 0, yy = img->h; y < yy; y++) {
+            #if defined(ARM_MATH_DSP)
+            int32_t threshold_x4 = __USAT(threshold, 7) * 0x01010101;
+            uint32_t e_or_d_mask_x4 = e_or_d ? 0xFFFFFFFF : 0x00000000;
+            #endif
+
+            for (int y = 0; y < img->h; y++) {
                 uint8_t *row_ptr = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(img, y);
                 uint8_t *buf_row_ptr = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(&buf, (y % brows));
                 int acc = 0;
 
-                for (int x = 0, xx = img->w; x < xx; x++) {
+                for (int x = 0; x < img->w; x++) {
                     int pixel = IMAGE_GET_GRAYSCALE_PIXEL_FAST(row_ptr, x);
                     IMAGE_PUT_GRAYSCALE_PIXEL_FAST(buf_row_ptr, x, pixel);
 
@@ -1021,13 +1027,47 @@ static void imlib_erode_dilate(image_t *img, int ksize, int threshold, int e_or_
                     }
 
                     if (x > ksize && x < img->w - ksize && y >= ksize && y < img->h - ksize) {
-                        // faster
-                        for (int j = -ksize; j <= ksize; j++) {
-                            uint8_t *k_row_ptr = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(img, y + j);
-                            // subtract old left edge and add new right edge to sum
-                            acc -= (IMAGE_GET_GRAYSCALE_PIXEL_FAST(k_row_ptr, x - ksize - 1) > 0);
-                            acc += (IMAGE_GET_GRAYSCALE_PIXEL_FAST(k_row_ptr, x + ksize) > 0);
-                        } // for j
+                        if (0) {
+                        #if defined(ARM_MATH_DSP)
+                            // acc will never be larger than 121 (<= 127) for ksize <= 5.
+                        } else if ((x < img->w - ksize - 3) && (ksize <= 5) && (!mask)) {
+                            int32_t acc_x4 = acc & 0xFF;
+
+                            for (int j = -ksize; j <= ksize; j++) {
+                                uint8_t *k_row_ptr = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(img, y + j);
+                                // subtract old left edge 4x
+                                __USUB8(*((uint32_t *) (k_row_ptr + x - ksize - 1)), 0x01010101);
+                                acc_x4 = __SSUB8(acc_x4, __SEL(0x01010101, 0));
+                                // add new right edge to sum 4x
+                                __USUB8(*((uint32_t *) (k_row_ptr + x + ksize)), 0x01010101);
+                                acc_x4 = __SADD8(acc_x4, __SEL(0x01010101, 0));
+                            }
+
+                            // After the loop the lowest 8-bits contain a valid acc value. We
+                            // compute the next 3 acc values by adding the sums up.
+
+                            acc_x4 = __SADD8(acc_x4, acc_x4 << 8);
+                            acc_x4 = __SADD8(acc_x4, acc_x4 << 16);
+                            acc = acc_x4 >> 24;
+
+                            // Compute all erode/dilate thresholds at once.
+
+                            uint32_t pixel_x4 = *((uint32_t *) (row_ptr + x));
+                            __SSUB8(e_or_d ? threshold_x4 : acc_x4, e_or_d ? acc_x4 : threshold_x4);
+                            *((uint32_t *) (buf_row_ptr + x)) = __SEL(pixel_x4, e_or_d_mask_x4);
+
+                            x += 3;
+                            continue;
+                        #endif
+                        } else {
+                            // faster
+                            for (int j = -ksize; j <= ksize; j++) {
+                                uint8_t *k_row_ptr = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(img, y + j);
+                                // subtract old left edge and add new right edge to sum
+                                acc -= (IMAGE_GET_GRAYSCALE_PIXEL_FAST(k_row_ptr, x - ksize - 1) > 0);
+                                acc += (IMAGE_GET_GRAYSCALE_PIXEL_FAST(k_row_ptr, x + ksize) > 0);
+                            }
+                        }
                     } else {
                         // slower way which checks boundaries per pixel
                         acc = e_or_d ? 0 : -1; // Don't count center pixel...
@@ -1038,21 +1078,19 @@ static void imlib_erode_dilate(image_t *img, int ksize, int threshold, int e_or_
                             for (int k = -ksize; k <= ksize; k++) {
                                 int x_k = IM_CLAMP(x + k, 0, (img->w - 1));
                                 acc += IMAGE_GET_GRAYSCALE_PIXEL_FAST(k_row_ptr, x_k) > 0;
-                            }  // for k
-                        } // for j
+                            }
+                        }
                     }
 
                     if (!e_or_d) {
                         // Preserve original pixel value... or clear it.
                         if (acc < threshold) {
-                            IMAGE_PUT_GRAYSCALE_PIXEL_FAST(buf_row_ptr, x,
-                                                           COLOR_GRAYSCALE_BINARY_MIN);
+                            IMAGE_PUT_GRAYSCALE_PIXEL_FAST(buf_row_ptr, x, COLOR_GRAYSCALE_BINARY_MIN);
                         }
                     } else {
                         // Preserve original pixel value... or set it.
                         if (acc > threshold) {
-                            IMAGE_PUT_GRAYSCALE_PIXEL_FAST(buf_row_ptr, x,
-                                                           COLOR_GRAYSCALE_BINARY_MAX);
+                            IMAGE_PUT_GRAYSCALE_PIXEL_FAST(buf_row_ptr, x, COLOR_GRAYSCALE_BINARY_MAX);
                         }
                     }
                 }
@@ -1066,7 +1104,7 @@ static void imlib_erode_dilate(image_t *img, int ksize, int threshold, int e_or_
             }
 
             // Copy any remaining lines from the buffer image...
-            for (int y = IM_MAX(img->h - ksize, 0), yy = img->h; y < yy; y++) {
+            for (int y = IM_MAX(img->h - ksize, 0); y < img->h; y++) {
                 memcpy(IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(img, y),
                        IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(&buf, (y % brows)),
                        IMAGE_GRAYSCALE_LINE_LEN_BYTES(img));
@@ -1078,12 +1116,17 @@ static void imlib_erode_dilate(image_t *img, int ksize, int threshold, int e_or_
         case PIXFORMAT_RGB565: {
             buf.data = fb_alloc(IMAGE_RGB565_LINE_LEN_BYTES(img) * brows, FB_ALLOC_NO_HINT);
 
-            for (int y = 0, yy = img->h; y < yy; y++) {
+            #if defined(ARM_MATH_DSP)
+            int32_t threshold_x2 = __USAT(threshold, 15) * 0x00010001;
+            uint32_t e_or_d_mask_x2 = e_or_d ? 0xFFFFFFFF : 0x00000000;
+            #endif
+
+            for (int y = 0; y < img->h; y++) {
                 uint16_t *row_ptr = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(img, y);
                 uint16_t *buf_row_ptr = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(&buf, (y % brows));
                 int acc = 0;
 
-                for (int x = 0, xx = img->w; x < xx; x++) {
+                for (int x = 0; x < img->w; x++) {
                     int pixel = IMAGE_GET_RGB565_PIXEL_FAST(row_ptr, x);
                     IMAGE_PUT_RGB565_PIXEL_FAST(buf_row_ptr, x, pixel);
 
@@ -1092,12 +1135,45 @@ static void imlib_erode_dilate(image_t *img, int ksize, int threshold, int e_or_
                     }
 
                     if (x > ksize && x < img->w - ksize && y >= ksize && y < img->h - ksize) {
-                        // faster
-                        for (int j = -ksize; j <= ksize; j++) {
-                            uint16_t *k_row_ptr = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(img, y + j);
-                            // subtract old left column and add new right column
-                            acc -= IMAGE_GET_RGB565_PIXEL_FAST(k_row_ptr, x - ksize - 1) > 0;
-                            acc += IMAGE_GET_RGB565_PIXEL_FAST(k_row_ptr, x + ksize) > 0;
+                        if (0) {
+                        #if defined(ARM_MATH_DSP)
+                            // acc will never be larger than 32,761 (<= 32767) for ksize <= 90.
+                        } else if ((x < img->w - ksize - 1) && (ksize <= 90) && (!mask)) {
+                            int32_t acc_x2 = acc & 0xFFFF;
+
+                            for (int j = -ksize; j <= ksize; j++) {
+                                uint16_t *k_row_ptr = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(img, y + j);
+                                // subtract old left edge 2x
+                                __USUB16(*((uint32_t *) (k_row_ptr + x - ksize - 1)), 0x00010001);
+                                acc_x2 = __SSUB16(acc_x2, __SEL(0x00010001, 0));
+                                // add new right edge to sum 2x
+                                __USUB16(*((uint32_t *) (k_row_ptr + x + ksize)), 0x00010001);
+                                acc_x2 = __SADD16(acc_x2, __SEL(0x00010001, 0));
+                            }
+
+                            // After the loop the lowest 16-bits contain a valid acc value. We
+                            // compute the next acc value by adding the sums up.
+
+                            acc_x2 = __SADD16(acc_x2, acc_x2 << 16);
+                            acc = acc_x2 >> 16;
+
+                            // Compute all erode/dilate thresholds at once.
+
+                            uint32_t pixel_x2 = *((uint32_t *) (row_ptr + x));
+                            __SSUB16(e_or_d ? threshold_x2 : acc_x2, e_or_d ? acc_x2 : threshold_x2);
+                            *((uint32_t *) (buf_row_ptr + x)) = __SEL(pixel_x2, e_or_d_mask_x2);
+
+                            x += 1;
+                            continue;
+                        #endif
+                        } else {
+                            // faster
+                            for (int j = -ksize; j <= ksize; j++) {
+                                uint16_t *k_row_ptr = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(img, y + j);
+                                // subtract old left column and add new right column
+                                acc -= IMAGE_GET_RGB565_PIXEL_FAST(k_row_ptr, x - ksize - 1) > 0;
+                                acc += IMAGE_GET_RGB565_PIXEL_FAST(k_row_ptr, x + ksize) > 0;
+                            }
                         }
                     } else {
                         // need to check boundary conditions for each pixel
@@ -1116,14 +1192,12 @@ static void imlib_erode_dilate(image_t *img, int ksize, int threshold, int e_or_
                     if (!e_or_d) {
                         // Preserve original pixel value... or clear it.
                         if (acc < threshold) {
-                            IMAGE_PUT_RGB565_PIXEL_FAST(buf_row_ptr, x,
-                                                        COLOR_RGB565_BINARY_MIN);
+                            IMAGE_PUT_RGB565_PIXEL_FAST(buf_row_ptr, x, COLOR_RGB565_BINARY_MIN);
                         }
                     } else {
                         // Preserve original pixel value... or set it.
                         if (acc > threshold) {
-                            IMAGE_PUT_RGB565_PIXEL_FAST(buf_row_ptr, x,
-                                                        COLOR_RGB565_BINARY_MAX);
+                            IMAGE_PUT_RGB565_PIXEL_FAST(buf_row_ptr, x, COLOR_RGB565_BINARY_MAX);
                         }
                     }
                 }
@@ -1137,7 +1211,7 @@ static void imlib_erode_dilate(image_t *img, int ksize, int threshold, int e_or_
             }
 
             // Copy any remaining lines from the buffer image...
-            for (int y = IM_MAX(img->h - ksize, 0), yy = img->h; y < yy; y++) {
+            for (int y = IM_MAX(img->h - ksize, 0); y < img->h; y++) {
                 memcpy(IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(img, y),
                        IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(&buf, (y % brows)),
                        IMAGE_RGB565_LINE_LEN_BYTES(img));


### PR DESCRIPTION
This PR provides huge performance boost to erode and dilate using cortex-m SIMD:

At the VGA resolution for erode/dilate:

---GRAYSCALE---
kernel size 0 (1x1) -> old 31ms -> new 12ms (158% speedup)
kernel size 1 (3x3) -> old 47ms -> new 18ms (161% speedup)
kernel size 2 (5x5) -> old 62ms -> new 25ms (148% speedup)
kernel size 3 (7x7) -> old 79ms -> new 34ms (132% speedup)
kernel size 4 (9x9) -> old 101ms -> new 48ms (110% speedup)
kernel size 5 (11x11) -> old 126ms -> new 65ms (93% speedup)

---RGB565---
kernel size 0 (1x1) -> old 33ms -> new 24ms (37% speedup)
kernel size 1 (3x3) -> old 47ms -> new 35ms (34% speedup)
kernel size 2 (5x5) -> old 62ms -> new 50ms (24% speedup)
kernel size 3 (7x7) -> old 78ms -> new 64ms (21% speedup)
kernel size 4 (9x9) -> old 101ms -> new 88ms (14% speedup)
kernel size 5 (11x11) -> old 130ms -> new 114ms (14% speedup)

Fixes: https://github.com/openmv/openmv/issues/2064

Since no kernel is applied per element, you can use the sliding window approach with erode/dilate. This approach then lends itself nicely to SIMD acceleration since you repeatedly do the same operation on each column. So, I can do 4x the work with grayscale and 2x with RGB565. Finally, this approach illuminates how to speed the code up with helium for an additional 8x and 4x performance boost. 

