### PR TITLE
examples/ServoShield: Change to SoftI2c for RT.

### DIFF
--- a/scripts/examples/50-OpenMV-Boards/60-Shields/61-Servo-Shield/main.py
+++ b/scripts/examples/50-OpenMV-Boards/60-Shields/61-Servo-Shield/main.py
@@ -13,9 +13,9 @@
 
 import time
 from servo import Servos
-from machine import I2C, Pin
+from machine import SoftI2C, Pin
 
-i2c = I2C(sda=Pin("P5"), scl=Pin("P4"))
+i2c = SoftI2C(sda=Pin("P5"), scl=Pin("P4"))
 servo = Servos(i2c, address=0x40, freq=50, min_us=650, max_us=2800, degrees=180)
 
 while True:


### PR DESCRIPTION
Use SoftI2C to support OpenMV RT.