### PR TITLE
modules/py_ml: Add tensor area memory address to model object.

### DIFF
--- a/src/lib/tflm/tflm_backend.cc
+++ b/src/lib/tflm/tflm_backend.cc
@@ -286,6 +286,7 @@ int ml_backend_init_model(py_ml_model_obj_t *model) {
     }
 
     model->state = state;
+    model->memory_addr = (uint32_t) state->arena;
     return 0;
 }
 

--- a/src/omv/modules/py_ml.c
+++ b/src/omv/modules/py_ml.c
@@ -165,7 +165,7 @@ static mp_obj_t py_ml_dtype_char_tuple(const mp_obj_tuple_t *dtype) {
 
 static void py_ml_model_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     py_ml_model_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "{size: %d, ram: %d", self->size, self->memory_size);
+    mp_printf(print, "{ size: %d, ram: %d, addr: 0x%x", self->size, self->memory_size, self->memory_addr);
     mp_printf(print, ", input_shape: ");
     mp_obj_print_helper(print, self->input_shape, kind);
     mp_printf(print, ", input_scale: ");
@@ -182,7 +182,7 @@ static void py_ml_model_print(const mp_print_t *print, mp_obj_t self_in, mp_prin
     mp_obj_print_helper(print, self->output_zero_point, kind);
     mp_printf(print, ", output_dtype: ");
     mp_obj_print_helper(print, py_ml_dtype_char_tuple(self->output_dtype), kind);
-    mp_printf(print, "}");
+    mp_printf(print, " }");
 }
 
 static mp_obj_t py_ml_model_predict(uint n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {

--- a/src/omv/modules/py_ml.h
+++ b/src/omv/modules/py_ml.h
@@ -16,6 +16,7 @@ typedef struct py_ml_model_obj {
     unsigned int size;
     unsigned char *data;
     size_t memory_size;
+    uint32_t memory_addr;
     bool fb_alloc;
     size_t inputs_size;
     mp_obj_tuple_t *input_shape;


### PR DESCRIPTION
It helps to know where the arena ended up going, for debugging performance in the future. Fixes #2273