### PR TITLE
ports/stm32: Fix MPU region protection bug.

### DIFF
--- a/src/omv/common/common.ld.S
+++ b/src/omv/common/common.ld.S
@@ -5,7 +5,7 @@
 /* Adds a section to a table */
 #define OMV_ADD_SECTION(s) \
   LONG (ADDR(s)) \
-  LONG (SIZEOF(s) / 4)
+  LONG (SIZEOF(s))
 
 /* Aligns a section to the next power of 2. */
 #define OMV_ALIGN_DMA_SECTION(section) \

--- a/src/omv/common/mp_utils.c
+++ b/src/omv/common/mp_utils.c
@@ -140,7 +140,7 @@ void mp_init_gc_stack(void *sstack, void *estack, void *heap_start, void *heap_e
     // Add GC blocks (if enabled).
     #ifdef OMV_GC_BLOCK1_MEMORY
     typedef struct {
-        uint32_t *addr;
+        uint8_t *addr;
         uint32_t size;
     } gc_blocks_table_t;
 

--- a/src/omv/ports/stm32/stm32fxxx_hal_msp.c
+++ b/src/omv/ports/stm32/stm32fxxx_hal_msp.c
@@ -53,7 +53,7 @@ void HAL_MspInit(void) {
     }
 
     typedef struct {
-        uint32_t *addr;
+        uint8_t *addr;
         uint32_t size;
     } dma_memory_table_t;
 
@@ -65,7 +65,7 @@ void HAL_MspInit(void) {
         if (buf->size >= 32) {
             MPU_InitStruct.Number = region_number--;
             MPU_InitStruct.Enable = MPU_REGION_ENABLE;
-            MPU_InitStruct.BaseAddress = *(buf->addr);
+            MPU_InitStruct.BaseAddress = (uint32_t) buf->addr;
             MPU_InitStruct.Size = dma_utils_mpu_region_size(buf->size);
             HAL_MPU_ConfigRegion(&MPU_InitStruct);
         }


### PR DESCRIPTION
While the GC block allocation code worked correctly, the MPU protection code suffered from two bugs:

1. The MPU was being programmed to protect the dereferenced memory address of the address it should protect.
2. The MPU protection size was 1/4th of what it should be.