### PR TITLE
scripts/rpc.py: Updated to use machine.SPI for rpc_spi_master.

### DIFF
--- a/scripts/libraries/rpc.py
+++ b/scripts/libraries/rpc.py
@@ -545,26 +545,28 @@ class rpc_i2c_slave(rpc_slave):
 
 class rpc_spi_master(rpc_master):
     def __init__(
-        self, cs_pin="P3", freq=1000000, clk_polarity=1, clk_phase=0, spi_bus=2
+        self, cs_pin="P3", freq=1000000, clk_polarity=1, clk_phase=0, spi_bus=0
     ):  # private
-        import pyb
-        self.__pin = pyb.Pin(cs_pin, pyb.Pin.OUT_PP)
+        import machine.SPI
+        import machine.Pin
+        self.__pin = machine.Pin(cs_pin, machine.Pin.OUT)
         self.__freq = freq
         self.__polarity = clk_polarity
         self.__clk_phase = clk_phase
-        self.__spi = pyb.SPI(spi_bus)
+        self.__spi = machine.SPI(spi_bus)
         rpc_master.__init__(self)
         self._stream_writer_queue_depth_max = 1
 
     def get_bytes(self, buff, timeout_ms):  # protected
-        import pyb
+        import machine.SPI
+        import machine.Pin
         self.__pin.value(False)
         time.sleep_us(100)  # Give slave time to get ready.
         self.__spi.init(
-            pyb.SPI.MASTER, self.__freq, polarity=self.__polarity, phase=self.__clk_phase
+            self.__freq, polarity=self.__polarity, phase=self.__clk_phase
         )
         try:
-            self.__spi.send_recv(buff, buff, timeout=timeout_ms)  # SPI.recv() is broken.
+            self.__spi.write_readinto(buff, buff, timeout=timeout_ms)  # SPI.recv() is broken.
         except OSError:
             buff = None
         self.__spi.deinit()
@@ -574,14 +576,15 @@ class rpc_spi_master(rpc_master):
         return buff
 
     def put_bytes(self, data, timeout_ms):  # protected
-        import pyb
+        import machine.SPI
+        import machine.Pin
         self.__pin.value(False)
         time.sleep_us(100)  # Give slave time to get ready.
         self.__spi.init(
-            pyb.SPI.MASTER, self.__freq, polarity=self.__polarity, phase=self.__clk_phase
+            self.__freq, polarity=self.__polarity, phase=self.__clk_phase
         )
         try:
-            self.__spi.send(data, timeout=timeout_ms)
+            self.__spi.read(data)
         except OSError:
             pass
         self.__spi.deinit()


### PR DESCRIPTION
Changed dependency from pyb to machine.


Note: Couldn't update the slave class because machine doesn't support SPI slaving. Someone will also need to update the arduino library to add slave support for SPI.