### PR TITLE
misc/README: Update builld instructions.

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -45,7 +45,7 @@ This step can be skipped if your distro package manager provides an ARM toolchai
 TOOLCHAIN_PATH=${HOME}/cache/gcc
 TOOLCHAIN_URL="https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-arm-none-eabi.tar.xz"
 sudo mkdir ${TOOLCHAIN_PATH}
-wget --no-check-certificate -O - ${TOOLCHAIN_URL} | tar --strip-components=1 -Jx -C ${TOOLCHAIN_PATH}
+wget --no-check-certificate -O - ${TOOLCHAIN_URL} | sudo tar --strip-components=1 -Jx -C ${TOOLCHAIN_PATH}
 export PATH=${TOOLCHAIN_PATH}/bin:${PATH}
 ```
 

--- a/src/README.md
+++ b/src/README.md
@@ -44,8 +44,8 @@ This step can be skipped if your distro package manager provides an ARM toolchai
 ```
 TOOLCHAIN_PATH=${HOME}/cache/gcc
 TOOLCHAIN_URL="https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-arm-none-eabi.tar.xz"
-sudo mkdir ${TOOLCHAIN_PATH}
-wget --no-check-certificate -O - ${TOOLCHAIN_URL} | sudo tar --strip-components=1 -Jx -C ${TOOLCHAIN_PATH}
+mkdir ${TOOLCHAIN_PATH}
+wget --no-check-certificate -O - ${TOOLCHAIN_URL} | tar --strip-components=1 -Jx -C ${TOOLCHAIN_PATH}
 export PATH=${TOOLCHAIN_PATH}/bin:${PATH}
 ```
 


### PR DESCRIPTION
I tested the build process on a new machine and needed to add `sudo` - without it there were permission errors.