### PR TITLE
modules/py_tf: Refactor predict callback code.

### DIFF
--- a/scripts/examples/03-Machine-Learning/00-TensorFlow/tf_image_classification.py
+++ b/scripts/examples/03-Machine-Learning/00-TensorFlow/tf_image_classification.py
@@ -1,5 +1,5 @@
 # This work is licensed under the MIT license.
-# Copyright (c) 2013-2023 OpenMV LLC. All rights reserved.
+# Copyright (c) 2013-2024 OpenMV LLC. All rights reserved.
 # https://github.com/openmv/openmv/blob/master/LICENSE
 #
 # TensorFlow Lite Mobilenet V1 Example
@@ -12,15 +12,11 @@
 # default model is not really usable for anything. You have to use transfer
 # learning to apply the model to a target problem by re-training the model.
 #
-# NOTE: This example only works on the OpenMV Cam H7 Pro (that has SDRAM) and better!
+# NOTE: This example only works on the OpenMV Cam H7 Plus (that has SDRAM) and better!
 # To get the models please see the CNN Network library in OpenMV IDE under
 # Tools -> Machine Vision. The labels are there too.
 # You should insert a microSD card into your camera and copy-paste the mobilenet_labels.txt
 # file and your chosen model into the root folder for this script to work.
-#
-# In this example we slide the detector window over the image and get a list
-# of activations. Note that use a CNN with a sliding window is extremely compute
-# expensive so for an exhaustive search do not expect the CNN to be real-time.
 
 import sensor
 import time
@@ -41,6 +37,8 @@ mobilenet = "mobilenet_v%s_%s_%s_quant.tflite" % (
     mobilenet_width,
     mobilenet_resolution,
 )
+
+net = tf.Model(mobilenet, load_to_fb=True)
 labels = [line.rstrip("\n") for line in open("mobilenet_labels.txt")]
 
 clock = time.clock()
@@ -49,31 +47,12 @@ while True:
 
     img = sensor.snapshot()
 
-    # net.classify() will run the network on an roi in the image (or on the whole image if the roi is not
-    # specified). A classification score output vector will be generated for each location. At each scale the
-    # detection window is moved around in the ROI using x_overlap (0-1) and y_overlap (0-1) as a guide.
-    # If you set the overlap to 0.5 then each detection window will overlap the previous one by 50%. Note
-    # the computational work load goes WAY up the more overlap. Finally, for multi-scale matching after
-    # sliding the network around in the x/y dimensions the detection window will shrink by scale_mul (0-1)
-    # down to min_scale (0-1). For example, if scale_mul is 0.5 the detection window will shrink by 50%.
-    # Note that at a lower scale there's even more area to search if x_overlap and y_overlap are small...
-
-    # default settings just do one detection... change them to search the image...
-    # Setting x_overlap=-1 forces the window to stay centered in the ROI in the x direction always. If
-    # y_overlap is not -1 the method will search in all vertical positions.
-    # Setting y_overlap=-1 forces the window to stay centered in the ROI in the y direction always. If
-    # x_overlap is not -1 the method will search in all horizontal positions.
-
-    for obj in tf.classify(
-        mobilenet, img, min_scale=1.0, scale_mul=0.5, x_overlap=0.0, y_overlap=0.0
-    ):
-        print("**********\nTop 5 Detections at [x=%d,y=%d,w=%d,h=%d]" % obj.rect())
-        img.draw_rectangle(obj.rect())
-        # This combines the labels and confidence values into a list of tuples
-        # and then sorts that list by the confidence values.
-        sorted_list = sorted(
-            zip(labels, obj.output()), key=lambda x: x[1], reverse=True
-        )
-        for i in range(5):
-            print("%s = %f" % (sorted_list[i][0], sorted_list[i][1]))
+    print("**********\nTop 5 Detections")
+    # This combines the labels and confidence values into a list of tuples
+    # and then sorts that list by the confidence values.
+    sorted_list = sorted(
+        zip(labels, net.predict(img)), key=lambda x: x[1], reverse=True
+    )
+    for i in range(5):
+        print("%s = %f" % (sorted_list[i][0], sorted_list[i][1]))
     print(clock.fps(), "fps")

--- a/scripts/examples/03-Machine-Learning/00-TensorFlow/tf_object_detection.py
+++ b/scripts/examples/03-Machine-Learning/00-TensorFlow/tf_object_detection.py
@@ -14,10 +14,10 @@ import math
 sensor.reset()  # Reset and initialize the sensor.
 sensor.set_pixformat(sensor.RGB565)  # Set pixel format to RGB565 (or GRAYSCALE)
 sensor.set_framesize(sensor.QVGA)  # Set frame size to QVGA (320x240)
-sensor.set_windowing((240, 240))  # Set 240x240 window.
 sensor.skip_frames(time=2000)  # Let the camera adjust.
 
 min_confidence = 0.4
+threshold_list = [(math.ceil(min_confidence * 255), 255)]
 
 # Load built-in FOMO face detection model
 labels, net = tf.Model("fomo_face_detection")
@@ -36,18 +36,38 @@ colors = [  # Add more colors if you are detecting more than 7 types of classes 
     (255, 255, 255),
 ]
 
+# FOMO outputs an image per class where each pixel in the image is the centroid of the trained
+# object. So, we will get those output images and then run find_blobs() on them to extract the
+# centroids. We will also run get_stats() on the detected blobs to determine their score.
+# The Non-Max-Supression (NMS) object then filters out overlapping detections and maps their
+# position in the output image back to the original input image. The callback then returns a
+# list per class which each contain a list of (rect, score) tuples representing the detected
+# objects.
+
+
+def fomo_callback(model, rect):
+    out = model.output[0]
+    oh, ow, oc = model.output_shape
+    nms = tf.NMS(ow, oh, rect)
+    for i in range(oc):
+        img = out.get_image(i)
+        blobs = img.find_blobs(threshold_list, x_stride=1, area_threshold=1, pixels_threshold=1)
+        for b in blobs:
+            rect = b.rect()
+            x, y, w, h = rect
+            score = img.get_statistics(thresholds=threshold_list, roi=rect).l_mean() / 255.0
+            nms.add_bounding_box(x, y, x + w, y + h, score, i)
+    return nms.get_bounding_boxes()
+
+
 clock = time.clock()
 while True:
     clock.tick()
 
     img = sensor.snapshot()
 
-    # detect() returns all objects found in the image (splitted out per class already)
-    # we skip class index 0, as that is the background, and then draw circles of the center
-    # of our objects
-
     for i, detection_list in enumerate(
-        net.detect(img, thresholds=[(math.ceil(min_confidence * 255), 255)])
+        net.predict(img, callback=fomo_callback)
     ):
         if i == 0:
             continue  # background class

--- a/scripts/examples/03-Machine-Learning/00-TensorFlow/tf_object_detection.py
+++ b/scripts/examples/03-Machine-Learning/00-TensorFlow/tf_object_detection.py
@@ -1,5 +1,5 @@
 # This work is licensed under the MIT license.
-# Copyright (c) 2013-2023 OpenMV LLC. All rights reserved.
+# Copyright (c) 2013-2024 OpenMV LLC. All rights reserved.
 # https://github.com/openmv/openmv/blob/master/LICENSE
 #
 # TensorFlow Lite Object Detection Example
@@ -20,10 +20,10 @@ sensor.skip_frames(time=2000)  # Let the camera adjust.
 min_confidence = 0.4
 
 # Load built-in FOMO face detection model
-labels, net = tf.load_builtin_model("fomo_face_detection")
+labels, net = tf.Model("fomo_face_detection")
 
 # Alternatively, models can be loaded from the filesystem storage.
-# net = tf.load('<object_detection_network>', load_to_fb=True)
+# net = tf.Model('<object_detection_network>', load_to_fb=True)
 # labels = [line.rstrip('\n') for line in open("labels.txt")]
 
 colors = [  # Add more colors if you are detecting more than 7 types of classes at once.
@@ -55,11 +55,10 @@ while True:
             continue  # no detections for this class?
 
         print("********** %s **********" % labels[i])
-        for d in detection_list:
-            [x, y, w, h] = d.rect()
+        for (x, y, w, h), score in detection_list:
             center_x = math.floor(x + (w / 2))
             center_y = math.floor(y + (h / 2))
-            print(f"x {center_x}\ty {center_y}")
+            print(f"x {center_x}\ty {center_y}\tscore {score}")
             img.draw_circle((center_x, center_y, 12), color=colors[i], thickness=2)
 
     print(clock.fps(), "fps", end="\n")

--- a/scripts/examples/03-Machine-Learning/00-TensorFlow/tf_regression.py
+++ b/scripts/examples/03-Machine-Learning/00-TensorFlow/tf_regression.py
@@ -1,0 +1,33 @@
+# This work is licensed under the MIT license.
+# Copyright (c) 2013-2024 OpenMV LLC. All rights reserved.
+# https://github.com/openmv/openmv/blob/master/LICENSE
+#
+# TensorFlow Lite Regression Example
+#
+# This example shows off running a regression model on the OpenMV Cam.
+# A regression model takes an input list of numbers and produces an
+# output list of numbers. You may pass 1D/2D/3D arrays to predict()
+# and you will get a list of the results back.
+#
+# Note: The input list of numbers must be the same size as the input
+# tensor size of the model. As mentioned before you can pass 1D/2D/3D arrays.
+
+import tf
+
+i = [-3, -1, -2, 5, -2, 10, -1, 9, 0, 2, 0, 9, 1, 10, 2, -1, 3,
+     5, 3, 9, 3, 9, 6, 2, 6, 7, 5, 10, 6, -1, 7, 4, 7, 8,
+     5, 7]
+
+# Grab the model here:
+# https://cdn.shopify.com/s/files/1/0803/9211/files/force_float32_quant.tflite?v=1718936445
+m = tf.Model("force_float32_quant.tflite")
+print(m)
+print(m.predict(i))
+# Should print 54.4129
+
+# Grab the model here:
+# https://cdn.shopify.com/s/files/1/0803/9211/files/force_int_quant.tflite?v=1718936445
+m = tf.Model("force_int_quant.tflite")
+print(m)
+print(m.predict(i))
+# Should print 53.7833

--- a/src/omv/imlib/collections.h
+++ b/src/omv/imlib/collections.h
@@ -88,12 +88,15 @@ void list_copy(list_t *dst, list_t *src);
 void list_free(list_t *ptr);
 void list_clear(list_t *ptr);
 size_t list_size(list_t *ptr);
+void list_insert(list_t *ptr, list_lnk_t *lnk, void *data);
 void list_push_front(list_t *ptr, void *data);
 void list_push_back(list_t *ptr, void *data);
+void list_remove(list_t *ptr, list_lnk_t *lnk, void *data);
 void list_pop_front(list_t *ptr, void *data);
 void list_pop_back(list_t *ptr, void *data);
-void list_insert(list_t *ptr, list_lnk_t *lnk, void *data);
-void list_remove(list_t *ptr, list_lnk_t *lnk, void *data);
+void list_move(list_t *dst, list_t *src, list_lnk_t *before, list_lnk_t *lnk);
+void list_move_front(list_t *dst, list_t *src, list_lnk_t *lnk);
+void list_move_back(list_t *dst, list_t *src, list_lnk_t *lnk);
 #define list_for_each(iterator, list) \
     for (list_lnk_t *iterator = list->head; iterator != NULL; iterator = iterator->next)
 #define list_get_data(iterator) ((void *) iterator->data)

--- a/src/omv/imlib/imlib.h
+++ b/src/omv/imlib/imlib.h
@@ -145,6 +145,12 @@ typedef struct rectangle {
     int16_t h;
 } rectangle_t;
 
+typedef struct bounding_box_lnk_data {
+    rectangle_t rect;
+    float score;
+    int label_index;
+} bounding_box_lnk_data_t;
+
 void rectangle_init(rectangle_t *ptr, int x, int y, int w, int h);
 void rectangle_copy(rectangle_t *dst, rectangle_t *src);
 bool rectangle_equal_fast(rectangle_t *ptr0, rectangle_t *ptr1);
@@ -152,6 +158,9 @@ bool rectangle_overlap(rectangle_t *ptr0, rectangle_t *ptr1);
 void rectangle_intersected(rectangle_t *dst, rectangle_t *src);
 void rectangle_united(rectangle_t *dst, rectangle_t *src);
 float rectangle_iou(rectangle_t *r1, rectangle_t *r2);
+void rectangle_nms_add_bounding_box(list_t *bounding_boxes, bounding_box_lnk_data_t *box);
+int rectangle_nms_get_bounding_boxes(list_t *bounding_boxes, float threshold, float sigma);
+void rectangle_map_bounding_boxes(list_t *bounding_boxes, int window_w, int window_h, rectangle_t *roi);
 
 /////////////////
 // Color Stuff //

--- a/src/omv/modules/py_tf.c
+++ b/src/omv/modules/py_tf.c
@@ -218,18 +218,17 @@ STATIC void py_tf_input_callback(void *callback_data,
     float fscale = 1.0f, fadd = 0.0f;
 
     switch (arg->scale) {
-        case PY_TF_SCALE_0_1:
+        case PY_TF_SCALE_0_1: // convert 0->255 to 0->1
             fscale = 1.0f / 255.0f;
             break;
-        case PY_TF_SCALE_S1_1:
+        case PY_TF_SCALE_S1_1: // convert 0->255 to -1->1
             fscale = 2.0f / 255.0f;
             fadd = -1.0f;
             break;
-        case PY_TF_SCALE_S128_127:
-            fscale = 255.0f / 127.0f;
+        case PY_TF_SCALE_S128_127: // convert 0->255 to -128->127
             fadd = -128.0f;
             break;
-        case PY_TF_SCALE_NONE:
+        case PY_TF_SCALE_NONE: // convert 0->255 to 0->255
         default:
             break;
     }

--- a/src/omv/modules/py_tf.c
+++ b/src/omv/modules/py_tf.c
@@ -709,7 +709,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(py_tf_model_deinit_obj, py_tf_model_deinit);
 
 STATIC const mp_rom_map_elem_t py_tf_model_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR___del__),             MP_ROM_PTR(&py_tf_model_deinit_obj) },
-    { MP_ROM_QSTR(MP_QSTR_regression),          MP_ROM_PTR(&py_tf_model_predict_obj) },
     { MP_ROM_QSTR(MP_QSTR_predict),             MP_ROM_PTR(&py_tf_model_predict_obj) },
 };
 
@@ -735,8 +734,6 @@ STATIC const mp_rom_map_elem_t py_tf_globals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_SCALE_S128_127),      MP_ROM_INT(PY_TF_SCALE_S128_127) },
     { MP_ROM_QSTR(MP_QSTR_Model),               MP_ROM_PTR(&py_tf_model_type) },
     { MP_ROM_QSTR(MP_QSTR_NMS),                 MP_ROM_PTR(&py_tf_nms_type) },
-    { MP_ROM_QSTR(MP_QSTR_load),                MP_ROM_PTR(&py_tf_model_type) },
-    { MP_ROM_QSTR(MP_QSTR_load_builtin_model),  MP_ROM_PTR(&py_tf_model_type) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(py_tf_globals_dict, py_tf_globals_dict_table);

--- a/src/omv/modules/py_tf.c
+++ b/src/omv/modules/py_tf.c
@@ -159,31 +159,13 @@ typedef struct py_tf_model_output_obj {
     mp_obj_base_t base;
     void *model_output;
     libtf_parameters_t *params;
-    // Pre-compute for lookup speed.
     size_t output_size;
-    mp_obj_t rect;
 } py_tf_model_output_obj_t;
-
-STATIC void py_tf_model_output_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
-    py_tf_model_output_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    if (dest[0] == MP_OBJ_NULL) {
-        // Load attribute.
-        switch (attr) {
-            case MP_QSTR_rect:
-                dest[0] = self->rect;
-                break;
-            default:
-                // Continue lookup in locals_dict.
-                dest[1] = MP_OBJ_SENTINEL;
-                break;
-        }
-    }
-}
 
 STATIC mp_obj_t py_tf_model_output_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
     if (value == MP_OBJ_SENTINEL) {
         // load
-        py_tf_model_output_obj_t *self = self_in;
+        py_tf_model_output_obj_t *self = MP_OBJ_TO_PTR(self_in);
         void *model_output = self->model_output;
         libtf_parameters_t *params = self->params;
         if (MP_OBJ_IS_TYPE(index, &mp_type_slice)) {
@@ -235,7 +217,6 @@ STATIC MP_DEFINE_CONST_OBJ_TYPE(
     py_tf_model_output_type,
     MP_QSTR_tf_model_output,
     MP_TYPE_FLAG_NONE,
-    attr, py_tf_model_output_attr,
     subscr, py_tf_model_output_subscr
     );
 
@@ -523,16 +504,25 @@ STATIC void py_tf_predict_output_callback(void *callback_data,
                                           void *model_output,
                                           libtf_parameters_t *params) {
     py_tf_predict_callback_data_t *arg = (py_tf_predict_callback_data_t *) callback_data;
+    py_tf_model_obj_t *model = MP_OBJ_TO_PTR(arg->model);
+    mp_obj_t rect = mp_obj_new_tuple(4, (mp_obj_t []) {mp_obj_new_int(arg->roi->x),
+                                                       mp_obj_new_int(arg->roi->y),
+                                                       mp_obj_new_int(arg->roi->w),
+                                                       mp_obj_new_int(arg->roi->h)});
+
+    // This will support multiple output tensors once the API is updated.
+    mp_obj_list_t *list = MP_OBJ_TO_PTR(mp_obj_new_list(0, NULL));
+
     py_tf_model_output_obj_t *o = m_new_obj(py_tf_model_output_obj_t);
     o->base.type = &py_tf_model_output_type;
     o->model_output = model_output;
     o->params = params;
     o->output_size = params->output_height * params->output_width * params->output_channels;
-    o->rect = mp_obj_new_tuple(4, (mp_obj_t []) {mp_obj_new_int(arg->roi->x),
-                                                 mp_obj_new_int(arg->roi->y),
-                                                 mp_obj_new_int(arg->roi->w),
-                                                 mp_obj_new_int(arg->roi->h)});
-    *(arg->out) = mp_call_function_2(arg->callback, arg->model, o);
+    mp_obj_list_append(list, o);
+
+    model->model_output_list = list;
+    *(arg->out) = mp_call_function_2(arg->callback, model, rect);
+    model->model_output_list = mp_const_none;
 }
 
 // TF Model Object.
@@ -841,6 +831,9 @@ STATIC void py_tf_model_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
             case MP_QSTR_output_zero_point:
                 dest[0] = mp_obj_new_int(self->params.output_zero_point);
                 break;
+            case MP_QSTR_output:
+                dest[0] = self->model_output_list;
+                break;
             default:
                 // Continue lookup in locals_dict.
                 dest[1] = MP_OBJ_SENTINEL;
@@ -917,6 +910,8 @@ mp_obj_t py_tf_model_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
     model->output_shape = mp_obj_new_tuple(3, (mp_obj_t []) {mp_obj_new_int(model->params.output_height),
                                                              mp_obj_new_int(model->params.output_width),
                                                              mp_obj_new_int(model->params.output_channels)});
+
+    model->model_output_list = mp_const_none;
 
     if (model->fb_alloc) {
         // The model data will Not be free'd on exceptions.

--- a/src/omv/modules/py_tf.h
+++ b/src/omv/modules/py_tf.h
@@ -21,6 +21,7 @@ typedef struct py_tf_model_obj {
     bool fb_alloc;
     mp_obj_t input_shape;
     mp_obj_t output_shape;
+    mp_obj_t model_output_list;
     libtf_parameters_t params;
 } py_tf_model_obj_t;
 

--- a/src/omv/modules/py_tf_nms.c
+++ b/src/omv/modules/py_tf_nms.c
@@ -1,0 +1,143 @@
+/*
+ * This file is part of the OpenMV project.
+ *
+ * Copyright (c) 2013-2024 Ibrahim Abdelkader <iabdalkader@openmv.io>
+ * Copyright (c) 2013-2024 Kwabena W. Agyeman <kwagyeman@openmv.io>
+ *
+ * This work is licensed under the MIT license, see the file LICENSE for details.
+ *
+ * Python NMS class.
+ */
+
+#include "imlib_config.h"
+
+#ifdef IMLIB_ENABLE_TF
+#include "py/runtime.h"
+#include "py_helper.h"
+
+// TF NMS Object.
+typedef struct py_tf_nms_obj {
+    mp_obj_base_t base;
+    int window_w;
+    int window_h;
+    rectangle_t roi;
+    list_t bounding_boxes;
+} py_tf_nms_obj_t;
+
+// The use of mp_arg_parse_all() is deliberately avoided here to ensure this method remains fast.
+STATIC mp_obj_t py_tf_nms_add_bounding_box(uint n_args, const mp_obj_t *pos_args) {
+    enum { ARG_self, ARG_xmin, ARG_ymin, ARG_xmax, ARG_ymax, ARG_score, ARG_label_index };
+    py_tf_nms_obj_t *self_in = MP_OBJ_TO_PTR(pos_args[ARG_self]);
+
+    bounding_box_lnk_data_t lnk_data;
+    lnk_data.score = mp_obj_get_float(pos_args[ARG_score]);
+
+    if ((lnk_data.score >= 0.0f) && (lnk_data.score <= 1.0f)) {
+        float xmin = IM_CLAMP(mp_obj_get_float(pos_args[ARG_xmin]), 0.0f, ((float) self_in->window_w));
+        float ymin = IM_CLAMP(mp_obj_get_float(pos_args[ARG_ymin]), 0.0f, ((float) self_in->window_h));
+        float xmax = IM_CLAMP(mp_obj_get_float(pos_args[ARG_xmax]), 0.0f, ((float) self_in->window_w));
+        float ymax = IM_CLAMP(mp_obj_get_float(pos_args[ARG_ymax]), 0.0f, ((float) self_in->window_h));
+
+        lnk_data.rect.w = fast_floorf(xmax - xmin);
+        lnk_data.rect.h = fast_floorf(ymax - ymin);
+
+        if ((lnk_data.rect.w > 0) && (lnk_data.rect.h > 0)) {
+            lnk_data.rect.x = fast_floorf(xmin);
+            lnk_data.rect.y = fast_floorf(ymin);
+            lnk_data.label_index = mp_obj_get_int(pos_args[ARG_label_index]);
+            rectangle_nms_add_bounding_box(&self_in->bounding_boxes, &lnk_data);
+        }
+    }
+
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(py_tf_nms_add_bounding_box_obj, 7, 7, py_tf_nms_add_bounding_box);
+
+STATIC mp_obj_t py_tf_nms_get_bounding_boxes(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_threshold, ARG_sigma };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_threshold,  MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_rom_obj = MP_ROM_NONE } },
+        { MP_QSTR_sigma,  MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_rom_obj = MP_ROM_NONE } },
+    };
+
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    py_tf_nms_obj_t *self_in = MP_OBJ_TO_PTR(pos_args[0]);
+    float threshold = py_helper_arg_to_float(args[ARG_threshold].u_obj, 0.1f);
+    float sigma = py_helper_arg_to_float(args[ARG_sigma].u_obj, 0.1f);
+    int max_label = rectangle_nms_get_bounding_boxes(&self_in->bounding_boxes, threshold, sigma);
+    rectangle_map_bounding_boxes(&self_in->bounding_boxes, self_in->window_w, self_in->window_h, &self_in->roi);
+
+    // Create a list per class label.
+    mp_obj_list_t *list = MP_OBJ_TO_PTR(mp_obj_new_list(max_label + 1, NULL));
+    for (size_t i = 0; i <= max_label; i++) {
+        list->items[i] = mp_obj_new_list(0, NULL);
+    }
+
+    list_for_each(it, (&self_in->bounding_boxes)) {
+        bounding_box_lnk_data_t *lnk_data = (bounding_box_lnk_data_t *) it->data;
+        mp_obj_t rect = mp_obj_new_tuple(4, (mp_obj_t []) {mp_obj_new_int(lnk_data->rect.x),
+                                                           mp_obj_new_int(lnk_data->rect.y),
+                                                           mp_obj_new_int(lnk_data->rect.w),
+                                                           mp_obj_new_int(lnk_data->rect.h)});
+        mp_obj_t o = mp_obj_new_tuple(2, (mp_obj_t []) {rect, mp_obj_new_float(lnk_data->score)});
+        mp_obj_list_append(list->items[lnk_data->label_index], o);
+    }
+
+    return list;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(py_tf_nms_get_bounding_boxes_obj, 1, py_tf_nms_get_bounding_boxes);
+
+const mp_obj_type_t py_tf_nms_type;
+
+mp_obj_t py_tf_nms_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
+    enum { ARG_window_w, ARG_window_h, ARG_roi };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_window_w, MP_ARG_INT | MP_ARG_REQUIRED, {.u_int = 0 } },
+        { MP_QSTR_window_h, MP_ARG_INT | MP_ARG_REQUIRED, {.u_int = 0 } },
+        { MP_QSTR_roi, MP_ARG_OBJ | MP_ARG_REQUIRED, {.u_rom_obj = MP_ROM_NONE} },
+    };
+
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    // Extract the ROI manually as we do not have an image to validate against.
+    mp_obj_t *roi_obj;
+    mp_obj_get_array_fixed_n(args[ARG_roi].u_obj, 4, &roi_obj);
+
+    rectangle_t roi;
+    roi.x = mp_obj_get_int(roi_obj[0]);
+    roi.y = mp_obj_get_int(roi_obj[1]);
+    roi.w = mp_obj_get_int(roi_obj[2]);
+    roi.h = mp_obj_get_int(roi_obj[3]);
+
+    if ((roi.w < 1) || (roi.h < 1)) {
+        mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("Invalid ROI dimensions!"));
+    }
+
+    py_tf_nms_obj_t *model = m_new_obj(py_tf_nms_obj_t);
+    model->base.type = &py_tf_nms_type;
+    model->window_w = args[ARG_window_w].u_int;
+    model->window_h = args[ARG_window_h].u_int;
+    model->roi = roi;
+    list_init(&model->bounding_boxes, sizeof(bounding_box_lnk_data_t));
+    return MP_OBJ_FROM_PTR(model);
+}
+
+STATIC const mp_rom_map_elem_t py_tf_nms_locals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_add_bounding_box),    MP_ROM_PTR(&py_tf_nms_add_bounding_box_obj) },
+    { MP_ROM_QSTR(MP_QSTR_get_bounding_boxes),  MP_ROM_PTR(&py_tf_nms_get_bounding_boxes_obj) },
+};
+
+STATIC MP_DEFINE_CONST_DICT(py_tf_nms_locals_dict, py_tf_nms_locals_table);
+
+MP_DEFINE_CONST_OBJ_TYPE(
+    py_tf_nms_type,
+    MP_QSTR_tf_nms,
+    MP_TYPE_FLAG_NONE,
+    make_new, py_tf_nms_make_new,
+    locals_dict, &py_tf_nms_locals_dict
+    );
+
+#endif // IMLIB_ENABLE_TF


### PR DESCRIPTION
This PR does the following:

0: A bug commit is included to make loaded networks work still.

1: I noticed that I was doing free() and then new() to move items between lists. So, I updated the list code to have the ability to move items between lists without doing that. I then noticed the list code could be significantly cleaned up and reduced all the logic down to just two functions list_link() and list_unlink(). The rest of the functions are then 1-2 liners around these.

2: I refactored the NMS code into it's own object. I like this improved interface for it. I left the new object in py_tf for the moment. It can be moved into a new module as it has no dependencies on anything in py_tf. However, I'm unsure what that new module should be named if we want to do that.

3: I merged the model output object with the model object.

4: I removed the classification object/method and updated the tensorflow example scripts. Note that the removal of this object/method is a breaking API change. That said, it's very easy to fix. We will need to inform EdgeImpulse of this, but providing help and support for the change to our users should be simple (removing detect() will be much harder given the need for a python callback).

(These commits are in the same PR because they build on each other).

Here's the new API:

```
import time
import tf
import image

model = 'yolo/lpd-yolov5-int8-quantized.tflite'

# Alternatively, models can be loaded from the filesystem storage.
net = tf.load(model, load_to_fb=True)
labels = ["plate"]
print(net)

colors = [  # Add more colors if you are detecting more than 7 types of classes at once.
    (255, 0, 0),
    (0, 255, 0),
    (255, 255, 0),
    (0, 0, 255),
    (255, 0, 255),
    (0, 255, 255),
    (255, 255, 255),
]

@micropython.native
def yolov5(model, rect):
    oh, ow, oc = model.output_shape
    if oh != 1:
        raise(ValueError("Expected model output height to be 1!"))
    if oc < 6:
        raise(ValueError("Expected model output channels to be >= 6"))
    # cx, cy, cw, ch, score, classes[n]
    ol = oh * ow * oc
    ih, iw, ic = model.input_shape
    nms = tf.NMS(iw, ih, rect)
    m = time.ticks_ms()
    for i in range(0, ol, oc):
        score = model[i + 4]
        if (score > 0.5):
            cx = model[i + 0]
            cy = model[i + 1]
            cw = model[i + 2] * 0.5
            ch = model[i + 3] * 0.5
            xmin = (cx - cw) * iw
            ymin = (cy - ch) * ih
            xmax = (cx + cw) * iw
            ymax = (cy + ch) * ih
            labels = model[i + 5: i + oc]
            label_index = max(enumerate(labels), key=lambda x: x[1])[0]
            nms.add_bounding_box(xmin, ymin, xmax, ymax, score, label_index)
    boxes = nms.get_bounding_boxes()
    print("time", time.ticks_diff(time.ticks_ms(), m))
    return boxes

clock = time.clock()
while True:
    clock.tick()

    img = image.Image("yolo/plate.jpg", copy_to_fb=True)
    img.to_rgb565()

    for i, detection_list in enumerate(
        net.predict(img, callback=yolov5, scale=tf.SCALE_NONE)
    ):
        print("********** %s **********" % labels[i])
        for rect, score in detection_list:
            print(rect, "score", score)
            img.draw_rectangle(rect, color=colors[i], thickness=2)

    print(clock.fps(), "fps", end="\n")
```

Since I removed the need for the output object now things can be accessed in more pythonic way. I like how things are improved.

