### PR TITLE
scripts/examples: Fix light shield example.

### DIFF
--- a/scripts/examples/50-OpenMV-Boards/60-Shields/68-Light-Shield/light.py
+++ b/scripts/examples/50-OpenMV-Boards/60-Shields/68-Light-Shield/light.py
@@ -1,13 +1,19 @@
 # This work is licensed under the MIT license.
-# Copyright (c) 2013-2023 OpenMV LLC. All rights reserved.
+# Copyright (c) 2013-2026 OpenMV LLC. All rights reserved.
 # https://github.com/openmv/openmv/blob/master/LICENSE
 #
+# This example shows off using the light shield with the Machine Module.
+
 import time
-from pyb import Pin, Timer
+from machine import PWM, Pin
 
 # 50kHz pin6 timer2 channel1
-light = Timer(2, freq=50000).channel(1, Timer.PWM, pin=Pin("P6"))
-light.pulse_width_percent(100)  # adjust light 0~100
+pwm = PWM(Pin("P6"), freq=50000, duty_u16=0)
 
 while True:
-    time.sleep_ms(1000)
+    for i in range(101):
+        pwm.duty_u16((i * 65535) // 100)
+        time.sleep_ms(10)
+    for i in range(101):
+        pwm.duty_u16(((100 - i) * 65535) // 100)
+        time.sleep_ms(10)


### PR DESCRIPTION
Fixes: https://github.com/openmv/openmv/issues/2240

I was not able to use the PWM module on the H7. It's missing from the machine module for all STM32 boards. So, I just made the code support both ways.