### PR TITLE
boards/OPENMV_RT1060: Add support for RAW streaming.

### DIFF
--- a/src/omv/common/usbdbg.c
+++ b/src/omv/common/usbdbg.c
@@ -146,10 +146,11 @@ void usbdbg_data_in(uint32_t size, usbdbg_write_callback_t write_callback) {
         case USBDBG_FRAME_SIZE: {
             // Return 0 if FB is locked or not ready.
             uint32_t buffer[3] = { 0 };
-            // Try to lock FB. If header size == 0 frame is not ready
+            buffer[2] = -1; // size < 0
+            // Try to lock FB. If header size < 0 frame is not ready
             if (mutex_try_lock_alternate(&JPEG_FB()->lock, MUTEX_TID_IDE)) {
-                // If header size == 0 frame is not ready
-                if (JPEG_FB()->size == 0) {
+                // If header size < 0 frame is not ready
+                if (JPEG_FB()->size < 0) {
                     // unlock FB
                     mutex_unlock(&JPEG_FB()->lock, MUTEX_TID_IDE);
                 } else {
@@ -170,7 +171,7 @@ void usbdbg_data_in(uint32_t size, usbdbg_write_callback_t write_callback) {
                 xfer_offs += size;
                 if (xfer_offs == xfer_size) {
                     cmd = USBDBG_NONE;
-                    JPEG_FB()->w = 0; JPEG_FB()->h = 0; JPEG_FB()->size = 0;
+                    JPEG_FB()->w = 0; JPEG_FB()->h = 0; JPEG_FB()->size = -1;
                     mutex_unlock(&JPEG_FB()->lock, MUTEX_TID_IDE);
                 }
             }
@@ -203,6 +204,7 @@ void usbdbg_data_in(uint32_t size, usbdbg_write_callback_t write_callback) {
 
         case USBDBG_GET_STATE: {
             uint32_t buffer[16] = { 0 };
+            buffer[3] = -1; // size < 0
 
             // Set script running flag
             if (script_running) {
@@ -215,10 +217,10 @@ void usbdbg_data_in(uint32_t size, usbdbg_write_callback_t write_callback) {
                 buffer[0] |= USBDBG_STATE_FLAGS_TEXT;
             }
 
-            // Try to lock FB. If header size == 0 frame is not ready
+            // Try to lock FB. If header size < 0 frame is not ready
             if (mutex_try_lock_alternate(&JPEG_FB()->lock, MUTEX_TID_IDE)) {
-                // If header size == 0 frame is not ready
-                if (JPEG_FB()->size == 0) {
+                // If header size < 0 frame is not ready
+                if (JPEG_FB()->size < 0) {
                     // unlock FB
                     mutex_unlock(&JPEG_FB()->lock, MUTEX_TID_IDE);
                 } else {

--- a/src/omv/imlib/draw.c
+++ b/src/omv/imlib/draw.c
@@ -3009,12 +3009,6 @@ void imlib_draw_image(image_t *dst_img,
         hint &= ~(IMAGE_HINT_AREA | IMAGE_HINT_BILINEAR);
     }
 
-    // Bicbuic and bilinear both shift the image right by (0.5, 0.5) so we have to undo that.
-    if (hint & (IMAGE_HINT_BICUBIC | IMAGE_HINT_BILINEAR)) {
-        src_x_accum_reset -= 0x8000;
-        src_y_accum_reset -= 0x8000;
-    }
-
     // rgb_channel extracted / color_palette applied image
     image_t new_src_img;
 
@@ -3254,6 +3248,12 @@ void imlib_draw_image(image_t *dst_img,
         }
     }
     #endif
+
+    // Bicbuic and bilinear both shift the image right by (0.5, 0.5) so we have to undo that.
+    if (hint & (IMAGE_HINT_BICUBIC | IMAGE_HINT_BILINEAR)) {
+        src_x_accum_reset -= 0x8000;
+        src_y_accum_reset -= 0x8000;
+    }
 
     imlib_draw_row_data_t imlib_draw_row_data;
     imlib_draw_row_data.dst_img = dst_img;

--- a/src/omv/imlib/framebuffer.c
+++ b/src/omv/imlib/framebuffer.c
@@ -86,6 +86,9 @@ void framebuffer_init0() {
     // Enable streaming.
     MAIN_FB()->streaming_enabled = true; // controlled by the OpenMV Cam.
 
+    // Set invalid size.
+    JPEG_FB()->size = -1;
+
     // Set default quality
     JPEG_FB()->quality = ((OMV_JPEG_QUALITY_HIGH - OMV_JPEG_QUALITY_LOW) / 2) + OMV_JPEG_QUALITY_LOW;
 
@@ -117,7 +120,7 @@ static void jpegbuffer_init_from_image(image_t *img) {
     if (img == NULL) {
         jpeg_framebuffer->w = 0;
         jpeg_framebuffer->h = 0;
-        jpeg_framebuffer->size = 0;
+        jpeg_framebuffer->size = -1;
     } else {
         jpeg_framebuffer->w = img->w;
         jpeg_framebuffer->h = img->h;


### PR DESCRIPTION
draw_image() was not being invoked correctly to cause it to scale. This has been fixed. Also, the offset for the bilinear scaler has been moved to affect only the software code. Finally, I switched the empty flag for jpeg streaming to -1 from 0 which fixes binary image support.