### PR TITLE
imlib: Add support for sending raw preview frames.

### DIFF
--- a/src/omv/imlib/framebuffer.c
+++ b/src/omv/imlib/framebuffer.c
@@ -10,6 +10,7 @@
  */
 #include <stdio.h>
 #include "mpprint.h"
+#include "fmath.h"
 #include "framebuffer.h"
 #include "omv_boardconfig.h"
 
@@ -166,8 +167,32 @@ void framebuffer_update_jpeg_buffer() {
                     .size = OMV_JPEG_BUFFER_SIZE_MAX,
                     .pixels = jpeg_framebuffer->pixels
                 };
-                // Note: lower quality saves USB bandwidth and results in a faster IDE FPS.
-                bool overflow = jpeg_compress(src, &dst, jpeg_framebuffer->quality, false, JPEG_SUBSAMPLING_AUTO);
+                bool overflow = false;
+                if (0) {
+                #if OMV_RAW_PREVIEW_ENABLE
+                } else if (src->is_mutable &&
+                           image_size(src) <= OMV_JPEG_BUFFER_SIZE_MAX) {
+                    // Down-scale the frame (if necessary) and send the raw frame.
+                    dst.size = src->bpp;
+                    dst.pixfmt = src->pixfmt;
+                    if (src->w <= OMV_RAW_PREVIEW_WIDTH && src->h <= OMV_RAW_PREVIEW_HEIGHT) {
+                        memcpy(dst.pixels, src->pixels, image_size(src));
+                    } else {
+                        dst.w = OMV_RAW_PREVIEW_WIDTH;
+                        dst.h = OMV_RAW_PREVIEW_HEIGHT;
+                        if (src->w > src->h) {
+                            dst.h = fast_floorf(dst.h * (src->h / (float) src->w));
+                        } else if (src->h > src->w) {
+                            dst.w = fast_floorf(dst.w * (src->w / (float) src->h));
+                        }
+                        imlib_draw_image(&dst, src, 0, 0, 1.0f, 1.0f, NULL, -1, 255,
+                                         NULL, NULL, IMAGE_HINT_BILINEAR, NULL, NULL, NULL);
+                    }
+                #endif
+                } else {
+                    // For all other formats, send a compressed frame.
+                    overflow = jpeg_compress(src, &dst, jpeg_framebuffer->quality, false, JPEG_SUBSAMPLING_AUTO);
+                }
 
                 if (overflow) {
                     // JPEG buffer overflowed, reduce JPEG quality for the next frame


### PR DESCRIPTION
This allows boards that don't have a hardware JPEG encoder, but do have fast scaling, to bypass JPEG encoding and send down-scaled raw frames. The raw preview frames are capped at a configurable max, but should not exceed ~60KBs.