### PR TITLE
misc/linker: Update linker script variables.

### DIFF
--- a/src/omv/alloc/fb_alloc.c
+++ b/src/omv/alloc/fb_alloc.c
@@ -13,8 +13,8 @@
 #include "omv_boardconfig.h"
 #include "omv_common.h"
 
-extern char _fballoc;
-static char *pointer = &_fballoc;
+extern char _fb_alloc_end;
+static char *pointer = &_fb_alloc_end;
 
 #if defined(FB_ALLOC_STATS)
 static uint32_t alloc_bytes;
@@ -40,7 +40,7 @@ MP_WEAK NORETURN void fb_alloc_fail() {
 }
 
 void fb_alloc_init0() {
-    pointer = &_fballoc;
+    pointer = &_fb_alloc_end;
     #if defined(OMV_FB_OVERLAY_MEMORY)
     pointer_overlay = &_fballoc_overlay_end;
     #endif
@@ -79,7 +79,7 @@ static void int_fb_alloc_free_till_mark(bool free_permanent) {
     // This does not really help you in complex memory allocation operations where you want to be
     // able to unwind things until after a certain point. It also did not handle preventing
     // fb_alloc_free_till_mark() from running in recursive call situations (see find_blobs()).
-    while (pointer < &_fballoc) {
+    while (pointer < &_fb_alloc_end) {
         uint32_t size = *((uint32_t *) pointer);
         if ((!free_permanent) && (size & FB_PERMANENT_FLAG)) {
             return;
@@ -107,7 +107,7 @@ void fb_alloc_free_till_mark() {
 }
 
 void fb_alloc_mark_permanent() {
-    if (pointer < &_fballoc) {
+    if (pointer < &_fb_alloc_end) {
         *((uint32_t *) pointer) |= FB_PERMANENT_FLAG;
     }
 }
@@ -239,7 +239,7 @@ void *fb_alloc0_all(uint32_t *size, int hints) {
 }
 
 void fb_free() {
-    if (pointer < &_fballoc) {
+    if (pointer < &_fb_alloc_end) {
         uint32_t size = *((uint32_t *) pointer);
         size &= ~FB_PERMANENT_FLAG;
         #if defined(OMV_FB_OVERLAY_MEMORY)
@@ -257,7 +257,7 @@ void fb_free() {
 }
 
 void fb_free_all() {
-    while (pointer < &_fballoc) {
+    while (pointer < &_fb_alloc_end) {
         uint32_t size = *((uint32_t *) pointer);
         size &= ~FB_PERMANENT_FLAG;
         #if defined(OMV_FB_OVERLAY_MEMORY)

--- a/src/omv/boards/ARDUINO_GIGA/omv_boardconfig.h
+++ b/src/omv/boards/ARDUINO_GIGA/omv_boardconfig.h
@@ -121,7 +121,7 @@
 #define OMV_FB_OVERLAY_MEMORY               AXI_SRAM    // Fast fb_alloc memory.
 #define OMV_FB_OVERLAY_SIZE                 (450K)  // Fast fb_alloc memory size.
 #define OMV_JPEG_MEMORY                     DRAM    // JPEG buffer memory buffer.
-#define OMV_JPEG_SIZE                       (1024 * 1024)    // IDE JPEG buffer (header + data).
+#define OMV_JPEG_SIZE                       (1M)    // IDE JPEG buffer (header + data).
 #define OMV_VOSPI_MEMORY                    DTCM    // VoSPI buffer memory.
 #define OMV_VOSPI_SIZE                      (38K)
 #define OMV_DMA_MEMORY                      SRAM3   // Misc DMA buffers memory.

--- a/src/omv/boards/ARDUINO_NANO_33_BLE_SENSE/omv_boardconfig.h
+++ b/src/omv/boards/ARDUINO_NANO_33_BLE_SENSE/omv_boardconfig.h
@@ -55,7 +55,7 @@
 #define OMV_FB_ALLOC_SIZE          (16K)  // minimum fb alloc size
 #define OMV_GC_BLOCK0_MEMORY       SRAM   // Main GC block.
 #define OMV_GC_BLOCK0_SIZE         (64K)
-#define OMV_JPEG_SIZE              (16 * 1024) // IDE JPEG buffer (header + data).
+#define OMV_JPEG_SIZE              (16K) // IDE JPEG buffer (header + data).
 
 #define OMV_TEXT_ORIGIN            0x00026000
 #define OMV_FFS_LENGTH             64K

--- a/src/omv/boards/ARDUINO_NANO_RP2040_CONNECT/omv_boardconfig.h
+++ b/src/omv/boards/ARDUINO_NANO_RP2040_CONNECT/omv_boardconfig.h
@@ -54,7 +54,7 @@ extern unsigned char *OMV_BOARD_UID_ADDR;    // Unique address.
 #define OMV_FB_ALLOC_SIZE          (16K) // minimum fb alloc size
 #define OMV_GC_BLOCK0_MEMORY       RAM // Main GC block
 #define OMV_GC_BLOCK0_SIZE         (60 * 1024) // MicroPython's heap
-#define OMV_JPEG_SIZE              (20 * 1024) // IDE JPEG buffer (header + data).
+#define OMV_JPEG_SIZE              (20K) // IDE JPEG buffer (header + data).
 
 // GP LED
 #define OMV_LED_PIN                (6)

--- a/src/omv/boards/ARDUINO_NICLA_VISION/omv_boardconfig.h
+++ b/src/omv/boards/ARDUINO_NICLA_VISION/omv_boardconfig.h
@@ -110,7 +110,7 @@
 #define OMV_FB_SIZE                           (400K)    // FB memory: header + VGA/GS image
 #define OMV_FB_ALLOC_SIZE                     (76K)     // minimum fb alloc size
 #define OMV_JPEG_MEMORY                       AXI_SRAM  // JPEG buffer memory buffer.
-#define OMV_JPEG_SIZE                         (32 * 1024)   // IDE JPEG buffer (header + data).
+#define OMV_JPEG_SIZE                         (32K)     // IDE JPEG buffer (header + data).
 #define OMV_DMA_MEMORY                        SRAM2     // DMA buffers memory.
 #define OMV_DMA_MEMORY_D1                     AXI_SRAM  // Domain 1 DMA buffers.
 #define OMV_DMA_MEMORY_D2                     SRAM2     // Domain 2 DMA buffers.

--- a/src/omv/boards/ARDUINO_PORTENTA_H7/omv_boardconfig.h
+++ b/src/omv/boards/ARDUINO_PORTENTA_H7/omv_boardconfig.h
@@ -123,7 +123,7 @@
 #define OMV_FB_OVERLAY_MEMORY               AXI_SRAM    // Fast fb_alloc memory.
 #define OMV_FB_OVERLAY_SIZE                 (480K)  // Fast fb_alloc memory size.
 #define OMV_JPEG_MEMORY                     DRAM    // JPEG buffer memory buffer.
-#define OMV_JPEG_SIZE                       (1024 * 1024)    // IDE JPEG buffer (header + data).
+#define OMV_JPEG_SIZE                       (1M)    // IDE JPEG buffer (header + data).
 #define OMV_VOSPI_MEMORY                    SRAM4   // VoSPI buffer memory.
 #define OMV_VOSPI_SIZE                      (38K)
 #define OMV_DMA_MEMORY                      SRAM3   // Misc DMA buffers memory.

--- a/src/omv/boards/OPENMV2/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV2/omv_boardconfig.h
@@ -74,7 +74,7 @@
 #define OMV_DMA_MEMORY                        SRAM2 // Misc DMA buffers
 #define OMV_GC_BLOCK0_MEMORY                  DTCM  // Main GC block
 #define OMV_GC_BLOCK0_SIZE                    (46K)
-#define OMV_JPEG_SIZE                         (8 * 1024) // IDE JPEG buffer size (header + data).
+#define OMV_JPEG_SIZE                         (8K)  // IDE JPEG buffer size (header + data).
 #define OMV_MSC_BUF_SIZE                      (2K)  // USB MSC bot data
 #define OMV_VFS_BUF_SIZE                      (1K)  // VFS struct + FATFS file buffer (624 bytes)
 #define OMV_FFS_BUF_SIZE                      (16K) // Flash filesystem cache

--- a/src/omv/boards/OPENMV3/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV3/omv_boardconfig.h
@@ -73,7 +73,7 @@
 #define OMV_DMA_MEMORY                        DTCM // Misc DMA buffers
 #define OMV_GC_BLOCK0_MEMORY                  DTCM // Main GC block
 #define OMV_GC_BLOCK0_SIZE                    (54K)
-#define OMV_JPEG_SIZE                         (22 * 1024) // IDE JPEG buffer (header + data).
+#define OMV_JPEG_SIZE                         (22K) // IDE JPEG buffer (header + data).
 #define OMV_MSC_BUF_SIZE                      (2K) // USB MSC bot data
 #define OMV_VFS_BUF_SIZE                      (1K) // VFS struct + FATFS file buffer (624 bytes)
 #define OMV_FFS_BUF_SIZE                      (32K) // Flash filesystem cache

--- a/src/omv/boards/OPENMV4/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4/omv_boardconfig.h
@@ -125,7 +125,7 @@
 #define OMV_FB_SIZE                           (400K)    // FB memory: header + VGA/GS image
 #define OMV_FB_ALLOC_SIZE                     (80K)     // minimum fb alloc size
 #define OMV_JPEG_MEMORY                       AXI_SRAM  // JPEG buffer memory.
-#define OMV_JPEG_SIZE                         (32 * 1024) // IDE JPEG buffer (header + data).
+#define OMV_JPEG_SIZE                         (32K) // IDE JPEG buffer (header + data).
 #define OMV_VOSPI_MEMORY                      SRAM4 // VoSPI buffer memory.
 #define OMV_VOSPI_SIZE                        (38K)
 #define OMV_DMA_MEMORY                        SRAM2 // Misc DMA buffers memory.

--- a/src/omv/boards/OPENMV4P/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4P/omv_boardconfig.h
@@ -127,7 +127,7 @@
 #define OMV_FB_OVERLAY_MEMORY                 AXI_SRAM  // Fast fb_alloc memory.
 #define OMV_FB_OVERLAY_SIZE                   (496K) // Fast fb_alloc memory size.
 #define OMV_JPEG_MEMORY                       DRAM   // JPEG buffer memory buffer.
-#define OMV_JPEG_SIZE                         (1024 * 1024) // IDE JPEG buffer (header + data).
+#define OMV_JPEG_SIZE                         (1M)   // IDE JPEG buffer (header + data).
 #define OMV_VOSPI_MEMORY                      SRAM4  // VoSPI buffer memory.
 #define OMV_VOSPI_SIZE                        (38K)
 #define OMV_DMA_MEMORY                        SRAM3  // Misc DMA buffers memory.

--- a/src/omv/boards/OPENMV4_PRO/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV4_PRO/omv_boardconfig.h
@@ -137,7 +137,7 @@
 #define OMV_FB_OVERLAY_MEMORY                 AXI_SRAM // Fast fb_alloc memory.
 #define OMV_FB_OVERLAY_SIZE                   (496K) // Fast fb_alloc memory size.
 #define OMV_JPEG_MEMORY                       DRAM  // JPEG buffer memory buffer.
-#define OMV_JPEG_SIZE                         (1024 * 1024) // IDE JPEG buffer (header + data).
+#define OMV_JPEG_SIZE                         (1M)  // IDE JPEG buffer (header + data).
 #define OMV_VOSPI_MEMORY                      SRAM4 // VoSPI buffer memory.
 #define OMV_VOSPI_SIZE                        (38K)
 #define OMV_DMA_MEMORY                        SRAM3 // Misc DMA buffers memory.

--- a/src/omv/boards/OPENMVPT/omv_boardconfig.h
+++ b/src/omv/boards/OPENMVPT/omv_boardconfig.h
@@ -119,7 +119,7 @@
 #define OMV_FB_OVERLAY_MEMORY                   AXI_SRAM // Fast fb_alloc memory.
 #define OMV_FB_OVERLAY_SIZE                     (496K)  // Fast fb_alloc memory size.
 #define OMV_JPEG_MEMORY                         DRAM    // JPEG buffer memory buffer.
-#define OMV_JPEG_SIZE                           (1024 * 1024) // IDE JPEG buffer (header + data).
+#define OMV_JPEG_SIZE                           (1M)    // IDE JPEG buffer (header + data).
 #define OMV_VOSPI_MEMORY                        SRAM4   // VoSPI buffer memory.
 #define OMV_VOSPI_SIZE                          (38K)
 #define OMV_DMA_MEMORY                          SRAM3   // DMA buffers memory.

--- a/src/omv/boards/OPENMV_RT1060/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV_RT1060/omv_boardconfig.h
@@ -77,7 +77,7 @@
 #define OMV_STACK_MEMORY                ITCM1   // stack memory
 #define OMV_STACK_SIZE                  (32K)
 #define OMV_JPEG_MEMORY                 DRAM    // JPEG buffer memory buffer.
-#define OMV_JPEG_SIZE                   (1024 * 1024)  // IDE JPEG buffer (header + data).
+#define OMV_JPEG_SIZE                   (1M)    // IDE JPEG buffer (header + data).
 #define OMV_FB_MEMORY                   DRAM    // Framebuffer, fb_alloc
 #define OMV_FB_SIZE                     (13M)   // FB memory: header + VGA/GS image
 #define OMV_FB_ALLOC_SIZE               (10M)   // minimum fb alloc size

--- a/src/omv/boards/PICO/omv_boardconfig.h
+++ b/src/omv/boards/PICO/omv_boardconfig.h
@@ -46,15 +46,15 @@ extern unsigned char *OMV_BOARD_UID_ADDR;   // Unique ID address.
 #define OMV_USB1_IRQ_HANDLER       (USBD_IRQHandler)
 
 // Linker script constants (see the linker script template port/x.ld.S).
-#define OMV_MAIN_MEMORY            RAM          // Data/BSS memory
-#define OMV_GC_BLOCK0_MEMORY       RAM          // Main GC block.
+#define OMV_MAIN_MEMORY            RAM    // Data/BSS memory
+#define OMV_GC_BLOCK0_MEMORY       RAM    // Main GC block.
 #define OMV_GC_BLOCK0_SIZE         (32 * 1024)
-#define OMV_STACK_MEMORY           RAM          // stack memory
+#define OMV_STACK_MEMORY           RAM    // stack memory
 #define OMV_STACK_SIZE             (8K)
-#define OMV_FB_MEMORY              RAM          // Framebuffer, fb_alloc
-#define OMV_FB_SIZE                (151K)       // FB memory: header + QVGA/GS image
-#define OMV_FB_ALLOC_SIZE          (12K)        // minimum fb alloc size
-#define OMV_JPEG_SIZE              (20 * 1024)  // IDE JPEG buffer (header + data).
+#define OMV_FB_MEMORY              RAM    // Framebuffer, fb_alloc
+#define OMV_FB_SIZE                (151K) // FB memory: header + QVGA/GS image
+#define OMV_FB_ALLOC_SIZE          (12K)  // minimum fb alloc size
+#define OMV_JPEG_SIZE              (20K)  // IDE JPEG buffer (header + data).
 
 // GP LED
 #define OMV_LED_PIN                (25)

--- a/src/omv/common/common.ld.S
+++ b/src/omv/common/common.ld.S
@@ -104,9 +104,10 @@ PROVIDE(__stack = __StackTop);
 .jpeg_memory (NOLOAD) :
 {
   . = ALIGN(4);
-  _jpeg_buf = .;
+  _jpeg_memory_start = .;
   . = . + OMV_JPEG_SIZE;
   . = ALIGN(4);
+  _jpeg_memory_end = .;
 } >OMV_JPEG_MEMORY
 #endif
 
@@ -160,14 +161,13 @@ PROVIDE(__stack = __StackTop);
 .fb_memory (NOLOAD) :
 {
   . = ALIGN(4);
-  _fb_base = .;
+  _fb_memory_start = .;
   . += OMV_FB_SIZE;
-
-  _fb_end = .;
-  . += OMV_FB_ALLOC_SIZE;
-
   . = ALIGN(4);
-  _fballoc = .;
+  _fb_memory_end = .;
+  . += OMV_FB_ALLOC_SIZE;
+  . = ALIGN(4);
+  _fb_alloc_end = .;
   . = ALIGN(4);
 } >OMV_FB_MEMORY
 #endif
@@ -209,8 +209,9 @@ PROVIDE(__stack = __StackTop);
 
   #if defined(OMV_JPEG_SIZE) && !defined(OMV_JPEG_MEMORY)
   . = ALIGN(16);
-  _jpeg_buf = .;      // IDE JPEG buffer
+  _jpeg_memory_start = .;
   . = . + OMV_JPEG_SIZE;
+  _jpeg_memory_end = .;
   #endif
 
   /* FFS (internal) filesystem buffer */

--- a/src/omv/ports/rp2/rp2.ld.S
+++ b/src/omv/ports/rp2/rp2.ld.S
@@ -187,21 +187,20 @@ SECTIONS
     .fb_memory (NOLOAD) :
     {
       . = ALIGN(4);
-      _fb_base = .;
+      _fb_memory_start = .;
       . += OMV_FB_SIZE;
+      . = ALIGN(4);
+      _fb_memory_end = .;
 
-      _fb_end = .;
       . += OMV_FB_ALLOC_SIZE;
+      . = ALIGN(4);
+      _fb_alloc_end = .;
 
       . = ALIGN(4);
-      _fballoc = .;
-      . = ALIGN(4);
-
-      #if !defined(OMV_JPEG_MEMORY)
-      _jpeg_buf = .;      // IDE JPEG buffer
+      _jpeg_memory_start = .;
       . = . + OMV_JPEG_SIZE;
       . = ALIGN(4);
-      #endif
+      _jpeg_memory_end = .;
     } >OMV_FB_MEMORY
 
     .heap (COPY):


### PR DESCRIPTION
* Add start/end to JPEG buffer. This allows board config files to define them using linker script syntax (K, M etc..).
* Rename variables more consistently.
@kwagyeman FYI I replaced `JPEG_BUF_SIZE - 64` with `JPEG_BUF_SIZE - sizeof(jpegbuffer_t)`. I think the encoder ensures that will not overflow, but if the header size changes in the future, and gets bigger than 64, this could lead to a very hard to find bug.