### PR TITLE
sensors/PAG7920: Support PixArt image sensor PAG7920.

### DIFF
--- a/src/omv/Makefile
+++ b/src/omv/Makefile
@@ -43,6 +43,7 @@ SRCS += $(addprefix sensors/,   \
 	hm01b0.c                    \
 	hm0360.c                    \
 	gc2145.c                    \
+	pag7920.c                   \
 	paj6100.c                   \
 	frogeye2020.c               \
    )

--- a/src/omv/boards/OPENMV4/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4/omv_boardconfig.h
@@ -44,6 +44,7 @@
 #define OMV_MT9M114_ENABLE                    (1)
 #define OMV_MT9V0XX_ENABLE                    (1)
 #define OMV_LEPTON_ENABLE                     (1)
+#define OMV_PAG7920_ENABLE                    (1)
 #define OMV_PAJ6100_ENABLE                    (1)
 #define OMV_FROGEYE2020_ENABLE                (1)
 

--- a/src/omv/boards/OPENMV4P/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4P/omv_boardconfig.h
@@ -45,6 +45,7 @@
 #define OMV_MT9M114_ENABLE                    (1)
 #define OMV_MT9V0XX_ENABLE                    (1)
 #define OMV_LEPTON_ENABLE                     (1)
+#define OMV_PAG7920_ENABLE                    (1)
 #define OMV_PAJ6100_ENABLE                    (1)
 #define OMV_FROGEYE2020_ENABLE                (1)
 

--- a/src/omv/boards/OPENMV4_PRO/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4_PRO/omv_boardconfig.h
@@ -46,6 +46,7 @@
 #define OMV_MT9V0XX_ENABLE                    (1)
 #define OMV_LEPTON_ENABLE                     (1)
 #define OMV_HM01B0_ENABLE                     (0)
+#define OMV_PAG7920_ENABLE                    (1)
 #define OMV_PAJ6100_ENABLE                    (1)
 #define OMV_FROGEYE2020_ENABLE                (1)
 

--- a/src/omv/boards/OPENMV_RT1060/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV_RT1060/omv_boardconfig.h
@@ -42,6 +42,7 @@
 #define OMV_MT9M114_ENABLE              (1)
 #define OMV_MT9V0XX_ENABLE              (1)
 #define OMV_LEPTON_ENABLE               (1)
+#define OMV_PAG7920_ENABLE              (1)
 #define OMV_PAJ6100_ENABLE              (1)
 #define OMV_FROGEYE2020_ENABLE          (1)
 

--- a/src/omv/common/sensor.h
+++ b/src/omv/common/sensor.h
@@ -23,6 +23,7 @@
 #define HM0XX0_SLV_ADDR         (0x48)
 #define GC2145_SLV_ADDR         (0x78)
 #define FROGEYE2020_SLV_ADDR    (0x6E)
+#define PAG7920_SLV_ADDR        (0x80)
 
 // Chip ID Registers
 #define OV5640_CHIP_ID          (0x300A)
@@ -30,6 +31,7 @@
 #define ON_CHIP_ID              (0x00)
 #define HIMAX_CHIP_ID           (0x0001)
 #define GC_CHIP_ID              (0xF0)
+#define PIXART_CHIP_ID          (0x00)
 
 // Chip ID Values
 #define OV2640_ID               (0x26)
@@ -55,6 +57,7 @@
 #define HM01B0_ID               (0xB0)
 #define HM0360_ID               (0x60)
 #define GC2145_ID               (0x21)
+#define PAG7920_ID              (0x7920)
 #define PAJ6100_ID              (0x6100)
 #define FROGEYE2020_ID          (0x2020)
 

--- a/src/omv/common/sensor_utils.c
+++ b/src/omv/common/sensor_utils.c
@@ -26,6 +26,7 @@
 #include "lepton.h"
 #include "hm01b0.h"
 #include "hm0360.h"
+#include "pag7920.h"
 #include "paj6100.h"
 #include "frogeye2020.h"
 #include "gc2145.h"
@@ -232,6 +233,13 @@ static int sensor_detect() {
                 sensor.chip_id_w = FROGEYE2020_ID;
                 return slv_addr;
             #endif // (OMV_FROGEYE2020_ENABLE == 1)
+
+            #if (OMV_PAG7920_ENABLE == 1)
+            case PAG7920_SLV_ADDR:
+                omv_i2c_readw(&sensor.i2c_bus, slv_addr, ON_CHIP_ID, &sensor.chip_id_w);
+                sensor.chip_id_w = (sensor.chip_id_w << 8) | (sensor.chip_id_w >> 8);
+                return slv_addr;
+            #endif // (OMV_PAG7920_ENABLE == 1)
         }
     }
 
@@ -425,6 +433,15 @@ int sensor_probe_init(uint32_t bus_id, uint32_t bus_speed) {
             init_ret = gc2145_init(&sensor);
             break;
         #endif //(OMV_GC2145_ENABLE == 1)
+
+        #if (OMV_PAG7920_ENABLE == 1)
+        case PAG7920_ID:
+            if (sensor_set_xclk_frequency(OMV_PAG7920_XCLK_FREQ) != 0) {
+                return SENSOR_ERROR_TIM_INIT_FAILED;
+            }
+            init_ret = pag7920_init(&sensor);
+            break;
+        #endif // (OMV_PAG7920_ENABLE == 1)
 
         #if (OMV_PAJ6100_ENABLE == 1)
         case PAJ6100_ID:

--- a/src/omv/ports/mimxrt/omv_portconfig.mk
+++ b/src/omv/ports/mimxrt/omv_portconfig.mk
@@ -156,6 +156,7 @@ FIRM_OBJ += $(addprefix $(BUILD)/$(OMV_DIR)/sensors/,   \
 	hm01b0.o                    \
 	hm0360.o                    \
 	gc2145.o                    \
+	pag7920.o                   \
 	paj6100.o                   \
 	frogeye2020.o               \
    )
@@ -517,6 +518,7 @@ UVC_OBJ += $(addprefix $(BUILD)/$(OMV_DIR)/sensors/, \
 	hm01b0.o                                \
 	hm0360.o                                \
 	gc2145.o                                \
+	pag7920.o                               \
 	paj6100.o                               \
 	frogeye2020.o                           \
 	)

--- a/src/omv/ports/stm32/omv_portconfig.mk
+++ b/src/omv/ports/stm32/omv_portconfig.mk
@@ -171,6 +171,7 @@ FIRM_OBJ += $(addprefix $(BUILD)/$(OMV_DIR)/sensors/,   \
 	hm01b0.o                    \
 	hm0360.o                    \
 	gc2145.o                    \
+	pag7920.o                   \
 	paj6100.o                   \
 	frogeye2020.o               \
    )
@@ -566,6 +567,7 @@ UVC_OBJ += $(addprefix $(BUILD)/$(OMV_DIR)/sensors/, \
 	hm01b0.o                                \
 	hm0360.o                                \
 	gc2145.o                                \
+	pag7920.o                               \
 	paj6100.o                               \
 	frogeye2020.o                           \
 	)

--- a/src/omv/sensors/pag7920.c
+++ b/src/omv/sensors/pag7920.c
@@ -1,0 +1,653 @@
+/*
+ * This file is part of the OpenMV project.
+ *
+ * Copyright (c) 2023 Lake Fu <lake_fu@pixart.com> for PixArt Inc.
+ *
+ * This work is licensed under the MIT license, see the file LICENSE for details.
+ *
+ * PAG7920 driver.
+ */
+#include "omv_boardconfig.h"
+#if (OMV_PAG7920_ENABLE == 1)
+
+#include <stdint.h>
+#include <stdio.h>
+#include <math.h>
+#include "py/mphal.h"
+
+#include "sensor.h"
+#include "framebuffer.h"
+#include "omv_i2c.h"
+
+#include "pag7920.h"
+#include "pag7920_reg.h"
+
+#define SENSOR_I2C_DEBUG (0)
+
+#define US (1000000)  // microsecond
+#ifndef M_LN29
+#define M_LN29  (3.36729582998647402718)
+#endif
+
+// Grayscale/QVGA
+const uint16_t default_regs [][2] = {
+    {0xEF, 0x00},
+    {0x1D, 0x41},
+    {0x64, 0x01},
+    {0x45, 0x44},
+    {0x12, 0x20},
+    {0x0C, 0xC8},
+    {0x11, 0xC8},
+    {0x42, 0xC8},
+    {0x43, 0xC8},
+    {0x44, 0xC8},
+    {0xAF, 0x31},
+    {0x69, 0x14},
+    {0xEF, 0x00},
+    {0x4C, 0x00},
+    {0x4D, 0x35},
+    {0x4E, 0x0C},
+    {0x4F, 0x00},
+    {0xEF, 0x02},
+    {0x02, 0x64},
+    {0x03, 0x08},
+    {0xEF, 0x04},
+    {0x2C, 0xC6},
+    {0x2D, 0x2D},
+    {0x2E, 0x00},
+    {0x30, 0x31},
+    {0x31, 0x80},
+    {0x40, 0x1D},
+    {0x41, 0x00},
+    {0x42, 0xD0},
+    {0x43, 0x01},
+    {0x44, 0xF0},
+    {0x45, 0x00},
+    {0x46, 0x00},
+    {0x47, 0x00},
+    {0x48, 0xF0},
+    {0x49, 0x0D},
+    {0x4A, 0x0C},
+    {0x4B, 0x00},
+    {0x51, 0x1D},
+    {0x52, 0x00},
+    {0x53, 0xC0},
+    {0x54, 0xD4},
+    {0x55, 0x01},
+    {0x56, 0x00},
+    {0xEF, 0x01},
+    {0xC4, 0x02},
+    {0xC6, 0x40},
+    {0xC7, 0x01},
+    {0xC8, 0xF0},
+    {0xC9, 0x00},
+    {0xEF, 0x02},
+    {0x11, 0x03},
+    {0x19, 0xFC},
+    {0x1A, 0x00},
+    {0x21, 0x40},
+    {0x22, 0x01},
+    {0x23, 0xF0},
+    {0x24, 0x00},
+    {0x27, 0x0C},
+    {0x28, 0x00},
+    {0x2D, 0xF0},
+    {0x2E, 0x00},
+    {0x56, 0x40},
+    {0x57, 0x01},
+    {0x58, 0xFE},
+    {0x59, 0x00},
+    {0xEF, 0x01},
+    {0x33, 0x46},
+    {0x3B, 0x30},
+    {0x40, 0x96},
+    {0xD9, 0x32},
+    {0xDB, 0x64},
+    {0xDD, 0x64},
+    {0xEF, 0x02},
+    {0xA5, 0x00},
+    {0xA6, 0x96},
+    {0xEF, 0x00},
+    {0x09, 0x10},
+    {0x18, 0x01},
+    {0x2F, 0x44},
+    {0x37, 0x04},
+    {0x38, 0x06},
+    {0x3F, 0x01},
+    {0x55, 0x01},
+    {0x66, 0x01},
+    {0xEF, 0x01},
+    {0x03, 0x00},
+    {0x04, 0xAB},
+    {0x07, 0x02},
+    {0x0A, 0x00},
+    {0x0B, 0x40},
+    {0x0F, 0x0B},
+    {0x11, 0x0A},
+    {0x13, 0x0C},
+    {0x16, 0x00},
+    {0x17, 0xA9},
+    {0x36, 0x00},
+    {0x37, 0x02},
+    {0x4D, 0x02},
+    {0x56, 0xB8},
+    {0x57, 0x01},
+    {0x58, 0xB8},
+    {0x59, 0x01},
+    {0x62, 0x00},
+    {0x63, 0x06},
+    {0x69, 0x1C},
+    {0x6A, 0x1D},
+    {0x6B, 0x68},
+    {0x6C, 0x67},
+    {0x76, 0x06},
+    {0x77, 0x09},
+    {0x78, 0x02},
+    {0x79, 0x03},
+    {0x84, 0x19},
+    {0x86, 0x14},
+    {0x87, 0x19},
+    {0x89, 0x14},
+    {0x8A, 0x23},
+    {0x8C, 0x1E},
+    {0x8D, 0x23},
+    {0x8F, 0x1E},
+    {0x9D, 0x0A},
+    {0xA0, 0x00},
+    {0xD1, 0xC8},
+    {0xD2, 0x00},
+    {0xEF, 0x02},
+    {0x92, 0x11},
+    {0x93, 0x01},
+    {0xC3, 0xC8},
+    {0xC4, 0x00},
+    {0xC5, 0xC8},
+    {0xC6, 0x00},
+    {0xD1, 0x45},
+    {0xEF, 0x00},
+    {0xEB, 0x80},
+    {0xEF, 0x00},
+    {0x30, 0x01},
+    // OpenMV typical end token.
+    {0x00, 0x00},
+};
+
+typedef union {
+    struct {
+        uint8_t b0 : 1;
+        uint8_t b1 : 1;
+        uint8_t b2 : 1;
+        uint8_t b3 : 1;
+        uint8_t b4 : 1;
+        uint8_t b5 : 1;
+        uint8_t b6 : 1;
+        uint8_t b7 : 1;
+    } bits;
+    uint8_t byte_val;
+} bitplane;
+
+extern uint8_t _line_buf;
+static int8_t g_bank_cache = -1;
+
+static bool g_f_hflip = false;
+static bool g_f_vflip = false;
+
+static int switch_bank(sensor_t *sensor, uint8_t bank) {
+    if (g_bank_cache != bank) {
+        debug_printf("W Reg: 0x%02X 0x%02X\r\n", REG_BANK, bank);
+        int res = omv_i2c_writeb(&sensor->i2c_bus, sensor->slv_addr, REG_BANK, bank);
+        if (res) {
+            g_bank_cache = -1;  // Encountered an unknown error, clear cache.
+            printf("switch bank failed, res = %d\n", res);
+        } else {
+            g_bank_cache = bank;
+        }
+        return res;
+    }
+    return 0;
+}
+
+static int write_reg_w_bank(sensor_t *sensor, uint8_t bank, uint8_t addr,
+                            uint8_t val) {
+    if (switch_bank(sensor, bank)) {
+        printf("write_reg failed.\n");
+        return -1;
+    }
+    if (addr == REG_BANK) {
+        g_bank_cache = -1;
+    }
+
+    debug_printf("W Reg: 0x%02X 0x%02X\r\n", addr, val);
+    return omv_i2c_writeb(&sensor->i2c_bus, sensor->slv_addr, addr, val);
+}
+
+static int read_reg_w_bank(sensor_t *sensor, uint8_t bank, uint8_t addr,
+                           uint8_t *p_val) {
+    if (switch_bank(sensor, bank)) {
+        printf("read_reg_w_bank() failed.\n");
+        return -1;
+    }
+
+    debug_printf("R Reg: 0x%02X\r\n", addr);
+    return omv_i2c_readb(&sensor->i2c_bus, sensor->slv_addr, addr, p_val);
+}
+
+static int init_sensor(sensor_t *sensor) {
+    write_reg_w_bank(sensor, BANK_0, R_GLOBAL_RESET, V_GLOBAL_RESET);
+    mp_hal_delay_ms(50);
+#define ta_seq default_regs
+    for (int i = 0; ta_seq[i][0]; i++) {
+        debug_printf("W Reg: 0x%02X 0x%02X\r\n", ta_seq[i][0], ta_seq[i][1]);
+        int res = omv_i2c_writeb(&sensor->i2c_bus, sensor->slv_addr, ta_seq[i][0],
+                                 ta_seq[i][1]);
+        if (res) {
+            return res;
+        }
+    }
+#undef ta_seq
+    return 0;
+}
+
+static int reset(sensor_t *sensor) {
+    // Reset internal flag.
+    g_f_hflip = g_f_vflip = false;
+    g_bank_cache = -1;
+    return init_sensor(sensor);
+}
+
+static int sleep(sensor_t *sensor, int enable) {
+    int ret = write_reg_w_bank(sensor, 0, TG_En,
+                               enable == 1 ? TG_En_V2 : TG_En_V1);
+    if (ret) {
+        printf("sleep() failed.\n");
+    }
+    return ret;
+}
+
+static int read_reg(sensor_t *sensor, uint16_t reg_addr) {
+    uint8_t val = 0;
+    if (omv_i2c_readb(&sensor->i2c_bus, sensor->slv_addr, (uint8_t) reg_addr, &val)) {
+        return -1;
+    }
+    return val;
+}
+
+static int write_reg(sensor_t *sensor, uint16_t reg_addr, uint16_t reg_data) {
+    int ret;
+    ret = omv_i2c_writeb(&sensor->i2c_bus, sensor->slv_addr, (uint8_t) reg_addr,
+                         (uint8_t) reg_data);
+    if (ret == 0 && reg_addr == REG_BANK) {
+        g_bank_cache = (uint8_t) reg_data;
+    }
+
+    return ret;
+}
+
+static int set_pixformat(sensor_t *sensor, pixformat_t pixformat) {
+    switch (pixformat) {
+        case PIXFORMAT_GRAYSCALE:
+            break;
+        default:
+            return -1;
+    }
+    return 0;
+}
+
+static int set_framesize(sensor_t *sensor, framesize_t framesize) {
+    int res = 0;
+    uint8_t val_R0_15, val_R0_16, val_R0_1C,
+            val_R0_3E_B2, val_R1_4B_B0,
+            val_R1_4B_B4, val_R1_70, val_R1_C2,
+            val_R_VSize, val_R_ABC_2_Start, val_R_WOI_VSize,
+            val_R_WOI_VStart, val_R_ABC_grad1, val_R2_D9_B0, val_R2_D9_B1,
+            val_R_AE_Size__div4_X, val_R_AE_Size__div4_Y, val_R009_H;
+    switch (framesize) {
+        case FRAMESIZE_QVGA:
+            val_R0_15 = 0;
+            val_R0_16 = 0;
+            val_R0_1C = 0;
+            val_R0_3E_B2 = 0;
+            val_R1_4B_B0 = 0;
+            val_R1_4B_B4 = 0;
+            val_R1_70 = 0;
+            val_R1_C2 = g_f_vflip ? V_R1C2_Q_V_ON : V_R1C2_Q_V_OFF;
+            val_R_VSize = 240;
+            val_R_ABC_2_Start = 252;
+            val_R_WOI_VSize = 240;
+            val_R_WOI_VStart = 12;
+            val_R_ABC_grad1 = 240;
+            val_R2_D9_B0 = 0;
+            val_R009_H = g_f_hflip ? V_R009_Q_H_ON : V_R009_Q_H_OFF;
+            val_R2_D9_B1 = g_f_hflip ? V_R2D9_Q_H_ON : V_R2D9_Q_H_OFF;
+            val_R_AE_Size__div4_X = 80;
+            val_R_AE_Size__div4_Y = 60;
+            break;
+        case FRAMESIZE_QQVGA:
+            val_R0_15 = 1;
+            val_R0_16 = 1;
+            val_R0_1C = 1;
+            val_R0_3E_B2 = 1;
+            val_R1_4B_B0 = 1;
+            val_R1_4B_B4 = 1;
+            val_R1_70 = 1;
+            val_R1_C2 = g_f_vflip?V_R1C2_QQ_V_ON:V_R1C2_QQ_V_OFF;
+            val_R_VSize = 120;
+            val_R_ABC_2_Start = 129;
+            val_R_WOI_VSize = 120;
+            val_R_WOI_VStart = 9;
+            val_R_ABC_grad1 = 120;
+            val_R2_D9_B0 = 1;
+            val_R009_H = g_f_hflip ? V_R009_QQ_H_ON : V_R009_QQ_H_OFF;
+            val_R2_D9_B1 = 0;
+            val_R_AE_Size__div4_X = 40;
+            val_R_AE_Size__div4_Y = 30;
+            break;
+        default:
+            return -1;
+    }
+    bitplane tmp = {.byte_val = 0};
+    res |= read_reg_w_bank(sensor, BANK_0, R0_15, &tmp.byte_val);
+    tmp.bits.b5 = val_R0_15;
+    res |= write_reg_w_bank(sensor, BANK_0, R0_15, tmp.byte_val);
+
+    res |= read_reg_w_bank(sensor, BANK_0, R0_16, &tmp.byte_val);
+    tmp.bits.b0 = val_R0_16;
+    res |= write_reg_w_bank(sensor, BANK_0, R0_16, tmp.byte_val);
+
+    res |= read_reg_w_bank(sensor, BANK_0, R0_1C, &tmp.byte_val);
+    tmp.bits.b1 = val_R0_1C;
+    res |= write_reg_w_bank(sensor, BANK_0, R0_1C, tmp.byte_val);
+
+    res |= read_reg_w_bank(sensor, BANK_0, R0_3E_B2, &tmp.byte_val);
+    tmp.bits.b2 = val_R0_3E_B2;
+    //tmp.bits.b5 = val_R0_3E_B5;
+    res |= write_reg_w_bank(sensor, BANK_0, R0_3E_B2, tmp.byte_val);
+
+    res |= write_reg_w_bank(sensor, BANK_0, R0_09_B1, val_R009_H);
+
+    res |= read_reg_w_bank(sensor, BANK_1, R1_4B_B0, &tmp.byte_val);
+    tmp.bits.b0 = val_R1_4B_B0;
+    tmp.bits.b4 = val_R1_4B_B4 & 0x01;
+    tmp.bits.b5 = (val_R1_4B_B4 >> 1) & 0x01;
+    res |= write_reg_w_bank(sensor, BANK_1, R1_4B_B0, tmp.byte_val);
+
+    res |= read_reg_w_bank(sensor, BANK_1, R1_70, &tmp.byte_val);
+    tmp.bits.b4 = val_R1_70;
+    res |= write_reg_w_bank(sensor, BANK_1, R1_70, tmp.byte_val);
+
+    tmp.byte_val = val_R1_C2;
+    res |= write_reg_w_bank(sensor, BANK_1, R1_C2, tmp.byte_val);
+
+    tmp.byte_val = val_R_VSize;
+    res |= write_reg_w_bank(sensor, BANK_1, R1_C8, tmp.byte_val);
+
+    tmp.byte_val = val_R_ABC_2_Start;
+    res |= write_reg_w_bank(sensor, BANK_2, R2_19, tmp.byte_val);
+
+    tmp.byte_val = val_R_WOI_VSize;
+    res |= write_reg_w_bank(sensor, BANK_2, R2_23, tmp.byte_val);
+
+    tmp.byte_val = val_R_WOI_VStart;
+    res |= write_reg_w_bank(sensor, BANK_2, R2_27, tmp.byte_val);
+
+    tmp.byte_val = val_R_ABC_grad1;
+    res |= write_reg_w_bank(sensor, BANK_2, R2_2D, tmp.byte_val);
+
+    res |= read_reg_w_bank(sensor, BANK_2, R2_D9_B0, &tmp.byte_val);
+    tmp.bits.b0 = val_R2_D9_B0;
+    tmp.bits.b1 = val_R2_D9_B1;
+    res |= write_reg_w_bank(sensor, BANK_2, R2_D9_B0, tmp.byte_val);
+
+    res |=
+        write_reg_w_bank(sensor, BANK_4, R_AE_Size__div4_X, val_R_AE_Size__div4_X);
+
+    res |=
+        write_reg_w_bank(sensor, BANK_4, R_AE_Size__div4_Y, val_R_AE_Size__div4_Y);
+
+    res |= write_reg_w_bank(sensor, BANK_0, R_UPDATE_FLAG, V_UPDATE_VALUE);
+    res |= write_reg_w_bank(sensor, BANK_0, TG_En, 1);
+
+    return res;
+}
+
+static int set_gainceiling(sensor_t *sensor, gainceiling_t gainceiling) {
+    return 0;
+}
+
+static int set_auto_gain(sensor_t *sensor, int enable, float gain_db,
+                         float gain_db_ceiling) {
+    static const uint32_t digital = (OMV_PAG7920_XCLK_FREQ / US) / 2;
+    uint32_t frame_time;
+    read_reg_w_bank(sensor, BANK_0, R_Frame_Time_0, (uint8_t *) &frame_time);
+    read_reg_w_bank(sensor, BANK_0, R_Frame_Time_1, (uint8_t *) (&frame_time) + 1);
+    read_reg_w_bank(sensor, BANK_0, R_Frame_Time_2, (uint8_t *) (&frame_time) + 2);
+    read_reg_w_bank(sensor, BANK_0, R_Frame_Time_3, (uint8_t *) (&frame_time) + 3);
+    uint16_t gain_code;
+    if (!enable && (!isnanf(gain_db)) && (!isinff(gain_db))) {
+        float exponent = gain_db / 20.0f;
+        gain_code = IM_MIN(fast_roundf(expf(M_LN29 + (exponent * M_LN10))), 464);
+        write_reg_w_bank(sensor, BANK_4, R_AE_Gain_manual_L,
+                         *((uint8_t *) &gain_code));
+        write_reg_w_bank(sensor, BANK_4, R_AE_Gain_manual_H,
+                         *((uint8_t *) &gain_code + 1));
+        write_reg_w_bank(sensor, BANK_0, R_UPDATE_FLAG, V_UPDATE_VALUE);
+
+        // AE disable.
+        write_reg_w_bank(sensor, BANK_4, R_AE_EnH, 0x32);
+        // Delay a frame time.
+        mp_hal_delay_ms((frame_time / digital) / 1000);
+        write_reg_w_bank(sensor, BANK_4, R_AE_MinGain_L, *((uint8_t *) &gain_code));
+        write_reg_w_bank(sensor, BANK_4, R_AE_MinGain_H, *((uint8_t *) &gain_code + 1));
+        write_reg_w_bank(sensor, BANK_4, R_AE_MaxGain_L, *((uint8_t *) &gain_code));
+        write_reg_w_bank(sensor, BANK_4, R_AE_MaxGain_H, *((uint8_t *) &gain_code + 1));
+    } else if (enable && (!isnanf(gain_db_ceiling)) && (!isinff(gain_db_ceiling))) {
+        float exponent = gain_db_ceiling / 20.0f;
+        gain_code = IM_MIN(fast_roundf(expf(M_LN29 + (exponent * M_LN10))), 464);
+        // Min gain code = 29
+        write_reg_w_bank(sensor, BANK_4, R_AE_MinGain_L, 0x1D);
+        write_reg_w_bank(sensor, BANK_4, R_AE_MinGain_H, 0);
+        write_reg_w_bank(sensor, BANK_4, R_AE_MaxGain_L, *((uint8_t *) &gain_code));
+        write_reg_w_bank(sensor, BANK_4, R_AE_MaxGain_H, *((uint8_t *) &gain_code + 1));
+    }
+
+    // AE enable.
+    write_reg_w_bank(sensor, BANK_4, R_AE_EnH, 0x31);
+
+    return 0;
+}
+
+static int get_gain_db(sensor_t *sensor, float *gain_db) {
+    uint16_t gain_code;
+    read_reg_w_bank(sensor, BANK_4, AE_Total_Gain_L, (uint8_t *) &gain_code);
+    read_reg_w_bank(sensor, BANK_4, AE_Total_Gain_H, (uint8_t *) &gain_code + 1);
+    gain_code &= 0x07ff;
+    *gain_db = 20.0f * log10f(gain_code / 29.0f);
+    return 0;
+}
+
+static int set_auto_exposure(sensor_t *sensor, int enable, int expo_us) {
+    const uint32_t digital = (OMV_PAG7920_XCLK_FREQ / US) / 2;
+    uint32_t frame_time, expo_max_us, expo_min_us;
+    read_reg_w_bank(sensor, BANK_0, R_Frame_Time_0, (uint8_t *) &frame_time);
+    read_reg_w_bank(sensor, BANK_0, R_Frame_Time_1, (uint8_t *) (&frame_time) + 1);
+    read_reg_w_bank(sensor, BANK_0, R_Frame_Time_2, (uint8_t *) (&frame_time) + 2);
+    read_reg_w_bank(sensor, BANK_0, R_Frame_Time_3, (uint8_t *) (&frame_time) + 3);
+    uint32_t expo_max_factor = (frame_time - 10000);
+    const uint32_t expo_min_factor = 240;
+    expo_max_us = expo_max_factor / digital;
+    expo_min_us = expo_min_factor / digital;
+
+    if (!enable) {
+        uint32_t expo_manual_factor;
+        if (expo_us > expo_max_us) {
+            expo_manual_factor = expo_max_factor;
+        } else if (expo_us < expo_min_us) {
+            expo_manual_factor = expo_min_factor;
+        } else {
+            expo_manual_factor = expo_us * digital;
+        }
+        write_reg_w_bank(sensor, BANK_4, R_AE_Expo_manual_0,
+                         *((uint8_t *) &expo_manual_factor));
+        write_reg_w_bank(sensor, BANK_4, R_AE_Expo_manual_1,
+                         *((uint8_t *) &expo_manual_factor + 1));
+        write_reg_w_bank(sensor, BANK_4, R_AE_Expo_manual_2,
+                         *((uint8_t *) &expo_manual_factor + 2));
+        write_reg_w_bank(sensor, BANK_4, R_AE_Expo_manual_3,
+                         *((uint8_t *) &expo_manual_factor + 3));
+
+        write_reg_w_bank(sensor, BANK_0, R_UPDATE_FLAG, V_UPDATE_VALUE);
+        // AE disable.
+        write_reg_w_bank(sensor, BANK_4, R_AE_EnH, 0x32);
+        // Delay a frame time.
+        mp_hal_delay_ms(((frame_time / digital) / 1000));
+
+        // Bundle AE upbound and lowbound.
+        write_reg_w_bank(sensor, BANK_4, R_AE_MinExpo_0, *((uint8_t *) &expo_manual_factor));
+        write_reg_w_bank(sensor, BANK_4, R_AE_MinExpo_1,
+                         *((uint8_t *) &expo_manual_factor + 1));
+        write_reg_w_bank(sensor, BANK_4, R_AE_MinExpo_2,
+                         *((uint8_t *) &expo_manual_factor + 2));
+        write_reg_w_bank(sensor, BANK_4, R_AE_MinExpo_3,
+                         *((uint8_t *) &expo_manual_factor + 3));
+        write_reg_w_bank(sensor, BANK_4, R_AE_MaxExpo_0, *((uint8_t *) &expo_manual_factor));
+        write_reg_w_bank(sensor, BANK_4, R_AE_MaxExpo_1,
+                         *((uint8_t *) &expo_manual_factor + 1));
+        write_reg_w_bank(sensor, BANK_4, R_AE_MaxExpo_2,
+                         *((uint8_t *) &expo_manual_factor + 2));
+        write_reg_w_bank(sensor, BANK_4, R_AE_MaxExpo_3,
+                         *((uint8_t *) &expo_manual_factor + 3));
+        // AE enable.
+        write_reg_w_bank(sensor, BANK_4, R_AE_EnH, 0x31);
+    } else {
+        write_reg_w_bank(sensor, BANK_4, R_AE_MinExpo_0, *((uint8_t *) &expo_min_factor));
+        write_reg_w_bank(sensor, BANK_4, R_AE_MinExpo_1,
+                         *((uint8_t *) &expo_min_factor + 1));
+        write_reg_w_bank(sensor, BANK_4, R_AE_MinExpo_2,
+                         *((uint8_t *) &expo_min_factor + 2));
+        write_reg_w_bank(sensor, BANK_4, R_AE_MinExpo_3,
+                         *((uint8_t *) &expo_min_factor + 3));
+        write_reg_w_bank(sensor, BANK_4, R_AE_MaxExpo_0, *((uint8_t *) &expo_max_factor));
+        write_reg_w_bank(sensor, BANK_4, R_AE_MaxExpo_1,
+                         *((uint8_t *) &expo_max_factor + 1));
+        write_reg_w_bank(sensor, BANK_4, R_AE_MaxExpo_2,
+                         *((uint8_t *) &expo_max_factor + 2));
+        write_reg_w_bank(sensor, BANK_4, R_AE_MaxExpo_3,
+                         *((uint8_t *) &expo_max_factor + 3));
+    }
+    return 0;
+}
+
+static int get_exposure_us(sensor_t *sensor, int *exposure_us) {
+    static const uint32_t digital = (OMV_PAG7920_XCLK_FREQ / US) / 2;
+    uint32_t clk_num;
+
+    read_reg_w_bank(sensor, BANK_4, Reg_ExpPxclkNum_0, (uint8_t *) &clk_num);
+    read_reg_w_bank(sensor, BANK_4, Reg_ExpPxclkNum_1, (uint8_t *) (&clk_num) + 1);
+    read_reg_w_bank(sensor, BANK_4, Reg_ExpPxclkNum_2, (uint8_t *) (&clk_num) + 2);
+    read_reg_w_bank(sensor, BANK_4, Reg_ExpPxclkNum_3, (uint8_t *) (&clk_num) + 3);
+    clk_num &= 0x0fffffff;
+    debug_printf("Reg_ExpPxclkNum = %ld\n", clk_num);
+    *exposure_us = (int) clk_num / digital;
+    return 0;
+}
+
+static int set_auto_whitebal(sensor_t *sensor, int enable, float r_gain_db,
+                             float g_gain_db, float b_gain_db) {
+    return 0;
+}
+
+static int get_rgb_gain_db(sensor_t *sensor, float *r_gain_db, float *g_gain_db,
+                           float *b_gain_db) {
+    return 0;
+}
+
+static int set_hmirror(sensor_t *sensor, int enable) {
+    int res = 0;
+
+    switch (sensor->framesize) {
+        case FRAMESIZE_QVGA:
+            res |= write_reg_w_bank(sensor, BANK_0, R0_09_B1,
+                                    enable?V_R009_Q_H_ON:V_R009_Q_H_OFF);
+            res |= write_reg_w_bank(sensor, BANK_2, R2_D9_B1,
+                                    enable?V_R2D9_Q_H_ON:V_R2D9_Q_H_OFF);
+            break;
+        case FRAMESIZE_QQVGA:
+            res |= write_reg_w_bank(sensor, BANK_0, R0_09_B1,
+                                    enable?V_R009_QQ_H_ON:V_R009_QQ_H_OFF);
+            break;
+        default:
+            return -1;
+    }
+
+    res |= write_reg_w_bank(sensor, BANK_0, R_UPDATE_FLAG, V_UPDATE_VALUE);
+    res |= write_reg_w_bank(sensor, BANK_0, TG_En, 1);
+
+    if (res == 0) {
+        g_f_hflip = enable ? true : false;
+    }
+    return res;
+}
+
+static int set_vflip(sensor_t *sensor, int enable) {
+    int res = 0;
+
+    switch (sensor->framesize) {
+        case FRAMESIZE_QVGA:
+            res |= write_reg_w_bank(sensor, BANK_1, R1_C2,
+                                    enable?V_R1C2_Q_V_ON:V_R1C2_Q_V_OFF);
+            break;
+        case FRAMESIZE_QQVGA:
+            res |= write_reg_w_bank(sensor, BANK_1, R1_C2,
+                                    enable?V_R1C2_QQ_V_ON:V_R1C2_QQ_V_OFF);
+            break;
+        default:
+            return -1;
+    }
+
+    res |= write_reg_w_bank(sensor, BANK_1, R1_CB, enable?0xF3:0x04);
+    bitplane tmp = {.byte_val = 0};
+    res |= read_reg_w_bank(sensor, BANK_1, R1_CE_B2, &tmp.byte_val);
+    tmp.bits.b2 = enable ? 1 : 0;
+    res |= write_reg_w_bank(sensor, BANK_1, R1_CE_B2, tmp.byte_val);
+
+    res |= write_reg_w_bank(sensor, BANK_0, R_UPDATE_FLAG, V_UPDATE_VALUE);
+    res |= write_reg_w_bank(sensor, BANK_0, TG_En, 1);
+
+    if (res == 0) {
+        g_f_vflip = enable ? true : false;
+    }
+    return res;
+}
+
+int pag7920_init(sensor_t *sensor) {
+    // Initialize sensor structure.
+    sensor->reset = reset;
+    sensor->sleep = sleep;
+    sensor->read_reg = read_reg;
+    sensor->write_reg = write_reg;
+    sensor->set_pixformat = set_pixformat;
+    sensor->set_framesize = set_framesize;
+    sensor->set_gainceiling = set_gainceiling;
+    sensor->set_auto_gain = set_auto_gain;
+    sensor->get_gain_db = get_gain_db;
+    sensor->set_auto_exposure = set_auto_exposure;
+    sensor->get_exposure_us = get_exposure_us;
+    sensor->set_auto_whitebal = set_auto_whitebal;
+
+    sensor->get_rgb_gain_db = get_rgb_gain_db;
+    sensor->set_hmirror = set_hmirror;
+    sensor->set_vflip = set_vflip;
+
+    // Set sensor flags
+    sensor->hw_flags.vsync = 0;
+    sensor->hw_flags.hsync = 0;
+    sensor->hw_flags.pixck = 1;
+    sensor->hw_flags.fsync = 1;
+    sensor->hw_flags.jpege = 0;
+    sensor->hw_flags.gs_bpp = 1;
+
+    init_sensor(sensor);
+
+    return 0;
+}
+#endif

--- a/src/omv/sensors/pag7920.h
+++ b/src/omv/sensors/pag7920.h
@@ -1,0 +1,16 @@
+/*
+ * This file is part of the OpenMV project.
+ *
+ * Copyright (c) 2023 Lake Fu <lake_fu@pixart.com> for PixArt Inc.
+ *
+ * This work is licensed under the MIT license, see the file LICENSE for details.
+ *
+ * PAG7920 driver.
+ */
+#ifndef __PAG7920_H__
+#define __PAG7920_H__
+
+#define OMV_PAG7920_XCLK_FREQ 24000000
+
+int pag7920_init(sensor_t *sensor);
+#endif

--- a/src/omv/sensors/pag7920_reg.h
+++ b/src/omv/sensors/pag7920_reg.h
@@ -1,0 +1,98 @@
+/*
+ * This file is part of the OpenMV project.
+ *
+ * Copyright (c) 2023 Lake Fu <lake_fu@pixart.com> for PixArt Inc.
+ *
+ * This work is licensed under the MIT license, see the file LICENSE for details.
+ *
+ * PAG7920 driver.
+ */
+#include <stdint.h>
+
+#define REG_BANK                    0xEF
+// =======================================
+#define BANK_0                      0x00
+// ---------------------------------------
+#define R_PART_ID_L                 0x00
+#define R_PART_ID_H                 0x01
+#define TG_En                       0x30
+#define TG_En_V1                    0x01
+#define TG_En_V2                    0x00
+#define R0_09_B1                    0x09
+#define R0_15                       0x15
+#define R0_16                       0x16
+#define R0_1C                       0x1C
+#define R0_3E_B2                    0x3E
+#define R0_3E_B5                    0x3E
+#define R_Frame_Time_0              0x4C
+#define R_Frame_Time_1              0x4D
+#define R_Frame_Time_2              0x4E
+#define R_Frame_Time_3              0x4F
+#define R_UPDATE_FLAG               0xEB
+#define V_UPDATE_VALUE              0x80
+#define R_GLOBAL_RESET              0xEE
+#define V_GLOBAL_RESET              0xFF
+// =======================================
+#define BANK_1                      0x01
+// ---------------------------------------
+#define R1_4B_B0                    0x4B
+#define R1_4B_B4                    0x4B
+#define R1_70                       0x70
+#define R1_C2                       0xC2
+#define R1_C3                       0xC3
+#define R1_C8                       0xC8
+#define R1_CB                       0xCB
+#define R1_CE_B2                    0xCE
+// =======================================
+#define BANK_2                      0x02
+// ---------------------------------------
+#define R2_19                       0x19
+#define R2_23                       0x23
+#define R2_27                       0x27
+#define R2_2D                       0x2D
+#define R2_D9_B0                    0xD9
+#define R2_D9_B1                    0xD9
+// =======================================
+#define BANK_4                      0x04
+// ---------------------------------------
+#define R_AE_EnH                    0x30
+#define R_AE_manual_En              0x30
+#define R_AE_Size__div4_X           0x3A
+#define R_AE_Size__div4_Y           0x3B
+#define R_AE_MinGain_L              0x40
+#define R_AE_MinGain_H              0x41
+#define R_AE_MaxGain_L              0x42
+#define R_AE_MaxGain_H              0x43
+#define R_AE_MinExpo_0              0x44
+#define R_AE_MinExpo_1              0x45
+#define R_AE_MinExpo_2              0x46
+#define R_AE_MinExpo_3              0x47
+#define R_AE_MaxExpo_0              0x48
+#define R_AE_MaxExpo_1              0x49
+#define R_AE_MaxExpo_2              0x4A
+#define R_AE_MaxExpo_3              0x4B
+#define R_AE_Gain_manual_L          0x51
+#define R_AE_Gain_manual_H          0x52
+#define R_AE_Expo_manual_0          0x53
+#define R_AE_Expo_manual_1          0x54
+#define R_AE_Expo_manual_2          0x55
+#define R_AE_Expo_manual_3          0x56
+#define AE_Total_Gain_L             0xA5
+#define AE_Total_Gain_H             0xA6
+#define Reg_ExpPxclkNum_0           0xA7
+#define Reg_ExpPxclkNum_1           0xA8
+#define Reg_ExpPxclkNum_2           0xA9
+#define Reg_ExpPxclkNum_3           0xAA
+
+#define V_R009_Q_H_ON               (0x02)
+#define V_R009_Q_H_OFF              (0x10)
+#define V_R2D9_Q_H_ON               (0x02)
+#define V_R2D9_Q_H_OFF              (0x00)
+
+#define V_R009_QQ_H_ON              (0x02)
+#define V_R009_QQ_H_OFF             (0x00)
+
+#define V_R1C2_Q_V_ON               (0xF7)
+#define V_R1C2_Q_V_OFF              (0x00)
+#define V_R1C2_QQ_V_ON              (0xF5)
+#define V_R1C2_QQ_V_OFF             (0x02)


### PR DESCRIPTION
1. Add a sensor driver for PAG7920.
2. Add PAG7920-related definitions.