### PR TITLE
ports/mimxrt: Fix I2C for the MLX90640 driver.

### DIFF
--- a/src/drivers/mlx90641/src/MLX90641_I2C_Driver.c
+++ b/src/drivers/mlx90641/src/MLX90641_I2C_Driver.c
@@ -35,16 +35,23 @@ int MLX90641_I2CGeneralReset(void)
 
 int MLX90641_I2CRead(uint8_t slaveAddr, uint16_t startAddress, uint16_t nMemAddressRead, uint16_t *data)
 {
-    startAddress = __REVSH(startAddress);
+    for (uint16_t n = nMemAddressRead, *d = data; n; ) {
+        uint16_t write_address = __REVSH(startAddress);
+        uint16_t read_size = n > OMV_I2C_MAX_16BIT_XFER ? OMV_I2C_MAX_16BIT_XFER : n;
 
-    if (omv_i2c_write_bytes(bus, (slaveAddr<<1), (uint8_t *) &startAddress, 2, OMV_I2C_XFER_NO_STOP) != 0) {
-        return -1;
-	}
+        if (omv_i2c_write_bytes(bus, (slaveAddr<<1), (uint8_t *) &write_address, 2, OMV_I2C_XFER_NO_STOP) != 0) {
+            return -1;
+        }
 
 
-    if (omv_i2c_read_bytes(bus, (slaveAddr<<1), (uint8_t *) data, nMemAddressRead*2, OMV_I2C_XFER_NO_FLAGS) != 0) {
-        return -1;
-	}
+        if (omv_i2c_read_bytes(bus, (slaveAddr<<1), (uint8_t *) d, read_size*2, OMV_I2C_XFER_NO_FLAGS) != 0) {
+            return -1;
+        }
+
+        startAddress += read_size;
+        n -= read_size;
+        d += read_size;
+    }
 
     for(int i=0; i<nMemAddressRead; i++) {
         data[i] = __REVSH(data[i]);

--- a/src/omv/ports/mimxrt/omv_portconfig.h
+++ b/src/omv/ports/mimxrt/omv_portconfig.h
@@ -127,4 +127,6 @@ struct {                                                \
     lpspi_transfer_t xfer_descr;                        \
 };
 
+#define OMV_I2C_MAX_8BIT_XFER   (1024U)
+#define OMV_I2C_MAX_16BIT_XFER  (512U)
 #endif // __OMV_PORTCONFIG_H__

--- a/src/omv/ports/nrf/omv_portconfig.h
+++ b/src/omv/ports/nrf/omv_portconfig.h
@@ -31,4 +31,8 @@ typedef uint32_t omv_gpio_t;
 
 // omv_i2c_dev_t definition
 typedef nrfx_twi_t omv_i2c_dev_t;
+
+#define OMV_I2C_MAX_8BIT_XFER   (65535U)
+#define OMV_I2C_MAX_16BIT_XFER  (65535U)
+
 #endif // __OMV_PORTCONFIG_H__

--- a/src/omv/ports/stm32/omv_portconfig.h
+++ b/src/omv/ports/stm32/omv_portconfig.h
@@ -98,4 +98,6 @@ typedef I2C_HandleTypeDef *omv_i2c_dev_t;
         DMA_HandleTypeDef dma_descr_rx; \
     };
 
+#define OMV_I2C_MAX_8BIT_XFER   (65536U - 16U)
+#define OMV_I2C_MAX_16BIT_XFER  (65536U - 8U)
 #endif // __OMV_PORTCONFIG_H__


### PR DESCRIPTION
Fixes: https://github.com/openmv/openmv/issues/2229

The maximum I2C read size on the RT1062 is 1024 bytes. This PR causes the higher-level code to split up the bread into chunks for the MLX90640 and MLX90641.

I looked into trying to make omv_i2c_read_bytes handler larger reads than 1024 bytes but there's no way to stop it from NACKing the last byte in a 1024 transfer even if you get it not to stop the bus and start a new transfer without doing I2C start/stop.