### PR TITLE
modules/py_ml: Add support for multi-input tensor models.

### DIFF
--- a/scripts/examples/03-Machine-Learning/00-TensorFlow/tf_image_classification.py
+++ b/scripts/examples/03-Machine-Learning/00-TensorFlow/tf_image_classification.py
@@ -43,7 +43,7 @@ while True:
     # This combines the labels and confidence values into a list of tuples
     # and then sorts that list by the confidence values.
     sorted_list = sorted(
-        zip(labels, model.predict(img)[0]), key=lambda x: x[1], reverse=True
+        zip(labels, model.predict([ml.Image(img)])[0]), key=lambda x: x[1], reverse=True
     )
     for i in range(5):
         print("%s = %f" % (sorted_list[i][0], sorted_list[i][1]))

--- a/scripts/examples/03-Machine-Learning/00-TensorFlow/tf_object_detection.py
+++ b/scripts/examples/03-Machine-Learning/00-TensorFlow/tf_object_detection.py
@@ -45,9 +45,9 @@ colors = [  # Add more colors if you are detecting more than 7 types of classes 
 # position in the output image back to the original input image. The function then returns a
 # list per class which each contain a list of (rect, score) tuples representing the detected
 # objects.
-def fomo_post_process(model, output, rect):
+def fomo_post_process(model, input, output):
     n, oh, ow, oc = model.output_shape[0]
-    nms = ml.NMS(ow, oh, rect)
+    nms = ml.NMS(ow, oh, input[0].roi)
     for i in range(oc):
         img = image.Image(output[0], shape=(oh, ow, 1), strides=(i, oc), scale=(255, 0))
         blobs = img.find_blobs(
@@ -69,7 +69,7 @@ while True:
 
     img = sensor.snapshot()
 
-    for i, detection_list in enumerate(model.predict(img, callback=fomo_post_process)):
+    for i, detection_list in enumerate(model.predict([ml.Image(img)], callback=fomo_post_process)):
         if i == 0:
             continue  # background class
         if len(detection_list) == 0:

--- a/scripts/libraries/ml.py
+++ b/scripts/libraries/ml.py
@@ -72,12 +72,12 @@ class MicroSpeech:
         # Roll the spectrogram to the left and add the new slice.
         self.spectrogram = np.roll(self.spectrogram, -_SLICE_SIZE, axis=1)
         self.spectrogram[0, -_SLICE_SIZE:] = self.preprocessor.predict(
-            self.audio_buffer
+            [self.audio_buffer]
         )
 
         # Roll the prediction history and add the new prediction.
         self.pred_history = np.roll(self.pred_history, -1, axis=0)
-        self.pred_history[-1] = self.micro_speech.predict(self.spectrogram)[0]
+        self.pred_history[-1] = self.micro_speech.predict([self.spectrogram])[0]
 
     def start_audio_streaming(self):
         if self.audio_started is False:

--- a/src/lib/tflm/tflm_backend.cc
+++ b/src/lib/tflm/tflm_backend.cc
@@ -29,7 +29,7 @@ extern "C" {
 #include "fb_alloc.h"
 
 using namespace tflite;
-#define TF_ARENA_ALIGNMENT   (16 - 1)
+#define TF_ARENA_ALIGNMENT  (16 - 1)
 typedef MicroMutableOpResolver<113> MicroOpsResolver;
 
 typedef struct ml_backend_state {
@@ -40,7 +40,7 @@ typedef struct ml_backend_state {
 } ml_backend_state_t;
 
 void abort(void) {
-  while (1);
+    while (1);
 }
 
 void ml_backend_log_handler(const char *s) {
@@ -323,14 +323,5 @@ void *ml_backend_get_output(py_ml_model_obj_t *model, size_t index) {
     }
     mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("Invalid output tensor index"));
 }
-
-int ml_backend_generate_micro_features(const int16_t *input,
-                                       int input_size,
-                                       int output_size,
-                                       int8_t *output,
-                                       size_t *num_samples_read) {
-    return 0;
-}
-
 } // extern "C"
-#endif //IMLIB_ENABLE_TFLM
+#endif // IMLIB_ENABLE_TFLM

--- a/src/lib/tflm/tflm_backend.cc
+++ b/src/lib/tflm/tflm_backend.cc
@@ -278,21 +278,14 @@ int ml_backend_init_model(py_ml_model_obj_t *model) {
     return 0;
 }
 
-int ml_backend_run_inference(py_ml_model_obj_t *model,
-                             ml_backend_input_callback_t input_callback,
-                             void *input_arg,
-                             ml_backend_output_callback_t output_callback,
-                             void *output_arg) {
+int ml_backend_run_inference(py_ml_model_obj_t *model) {
     RegisterDebugLogCallback(ml_backend_log_handler);
     ml_backend_state_t *state = (ml_backend_state_t *) model->state;
-
-    input_callback(model, input_arg);
 
     if (state->interpreter->Invoke() != kTfLiteOk) {
         mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("Invoke failed"));
     }
 
-    output_callback(model, output_arg);
     return 0;
 }
 

--- a/src/omv/modules/py_ml.h
+++ b/src/omv/modules/py_ml.h
@@ -1,8 +1,8 @@
 /*
  * This file is part of the OpenMV project.
  *
- * Copyright (c) 2013-2021 Ibrahim Abdelkader <iabdalkader@openmv.io>
- * Copyright (c) 2013-2021 Kwabena W. Agyeman <kwagyeman@openmv.io>
+ * Copyright (c) 2013-2024 Ibrahim Abdelkader <iabdalkader@openmv.io>
+ * Copyright (c) 2013-2024 Kwabena W. Agyeman <kwagyeman@openmv.io>
  *
  * This work is licensed under the MIT license, see the file LICENSE for details.
  *
@@ -10,6 +10,8 @@
  */
 #ifndef __PY_ML_H__
 #define __PY_ML_H__
+#include "imlib.h"
+
 typedef enum {
     PY_ML_SCALE_NONE,
     PY_ML_SCALE_0_1,
@@ -44,14 +46,21 @@ typedef struct py_ml_model_obj {
     void *state; // Private context for the backend.
 } py_ml_model_obj_t;
 
+typedef void (py_ml_input_callback_t) (void *self, py_ml_model_obj_t *model, size_t index);
+
+// ML Image Arg Object.
+typedef struct py_ml_image_arg_obj {
+    mp_obj_base_t base;
+    py_ml_input_callback_t *input_callback;
+    image_t *image;
+    rectangle_t roi;
+    py_ml_scale_t scale;
+    float mean[3];
+    float stdev[3];
+} py_image_arg_obj_t;
+
 // Initialize a model.
 int ml_backend_init_model(py_ml_model_obj_t *model);
-
-// Callback to populate the model input data.
-typedef void (*ml_backend_input_callback_t) (py_ml_model_obj_t *model, void *arg);
-
-// Callback to get the model output data.
-typedef void (*ml_backend_output_callback_t) (py_ml_model_obj_t *model, void *arg);
 
 // Return an input tensor by index.
 void *ml_backend_get_input(py_ml_model_obj_t *model, size_t index);
@@ -60,9 +69,5 @@ void *ml_backend_get_input(py_ml_model_obj_t *model, size_t index);
 void *ml_backend_get_output(py_ml_model_obj_t *model, size_t index);
 
 // Run inference.
-int ml_backend_run_inference(py_ml_model_obj_t *model,
-                             ml_backend_input_callback_t input_callback, // Callback to populate the model input data.
-                             void *input_data, // User data structure passed to input callback.
-                             ml_backend_output_callback_t output_callback, // Callback to use the model output data.
-                             void *output_data); // User data structure passed to output callback.
+int ml_backend_run_inference(py_ml_model_obj_t *model);
 #endif // __PY_ML_H__

--- a/src/omv/modules/py_ml.h
+++ b/src/omv/modules/py_ml.h
@@ -33,16 +33,14 @@ typedef struct py_ml_model_obj {
     unsigned char *data;
     size_t memory_size;
     bool fb_alloc;
-    size_t inputs_size;
     mp_obj_tuple_t *input_shape;
-    float input_scale;
-    int input_zero_point;
-    py_ml_dtype_t input_dtype;
-    size_t outputs_size;
+    mp_obj_tuple_t *input_scale;
+    mp_obj_tuple_t *input_zero_point;
+    mp_obj_tuple_t *input_dtype;
     mp_obj_tuple_t *output_shape;
-    float output_scale;
-    int output_zero_point;
-    py_ml_dtype_t output_dtype;
+    mp_obj_tuple_t *output_scale;
+    mp_obj_tuple_t *output_zero_point;
+    mp_obj_tuple_t *output_dtype;
     void *state; // Private context for the backend.
 } py_ml_model_obj_t;
 

--- a/src/omv/modules/py_ml_image_arg.c
+++ b/src/omv/modules/py_ml_image_arg.c
@@ -1,0 +1,221 @@
+/*
+ * This file is part of the OpenMV project.
+ *
+ * Copyright (c) 2013-2024 Ibrahim Abdelkader <iabdalkader@openmv.io>
+ * Copyright (c) 2013-2024 Kwabena W. Agyeman <kwagyeman@openmv.io>
+ *
+ * This work is licensed under the MIT license, see the file LICENSE for details.
+ *
+ * ML Image Arg class.
+ */
+#include "imlib_config.h"
+
+#ifdef IMLIB_ENABLE_TFLM
+#include "py/runtime.h"
+#include "py_helper.h"
+#include "py_image.h"
+#include "py_ml.h"
+
+#define PY_ML_GRAYSCALE_RANGE   ((COLOR_GRAYSCALE_MAX) -(COLOR_GRAYSCALE_MIN))
+#define PY_ML_GRAYSCALE_MID     (((PY_ML_GRAYSCALE_RANGE) +1) / 2)
+
+static void py_ml_image_arg_input_callback(void *self, py_ml_model_obj_t *model, size_t index) {
+    py_image_arg_obj_t *image_arg = MP_OBJ_TO_PTR(self);
+    void *model_input = ml_backend_get_input(model, index);
+    mp_obj_tuple_t *input_shape = MP_OBJ_TO_PTR(model->input_shape->items[index]);
+
+    if ((input_shape->len != 3) && (input_shape->len != 4)) {
+        mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("Expected a tensor of (1, h, w, c) or (h, w, c)!"));
+    }
+
+    int offset = (input_shape->len == 4) ? 1 : 0;
+    int input_height = mp_obj_get_int(input_shape->items[offset]);
+    int input_width = mp_obj_get_int(input_shape->items[offset + 1]);
+    int input_channels = mp_obj_get_int(input_shape->items[offset + 2]);
+
+    if ((input_height <= 0) || (input_width <= 0)) {
+        mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("Invalid tensor height or width!"));
+    }
+
+    int shift = (model->input_dtype == PY_ML_DTYPE_INT8) ? PY_ML_GRAYSCALE_MID : 0;
+    float fscale = 1.0f, fadd = 0.0f;
+
+    switch (image_arg->scale) {
+        case PY_ML_SCALE_0_1: // convert 0->255 to 0->1
+            fscale = 1.0f / 255.0f;
+            break;
+        case PY_ML_SCALE_S1_1: // convert 0->255 to -1->1
+            fscale = 2.0f / 255.0f;
+            fadd = -1.0f;
+            break;
+        case PY_ML_SCALE_S128_127: // convert 0->255 to -128->127
+            fadd = -128.0f;
+            break;
+        case PY_ML_SCALE_NONE: // convert 0->255 to 0->255
+        default:
+            break;
+    }
+
+    float fscale_r = fscale, fadd_r = fadd;
+    float fscale_g = fscale, fadd_g = fadd;
+    float fscale_b = fscale, fadd_b = fadd;
+
+    // To normalize the input image we need to subtract the mean and divide by the standard deviation.
+    // We can do this by applying the normalization to fscale and fadd outside the loop.
+
+    // Red
+    fadd_r = (fadd_r - image_arg->mean[0]) / image_arg->stdev[0];
+    fscale_r /= image_arg->stdev[0];
+
+    // Green
+    fadd_g = (fadd_g - image_arg->mean[1]) / image_arg->stdev[1];
+    fscale_g /= image_arg->stdev[1];
+
+    // Blue
+    fadd_b = (fadd_b - image_arg->mean[2]) / image_arg->stdev[2];
+    fscale_b /= image_arg->stdev[2];
+
+    // Grayscale -> Y = 0.299R + 0.587G + 0.114B
+    float mean = (image_arg->mean[0] * 0.299f) + (image_arg->mean[1] * 0.587f) + (image_arg->mean[2] * 0.114f);
+    float std = (image_arg->stdev[0] * 0.299f) + (image_arg->stdev[1] * 0.587f) + (image_arg->stdev[2] * 0.114f);
+    fadd = (fadd - mean) / std;
+    fscale /= std;
+
+    image_t dst_img;
+    dst_img.w = input_width;
+    dst_img.h = input_height;
+    dst_img.data = (uint8_t *) model_input;
+
+    if (input_channels == 1) {
+        dst_img.pixfmt = PIXFORMAT_GRAYSCALE;
+    } else if (input_channels == 3) {
+        dst_img.pixfmt = PIXFORMAT_RGB565;
+    } else {
+        mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("Expected model input channels to be 1 or 3!"));
+    }
+
+    imlib_draw_image(&dst_img, image_arg->image, 0, 0, 1.0f, 1.0f, &image_arg->roi,
+                     -1, 256, NULL, NULL, IMAGE_HINT_BILINEAR | IMAGE_HINT_CENTER |
+                     IMAGE_HINT_SCALE_ASPECT_EXPAND | IMAGE_HINT_BLACK_BACKGROUND, NULL, NULL, NULL);
+
+    int size = (input_width * input_height) - 1; // must be int per countdown loop
+
+    if (input_channels == 1) {
+        // GRAYSCALE
+        if (model->input_dtype == PY_ML_DTYPE_FLOAT) {
+            // convert u8 -> f32
+            uint8_t *model_input_u8 = (uint8_t *) model_input;
+            float *model_input_f32 = (float *) model_input;
+            for (; size >= 0; size -= 1) {
+                model_input_f32[size] = (model_input_u8[size] * fscale) + fadd;
+            }
+        } else {
+            if (shift) {
+                // convert u8 -> s8
+                uint8_t *model_input_8 = (uint8_t *) model_input;
+                #if (__ARM_ARCH > 6)
+                for (; size >= 3; size -= 4) {
+                    *((uint32_t *) (model_input_8 + size - 3)) ^= 0x80808080;
+                }
+                #endif
+                for (; size >= 0; size -= 1) {
+                    model_input_8[size] ^= PY_ML_GRAYSCALE_MID;
+                }
+            }
+        }
+    } else if (input_channels == 3) {
+        // RGB888
+        int rgb_size = size * 3; // must be int per countdown loop
+        if (model->input_dtype == PY_ML_DTYPE_FLOAT) {
+            uint16_t *model_input_u16 = (uint16_t *) model_input;
+            float *model_input_f32 = (float *) model_input;
+            for (; size >= 0; size -= 1, rgb_size -= 3) {
+                int pixel = model_input_u16[size];
+                model_input_f32[rgb_size] = (COLOR_RGB565_TO_R8(pixel) * fscale_r) + fadd_r;
+                model_input_f32[rgb_size + 1] = (COLOR_RGB565_TO_G8(pixel) * fscale_g) + fadd_g;
+                model_input_f32[rgb_size + 2] = (COLOR_RGB565_TO_B8(pixel) * fscale_b) + fadd_b;
+            }
+        } else {
+            uint16_t *model_input_u16 = (uint16_t *) model_input;
+            uint8_t *model_input_8 = (uint8_t *) model_input;
+            for (; size >= 0; size -= 1, rgb_size -= 3) {
+                int pixel = model_input_u16[size];
+                model_input_8[rgb_size] = COLOR_RGB565_TO_R8(pixel) ^ shift;
+                model_input_8[rgb_size + 1] = COLOR_RGB565_TO_G8(pixel) ^ shift;
+                model_input_8[rgb_size + 2] = COLOR_RGB565_TO_B8(pixel) ^ shift;
+            }
+        }
+    }
+}
+
+static void py_ml_image_arg_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
+    py_image_arg_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    if (dest[0] == MP_OBJ_NULL) {
+        // Load attribute.
+        switch (attr) {
+            case MP_QSTR_image:
+                dest[0] = py_image_from_struct(self->image);
+                break;
+            case MP_QSTR_roi:
+                dest[0] = mp_obj_new_tuple(4, (mp_obj_t []) {mp_obj_new_int(self->roi.x),
+                                                             mp_obj_new_int(self->roi.y),
+                                                             mp_obj_new_int(self->roi.w),
+                                                             mp_obj_new_int(self->roi.h)});
+                break;
+            case MP_QSTR_scale:
+                dest[0] = mp_obj_new_int(self->scale);
+                break;
+            case MP_QSTR_mean:
+                dest[0] = mp_obj_new_tuple(3, (mp_obj_t []) {mp_obj_new_float(self->mean[0]),
+                                                             mp_obj_new_float(self->mean[1]),
+                                                             mp_obj_new_float(self->mean[2])});
+                break;
+            case MP_QSTR_stdev:
+                dest[0] = mp_obj_new_tuple(3, (mp_obj_t []) {mp_obj_new_float(self->stdev[0]),
+                                                             mp_obj_new_float(self->stdev[1]),
+                                                             mp_obj_new_float(self->stdev[2])});
+                break;
+            default:
+                // Continue lookup in locals_dict.
+                dest[1] = MP_OBJ_SENTINEL;
+                break;
+        }
+    }
+}
+
+const mp_obj_type_t py_ml_image_arg_type;
+
+mp_obj_t py_ml_image_arg_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
+    enum { ARG_image, ARG_roi, ARG_scale, ARG_mean, ARG_stdev };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_image, MP_ARG_OBJ | MP_ARG_REQUIRED, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_roi, MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_scale, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = PY_ML_SCALE_0_1} },
+        { MP_QSTR_mean, MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_stdev, MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_rom_obj = MP_ROM_NONE} },
+    };
+
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    py_image_arg_obj_t *image_arg = m_new_obj(py_image_arg_obj_t);
+    image_arg->base.type = &py_ml_image_arg_type;
+    image_arg->input_callback = py_ml_image_arg_input_callback;
+    image_arg->image = py_helper_arg_to_image(args[ARG_image].u_obj, ARG_IMAGE_ANY);
+    image_arg->roi = py_helper_arg_to_roi(args[ARG_roi].u_obj, image_arg->image);
+    image_arg->scale = args[ARG_scale].u_int;
+    memcpy(image_arg->mean, (float[]) {0.0f, 0.0f, 0.0f}, 3 * sizeof(float));
+    memcpy(image_arg->stdev, (float[]) {1.0f, 1.0f, 1.0f}, 3 * sizeof(float));
+    py_helper_arg_to_float_array(args[ARG_mean].u_obj, image_arg->mean, 3);
+    py_helper_arg_to_float_array(args[ARG_stdev].u_obj, image_arg->stdev, 3);
+    return MP_OBJ_FROM_PTR(image_arg);
+}
+
+MP_DEFINE_CONST_OBJ_TYPE(
+    py_ml_image_arg_type,
+    MP_QSTR_ml_image_arg,
+    MP_TYPE_FLAG_NONE,
+    attr, py_ml_image_arg_attr,
+    make_new, py_ml_image_arg_make_new
+    );
+#endif // IMLIB_ENABLE_TFLM

--- a/src/omv/modules/py_ml_image_arg.c
+++ b/src/omv/modules/py_ml_image_arg.c
@@ -23,6 +23,7 @@ static void py_ml_image_arg_input_callback(void *self, py_ml_model_obj_t *model,
     py_image_arg_obj_t *image_arg = MP_OBJ_TO_PTR(self);
     void *model_input = ml_backend_get_input(model, index);
     mp_obj_tuple_t *input_shape = MP_OBJ_TO_PTR(model->input_shape->items[index]);
+    int input_dtype = mp_obj_get_int(model->input_dtype->items[index]);
 
     if ((input_shape->len != 3) && (input_shape->len != 4)) {
         mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("Expected a tensor of (1, h, w, c) or (h, w, c)!"));
@@ -37,7 +38,7 @@ static void py_ml_image_arg_input_callback(void *self, py_ml_model_obj_t *model,
         mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("Invalid tensor height or width!"));
     }
 
-    int shift = (model->input_dtype == PY_ML_DTYPE_INT8) ? PY_ML_GRAYSCALE_MID : 0;
+    int shift = (input_dtype == PY_ML_DTYPE_INT8) ? PY_ML_GRAYSCALE_MID : 0;
     float fscale = 1.0f, fadd = 0.0f;
 
     switch (image_arg->scale) {
@@ -102,7 +103,7 @@ static void py_ml_image_arg_input_callback(void *self, py_ml_model_obj_t *model,
 
     if (input_channels == 1) {
         // GRAYSCALE
-        if (model->input_dtype == PY_ML_DTYPE_FLOAT) {
+        if (input_dtype == PY_ML_DTYPE_FLOAT) {
             // convert u8 -> f32
             uint8_t *model_input_u8 = (uint8_t *) model_input;
             float *model_input_f32 = (float *) model_input;
@@ -126,7 +127,7 @@ static void py_ml_image_arg_input_callback(void *self, py_ml_model_obj_t *model,
     } else if (input_channels == 3) {
         // RGB888
         int rgb_size = size * 3; // must be int per countdown loop
-        if (model->input_dtype == PY_ML_DTYPE_FLOAT) {
+        if (input_dtype == PY_ML_DTYPE_FLOAT) {
             uint16_t *model_input_u16 = (uint16_t *) model_input;
             float *model_input_f32 = (float *) model_input;
             for (; size >= 0; size -= 1, rgb_size -= 3) {

--- a/src/omv/modules/py_ml_nms.c
+++ b/src/omv/modules/py_ml_nms.c
@@ -14,7 +14,7 @@
 #include "py/runtime.h"
 #include "py_helper.h"
 
-// TF NMS Object.
+// ML NMS Object.
 typedef struct py_ml_nms_obj {
     mp_obj_base_t base;
     int window_w;
@@ -134,7 +134,7 @@ static MP_DEFINE_CONST_DICT(py_ml_nms_locals_dict, py_ml_nms_locals_table);
 
 MP_DEFINE_CONST_OBJ_TYPE(
     py_ml_nms_type,
-    MP_QSTR_tf_nms,
+    MP_QSTR_ml_nms,
     MP_TYPE_FLAG_NONE,
     make_new, py_ml_nms_make_new,
     locals_dict, &py_ml_nms_locals_dict


### PR DESCRIPTION
[modules/py_ml: Add support for multi-input tensor models.](https://github.com/openmv/openmv/commit/3934c323b7444330de8353ed6aedaf9abbdc3b91)

This commit adds support for handling multiple input tensors in models. predict() now takes an array of objects equal to the number of input tensors it has. The input objects can either be ndarrays or ml.Image() objects.

The new ml.Image() object is a wrapper for images and their arguments that you would have passes previously to ml.predict(). By moving these to an object you can now pass different images with different arguments if you needed to.

Finally, the callback option has been simplified so that the callback is just passed the (model, inputs, and outputs). Where `inputs` is what was passed to predict.

...

Per our meeting, here's the proposed API with this PR:

```
def cb(model, inputs, outputs):
    some_ndarray1, ml_image, some_ndarray2 = inputs
    # and outputs is the list of output tensors
    roi = ml_image.roi
    ...

ml.predict([some_ndarray1, ml.Image(img, roi=(x, y, w, h), scale=ml.SCALE_NONE), some_ndarray2], callback=cb)
```

Arguments for the image are stored with it in the array and then are available with it in the callback.

The alternative API as discussed:

```
def cb(model, outputs, rects):
    # and outputs is the list of output tensors
    roi = rects[0]
    ...

ml.predict([some_ndarray1, img, some_ndarray2], roi=[(x, y, w, h)], scaling=[ml.SCALE_NONE], callback=cb)
# where the values in the arrays for roi/scaling are applied per image discovered in the input list.
```

The scaling value is unlikely to be needed in the callback. So, just rects can be supplied. The alternative API could also pass a global scaling value for all images in the Model() constructor versus having it in the predict call. I think we want to avoid a global value, though, for everything.

Either API above should future proof us for a few years. I think my suggestion is better designed though as all arguments are in one place and you have access to them in the callback. I agree, though it's an extra object. The alternative API is very simple comparatively and gives us just what we need and not extra. But, it may be less future-proof.

...

[modules/py_ml: Fully vectorize all input and output scaling/datatypes.](https://github.com/openmv/openmv/commit/89345830f84066773413d761412af2ec8224934b)

Fully vectorizes the scaling, zero-point, and datatype values. We should do this now so that if it does become the case in the future that a model has differently scaled tensor heads we have support already complete and don't have to break the API again. Given the backend can change and we may not necessarily always be running tensorflow models our code should handle each tensor being different.

[modules/py_ml_nms: Fix tf->ml naming.](https://github.com/openmv/openmv/commit/583c826e8ca836d7ac860e97cc575b51bb310e25)

This commit fixes a bug with `ml` module renaming of things.

[lib/tflm: Code cleanup.](https://github.com/openmv/openmv/commit/f9ab07cef14ac3e98fd4004cad3c929c5d09ef1b)

Minor code cleanup in the backend.

[modules/py_ml: Add support for arrays.](https://github.com/openmv/openmv/pull/2243/commits/1e6b2e693d9f611170a7c2b8fd77bc42a4e13d30)

This commit adds support for arrays. We should have this so that we have a backdoor to pass input to a model that needs some high-dimensional vector support. The code is much simpler now and just accepts a flattened list, which has to be the same length as the tensor shape. It looks roughly the same as the array code but doesn't have the shape-matching enforcement.



