### PR TITLE
ports/stm32: Reset vbuffer state when dropping frames.

### DIFF
--- a/src/omv/ports/stm32/sensor.c
+++ b/src/omv/ports/stm32/sensor.c
@@ -405,6 +405,12 @@ void HAL_DCMI_FrameEventCallback(DCMI_HandleTypeDef *hdcmi) {
     sensor.first_line = false;
     if (sensor.drop_frame) {
         sensor.drop_frame = false;
+        // If the frame was dropped, the buffer will not change, so its state
+        // must be reset.
+        vbuffer_t *buffer = framebuffer_get_tail(FB_PEEK);
+        if (buffer) {
+            buffer->reset_state = true;
+        }
         return;
     }
 


### PR DESCRIPTION
When dropping a frame the current vbuffer state was Not reset, which caused the following frame(s) to be corrupted, probably also overwriting the next vbuffer.
This bug is what caused transposed high-resolution frames to be corrupted. If the DMA is not keeping up you should simply just see slower FPS or no frames at all but definitely never corrupted frames, since they're dropped.

Test code now never corrupts a frame:
```Python
import sensor
import time
import image

sensor.reset()
sensor.set_pixformat(sensor.RGB565)
sensor.set_framesize(sensor.VGA)
sensor.set_transpose(True)

clock = time.clock()
while True:
    clock.tick()
    sensor.snapshot().to_rainbow(color_palette=image.PALETTE_IRONBOW)
    print(clock.fps())
```