### PR TITLE
scripts/libraries: Update rpc_spi_master to use the machine module.

### DIFF
--- a/scripts/libraries/rpc.py
+++ b/scripts/libraries/rpc.py
@@ -547,24 +547,22 @@ class rpc_spi_master(rpc_master):
     def __init__(
         self, cs_pin="P3", freq=1000000, clk_polarity=1, clk_phase=0, spi_bus=2
     ):  # private
-        import pyb
-        self.__pin = pyb.Pin(cs_pin, pyb.Pin.OUT_PP)
+        self.__pin = machine.Pin(cs_pin, machine.Pin.OUT)
         self.__freq = freq
         self.__polarity = clk_polarity
         self.__clk_phase = clk_phase
-        self.__spi = pyb.SPI(spi_bus)
+        self.__spi = machine.SPI(spi_bus)
         rpc_master.__init__(self)
         self._stream_writer_queue_depth_max = 1
 
     def get_bytes(self, buff, timeout_ms):  # protected
-        import pyb
         self.__pin.value(False)
         time.sleep_us(100)  # Give slave time to get ready.
         self.__spi.init(
-            pyb.SPI.MASTER, self.__freq, polarity=self.__polarity, phase=self.__clk_phase
+            baudrate=self.__freq, polarity=self.__polarity, phase=self.__clk_phase
         )
         try:
-            self.__spi.send_recv(buff, buff, timeout=timeout_ms)  # SPI.recv() is broken.
+            self.__spi.write_readinto(buff, buff)  # SPI.readinto() is broken.
         except OSError:
             buff = None
         self.__spi.deinit()
@@ -574,14 +572,13 @@ class rpc_spi_master(rpc_master):
         return buff
 
     def put_bytes(self, data, timeout_ms):  # protected
-        import pyb
         self.__pin.value(False)
         time.sleep_us(100)  # Give slave time to get ready.
         self.__spi.init(
-            pyb.SPI.MASTER, self.__freq, polarity=self.__polarity, phase=self.__clk_phase
+            baudrate=self.__freq, polarity=self.__polarity, phase=self.__clk_phase
         )
         try:
-            self.__spi.send(data, timeout=timeout_ms)
+            self.__spi.write(data)
         except OSError:
             pass
         self.__spi.deinit()


### PR DESCRIPTION
Tested:

Fixes: https://github.com/openmv/openmv/issues/2265

SPI (STM32 Master, using machine module <-> STM32 Slave, using pyb module)
I2C (STM32 Master, using machine module <-> STM32 Slave, using pyb module)
SPI (RT1062 Master, using machine module <-> STM32 Slave, using pyb module)
I2C (RT1062 Master, using machine module <-> Arduino Uno, using C++ library)

I2C (RT1062 Master, using machine module <-> STM32 Slave, using pyb module) doesn't work. The STM32 holds the SDA line low, preventing comms. Not sure what the issue is exactly as this works between STM32 devices. Whatever the case, this issue is unrelated to the PR and verified RT1062 I2C master functionality working with an Arduino Uno Slave I2C device.