### PR TITLE
modules/py_ml: print model address location too.

### DIFF
--- a/src/omv/modules/py_ml.c
+++ b/src/omv/modules/py_ml.c
@@ -177,7 +177,8 @@ static mp_obj_t py_ml_dtype_char_tuple(const mp_obj_tuple_t *dtype) {
 
 static void py_ml_model_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     py_ml_model_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "{ size: %d, ram: %d, addr: 0x%x", self->size, self->memory_size, self->memory_addr);
+    mp_printf(print, "{ model_size: %d, model_addr: 0x%x, ram_size: %d, ram_addr: 0x%x",
+              self->size, (uint32_t) self->data, self->memory_size, self->memory_addr);
     mp_printf(print, ", input_shape: ");
     mp_obj_print_helper(print, self->input_shape, kind);
     mp_printf(print, ", input_scale: ");


### PR DESCRIPTION
Thought we should add it as I was writing the docs.