### PR TITLE
scripts/libraries: Add missing return in microspeech.listen().

### DIFF
--- a/scripts/libraries/ml/ml/apps.py
+++ b/scripts/libraries/ml/ml/apps.py
@@ -84,4 +84,5 @@ class MicroSpeech:
                 return (None, average_scores)
             if timeout != 0 and (time.ticks_ms() - stat_ms) > timeout:
                 self.stop_audio_streaming()
+                return (None, average_scores)
             time.sleep_ms(1)


### PR DESCRIPTION
I realized it was missing when writing the documentation and noticing the infinite loop.