### PR TITLE
modules/py_image: Add support for turning lists/tuples into Images.

### DIFF
--- a/src/omv/modules/py_image.c
+++ b/src/omv/modules/py_image.c
@@ -6745,12 +6745,15 @@ mp_obj_t py_image_from_struct(image_t *img) {
 }
 
 mp_obj_t py_image_load_image(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum { ARG_height, ARG_pixformat, ARG_buffer, ARG_copy_to_fb };
+    enum { ARG_height, ARG_pixformat, ARG_buffer, ARG_copy_to_fb, ARG_shape, ARG_strides, ARG_scale};
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_height,       MP_ARG_INT, {.u_int = -1} },
         { MP_QSTR_pixformat,    MP_ARG_INT, {.u_int = -1} },
         { MP_QSTR_buffer,       MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_rom_obj = MP_ROM_NONE} },
         { MP_QSTR_copy_to_fb,   MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = false} },
+        { MP_QSTR_shape,        MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_strides,      MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_scale,        MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_rom_obj = MP_ROM_NONE} },
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
@@ -6779,6 +6782,96 @@ mp_obj_t py_image_load_image(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw
         #else
         mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("Image I/O is not supported"));
         #endif // IMLIB_ENABLE_IMAGE_FILE_IO
+    } else if (MP_OBJ_IS_TYPE(pos_args[0], &mp_type_tuple) || MP_OBJ_IS_TYPE(pos_args[0], &mp_type_list)) {
+        mp_obj_t *shape;
+        mp_obj_get_array_fixed_n(args[ARG_shape].u_obj, 3, &shape);
+
+        image.h = mp_obj_get_int(shape[0]);
+        PY_ASSERT_TRUE_MSG(image.h > 0, "Image height must be > 0");
+
+        image.w = mp_obj_get_int(shape[1]);
+        PY_ASSERT_TRUE_MSG(image.w > 0, "Image width must be > 0");
+
+        int channels = mp_obj_get_int(shape[2]);
+
+        if (channels == 1) {
+            image.pixfmt = PIXFORMAT_GRAYSCALE;
+        } else if (channels == 3) {
+            image.pixfmt = PIXFORMAT_RGB565;
+        } else {
+            mp_raise_ValueError(MP_ERROR_TEXT("Channels must be 1 or 3"));
+        }
+
+        mp_obj_t *strides;
+        mp_obj_get_array_fixed_n(args[ARG_strides].u_obj, 2, &strides);
+
+        int start = 0;
+        int start_r = 0;
+        int start_g = 0;
+        int start_b = 0;
+
+        if (channels == 1) {
+            start = mp_obj_get_int(strides[0]);
+            PY_ASSERT_TRUE_MSG(start >= 0, "Start must be >= 0");
+        } else {
+            mp_obj_t *rgb_strides;
+            mp_obj_get_array_fixed_n(strides[0], 3, &rgb_strides);
+
+            start_r = mp_obj_get_int(rgb_strides[0]);
+            PY_ASSERT_TRUE_MSG(start_r >= 0, "R Start must be >= 0");
+
+            start_g = mp_obj_get_int(rgb_strides[1]);
+            PY_ASSERT_TRUE_MSG(start_g >= 0, "G Start must be >= 0");
+
+            start_b = mp_obj_get_int(rgb_strides[2]);
+            PY_ASSERT_TRUE_MSG(start_b >= 0, "B Start must be >= 0");
+        }
+
+        int step = mp_obj_get_int(strides[1]);
+        PY_ASSERT_TRUE_MSG(step > 0, "Step must be > 0");
+
+        mp_obj_t *items;
+        size_t items_len;
+        mp_obj_get_array(pos_args[0], &items_len, &items);
+
+        int size = image.w * image.h;
+        int step_max = (size - 1) * step;
+
+        if (channels == 1) {
+            if (items_len <= (start + step_max)) {
+                mp_raise_ValueError(MP_ERROR_TEXT("Array too small"));
+            }
+        } else {
+            if ((items_len <= (start_r + step_max)) ||
+                (items_len <= (start_g + step_max)) ||
+                (items_len <= (start_b + step_max))) {
+                mp_raise_ValueError(MP_ERROR_TEXT("Array too small"));
+            }
+        }
+
+        mp_obj_t *scale;
+        mp_obj_get_array_fixed_n(args[ARG_scale].u_obj, 2, &scale);
+        float fscale = mp_obj_get_float(scale[0]);
+        float fadd = mp_obj_get_float(scale[1]);
+
+        if (args[ARG_copy_to_fb].u_bool) {
+            py_helper_set_to_framebuffer(&image);
+        } else {
+            image.data = xalloc(image_size(&image));
+        }
+
+        if (channels == 1) {
+            for (int i = 0; i < size; i++, start += step) {
+                ((uint8_t *) image.data)[i] = __USAT(fast_roundf((mp_obj_get_float(items[start]) * fscale) + fadd), 8);
+            }
+        } else {
+            for (int i = 0; i < size; i++, start_r += step, start_g += step, start_b += step) {
+                int r = __USAT(fast_roundf((mp_obj_get_float(items[start_r]) * fscale) + fadd), 8);
+                int g = __USAT(fast_roundf((mp_obj_get_float(items[start_g]) * fscale) + fadd), 8);
+                int b = __USAT(fast_roundf((mp_obj_get_float(items[start_b]) * fscale) + fadd), 8);
+                ((uint16_t *) image.data)[i] = COLOR_R8_G8_B8_TO_RGB565(r, g, b);
+            }
+        }
     } else {
         image.w = mp_obj_get_int(pos_args[0]);
         PY_ASSERT_TRUE_MSG(image.w > 0, "Image width must be > 0");


### PR DESCRIPTION
This PR gives Image() the ability to build an image from a list/tuple of values (which can be integers or floats).

Image has 3 new arguments to support this feature:

shape - This is just a tuple of 3 values of the `(height, width, channels)`. height/width are self-explanatory. channels is the color depth which is either 1 or 3 for grayscale or rgb565 support.

strides - This a 2 valued tuple. The first value is the start position in the list/tuple to cast. Generally, this is a small offset value `start`.  For 3 channels it is then a 3 valued tuple `(start_r, start_g, start_b)`. The second value is the `step` between valid pixels to grab. Pixels are grabbed, starting a `start` and incrementing by `step`.

_The reason for a start per color channel in the RGB case is so that you can handle BGR and etc. like stuff where channels are reversed on order. A step per channel is not provided though as you'd expect any output array to have some kind of regularity on color channels. While the order may change they should generally be `step` apart._

scale - This a 2 valued tuple which specifies a multiply and add value to apply per pixel. This lets you then scale a 0..1, -1..1, and -128..127 value read from the list/tuple to 0-255 for the grayscale image or RGB565 image (which is processed as an RGB888 image before being turned into RGB565).

...

Anyway, given the flexibility of the arguments, this new functionality can pretty much extract any image from a list/tuple, even when there are different forms of channel interleaving going on (which is the case for CNN segmentation outputs).

...

In the FOMO example:

```
image.Image(output, shape=(oh, ow, 1), strides=(i, oc), scale=(255, 0))
```

So, the segmentation output is (oh, ow, oc). Each channel encodes a different value per class.

Strides in this case allows us to grab the interleaved output by using `i` as the starting index into the channel we want to grab and then we step by the number of channels `oc`. scale is then taking the 0...1 value output by the model and mapping that to 0...255. Finally, the output shape we want is a grayscale image of (oh, ow) which maps to (oh, ow, 1).