### PR TITLE
misc: Increase delay after reset/power-down.

### DIFF
--- a/src/omv/boards/ARDUINO_PORTENTA_H7/omv_boardconfig.h
+++ b/src/omv/boards/ARDUINO_PORTENTA_H7/omv_boardconfig.h
@@ -236,6 +236,7 @@
 // The sensor probing process will detect the right reset or powerdown
 // polarity, so it should be fine to enable it for both boards.
 #define OMV_CSI_RESET_PIN                   (&omv_pin_C13_GPIO)
+#define OMV_CSI_RESET_DELAY                 (100)
 
 // GPIO.1 is connected to the sensor module frame sync pin (OUTPUT) on
 // the Portenta breakout board and to the INT pin (OUTPUT) on the Himax
@@ -246,6 +247,7 @@
 // and to the STROBE pin on the Himax shield, however it's not actually
 // used on the Himax shield and can be safely enable for the two boards.
 #define OMV_CSI_POWER_PIN                   (&omv_pin_D5_GPIO)
+#define OMV_CSI_POWER_DELAY                 (100)
 
 // Physical I2C buses.
 

--- a/src/omv/common/sensor_utils.c
+++ b/src/omv/common/sensor_utils.c
@@ -36,8 +36,16 @@
 #include "omv_gpio.h"
 #include "omv_i2c.h"
 
-#ifndef OMV_ISC_MAX_DEVICES
-#define OMV_ISC_MAX_DEVICES (5)
+#ifndef OMV_CSI_MAX_DEVICES
+#define OMV_CSI_MAX_DEVICES (5)
+#endif
+
+#ifndef OMV_CSI_RESET_DELAY
+#define OMV_CSI_RESET_DELAY (10)
+#endif
+
+#ifndef OMV_CSI_POWER_DELAY
+#define OMV_CSI_POWER_DELAY (10)
 #endif
 
 #ifndef __weak
@@ -156,7 +164,7 @@ __weak int sensor_reset() {
     }
     #endif
 
-    mp_hal_delay_ms(20);
+    mp_hal_delay_ms(OMV_CSI_RESET_DELAY);
 
     // Re-enable the bus.
     omv_i2c_enable(&sensor.i2c_bus, true);
@@ -174,10 +182,10 @@ __weak int sensor_reset() {
 }
 
 static int sensor_detect() {
-    uint8_t devs_list[OMV_ISC_MAX_DEVICES];
+    uint8_t devs_list[OMV_CSI_MAX_DEVICES];
     int n_devs = omv_i2c_scan(&sensor.i2c_bus, devs_list, OMV_ARRAY_SIZE(devs_list));
 
-    for (int i = 0; i < OMV_MIN(n_devs, OMV_ISC_MAX_DEVICES); i++) {
+    for (int i = 0; i < OMV_MIN(n_devs, OMV_CSI_MAX_DEVICES); i++) {
         uint8_t slv_addr = devs_list[i];
         switch (slv_addr) {
             #if (OMV_OV2640_ENABLE == 1)
@@ -256,7 +264,7 @@ int sensor_probe_init(uint32_t bus_id, uint32_t bus_speed) {
     mp_hal_delay_ms(10);
 
     omv_gpio_write(OMV_CSI_POWER_PIN, 0);
-    mp_hal_delay_ms(10);
+    mp_hal_delay_ms(OMV_CSI_POWER_DELAY);
     #endif
 
     #if defined(OMV_CSI_RESET_PIN)
@@ -266,7 +274,7 @@ int sensor_probe_init(uint32_t bus_id, uint32_t bus_speed) {
     mp_hal_delay_ms(10);
 
     omv_gpio_write(OMV_CSI_RESET_PIN, 0);
-    mp_hal_delay_ms(10);
+    mp_hal_delay_ms(OMV_CSI_RESET_DELAY);
     #endif
 
     // Initialize the camera bus.
@@ -281,21 +289,21 @@ int sensor_probe_init(uint32_t bus_id, uint32_t bus_speed) {
         #if defined(OMV_CSI_RESET_PIN)
         sensor.reset_pol = ACTIVE_LOW;
         omv_gpio_write(OMV_CSI_RESET_PIN, 1);
-        mp_hal_delay_ms(10);
+        mp_hal_delay_ms(OMV_CSI_RESET_DELAY);
         #endif
 
         if ((sensor.slv_addr = sensor_detect()) == 0) {
             #if defined(OMV_CSI_POWER_PIN)
             sensor.pwdn_pol = ACTIVE_LOW;
             omv_gpio_write(OMV_CSI_POWER_PIN, 1);
-            mp_hal_delay_ms(10);
+            mp_hal_delay_ms(OMV_CSI_POWER_DELAY);
             #endif
 
             if ((sensor.slv_addr = sensor_detect()) == 0) {
                 #if defined(OMV_CSI_RESET_PIN)
                 sensor.reset_pol = ACTIVE_HIGH;
                 omv_gpio_write(OMV_CSI_RESET_PIN, 0);
-                mp_hal_delay_ms(10);
+                mp_hal_delay_ms(OMV_CSI_RESET_DELAY);
                 #endif
                 sensor.slv_addr = sensor_detect();
             }


### PR DESCRIPTION
The Portenta sometimes fails to detect HM01B0 a soft-reset fixes it. I think this happens because reset is connected to an LDO, not to the sensor directly, so maybe it needs more time to settle down after it's enabled. Increasing the delay after reset/power-down seemed to fix it for me, but then I couldn't get it to fail again without this change, so I'm not sure if it's really needed.