### PR TITLE
misc: Add back original licenses.

### DIFF
--- a/src/drivers/display/LICENSE
+++ b/src/drivers/display/LICENSE
@@ -1,0 +1,67 @@
+SOFTWARE PACKAGE LICENSE AGREEMENT
+
+Under STMicroelectronics’ intellectual property rights and subject to applicable licensing terms for any third-party software
+incorporated in this software package and applicable Open Source Terms (as defined here below), the redistribution,
+reproduction and use in source and binary forms of the software package or any part thereof, with or without modification, are
+permitted provided that the following conditions are met:
+
+1. Redistribution of source code (modified or not) must retain any copyright notice, this list of conditions and the following
+disclaimer.
+
+2. Redistributions in binary form, except as embedded into microcontroller or microprocessor device manufactured by or for
+STMicroelectronics or a software update for such device, must reproduce the above copyright notice, this list of conditions
+and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of STMicroelectronics nor the names of other contributors to this software package may be used to
+endorse or promote products derived from this software package or part thereof without specific written permission.
+
+4. This software package or any part thereof, including modifications and/or derivative works of this software package, must
+be used and execute solely and exclusively on or in combination with a microcontroller or a microprocessor devices
+manufactured by or for STMicroelectronics.
+
+5. No use, reproduction or redistribution of this software package partially or totally may be done in any manner that would
+subject this software package to any Open Source Terms (as defined below).
+
+6. Some portion of the software package may contain software subject to Open Source Terms (as defined below) applicable
+for each such portion (“Open Source Software”), as further specified in the software package. Such Open Source Software
+is supplied under the applicable Open Source Terms and is not subject to the terms and conditions of license hereunder.
+“Open Source Terms” shall mean any open source license which requires as part of distribution of software that the source
+code of such software is distributed therewith or otherwise made available, or open source license that substantially
+complies with the Open Source definition specified at www.opensource.org and any other comparable open source license
+such as for example GNU General Public License (GPL), Eclipse Public License (EPL), Apache Software License, BSD
+license and MIT license.
+
+7. This software package may also include third party software as expressly specified in the software package subject to
+specific license terms from such third parties. Such third party software is supplied under such specific license terms and is
+not subject to the terms and conditions of license hereunder. By installing copying, downloading, accessing or otherwise
+using this software package, the recipient agrees to be bound by such license terms with regard to such third party
+software.
+
+8. STMicroelectronics has no obligation to provide any maintenance, support or updates for the software package.
+
+9. The software package is and will remain the exclusive property of STMicroelectronics and its licensors. The recipient will
+not take any action that jeopardizes STMicroelectronics and its licensors' proprietary rights or acquire any rights in the
+software package, except the limited rights specified hereunder.
+
+10. The recipient shall comply with all applicable laws and regulations affecting the use of the software package or any part
+thereof including any applicable export control law or regulation.
+
+11. Redistribution and use of this software package partially or any part thereof other than as permitted under this license is
+void and will automatically terminate your rights under this license.
+
+THIS SOFTWARE PACKAGE IS PROVIDED BY STMICROELECTRONICS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS, IMPLIED OR STATUTORY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT OF THIRD PARTY
+INTELLECTUAL PROPERTY RIGHTS ARE DISCLAIMED TO THE FULLEST EXTENT PERMITTED BY LAW. IN NO EVENT
+
+SHALL STMICROELECTRONICS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE PACKAGE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+EXCEPT AS EXPRESSLY PERMITTED HEREUNDER AND SUBJECT TO THE APPLICABLE LICENSING TERMS FOR ANY
+THIRD-PARTY SOFTWARE INCORPORATED IN THE SOFTWARE PACKAGE AND OPEN SOURCE TERMS AS
+APPLICABLE, NO LICENSE OR OTHER RIGHTS, WHETHER EXPRESS OR IMPLIED, ARE GRANTED UNDER ANY
+PATENT OR OTHER INTELLECTUAL PROPERTY RIGHTS OF STMICROELECTRONICS OR ANY THIRD PARTY.

--- a/src/drivers/display/include/cec.h
+++ b/src/drivers/display/include/cec.h
@@ -1,14 +1,24 @@
-/*
- * This file is part of the OpenMV project.
- *
- * Copyright (c) 2009 STMicroelectronics
- * Copyright (c) 2023 Ibrahim Abdelkader <iabdalkader@openmv.io>
- * Copyright (c) 2023 Kwabena W. Agyeman <kwagyeman@openmv.io>
- *
- * This work is licensed under the MIT license, see the file LICENSE for details.
- *
- * CEC driver.
- */
+/**
+  ******************************************************************************
+  * @file    stm32100e_eval_cec.h
+  * @author  MCD Application Team
+  * @version V4.5.0
+  * @date    07-March-2011
+  * @brief   This file contains all the functions prototypes for the stm32100e_eval_cec
+  *          firmware driver.
+  ******************************************************************************
+  * @attention
+  *
+  * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+  * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+  * TIME. AS A RESULT, STMICROELECTRONICS SHALL NOT BE HELD LIABLE FOR ANY
+  * DIRECT, INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+  * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+  * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+  *
+  * <h2><center>&copy; COPYRIGHT 2011 STMicroelectronics</center></h2>
+  ******************************************************************************  
+  */ 
 #ifndef __PY_LCD_CEC_H__
 #define __PY_LCD_CEC_H__
 int cec_init(void);

--- a/src/drivers/display/src/cec.c
+++ b/src/drivers/display/src/cec.c
@@ -1,14 +1,23 @@
-/*
- * This file is part of the OpenMV project.
- *
- * Copyright (c) 2009 STMicroelectronics
- * Copyright (c) 2023 Ibrahim Abdelkader <iabdalkader@openmv.io>
- * Copyright (c) 2023 Kwabena W. Agyeman <kwagyeman@openmv.io>
- *
- * This work is licensed under the MIT license, see the file LICENSE for details.
- *
- * CEC driver.
- */
+/**
+  ******************************************************************************
+  * @file    stm32100e_eval_cec.c
+  * @author  MCD Application Team
+  * @version V4.5.0
+  * @date    07-March-2011
+  * @brief   This file provides all the STM32100E-EVAL HDMI-CEC firmware functions.
+  ******************************************************************************
+  * @attention
+  *
+  * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+  * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+  * TIME. AS A RESULT, STMICROELECTRONICS SHALL NOT BE HELD LIABLE FOR ANY
+  * DIRECT, INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+  * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+  * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+  *
+  * <h2><center>&copy; COPYRIGHT 2011 STMicroelectronics</center></h2>
+  ******************************************************************************  
+  */
 #include "omv_boardconfig.h"
 
 #if OMV_DISPLAY_CEC_ENABLE

--- a/src/omv/common/ini.c
+++ b/src/omv/common/ini.c
@@ -1,13 +1,13 @@
-/*
- * This file is part of the OpenMV project.
- *
- * Copyright (c) 2013-2021 Ibrahim Abdelkader <iabdalkader@openmv.io>
- * Copyright (c) 2013-2021 Kwabena W. Agyeman <kwagyeman@openmv.io>
- *
- * This work is licensed under the MIT license, see the file LICENSE for details.
- *
- * Initialization file parser.
- */
+// Read an INI file into easy-to-access name/value pairs.
+
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Copyright (C) 2009-2020, Ben Hoyt
+
+// inih and INIReader are released under the New BSD license (see LICENSE.txt).
+// Go to the project home page for more info:
+//
+// https://github.com/benhoyt/inih
 #include <stddef.h>
 #include <stdbool.h>
 #include <string.h>

--- a/src/omv/common/ini.h
+++ b/src/omv/common/ini.h
@@ -1,15 +1,13 @@
-/*
- * This file is part of the OpenMV project.
- *
- * Copyright (c) 2013-2021 Ibrahim Abdelkader <iabdalkader@openmv.io>
- * Copyright (c) 2013-2021 Kwabena W. Agyeman <kwagyeman@openmv.io>
- *
- * This work is licensed under the MIT license, see the file LICENSE for details.
- *
- * Initialization file parser.
- * inih library is released under the New BSD license (see LICENSE.txt).
- * For more details see the following: https://github.com/benhoyt/inih
- */
+// Read an INI file into easy-to-access name/value pairs.
+
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Copyright (C) 2009-2020, Ben Hoyt
+
+// inih and INIReader are released under the New BSD license (see LICENSE.txt).
+// Go to the project home page for more info:
+//
+// https://github.com/benhoyt/inih
 #ifndef __INI_H__
 #define __INI_H__
 

--- a/src/omv/imlib/apriltag.c
+++ b/src/omv/imlib/apriltag.c
@@ -1,24 +1,4 @@
-/*
- * This file is part of the OpenMV project.
- *
- * Copyright (c) 2013-2021 Ibrahim Abdelkader <iabdalkader@openmv.io>
- * Copyright (c) 2013-2021 Kwabena W. Agyeman <kwagyeman@openmv.io>
- *
- * This work is licensed under the MIT license, see the file LICENSE for details.
- *
- * AprilTags library.
- */
-#include <float.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include "imlib.h"
-
 // *INDENT-OFF*
-// Enable new code optimizations
-#define OPTIMIZED
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-variable"
 
 /* Copyright (C) 2013-2016, The Regents of The University of Michigan.
 All rights reserved.
@@ -51,6 +31,17 @@ The views and conclusions contained in the software and documentation are those
 of the authors and should not be interpreted as representing official policies,
 either expressed or implied, of the Regents of The University of Michigan.
 */
+#include <float.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include "imlib.h"
+
+// Enable new code optimizations
+#define OPTIMIZED
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+
 #define fprintf(format, ...)
 #define free(ptr) ({ umm_free(ptr); })
 #define malloc(size) ({ void *_r = umm_malloc(size); if(!_r) umm_alloc_fail(); _r; })

--- a/src/omv/imlib/clahe.c
+++ b/src/omv/imlib/clahe.c
@@ -1,17 +1,4 @@
 /*
- * This file is part of the OpenMV project.
- *
- * Copyright (c) 2013-2021 Ibrahim Abdelkader <iabdalkader@openmv.io>
- * Copyright (c) 2013-2021 Kwabena W. Agyeman <kwagyeman@openmv.io>
- *
- * This work is licensed under the MIT license, see the file LICENSE for details.
- *
- * Contrast Limited Adaptive Histogram Equalization.
- */
-#include "imlib.h"
-#define BYTE_IMAGE
-
-/*
  * ANSI C code from the article
  * "Contrast Limited Adaptive Histogram Equalization"
  * by Karel Zuiderveld, karel@cv.ruu.nl
@@ -36,6 +23,8 @@
  *  Author: Karel Zuiderveld, Computer Vision Research Group,
  *           Utrecht, The Netherlands (karel@cv.ruu.nl)
  */
+#include "imlib.h"
+#define BYTE_IMAGE
 
 #ifdef BYTE_IMAGE
 typedef unsigned char kz_pixel_t;        /* for 8 bit-per-pixel images */

--- a/src/omv/imlib/dmtx.c
+++ b/src/omv/imlib/dmtx.c
@@ -1,13 +1,41 @@
-/*
- * This file is part of the OpenMV project.
- *
- * Copyright (c) 2013-2021 Ibrahim Abdelkader <iabdalkader@openmv.io>
- * Copyright (c) 2013-2021 Kwabena W. Agyeman <kwagyeman@openmv.io>
- *
- * This work is licensed under the MIT license, see the file LICENSE for details.
- *
- * Data Matrix Encoding/Decoding Library.
- */
+// *INDENT-OFF*
+
+/* Copyright 2005-2016 Mike Laughton, Vadim A. Misbakh-Soloviov and others.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The views and conclusions contained in the software and documentation are those
+of the authors and should not be interpreted as representing official policies,
+either expressed or implied, of the libdmtx project.
+
+--------------------------------------------------------------------------------
+
+ALTERNATE TERMS
+
+Redistributions in binary form, with or without modification, are permitted
+without including the above copyright notice, list of conditions, and disclaimer
+if express written permission has been obtained from Dragonfly Logic, Inc.
+*/
 #include <float.h>
 #include <stdio.h>
 #include "imlib.h"
@@ -53,7 +81,6 @@
 #define acos(x)                   acosf(x)
 #define asin(x)                   asinf(x)
 
-// *INDENT-OFF*
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////// "dmtx.h"
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/omv/imlib/jpegd.c
+++ b/src/omv/imlib/jpegd.c
@@ -1,12 +1,14 @@
 /*
  * This file is part of the OpenMV project.
  *
+ * Copyright (c) 1995-2020 Larry Bank bitbank@pobox.com
+ * Copyright (c) 1995-2020 BitBank Software, Inc. All Rights Reserved.
  * Copyright (c) 2013-2021 Ibrahim Abdelkader <iabdalkader@openmv.io>
  * Copyright (c) 2013-2021 Kwabena W. Agyeman <kwagyeman@openmv.io>
  *
  * This work is licensed under the MIT license, see the file LICENSE for details.
  *
- * Baseline JPEG decoder.
+ * JPEG decoder.
  */
 #include "imlib.h"
 

--- a/src/omv/imlib/jpegd.c
+++ b/src/omv/imlib/jpegd.c
@@ -3,8 +3,8 @@
  *
  * Copyright (c) 1995-2020 Larry Bank bitbank@pobox.com
  * Copyright (c) 1995-2020 BitBank Software, Inc. All Rights Reserved.
- * Copyright (c) 2013-2021 Ibrahim Abdelkader <iabdalkader@openmv.io>
- * Copyright (c) 2013-2021 Kwabena W. Agyeman <kwagyeman@openmv.io>
+ * Copyright (c) 2020-2024 Ibrahim Abdelkader <iabdalkader@openmv.io>
+ * Copyright (c) 2020-2024 Kwabena W. Agyeman <kwagyeman@openmv.io>
  *
  * This work is licensed under the MIT license, see the file LICENSE for details.
  *

--- a/src/omv/imlib/lsd.c
+++ b/src/omv/imlib/lsd.c
@@ -30,7 +30,7 @@
 #include <limits.h>
 #include "imlib.h"
 
-#ifdef IMLIB_ENABLE_FIND_LINE_SEGMENTS
+#if defined(IMLIB_ENABLE_FIND_LINE_SEGMENTS) && (!defined(OMV_NO_GPL))
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
 #pragma GCC diagnostic ignored "-Wunused-variable"

--- a/src/omv/imlib/qrcode.c
+++ b/src/omv/imlib/qrcode.c
@@ -1,6 +1,7 @@
 /*
  * This file is part of the OpenMV project.
  *
+ * Copyright (C) 2010-2012 Daniel Beer <dlbeer@gmail.com>
  * Copyright (c) 2013-2021 Ibrahim Abdelkader <iabdalkader@openmv.io>
  * Copyright (c) 2013-2021 Kwabena W. Agyeman <kwagyeman@openmv.io>
  *

--- a/src/omv/imlib/zbar.c
+++ b/src/omv/imlib/zbar.c
@@ -1,13 +1,25 @@
-/*
- * This file is part of the OpenMV project.
+/*------------------------------------------------------------------------
+ *  Copyright 2008-2010 (c) Jeff Brown <spadix@users.sourceforge.net>
  *
- * Copyright (c) 2013-2021 Ibrahim Abdelkader <iabdalkader@openmv.io>
- * Copyright (c) 2013-2021 Kwabena W. Agyeman <kwagyeman@openmv.io>
+ *  This file is part of the ZBar Bar Code Reader.
  *
- * This work is licensed under the MIT license, see the file LICENSE for details.
+ *  The ZBar Bar Code Reader is free software; you can redistribute it
+ *  and/or modify it under the terms of the GNU Lesser Public License as
+ *  published by the Free Software Foundation; either version 2.1 of
+ *  the License, or (at your option) any later version.
  *
- * This file is part of the ZBar Bar Code Reader library.
- */
+ *  The ZBar Bar Code Reader is distributed in the hope that it will be
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ *  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser Public License
+ *  along with the ZBar Bar Code Reader; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ *  Boston, MA  02110-1301  USA
+ *
+ *  http://sourceforge.net/projects/zbar
+ *------------------------------------------------------------------------*/
 #include <limits.h>
 #include "imlib.h"
 #ifdef IMLIB_ENABLE_BARCODES

--- a/src/omv/imlib/zbar.c
+++ b/src/omv/imlib/zbar.c
@@ -22,7 +22,7 @@
  *------------------------------------------------------------------------*/
 #include <limits.h>
 #include "imlib.h"
-#ifdef IMLIB_ENABLE_BARCODES
+#if defined(IMLIB_ENABLE_BARCODES) && (!defined(OMV_NO_GPL))
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"

--- a/src/omv/modules/py_image.c
+++ b/src/omv/modules/py_image.c
@@ -4713,7 +4713,7 @@ static mp_obj_t py_image_find_lines(uint n_args, const mp_obj_t *args, mp_map_t 
 static MP_DEFINE_CONST_FUN_OBJ_KW(py_image_find_lines_obj, 1, py_image_find_lines);
 #endif // IMLIB_ENABLE_FIND_LINES
 
-#ifdef IMLIB_ENABLE_FIND_LINE_SEGMENTS
+#if defined(IMLIB_ENABLE_FIND_LINE_SEGMENTS) && (!defined(OMV_NO_GPL))
 static mp_obj_t py_image_find_line_segments(uint n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     image_t *arg_img = py_image_cobj(args[0]);
 
@@ -5751,7 +5751,7 @@ static mp_obj_t py_image_find_datamatrices(uint n_args, const mp_obj_t *args, mp
 static MP_DEFINE_CONST_FUN_OBJ_KW(py_image_find_datamatrices_obj, 1, py_image_find_datamatrices);
 #endif // IMLIB_ENABLE_DATAMATRICES
 
-#ifdef IMLIB_ENABLE_BARCODES
+#if defined(IMLIB_ENABLE_BARCODES) && (!defined(OMV_NO_GPL))
 // BarCode Object //
 #define py_barcode_obj_size    8
 typedef struct py_barcode_obj {
@@ -6710,7 +6710,7 @@ static const mp_rom_map_elem_t locals_dict_table[] = {
     #else
     {MP_ROM_QSTR(MP_QSTR_find_lines),          MP_ROM_PTR(&py_func_unavailable_obj)},
     #endif
-    #ifdef IMLIB_ENABLE_FIND_LINE_SEGMENTS
+    #if defined(IMLIB_ENABLE_FIND_LINE_SEGMENTS) && (!defined(OMV_NO_GPL))
     {MP_ROM_QSTR(MP_QSTR_find_line_segments),  MP_ROM_PTR(&py_image_find_line_segments_obj)},
     #else
     {MP_ROM_QSTR(MP_QSTR_find_line_segments),  MP_ROM_PTR(&py_func_unavailable_obj)},
@@ -6740,7 +6740,7 @@ static const mp_rom_map_elem_t locals_dict_table[] = {
     #else
     {MP_ROM_QSTR(MP_QSTR_find_datamatrices),   MP_ROM_PTR(&py_func_unavailable_obj)},
     #endif
-    #ifdef IMLIB_ENABLE_BARCODES
+    #if defined(IMLIB_ENABLE_BARCODES) && (!defined(OMV_NO_GPL))
     {MP_ROM_QSTR(MP_QSTR_find_barcodes),       MP_ROM_PTR(&py_image_find_barcodes_obj)},
     #else
     {MP_ROM_QSTR(MP_QSTR_find_barcodes),       MP_ROM_PTR(&py_func_unavailable_obj)},


### PR DESCRIPTION
Need to add no GPL macro. Agast, LSD, and zbar are GPL code.

Fixes: https://github.com/openmv/openmv/issues/1887