### PR TITLE
imlib: Fix automatic vbuffer count.

### DIFF
--- a/src/omv/imlib/framebuffer.h
+++ b/src/omv/imlib/framebuffer.h
@@ -28,8 +28,9 @@ typedef struct framebuffer {
     int32_t u, v;
     PIXFORMAT_STRUCT;
     int32_t streaming_enabled;
-    uint32_t raw_buffer_size;
-    int32_t n_buffers;
+    uint32_t buff_size;
+    uint32_t n_buffers;
+    uint32_t frame_size;
     int32_t head;
     volatile int32_t tail;
     bool check_head;
@@ -106,11 +107,10 @@ void framebuffer_update_jpeg_buffer();
 // otherwise, retain the last frame in the fifo.
 void framebuffer_flush_buffers(bool fifo_flush);
 
-// Controls the number of virtual buffers in the frame buffer.
+// Set the number of virtual buffers in the frame buffer.
+// If n_buffers = -1 the number of virtual buffers will be set to 3 each  if possible.
+// If n_buffers = 1 the whole framebuffer is used. In this case, `frame_size` is ignored.
 int framebuffer_set_buffers(int32_t n_buffers);
-
-// Automatically finds the best buffering size given RAM.
-void framebuffer_auto_adjust_buffers();
 
 // Call when done with the current vbuffer to mark it as free.
 void framebuffer_free_current_buffer();


### PR DESCRIPTION
Before this patch, a 1.5MB framebuffer used a single vbuffer for VGA and smaller resolutions, causing the sensor driver to restart with every snapshot. With this patch, a 1.5MB frame buffer uses 2 vbuffers for VGA/RGB and 3 vbuffers for VGA/grayscale **by default**. In the case of 2 vbuffers, it should leave the rest for `fb_alloc` (not tested), so `fb_alloc` still gets some extra space, but only if there's any left. If you need more space for `fb_alloc`, reserve more if possible.

Additionally, `set_buffers` is now more efficient with buffer sizes. For example, if the source is 1bpp (Bayer) and the destination is 1bpp (grayscale or Bayer), the vbuffer size will be `w*h`, instead of assuming that everything is 2bpp, which allows for more vbuffers.

`set_buffers` now replaces `auto_adjust`. Passing `-1` to `set_buffers` will attempt to use 3 vbuffers, each with a size of `frame_size` if they fit; otherwise, the maximum possible buffers will be used. Passing `1` will use the whole framebuffer. In this case, `frame_size` is ignored.

**Note this definitely needs some more testing and I may have missed some corner cases.**