### PR TITLE
modules/py_tf: Add generic CNN processing support.

### DIFF
--- a/src/omv/imlib/imlib.h
+++ b/src/omv/imlib/imlib.h
@@ -151,6 +151,7 @@ bool rectangle_equal_fast(rectangle_t *ptr0, rectangle_t *ptr1);
 bool rectangle_overlap(rectangle_t *ptr0, rectangle_t *ptr1);
 void rectangle_intersected(rectangle_t *dst, rectangle_t *src);
 void rectangle_united(rectangle_t *dst, rectangle_t *src);
+float rectangle_iou(rectangle_t *r1, rectangle_t *r2);
 
 /////////////////
 // Color Stuff //

--- a/src/omv/imlib/rectangle.c
+++ b/src/omv/imlib/rectangle.c
@@ -116,3 +116,15 @@ void rectangle_expand(rectangle_t *r, int x, int y) {
         r->h = y;
     }
 }
+
+float rectangle_iou(rectangle_t *r1, rectangle_t *r2) {
+    int x1 = IM_MAX(r1->x, r2->x);
+    int y1 = IM_MAX(r1->y, r2->y);
+    int x2 = IM_MIN(r1->x + r1->w, r2->x + r2->w);
+    int y2 = IM_MIN(r1->y + r1->h, r2->y + r2->h);
+    int w = IM_MAX(0, x2 - x1);
+    int h = IM_MAX(0, y2 - y1);
+    int rect_intersection = w * h;
+    int rect_union = (r1->w * r1->h) + (r2->w * r2->h) - rect_intersection;
+    return ((float) rect_intersection) / ((float) rect_union);
+}

--- a/src/omv/modules/py_tf.h
+++ b/src/omv/modules/py_tf.h
@@ -18,6 +18,8 @@ typedef struct py_tf_model_obj {
     unsigned char *model_data;
     unsigned int model_data_len;
     libtf_parameters_t params;
+    mp_obj_t input_shape; // pre-allocated tuple for fast access
+    mp_obj_t output_shape; // pre-allocated tuple for fast access
 } py_tf_model_obj_t;
 
 // Log buffer


### PR DESCRIPTION
Replaces: https://github.com/openmv/openmv/pull/2134

...

This PR adds support for a new method called invoke() which takes and input image in, runs tensorflow, and outputs a a 1d arrary of the results of on the micropython heap organized in h/w/c order. This is the default behavior, though its not very efficent when used with large models.

Invoke() can additionally take in a callback method though that can access the model output while it's still in the frame buffer stack for much more efficent operation. The callback is passed a new "model_output" object which has a subscr [] method which can get any value from the output sensor that's organized in h/w/c order. You can get individual values or slices. The "model_output" class also provides all the necessary dimension information for you to write whatever post processing you need in python. Whatever this callback returns then will be the result of invoke().

To make post-processing easier the invoke_output class contains "add_bounding_box" and "get_bounding_boxes" methods which encapulsate common operations for object detector networks. This allows the python post processing code to just need to be written for reading the output of a network. The python code does not need to reimplement non-max impression which is handled by the bounding box code.

Finally, control over input scaling was added to support models trained on different input scales. The defaults match the previous input scaling behavior. Note, input scaling is only needed for models which have floating point input heads.

...

Here's how the API would look for processing a YOLOV5 Model:

```Python
import time
import tf
import image

model = 'yolo/lpd-yolov5-int8-quantized.tflite'

# Alternatively, models can be loaded from the filesystem storage.
net = tf.load(model, load_to_fb=True)
labels = ["plate"]
print(net)

colors = [  # Add more colors if you are detecting more than 7 types of classes at once.
    (255, 0, 0),
    (0, 255, 0),
    (255, 255, 0),
    (0, 0, 255),
    (255, 0, 255),
    (0, 255, 255),
    (255, 255, 255),
]

@micropython.native
def yolov5(model, o):
    oh, ow, oc = model.output_shape
    if oh!= 1:
        raise(ValueError("Expected model output height to be 1!"))
    if oc < 6:
        raise(ValueError("Expected model output channels to be >= 6"))
    # cx, cy, cw, ch, score, classes[n]
    ol = oh * ow * oc
    ih, iw, ic = model.input_shape
    m = time.ticks_ms()
    for i in range(0, ol, oc):
        score = o[i + 4]
        if (score > 0.5):
            cx = o[i + 0]
            cy = o[i + 1]
            cw = o[i + 2] * 0.5
            ch = o[i + 3] * 0.5
            xmin = (cx - cw) * iw
            ymin = (cy - ch) * ih
            xmax = (cx + cw) * iw
            ymax = (cy + ch) * ih
            labels = o[i + 5: i + oc]
            label_index = max(enumerate(labels), key=lambda x: x[1])[0]
            o.add_bounding_box(xmin, ymin, xmax, ymax, score, label_index)
    boxes = o.get_bounding_boxes()
    print("time", time.ticks_diff(time.ticks_ms(), m))
    return boxes

clock = time.clock()
while True:
    clock.tick()

    img = image.Image("yolo/plate.jpg", copy_to_fb=True)
    img.to_rgb565()

    for i, detection_list in enumerate(
        net.predict(img, callback=yolov5, scale=tf.SCALE_NONE)
    ):
        print("********** %s **********" % labels[i])
        for d in detection_list:
            print(d.rect(), "score", d.output())
            img.draw_rectangle(d.rect(), color=colors[i], thickness=2)

    print(clock.fps(), "fps", end="\n")
```

Post-processing a 6300 output head from a 320x320 input YOLOV5 model takes 7ms with this code on the H7 Plus. Comparable C code is 1ms. So, while the python is slower is it not unusable. Note that it's imperative to filter detections by the result threshold. You want to do as little work as possible in the loop since there's so much stuff to check. Also, you should add the @micropython.native to the post-processing function to make it as fast as possible, it would be 11ms otherwise without it. Finally, @micropython.viper cannot be used as the model_output class is not exposing the RAW output of the CNN but converting values on the fly as you request data into floating point form.
