### PR TITLE
sensors/hm0360: Enable HM0360 to work on GIGA.

### DIFF
--- a/src/omv/boards/ARDUINO_GIGA/omv_boardconfig.h
+++ b/src/omv/boards/ARDUINO_GIGA/omv_boardconfig.h
@@ -40,6 +40,8 @@
 
 #define OMV_HM01B0_ENABLE                   (1)
 #define OMV_HM0360_ENABLE                   (1)
+#define OMV_HM0360_XCLK_FREQ                (24000000)
+#define OMV_HM0360_PLL1_CONFIG              (0x04)
 
 // FIR sensor drivers configuration.
 #define OMV_FIR_MLX90621_ENABLE             (1)

--- a/src/omv/boards/ARDUINO_PORTENTA_H7/omv_boardconfig.h
+++ b/src/omv/boards/ARDUINO_PORTENTA_H7/omv_boardconfig.h
@@ -37,6 +37,9 @@
 
 #define OMV_HM01B0_ENABLE                   (1)
 #define OMV_HM0360_ENABLE                   (1)
+// This sensor uses an internal oscillator on the Arduino Portenta H7.
+#define OMV_HM0360_XCLK_FREQ                (0)
+#define OMV_HM0360_PLL1_CONFIG              (0x08)
 
 // FIR sensor drivers configuration.
 #define OMV_FIR_MLX90621_ENABLE             (1)

--- a/src/omv/sensors/hm0360.c
+++ b/src/omv/sensors/hm0360.c
@@ -84,7 +84,7 @@ static const uint16_t default_regs[][2] = {
 
     {0x3112,            0x00},  // PCLKO_polarity falling
 
-    {PLL1_CONFIG,       0x08},  // Core = 24MHz PCLKO = 24MHz I2C = 12MHz
+    {PLL1_CONFIG,       OMV_HM0360_PLL1_CONFIG},  // Core = 24MHz PCLKO = 24MHz I2C = 12MHz
     {PLL2_CONFIG,       0x0A},  // MIPI pre-dev (default)
     {PLL3_CONFIG,       0x77},  // PMU/MIPI pre-dev (default)
 

--- a/src/omv/sensors/hm0360.h
+++ b/src/omv/sensors/hm0360.h
@@ -10,7 +10,5 @@
  */
 #ifndef __HM0360_H__
 #define __HM0360_H__
-// This sensor uses an internal oscillator.
-#define OMV_HM0360_XCLK_FREQ    (0)
 int hm0360_init(sensor_t *sensor);
 #endif // __HM0360_H__


### PR DESCRIPTION
Fixes: https://github.com/openmv/openmv/issues/2226

The Arducam module doesn't configure the sensor to use it's internal clock.