### PR TITLE
imlib/draw: Refactor draw_image to support gpu offload.

### DIFF
--- a/src/omv/boards/ARDUINO_GIGA/imlib_config.h
+++ b/src/omv/boards/ARDUINO_GIGA/imlib_config.h
@@ -143,9 +143,6 @@
 // Enable selective_search()
 //#define IMLIB_ENABLE_SELECTIVE_SEARCH
 
-// Enable STM32 DMA2D
-#define IMLIB_ENABLE_DMA2D
-
 // Enable PNG encoder/decoder
 #define IMLIB_ENABLE_PNG_ENCODER
 #define IMLIB_ENABLE_PNG_DECODER

--- a/src/omv/boards/ARDUINO_GIGA/omv_boardconfig.h
+++ b/src/omv/boards/ARDUINO_GIGA/omv_boardconfig.h
@@ -24,6 +24,9 @@
 #define OMV_JPEG_QUALITY_HIGH               90
 #define OMV_JPEG_QUALITY_THRESHOLD          (320 * 240 * 2)
 
+// GPU Configuration
+#define OMV_GPU_ENABLE                      (1)
+
 // Image sensor drivers configuration.
 #define OMV_OV5640_ENABLE                   (1)
 #define OMV_OV5640_AF_ENABLE                (1)

--- a/src/omv/boards/ARDUINO_NANO_33_BLE_SENSE/imlib_config.h
+++ b/src/omv/boards/ARDUINO_NANO_33_BLE_SENSE/imlib_config.h
@@ -141,9 +141,6 @@
 // Enable selective_search()
 //#define IMLIB_ENABLE_SELECTIVE_SEARCH
 
-// Enable STM32 DMA2D
-//#define IMLIB_ENABLE_DMA2D
-
 // Stereo Imaging
 // #define IMLIB_ENABLE_STEREO_DISPARITY
 

--- a/src/omv/boards/ARDUINO_NANO_RP2040_CONNECT/imlib_config.h
+++ b/src/omv/boards/ARDUINO_NANO_RP2040_CONNECT/imlib_config.h
@@ -140,9 +140,6 @@
 // Enable selective_search()
 //#define IMLIB_ENABLE_SELECTIVE_SEARCH
 
-// Enable STM32 DMA2D
-//#define IMLIB_ENABLE_DMA2D
-
 // Stereo Imaging
 // #define IMLIB_ENABLE_STEREO_DISPARITY
 

--- a/src/omv/boards/ARDUINO_NICLA_VISION/imlib_config.h
+++ b/src/omv/boards/ARDUINO_NICLA_VISION/imlib_config.h
@@ -143,9 +143,6 @@
 // Enable selective_search()
 // #define IMLIB_ENABLE_SELECTIVE_SEARCH
 
-// Enable STM32 DMA2D
-#define IMLIB_ENABLE_DMA2D
-
 // Enable PNG encoder/decoder
 // #define IMLIB_ENABLE_PNG_ENCODER
 // #define IMLIB_ENABLE_PNG_DECODER

--- a/src/omv/boards/ARDUINO_NICLA_VISION/omv_boardconfig.h
+++ b/src/omv/boards/ARDUINO_NICLA_VISION/omv_boardconfig.h
@@ -24,6 +24,9 @@
 #define OMV_JPEG_QUALITY_HIGH                 (90)
 #define OMV_JPEG_QUALITY_THRESHOLD            (320 * 240 * 2)
 
+// GPU Configuration
+#define OMV_GPU_ENABLE                        (1)
+
 // Image sensor drivers configuration.
 #define OMV_GC2145_ENABLE                     (1)
 #define OMV_GC2145_ROTATE                     (1)

--- a/src/omv/boards/ARDUINO_PORTENTA_H7/imlib_config.h
+++ b/src/omv/boards/ARDUINO_PORTENTA_H7/imlib_config.h
@@ -143,9 +143,6 @@
 // Enable selective_search()
 //#define IMLIB_ENABLE_SELECTIVE_SEARCH
 
-// Enable STM32 DMA2D
-#define IMLIB_ENABLE_DMA2D
-
 // Enable PNG encoder/decoder
 // #define IMLIB_ENABLE_PNG_ENCODER
 // #define IMLIB_ENABLE_PNG_DECODER

--- a/src/omv/boards/ARDUINO_PORTENTA_H7/omv_boardconfig.h
+++ b/src/omv/boards/ARDUINO_PORTENTA_H7/omv_boardconfig.h
@@ -24,6 +24,9 @@
 #define OMV_JPEG_QUALITY_HIGH               (90)
 #define OMV_JPEG_QUALITY_THRESHOLD          (320 * 240 * 2)
 
+// GPU Configuration
+#define OMV_GPU_ENABLE                      (1)
+
 // Image sensor drivers configuration.
 #define OMV_OV5640_ENABLE                   (0)
 #define OMV_OV5640_AF_ENABLE                (1)

--- a/src/omv/boards/OPENMV1/imlib_config.h
+++ b/src/omv/boards/OPENMV1/imlib_config.h
@@ -75,9 +75,6 @@
 // Enable Tensor Flow
 //#define IMLIB_ENABLE_TFLM
 
-// Enable STM32 DMA2D
-#define IMLIB_ENABLE_DMA2D
-
 // Stereo Imaging
 // #define IMLIB_ENABLE_STEREO_DISPARITY
 

--- a/src/omv/boards/OPENMV2/imlib_config.h
+++ b/src/omv/boards/OPENMV2/imlib_config.h
@@ -132,9 +132,6 @@
 // Enable find_hog()
 //#define IMLIB_ENABLE_HOG
 
-// Enable STM32 DMA2D
-#define IMLIB_ENABLE_DMA2D
-
 // Stereo Imaging
 // #define IMLIB_ENABLE_STEREO_DISPARITY
 

--- a/src/omv/boards/OPENMV2/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV2/omv_boardconfig.h
@@ -24,6 +24,9 @@
 #define OMV_JPEG_QUALITY_HIGH                 (60)
 #define OMV_JPEG_QUALITY_THRESHOLD            (160 * 120 * 2)
 
+// GPU Configuration
+#define OMV_GPU_ENABLE                        (1)
+
 // Image sensor drivers configuration.
 #define OMV_OV2640_ENABLE                     (1)
 #define OMV_OV7725_ENABLE                     (1)

--- a/src/omv/boards/OPENMV3/imlib_config.h
+++ b/src/omv/boards/OPENMV3/imlib_config.h
@@ -138,9 +138,6 @@
 // Enable find_hog()
 // #define IMLIB_ENABLE_HOG
 
-// Enable STM32 DMA2D
-#define IMLIB_ENABLE_DMA2D
-
 // Enable PNG encoder/decoder
 #define IMLIB_ENABLE_PNG_ENCODER
 #define IMLIB_ENABLE_PNG_DECODER

--- a/src/omv/boards/OPENMV3/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV3/omv_boardconfig.h
@@ -24,6 +24,9 @@
 #define OMV_JPEG_QUALITY_HIGH                 (60)
 #define OMV_JPEG_QUALITY_THRESHOLD            (160 * 120 * 2)
 
+// GPU Configuration
+#define OMV_GPU_ENABLE                        (1)
+
 // Image sensor drivers configuration.
 #define OMV_OV7725_ENABLE                     (1)
 #define OMV_OV7725_PLL_CONFIG                 (0x81) // x6

--- a/src/omv/boards/OPENMV4/imlib_config.h
+++ b/src/omv/boards/OPENMV4/imlib_config.h
@@ -141,9 +141,6 @@
 // Enable selective_search()
 // #define IMLIB_ENABLE_SELECTIVE_SEARCH
 
-// Enable STM32 DMA2D
-#define IMLIB_ENABLE_DMA2D
-
 // Enable PNG encoder/decoder
 #define IMLIB_ENABLE_PNG_ENCODER
 #define IMLIB_ENABLE_PNG_DECODER

--- a/src/omv/boards/OPENMV4/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4/omv_boardconfig.h
@@ -24,6 +24,9 @@
 #define OMV_JPEG_QUALITY_HIGH                 (90)
 #define OMV_JPEG_QUALITY_THRESHOLD            (320 * 240 * 2)
 
+// GPU Configuration
+#define OMV_GPU_ENABLE                        (1)
+
 // Image sensor drivers configuration.
 #define OMV_OV2640_ENABLE                     (1)
 #define OMV_OV5640_ENABLE                     (1)

--- a/src/omv/boards/OPENMV4P/imlib_config.h
+++ b/src/omv/boards/OPENMV4P/imlib_config.h
@@ -141,9 +141,6 @@
 // Enable selective_search()
 // #define IMLIB_ENABLE_SELECTIVE_SEARCH
 
-// Enable STM32 DMA2D
-#define IMLIB_ENABLE_DMA2D
-
 // Enable PNG encoder/decoder
 #define IMLIB_ENABLE_PNG_ENCODER
 #define IMLIB_ENABLE_PNG_DECODER

--- a/src/omv/boards/OPENMV4P/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4P/omv_boardconfig.h
@@ -24,6 +24,9 @@
 #define OMV_JPEG_QUALITY_HIGH                 (90)
 #define OMV_JPEG_QUALITY_THRESHOLD            (1920 * 1080 * 2)
 
+// GPU Configuration
+#define OMV_GPU_ENABLE                        (1)
+
 // Image sensor drivers configuration.
 #define OMV_OV2640_ENABLE                     (1)
 

--- a/src/omv/boards/OPENMV4_PRO/imlib_config.h
+++ b/src/omv/boards/OPENMV4_PRO/imlib_config.h
@@ -141,9 +141,6 @@
 // Enable selective_search()
 // #define IMLIB_ENABLE_SELECTIVE_SEARCH
 
-// Enable STM32 DMA2D
-#define IMLIB_ENABLE_DMA2D
-
 // Enable PNG encoder/decoder
 #define IMLIB_ENABLE_PNG_ENCODER
 #define IMLIB_ENABLE_PNG_DECODER

--- a/src/omv/boards/OPENMV4_PRO/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4_PRO/omv_boardconfig.h
@@ -24,6 +24,9 @@
 #define OMV_JPEG_QUALITY_HIGH                 (90)
 #define OMV_JPEG_QUALITY_THRESHOLD            (1920 * 1080 * 2)
 
+// GPU Configuration
+#define OMV_GPU_ENABLE                        (1)
+
 // Image sensor drivers configuration.
 #define OMV_OV2640_ENABLE                     (1)
 

--- a/src/omv/boards/OPENMVPT/imlib_config.h
+++ b/src/omv/boards/OPENMVPT/imlib_config.h
@@ -141,9 +141,6 @@
 // Enable selective_search()
 // #define IMLIB_ENABLE_SELECTIVE_SEARCH
 
-// Enable STM32 DMA2D
-#define IMLIB_ENABLE_DMA2D
-
 // Enable PNG encoder/decoder
 #define IMLIB_ENABLE_PNG_ENCODER
 #define IMLIB_ENABLE_PNG_DECODER

--- a/src/omv/boards/OPENMVPT/omv_boardconfig.h
+++ b/src/omv/boards/OPENMVPT/omv_boardconfig.h
@@ -24,6 +24,9 @@
 #define OMV_JPEG_QUALITY_HIGH                   (90)
 #define OMV_JPEG_QUALITY_THRESHOLD              (1920 * 1080 * 2)
 
+// GPU Configuration
+#define OMV_GPU_ENABLE                          (1)
+
 // Image sensor drivers configuration.
 #define OMV_OV5640_ENABLE                       (1)
 #define OMV_OV5640_AF_ENABLE                    (1)

--- a/src/omv/boards/PICO/imlib_config.h
+++ b/src/omv/boards/PICO/imlib_config.h
@@ -141,9 +141,6 @@
 // Enable selective_search()
 //#define IMLIB_ENABLE_SELECTIVE_SEARCH
 
-// Enable STM32 DMA2D
-//#define IMLIB_ENABLE_DMA2D
-
 // Stereo Imaging
 // #define IMLIB_ENABLE_STEREO_DISPARITY
 

--- a/src/omv/common/omv_gpu.h
+++ b/src/omv/common/omv_gpu.h
@@ -1,0 +1,39 @@
+/*
+ * This file is part of the OpenMV project.
+ *
+ * Copyright (c) 2013-2024 Ibrahim Abdelkader <iabdalkader@openmv.io>
+ * Copyright (c) 2013-2024 Kwabena W. Agyeman <kwagyeman@openmv.io>
+ *
+ * This work is licensed under the MIT license, see the file LICENSE for details.
+ *
+ * GPU driver.
+ */
+#ifndef __OMV_GPU_H__
+#define __OMV_GPU_H__
+#include "imlib.h"
+
+int omv_gpu_init();
+int omv_gpu_deinit();
+
+// Draws src_rect from src_img to dst_rect in dst_img.
+// If the sizes of src_rect and dst_rect are different then the image must be scaled.
+// Alpha is the alpha value (0-256) to use when blending the source image with the destination image.
+// If color_palette is not NULL, it is used to map the source image's 8-bit Y to an 16-bit RGB565 color.
+// If alpha_palette is not NULL, it is used to map the source image's 8-bit Y to an 8-bit alpha value.
+//
+// Valid Hint Flags:
+//
+// * IMAGE_HINT_BILINEAR: Use 2D bilinear interpolation when scaling the image versus nearest-neighbor.
+// * IMAGE_HINT_HMIRROR: The destination image result should be horizontally mirrored from the source image.
+// * IMAGE_HINT_VFLIP: The destination image result should be vertically flipped from the source image.
+// * IMAGE_HINT_BLACK_BACKGROUND: The destination image should be considered to be black (0) for alpha blending.
+
+int omv_gpu_draw_image(image_t *src_img,
+                       rectangle_t *src_rect,
+                       image_t *dst_img,
+                       rectangle_t *dst_rect,
+                       int alpha,
+                       const uint16_t *color_palette,
+                       const uint8_t *alpha_palette,
+                       image_hint_t hint);
+#endif // __OMV_GPU_H__

--- a/src/omv/common/omv_gpu.h
+++ b/src/omv/common/omv_gpu.h
@@ -13,7 +13,7 @@
 #include "imlib.h"
 
 int omv_gpu_init();
-int omv_gpu_deinit();
+void omv_gpu_deinit();
 
 // Draws src_rect from src_img to dst_rect in dst_img.
 // If the sizes of src_rect and dst_rect are different then the image must be scaled.

--- a/src/omv/imlib/imlib.c
+++ b/src/omv/imlib/imlib.c
@@ -17,17 +17,21 @@
 #include "file_utils.h"
 #include "imlib.h"
 #include "omv_common.h"
+#include "omv_gpu.h"
 #include "omv_boardconfig.h"
 
 void imlib_init_all() {
+    #if (OMV_GPU_ENABLE == 1)
+    omv_gpu_init();
+    #endif
     #if (OMV_JPEG_CODEC_ENABLE == 1)
     imlib_hardware_jpeg_init();
     #endif
 }
 
 void imlib_deinit_all() {
-    #ifdef IMLIB_ENABLE_DMA2D
-    imlib_draw_row_deinit_all();
+    #if (OMV_GPU_ENABLE == 1)
+    omv_gpu_deinit();
     #endif
     #if (OMV_JPEG_CODEC_ENABLE == 1)
     imlib_hardware_jpeg_deinit();

--- a/src/omv/imlib/imlib.h
+++ b/src/omv/imlib/imlib.h
@@ -1136,18 +1136,7 @@ typedef struct imlib_draw_row_data {
     void *callback; // user
     void *callback_arg; // user
     void *dst_row_override; // user
-    int toggle; // private
-    void *row_buffer[2]; // private
-    #ifdef IMLIB_ENABLE_DMA2D
-    bool dma2d_request; // user
-    bool dma2d_enabled; // private
-    bool dma2d_initialized; // private
-    DMA2D_HandleTypeDef dma2d; // private
-    #if __DCACHE_PRESENT
-    void *dma2d_invalidate_addr; // private
-    int32_t dma2d_invalidate_dsize; // private
-    #endif
-    #endif
+    void *row_buffer; // private
     long smuad_alpha; // private
     uint32_t *smuad_alpha_palette; // private
 } imlib_draw_row_data_t;
@@ -1316,11 +1305,6 @@ void imlib_find_hog(image_t *src, rectangle_t *roi, int cell_size);
 void imlib_zero(image_t *img, image_t *mask, bool invert);
 void imlib_draw_row_setup(imlib_draw_row_data_t *data);
 void imlib_draw_row_teardown(imlib_draw_row_data_t *data);
-#ifdef IMLIB_ENABLE_DMA2D
-void imlib_draw_row_deinit_all();
-#endif
-void *imlib_draw_row_get_row_buffer(imlib_draw_row_data_t *data);
-void imlib_draw_row_put_row_buffer(imlib_draw_row_data_t *data, void *row_buffer);
 void imlib_draw_row(int x_start, int x_end, int y_row, imlib_draw_row_data_t *data);
 void imlib_draw_image_get_bounds(image_t *dst_img,
                                  image_t *src_img,

--- a/src/omv/ports/stm32/omv_gpu.c
+++ b/src/omv/ports/stm32/omv_gpu.c
@@ -1,0 +1,230 @@
+/*
+ * This file is part of the OpenMV project.
+ *
+ * Copyright (c) 2013-2024 Ibrahim Abdelkader <iabdalkader@openmv.io>
+ * Copyright (c) 2013-2024 Kwabena W. Agyeman <kwagyeman@openmv.io>
+ *
+ * This work is licensed under the MIT license, see the file LICENSE for details.
+ *
+ * GPU driver for STM32 port.
+ */
+#include "omv_boardconfig.h"
+#if (OMV_GPU_ENABLE == 1)
+#include "imlib.h"
+
+#include STM32_HAL_H
+#include "dma.h"
+
+#define TIME_GPU    (0)
+#if (TIME_GPU == 1)
+#include "py/mphal.h"
+#include <stdio.h>
+#endif
+
+int omv_gpu_init() {
+    return 0;
+}
+
+int omv_gpu_deinit() {
+    DMA2D_HandleTypeDef dma2d = {};
+    dma2d.Instance = DMA2D;
+    HAL_DMA2D_DeInit(&dma2d);
+    return 0;
+}
+
+int omv_gpu_draw_image(image_t *src_img,
+                       rectangle_t *src_rect,
+                       image_t *dst_img,
+                       rectangle_t *dst_rect,
+                       int alpha,
+                       const uint16_t *color_palette,
+                       const uint8_t *alpha_palette,
+                       image_hint_t hint) {
+    // DMA2D can only draw on RGB565 buffers and the destination/source buffers must be accessible by DMA.
+    if ((dst_img->pixfmt != PIXFORMAT_RGB565) || (!DMA_BUFFER(dst_img->data)) || (!DMA_BUFFER(src_img->data))) {
+        return -1;
+    }
+
+    // DMA2D can only read from RGB565 or GRAYSCALE buffers.
+    // If the source image is RGB565, it must not have a color or alpha palette.
+    if ((src_img->pixfmt != PIXFORMAT_GRAYSCALE) &&
+        ((src_img->pixfmt != PIXFORMAT_RGB565) || color_palette || alpha_palette)) {
+        return -1;
+    }
+
+    // DMA2D cannot scale so ensure that the source and destination rectangles are the same size.
+    // The bilinear/nearest-neighbor flag doesn't matter since we can't scale.
+    if ((dst_rect->w != src_rect->w) || (dst_rect->h != src_rect->h)) {
+        return -1;
+    }
+
+    // DMA2D cannot hmirror or vflip.
+    if (hint & (IMAGE_HINT_HMIRROR | IMAGE_HINT_VFLIP)) {
+        return -1;
+    }
+
+    // DMA2D must always fetch the background on the F4 and F7 series so do this in software.
+    #if defined(MCU_SERIES_F4) || defined(MCU_SERIES_F7)
+    if (hint & IMAGE_HINT_BLACK_BACKGROUND) {
+        return -1;
+    }
+    #endif
+
+    #if (TIME_GPU == 1)
+    mp_uint_t start = mp_hal_ticks_ms();
+    #endif
+
+    DMA2D_HandleTypeDef dma2d = {};
+
+    dma2d.Instance = DMA2D;
+
+    if (dst_img->pixfmt != src_img->pixfmt) {
+        dma2d.Init.Mode = DMA2D_M2M_PFC;
+    }
+
+    if ((alpha != 256) || alpha_palette) {
+        dma2d.Init.Mode = DMA2D_M2M_BLEND;
+    }
+
+    #if defined(MCU_SERIES_H7)
+    if (hint & IMAGE_HINT_BLACK_BACKGROUND) {
+        dma2d.Init.Mode = DMA2D_M2M_BLEND_BG;
+    }
+    #endif
+
+    dma2d.Init.ColorMode = DMA2D_OUTPUT_RGB565;
+    dma2d.Init.OutputOffset = dst_img->w - dst_rect->w;
+
+    HAL_DMA2D_Init(&dma2d);
+
+    dma2d.LayerCfg[0].InputOffset = dst_img->w - dst_rect->w;
+    dma2d.LayerCfg[0].InputColorMode = DMA2D_INPUT_RGB565;
+    dma2d.LayerCfg[0].AlphaMode = DMA2D_REPLACE_ALPHA;
+    dma2d.LayerCfg[0].InputAlpha = 0xff;
+
+    HAL_DMA2D_ConfigLayer(&dma2d, 0);
+
+    if (src_img->pixfmt == PIXFORMAT_GRAYSCALE) {
+        dma2d.LayerCfg[1].InputColorMode = DMA2D_INPUT_L8;
+        dma2d.LayerCfg[1].AlphaMode = DMA2D_COMBINE_ALPHA;
+        uint32_t *clut = fb_alloc(256 * sizeof(uint32_t), FB_ALLOC_CACHE_ALIGN);
+
+        if (!alpha_palette) {
+            if (!color_palette) {
+                for (int i = 0; i < 256; i++) {
+                    clut[i] = (0xff << 24) | COLOR_Y_TO_RGB888(i);
+                }
+            } else {
+                for (int i = 0; i < 256; i++) {
+                    int pixel = color_palette[i];
+                    clut[i] = (0xff << 24) |
+                              (COLOR_RGB565_TO_R8(pixel) << 16) |
+                              (COLOR_RGB565_TO_G8(pixel) << 8) |
+                              COLOR_RGB565_TO_B8(pixel);
+                }
+            }
+        } else {
+            if (!color_palette) {
+                for (int i = 0; i < 256; i++) {
+                    clut[i] = (alpha_palette[i] << 24) | COLOR_Y_TO_RGB888(i);
+                }
+            } else {
+                for (int i = 0; i < 256; i++) {
+                    int pixel = color_palette[i];
+                    clut[i] = (alpha_palette[i] << 24) |
+                              (COLOR_RGB565_TO_R8(pixel) << 16) |
+                              (COLOR_RGB565_TO_G8(pixel) << 8) |
+                              COLOR_RGB565_TO_B8(pixel);
+                }
+            }
+        }
+
+        DMA2D_CLUTCfgTypeDef cfg;
+        cfg.pCLUT = clut;
+        cfg.CLUTColorMode = DMA2D_CCM_ARGB8888;
+        cfg.Size = 255;
+        #if __DCACHE_PRESENT
+        SCB_CleanDCache_by_Addr(clut, 256 * sizeof(uint32_t));
+        #endif
+        HAL_DMA2D_CLUTLoad(&dma2d, cfg, 1);
+        HAL_DMA2D_PollForTransfer(&dma2d, 1000);
+    } else {
+        dma2d.LayerCfg[1].InputColorMode = DMA2D_INPUT_RGB565;
+        dma2d.LayerCfg[1].AlphaMode = DMA2D_REPLACE_ALPHA;
+    }
+
+    dma2d.LayerCfg[1].InputOffset = src_img->w - src_rect->w;
+    dma2d.LayerCfg[1].InputAlpha = (alpha * 255) / 256;
+
+    HAL_DMA2D_ConfigLayer(&dma2d, 1);
+
+    uint16_t *dst16 = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(dst_img, dst_rect->y) + dst_rect->x;
+
+    #if __DCACHE_PRESENT
+    // Ensures any cached writes to dst16 are flushed.
+    uint16_t *dst16_tmp = dst16;
+    for (int i = 0; i < dst_rect->h; i++) {
+        SCB_CleanInvalidateDCache_by_Addr(dst16_tmp, dst_rect->w * sizeof(uint16_t));
+        dst16_tmp += dst_img->w;
+    }
+    #endif
+
+    uint32_t src;
+
+    if (src_img->pixfmt == PIXFORMAT_GRAYSCALE) {
+        uint8_t *src8 = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(src_img, src_rect->y) + src_rect->x;
+        src = (uint32_t) src8;
+
+        #if __DCACHE_PRESENT
+        uint8_t *src8_tmp = src8;
+        for (int i = 0; i < src_rect->h; i++) {
+            SCB_CleanDCache_by_Addr(src8_tmp, src_rect->w);
+            src8_tmp += src_img->w;
+        }
+        #endif
+    } else {
+        uint16_t *src16 = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(src_img, src_rect->y) + src_rect->x;
+        src = (uint32_t) src16;
+
+        #if __DCACHE_PRESENT
+        uint16_t *src16_tmp = src16;
+        for (int i = 0; i < src_rect->h; i++) {
+            SCB_CleanDCache_by_Addr(src16_tmp, src_rect->w * sizeof(uint16_t));
+            src16_tmp += src_img->w;
+        }
+        #endif
+    }
+
+    uint32_t dst = (uint32_t) dst16;
+
+    #if defined(MCU_SERIES_H7)
+    if (hint & IMAGE_HINT_BLACK_BACKGROUND) {
+        dst = 0;
+    }
+    #endif
+
+    HAL_DMA2D_BlendingStart(&dma2d, src, dst, (uint32_t) dst16, dst_rect->w, dst_rect->h);
+    HAL_DMA2D_PollForTransfer(&dma2d, 1000);
+
+    #if __DCACHE_PRESENT
+    // Ensures any cached reads to dst16 are dropped.
+    dst16_tmp = dst16;
+    for (int i = 0; i < dst_rect->h; i++) {
+        SCB_InvalidateDCache_by_Addr(dst16_tmp, dst_rect->w * sizeof(uint16_t));
+        dst16_tmp += dst_img->w;
+    }
+    #endif
+
+    HAL_DMA2D_DeInit(&dma2d);
+
+    if (src_img->pixfmt == PIXFORMAT_GRAYSCALE) {
+        fb_free(); // clut
+    }
+
+    #if (TIME_GPU == 1)
+    printf("draw time: %u ms\n", mp_hal_ticks_ms() - start);
+    #endif
+
+    return 0;
+}
+#endif // (OMV_GPU_ENABLE == 1)

--- a/src/omv/ports/stm32/omv_gpu.c
+++ b/src/omv/ports/stm32/omv_gpu.c
@@ -25,11 +25,10 @@ int omv_gpu_init() {
     return 0;
 }
 
-int omv_gpu_deinit() {
+void omv_gpu_deinit() {
     DMA2D_HandleTypeDef dma2d = {};
     dma2d.Instance = DMA2D;
     HAL_DMA2D_DeInit(&dma2d);
-    return 0;
 }
 
 int omv_gpu_draw_image(image_t *src_img,

--- a/src/omv/ports/stm32/omv_portconfig.mk
+++ b/src/omv/ports/stm32/omv_portconfig.mk
@@ -630,6 +630,7 @@ UVC_OBJ += $(addprefix $(BUILD)/$(OMV_DIR)/ports/stm32/,\
 	ulpi.o                                  \
 	dma_utils.o                             \
 	omv_gpio.o                              \
+	omv_gpu.o                               \
 	omv_i2c.o                               \
 	omv_spi.o                               \
 	)


### PR DESCRIPTION
Fixes: https://github.com/openmv/openmv/issues/2269

I removed all the ping-pong buffer stuff going on in draw_image. This simplified a lot of code. It probably wasn't really even helping really. Also, DMA2D is used in it's fastest mode when it can offload a whole image copy. So, this likely speeds things up.

The GPU accelerated method is invoked if draw_image thinks it can use it. All checks for dealing with scaling, boundaries, centering, etc. are all handled already. The GPU is just given what it needs to do. Then, if it cannot support the operation, it should return false, and the software code will do it.

...

Regarding accelerating drawing methods like draw_lines and etc. New GPU stuff can accelerate these, too. However, this should be tackled later in another PR. This PR sets up our code to gain the best offload a GPU can support which is the giant image copy/scale operation.