### PR TITLE
misc/usbdbg: Implement USB debug GET_STATE command.

### DIFF
--- a/src/omv/common/usbdbg.h
+++ b/src/omv/common/usbdbg.h
@@ -49,6 +49,13 @@ enum usbdbg_cmd {
     USBDBG_SENSOR_ID       =0x90,
     USBDBG_TX_INPUT        =0x11,
     USBDBG_SET_TIME        =0x12,
+    USBDBG_GET_STATE       =0x93,
+};
+
+enum usbdbg_state_flags {
+    USBDBG_STATE_FLAGS_SCRIPT   = (1 << 0),
+    USBDBG_STATE_FLAGS_TEXT     = (1 << 1),
+    USBDBG_STATE_FLAGS_FRAME    = (1 << 2),
 };
 
 void usbdbg_init();


### PR DESCRIPTION
The GET_STATE command is a command that returns flags, frame width, height, size, and the text buffer (up to 40 bytes), in a single 64 bytes packet to reduce the bandwidth/overhead of the protocol.

The packet format is:
```
word    word    word    word    2 words     40 bytes
<flags> <width> <height> <size> <reserved>  <null-terminated text>
```
The flags are mostly reserved, only the following bits are defined:
0x001 script running
0x010 text buffer valid.
0x100 JPEG frame buffer ready.