### PR TITLE
Kwabena/optimize math ops

### DIFF
--- a/src/hal/cmsis/include/cmsis_extension.h
+++ b/src/hal/cmsis/include/cmsis_extension.h
@@ -184,6 +184,118 @@ __STATIC_FORCEINLINE uint32_t __USAT16(int32_t val, uint32_t sat)
 
 #if (defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1))
 
+__STATIC_FORCEINLINE uint32_t __SMULBB(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smulbb %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__STATIC_FORCEINLINE uint32_t __SMULBT(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smulbt %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__STATIC_FORCEINLINE uint32_t __SMULTB(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smultb %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__STATIC_FORCEINLINE uint32_t __SMULTT(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smultt %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__STATIC_FORCEINLINE uint32_t __SMULWB(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smulwb %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__STATIC_FORCEINLINE uint32_t __SMULWT(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smulwt %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__STATIC_FORCEINLINE uint32_t __SMLABB(uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("smlabb %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+__STATIC_FORCEINLINE uint32_t __SMLABT(uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("smlabt %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+__STATIC_FORCEINLINE uint32_t __SMLATB(uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("smlatb %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+__STATIC_FORCEINLINE uint32_t __SMLATT(uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("smlatt %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+__STATIC_FORCEINLINE uint32_t __SMLAWB(uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("smlawb %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+__STATIC_FORCEINLINE uint32_t __SMLAWT(uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("smlawt %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+__STATIC_FORCEINLINE uint32_t __SMMULR(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smmulr %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__STATIC_FORCEINLINE uint32_t __UXTH(uint32_t op1)
+{
+  uint32_t result;
+
+  __ASM volatile ("uxth %0, %1" : "=r" (result) : "r" (op1));
+  return(result);
+}
+
 __STATIC_FORCEINLINE uint32_t __UXTB(uint32_t op1)
 {
   uint32_t result;
@@ -216,6 +328,22 @@ __STATIC_FORCEINLINE uint32_t __UXTAB_RORn(uint32_t op1, uint32_t op2, uint32_t 
   return result;
 }
 
+__STATIC_FORCEINLINE uint32_t __UXTAB16_RORn(uint32_t op1, uint32_t op2, uint32_t rotate)
+{
+  uint32_t result;
+
+  __ASM volatile ("uxtab16 %0, %1, %2, ROR %3" : "=r" (result) : "r" (op1), "r" (op2), "i" (rotate) );
+  return result;
+}
+
+__STATIC_FORCEINLINE uint32_t __SXTH(uint32_t op1)
+{
+  uint32_t result;
+
+  __ASM volatile ("sxth %0, %1" : "=r" (result) : "r" (op1));
+  return(result);
+}
+
 __STATIC_FORCEINLINE uint32_t __SXTB(uint32_t op1)
 {
   uint32_t result;
@@ -232,7 +360,85 @@ __STATIC_FORCEINLINE uint32_t __SXTB_RORn(uint32_t op1, uint32_t rotate)
   return result;
 }
 
+__STATIC_FORCEINLINE uint32_t __SXTAB_RORn(uint32_t op1, uint32_t op2, uint32_t rotate)
+{
+  uint32_t result;
+
+  __ASM volatile ("sxtab %0, %1, %2, ROR %3" : "=r" (result) : "r" (op1), "r" (op2), "i" (rotate) );
+  return result;
+}
+
 #else
+
+__STATIC_FORCEINLINE int32_t __SMULBB(int32_t op1, int32_t op2)
+{
+  return ((op1 << 16) >> 16) * ((op2 << 16) >> 16);
+}
+
+__STATIC_FORCEINLINE int32_t __SMULBT(int32_t op1, int32_t op2)
+{
+  return ((op1 << 16) >> 16) * (op2 >> 16);
+}
+
+__STATIC_FORCEINLINE int32_t __SMULTB(int32_t op1, int32_t op2)
+{
+  return (op1 >> 16) * ((op2 << 16) >> 16);
+}
+
+__STATIC_FORCEINLINE int32_t __SMULTT(int32_t op1, int32_t op2)
+{
+  return (op1 >> 16) * (op2 >> 16);
+}
+
+__STATIC_FORCEINLINE int32_t __SMULWB(int32_t op1, int32_t op2)
+{
+  return (((int64_t) op1) * ((int64_t) ((op2 << 16) >> 16))) >> 16;
+}
+
+__STATIC_FORCEINLINE int32_t __SMULWT(int32_t op1, int32_t op2)
+{
+  return (((int64_t) op1) * ((int64_t) (op2 >> 16))) >> 16;
+}
+
+__STATIC_FORCEINLINE int32_t __SMLABB(int32_t op1, int32_t op2, int32_t op3)
+{
+  return (((op1 << 16) >> 16) * ((op2 << 16) >> 16)) + op3;
+}
+
+__STATIC_FORCEINLINE int32_t __SMLABT(int32_t op1, int32_t op2, int32_t op3)
+{
+  return (((op1 << 16) >> 16) * (op2 >> 16)) + op3;
+}
+
+__STATIC_FORCEINLINE int32_t __SMLATB(int32_t op1, int32_t op2, int32_t op3)
+{
+  return ((op1 >> 16) * ((op2 << 16) >> 16)) + op3;
+}
+
+__STATIC_FORCEINLINE int32_t __SMLATT(int32_t op1, int32_t op2, int32_t op3)
+{
+  return ((op1 >> 16) * (op2 >> 16)) + op3;
+}
+
+__STATIC_FORCEINLINE int32_t __SMLAWB(int32_t op1, int32_t op2, int32_t op3)
+{
+  return ((((int64_t) op1) * ((int64_t) ((op2 << 16) >> 16))) >> 16) + op3;
+}
+
+__STATIC_FORCEINLINE int32_t __SMLAWT(int32_t op1, int32_t op2, int32_t op3)
+{
+  return ((((int64_t) op1) * ((int64_t) (op2 >> 16))) >> 16) + op3;
+}
+
+__STATIC_FORCEINLINE int32_t __SMMULR(int32_t op1, int32_t op2)
+{
+  return ((((int64_t) op1) * ((int64_t) op2)) + 0x80000000) >> 32;
+}
+
+__STATIC_FORCEINLINE uint32_t __UXTH(uint32_t op1)
+{
+  return op1 & 0xFFFF;
+}
 
 __STATIC_FORCEINLINE uint32_t __UXTB(uint32_t op1)
 {
@@ -242,6 +448,31 @@ __STATIC_FORCEINLINE uint32_t __UXTB(uint32_t op1)
 __STATIC_FORCEINLINE uint32_t __UXTB_RORn(uint32_t op1, uint32_t rotate)
 {
   return (op1 >> rotate) & 0xFF;
+}
+
+__STATIC_FORCEINLINE uint32_t __UXTAB_RORn(uint32_t op1, uint32_t op2, uint32_t rotate)
+{
+  return ((op1 >> rotate) & 0xFF) + op2;
+}
+
+__STATIC_FORCEINLINE uint32_t __SXTH(int32_t op1)
+{
+  return (op1 << 16) >> 16;
+}
+
+__STATIC_FORCEINLINE uint32_t __SXTB(int32_t op1)
+{
+  return (op1 << 24) >> 24;
+}
+
+__STATIC_FORCEINLINE uint32_t __SXTB_RORn(int32_t op1, uint32_t rotate)
+{
+  return ((op1 >> rotate) << 24) >> 24;
+}
+
+__STATIC_FORCEINLINE uint32_t __SXTAB_RORn(int32_t op1, uint32_t op2, uint32_t rotate)
+{
+  return (((op1 >> rotate) << 24) >> 24) + op2;
 }
 
 __STATIC_FORCEINLINE uint32_t __SSUB16(uint32_t op1, uint32_t op2)

--- a/src/omv/Makefile
+++ b/src/omv/Makefile
@@ -110,7 +110,10 @@ SRCS += $(wildcard ports/$(PORT)/*.c)
 
 OBJS = $(addprefix $(BUILD)/, $(SRCS:.c=.o))
 ifeq ($(USE_CLANG),1)
-CLANG_OBJS = $(BUILD)/imlib/bayer.o
+CLANG_OBJS = $(BUILD)/imlib/bayer.o \
+			 $(BUILD)/imlib/binary.o \
+			 $(BUILD)/imlib/filter.o \
+			 $(BUILD)/imlib/mathop.o
 endif
 
 OBJ_DIRS = $(sort $(dir $(OBJS)))

--- a/src/omv/imlib/imlib.h
+++ b/src/omv/imlib/imlib.h
@@ -18,8 +18,7 @@
 #include <limits.h>
 #include <float.h>
 #include <math.h>
-#include <arm_math.h>
-#include <cmsis_extension.h>
+#include "simd.h"
 #include "fb_alloc.h"
 #include "file_utils.h"
 #include "umm_malloc.h"
@@ -763,6 +762,63 @@ bool image_get_mask_pixel(image_t *ptr, int x, int y);
         __typeof__ (y) _y = (y);                        \
         ((uint16_t *) _image->data) + (_image->w * _y); \
     })
+
+static inline void linebuf_copy_binary(int32_t y, int32_t ksize, int32_t brows, image_t *buf, image_t *dst) {
+    if (y >= ksize) {
+        // Transfer buffer lines...
+        int32_t y_offset = y - ksize;
+        vmemcpy_32(IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(dst, y_offset),
+                   IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(buf, (y_offset % brows)),
+                   IMAGE_BINARY_LINE_LEN_BYTES(dst));
+    }
+}
+
+static inline void linebuf_copy_binary_tail(int32_t ksize, int32_t brows, image_t *buf, image_t *dst) {
+    // Copy any remaining lines from the buffer image...
+    for (int32_t y = IM_MAX(dst->h - ksize, 0); y < dst->h; y++) {
+        vmemcpy_32(IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(dst, y),
+                   IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(buf, (y % brows)),
+                   IMAGE_BINARY_LINE_LEN_BYTES(dst));
+    }
+}
+
+static inline void linebuf_copy_grayscale(int32_t y, int32_t ksize, int32_t brows, image_t *buf, image_t *dst) {
+    if (y >= ksize) {
+        // Transfer buffer lines...
+        int32_t y_offset = y - ksize;
+        vmemcpy_8(IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(dst, y_offset),
+                  IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(buf, (y_offset % brows)),
+                  IMAGE_GRAYSCALE_LINE_LEN_BYTES(dst));
+    }
+}
+
+static inline void linebuf_copy_grayscale_tail(int32_t ksize, int32_t brows, image_t *buf, image_t *dst) {
+    // Copy any remaining lines from the buffer image...
+    for (int32_t y = IM_MAX(dst->h - ksize, 0); y < dst->h; y++) {
+        vmemcpy_8(IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(dst, y),
+                  IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(buf, (y % brows)),
+                  IMAGE_GRAYSCALE_LINE_LEN_BYTES(dst));
+    }
+}
+
+static inline void linebuf_copy_rgb565(int32_t y, int32_t ksize, int32_t brows, image_t *buf, image_t *dst) {
+    if (y >= ksize) {
+        // Transfer buffer lines...
+        int32_t y_offset = y - ksize;
+        vmemcpy_16(IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(dst, y_offset),
+                   IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(buf, (y_offset % brows)),
+                   IMAGE_RGB565_LINE_LEN_BYTES(dst));
+    }
+}
+
+static inline void linebuf_copy_rgb565_tail(int32_t ksize, int32_t brows, image_t *buf, image_t *dst) {
+    // Copy any remaining lines from the buffer image...
+    for (int32_t y = IM_MAX(dst->h - ksize, 0); y < dst->h; y++) {
+        vmemcpy_16(IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(dst, y),
+                   IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(buf, (y % brows)),
+                   IMAGE_RGB565_LINE_LEN_BYTES(dst));
+    }
+}
 
 ////////////////
 // JPEG Stuff //

--- a/src/omv/imlib/mathop.c
+++ b/src/omv/imlib/mathop.c
@@ -24,19 +24,16 @@ void imlib_add_line_op(int x, int x_end, int y_row, imlib_draw_row_data_t *data)
             uint8_t *row1 = (uint8_t *) data->dst_row_override;
 
             if (!mask) {
-                #if defined(ARM_MATH_DSP)
-                for (; (x_end - x) >= 4; x += 4) {
-                    uint32_t p0 = *((uint32_t *) (row0 + x));
-                    uint32_t p1 = *((uint32_t *) (row1 + x));
-                    *((uint32_t *) (row0 + x)) = __UQADD8(p0, p1);
-                }
-                #endif
+                uint32_t n = x_end - x;
 
-                for (; x < x_end; x++) {
-                    uint32_t p0 = IMAGE_GET_GRAYSCALE_PIXEL_FAST(row0, x);
-                    uint32_t p1 = IMAGE_GET_GRAYSCALE_PIXEL_FAST(row1, x);
-                    uint32_t p = __USAT(p0 + p1, 8);
-                    IMAGE_PUT_GRAYSCALE_PIXEL_FAST(row0, x, p);
+                for (; n >= UINT8_VECTOR_SIZE; n -= UINT8_VECTOR_SIZE, x += UINT8_VECTOR_SIZE) {
+                    vstr_u8(row0 + x, vqadd_u8(vldr_u8(row0 + x), vldr_u8(row1 + x)));
+                }
+
+                if (n) {
+                    v128_predicate_t pred = vpredicate_8(n);
+                    v2x_rows_t data = vldr_u8_pred_x2((v2x_row_ptrs_t) {.p0.u8 = row0, .p1.u8 = row1}, x, pred);
+                    vstr_u8_pred(row0 + x, vqadd_u8(data.r0, data.r1), pred);
                 }
             } else {
                 for (; x < x_end; x++) {
@@ -55,24 +52,30 @@ void imlib_add_line_op(int x, int x_end, int y_row, imlib_draw_row_data_t *data)
             uint16_t *row1 = (uint16_t *) data->dst_row_override;
 
             if (!mask) {
-                #if defined(ARM_MATH_DSP)
-                for (; (x_end - x) >= 2; x += 2) {
-                    uint32_t p0 = *((uint32_t *) (row0 + x));
-                    uint32_t p1 = *((uint32_t *) (row1 + x));
-                    uint32_t r = __USAT16(((p0 >> 11) & 0x1f001f) + ((p1 >> 11) & 0x1f001f), 5);
-                    uint32_t g = __USAT16(((p0 >> 5) & 0x3f003f) + ((p1 >> 5) & 0x3f003f), 6);
-                    uint32_t b = __USAT16((p0 & 0x1f001f) + (p1 & 0x1f001f), 5);
-                    *((uint32_t *) (row0 + x)) = COLOR_R5_G6_B5_TO_RGB565(r, g, b);
-                }
-                #endif
+                uint32_t n = x_end - x;
 
-                for (; x < x_end; x++) {
-                    uint32_t p0 = IMAGE_GET_RGB565_PIXEL_FAST(row0, x);
-                    uint32_t p1 = IMAGE_GET_RGB565_PIXEL_FAST(row1, x);
-                    uint32_t r = __USAT(COLOR_RGB565_TO_R5(p0) + COLOR_RGB565_TO_R5(p1), 5);
-                    uint32_t g = __USAT(COLOR_RGB565_TO_G6(p0) + COLOR_RGB565_TO_G6(p1), 6);
-                    uint32_t b = __USAT(COLOR_RGB565_TO_B5(p0) + COLOR_RGB565_TO_B5(p1), 5);
-                    IMAGE_PUT_RGB565_PIXEL_FAST(row0, x, COLOR_R5_G6_B5_TO_RGB565(r, g, b));
+                for (; n >= UINT16_VECTOR_SIZE; n -= UINT16_VECTOR_SIZE, x += UINT16_VECTOR_SIZE) {
+                    vrgb_pixels_t p0 = vrgb_rgb565_to_pixels565(vldr_u16(row0 + x));
+                    vrgb_pixels_t p1 = vrgb_rgb565_to_pixels565(vldr_u16(row1 + x));
+                    vrgb_pixels_t p = {
+                        .r = vusat_s16_narrow_u8(vadd_u32(p0.r, p1.r), 5),
+                        .g = vusat_s16_narrow_u8(vadd_u32(p0.g, p1.g), 6),
+                        .b = vusat_s16_narrow_u8(vadd_u32(p0.b, p1.b), 5)
+                    };
+                    vstr_u16(row0 + x, vrgb_pixels565_to_rgb565(p));
+                }
+
+                if (n) {
+                    v128_predicate_t pred = vpredicate_16(n);
+                    v2x_rows_t data = vldr_u16_pred_x2((v2x_row_ptrs_t) {.p0.u16 = row0, .p1.u16 = row1}, x, pred);
+                    vrgb_pixels_t p0 = vrgb_rgb565_to_pixels565(data.r0);
+                    vrgb_pixels_t p1 = vrgb_rgb565_to_pixels565(data.r1);
+                    vrgb_pixels_t p = {
+                        .r = vusat_s16_narrow_u8(vadd_u32(p0.r, p1.r), 5),
+                        .g = vusat_s16_narrow_u8(vadd_u32(p0.g, p1.g), 6),
+                        .b = vusat_s16_narrow_u8(vadd_u32(p0.b, p1.b), 5)
+                    };
+                    vstr_u16_pred(row0 + x, vrgb_pixels565_to_rgb565(p), pred);
                 }
             } else {
                 for (; x < x_end; x++) {
@@ -103,34 +106,41 @@ void imlib_sub_line_op(int x, int x_end, int y_row, imlib_draw_row_data_t *data)
             uint32_t *row1 = (uint32_t *) data->dst_row_override;
 
             if (!mask) {
-                #if (__ARM_ARCH > 6)
-                // Align to 32-bit boundary.
-                for (; (x % 32) && (x < x_end); x++) {
-                    uint32_t p0 = IMAGE_GET_BINARY_PIXEL_FAST(row0, x);
-                    uint32_t p1 = IMAGE_GET_BINARY_PIXEL_FAST(row1, x);
-                    uint32_t p = p0 > p1;
-                    IMAGE_PUT_BINARY_PIXEL_FAST(row0, x, p);
+                uint32_t n = x_end - x;
+                uint32_t unaligned = x % UINT32_T_BITS;
+
+                if (unaligned) {
+                    uint32_t unaligned_len = IM_MIN(UINT32_T_BITS - unaligned, n);
+                    uint32_t vp0 = vldr_binary_bits(row0, x, unaligned_len);
+                    uint32_t vp1 = vldr_binary_bits(row1, x, unaligned_len);
+                    vstr_binary_bits(row0, x, unaligned_len, vp0 & ~vp1);
+                    x += unaligned_len;
+                    n -= unaligned_len;
                 }
 
-                for (; (x_end - x) >= 32; x += 32) {
-                    uint32_t p0 = row0[x / 32];
-                    uint32_t p1 = row1[x / 32];
-                    row0[x / 32] = p0 & (~p1); // the same as p0 > p1 for all bits
+                if (UINT32_VECTOR_BITS > UINT32_T_BITS) {
+                    for (uint32_t i = x / UINT32_T_BITS; n >= UINT32_VECTOR_BITS;
+                         n -= UINT32_VECTOR_BITS, x += UINT32_VECTOR_BITS, i += UINT32_VECTOR_SIZE) {
+                        vstr_u32(row0 + i, vbic_u32(vldr_u32(row0 + i), vldr_u32(row1 + i)));
+                    }
                 }
-                #endif
 
-                for (; x < x_end; x++) {
-                    uint32_t p0 = IMAGE_GET_BINARY_PIXEL_FAST(row0, x);
-                    uint32_t p1 = IMAGE_GET_BINARY_PIXEL_FAST(row1, x);
-                    uint32_t p = p0 > p1;
-                    IMAGE_PUT_BINARY_PIXEL_FAST(row0, x, p);
+                for (uint32_t i = x / UINT32_T_BITS; n >= UINT32_T_BITS;
+                     n -= UINT32_T_BITS, x += UINT32_T_BITS, i++) {
+                    row0[i] = row0[i] & ~row1[i];
+                }
+
+                if (n) {
+                    uint32_t vp0 = vldr_binary_bits(row0, x, n);
+                    uint32_t vp1 = vldr_binary_bits(row1, x, n);
+                    vstr_binary_bits(row0, x, n, vp0 & ~vp1);
                 }
             } else {
                 for (; x < x_end; x++) {
                     if (image_get_mask_pixel(mask, x, y_row)) {
                         uint32_t p0 = IMAGE_GET_BINARY_PIXEL_FAST(row0, x);
                         uint32_t p1 = IMAGE_GET_BINARY_PIXEL_FAST(row1, x);
-                        uint32_t p = p0 > p1;
+                        uint32_t p = p0 & ~p1;
                         IMAGE_PUT_BINARY_PIXEL_FAST(row0, x, p);
                     }
                 }
@@ -142,26 +152,23 @@ void imlib_sub_line_op(int x, int x_end, int y_row, imlib_draw_row_data_t *data)
             uint8_t *row1 = (uint8_t *) data->dst_row_override;
 
             if (!mask) {
-                #if defined(ARM_MATH_DSP)
-                for (; (x_end - x) >= 4; x += 4) {
-                    uint32_t p0 = *((uint32_t *) (row0 + x));
-                    uint32_t p1 = *((uint32_t *) (row1 + x));
-                    *((uint32_t *) (row0 + x)) = __UQSUB8(p0, p1);
-                }
-                #endif
+                uint32_t n = x_end - x;
 
-                for (; x < x_end; x++) {
-                    uint32_t p0 = IMAGE_GET_GRAYSCALE_PIXEL_FAST(row0, x);
-                    uint32_t p1 = IMAGE_GET_GRAYSCALE_PIXEL_FAST(row1, x);
-                    uint32_t p = __USAT((int32_t) (p0 - p1), 8);
-                    IMAGE_PUT_GRAYSCALE_PIXEL_FAST(row0, x, p);
+                for (; n >= UINT8_VECTOR_SIZE; n -= UINT8_VECTOR_SIZE, x += UINT8_VECTOR_SIZE) {
+                    vstr_u8(row0 + x, vqsub_u8(vldr_u8(row0 + x), vldr_u8(row1 + x)));
+                }
+
+                if (n) {
+                    v128_predicate_t pred = vpredicate_8(n);
+                    v2x_rows_t data = vldr_u8_pred_x2((v2x_row_ptrs_t) {.p0.u8 = row0, .p1.u8 = row1}, x, pred);
+                    vstr_u8_pred(row0 + x, vqsub_u8(data.r0, data.r1), pred);
                 }
             } else {
                 for (; x < x_end; x++) {
                     if (image_get_mask_pixel(mask, x, y_row)) {
                         uint32_t p0 = IMAGE_GET_GRAYSCALE_PIXEL_FAST(row0, x);
                         uint32_t p1 = IMAGE_GET_GRAYSCALE_PIXEL_FAST(row1, x);
-                        uint32_t p = __USAT((int32_t) (p0 - p1), 8);
+                        uint32_t p = __USAT(((int32_t) p0) - ((int32_t) p1), 8);
                         IMAGE_PUT_GRAYSCALE_PIXEL_FAST(row0, x, p);
                     }
                 }
@@ -173,33 +180,39 @@ void imlib_sub_line_op(int x, int x_end, int y_row, imlib_draw_row_data_t *data)
             uint16_t *row1 = (uint16_t *) data->dst_row_override;
 
             if (!mask) {
-                #if defined(ARM_MATH_DSP)
-                for (; (x_end - x) >= 2; x += 2) {
-                    uint32_t p0 = *((uint32_t *) (row0 + x));
-                    uint32_t p1 = *((uint32_t *) (row1 + x));
-                    uint32_t r = __USAT16(__SSUB16((p0 >> 11) & 0x1f001f, (p1 >> 11) & 0x1f001f), 5);
-                    uint32_t g = __USAT16(__SSUB16((p0 >> 5) & 0x3f003f, (p1 >> 5) & 0x3f003f), 6);
-                    uint32_t b = __USAT16(__SSUB16(p0 & 0x1f001f, p1 & 0x1f001f), 5);
-                    *((uint32_t *) (row0 + x)) = COLOR_R5_G6_B5_TO_RGB565(r, g, b);
-                }
-                #endif
+                uint32_t n = x_end - x;
 
-                for (; x < x_end; x++) {
-                    uint32_t p0 = IMAGE_GET_RGB565_PIXEL_FAST(row0, x);
-                    uint32_t p1 = IMAGE_GET_RGB565_PIXEL_FAST(row1, x);
-                    uint32_t r = __USAT((int32_t) (COLOR_RGB565_TO_R5(p0) - COLOR_RGB565_TO_R5(p1)), 5);
-                    uint32_t g = __USAT((int32_t) (COLOR_RGB565_TO_G6(p0) - COLOR_RGB565_TO_G6(p1)), 6);
-                    uint32_t b = __USAT((int32_t) (COLOR_RGB565_TO_B5(p0) - COLOR_RGB565_TO_B5(p1)), 5);
-                    IMAGE_PUT_RGB565_PIXEL_FAST(row0, x, COLOR_R5_G6_B5_TO_RGB565(r, g, b));
+                for (; n >= UINT16_VECTOR_SIZE; n -= UINT16_VECTOR_SIZE, x += UINT16_VECTOR_SIZE) {
+                    vrgb_pixels_t p0 = vrgb_rgb565_to_pixels565(vldr_u16(row0 + x));
+                    vrgb_pixels_t p1 = vrgb_rgb565_to_pixels565(vldr_u16(row1 + x));
+                    vrgb_pixels_t p = {
+                        .r = vusat_s16_narrow_u8(vsub_s16(p0.r, p1.r), 5),
+                        .g = vusat_s16_narrow_u8(vsub_s16(p0.g, p1.g), 6),
+                        .b = vusat_s16_narrow_u8(vsub_s16(p0.b, p1.b), 5)
+                    };
+                    vstr_u16(row0 + x, vrgb_pixels565_to_rgb565(p));
+                }
+
+                if (n) {
+                    v128_predicate_t pred = vpredicate_16(n);
+                    v2x_rows_t data = vldr_u16_pred_x2((v2x_row_ptrs_t) {.p0.u16 = row0, .p1.u16 = row1}, x, pred);
+                    vrgb_pixels_t p0 = vrgb_rgb565_to_pixels565(data.r0);
+                    vrgb_pixels_t p1 = vrgb_rgb565_to_pixels565(data.r1);
+                    vrgb_pixels_t p = {
+                        .r = vusat_s16_narrow_u8(vsub_s16(p0.r, p1.r), 5),
+                        .g = vusat_s16_narrow_u8(vsub_s16(p0.g, p1.g), 6),
+                        .b = vusat_s16_narrow_u8(vsub_s16(p0.b, p1.b), 5)
+                    };
+                    vstr_u16_pred(row0 + x, vrgb_pixels565_to_rgb565(p), pred);
                 }
             } else {
                 for (; x < x_end; x++) {
                     if (image_get_mask_pixel(mask, x, y_row)) {
                         uint32_t p0 = IMAGE_GET_RGB565_PIXEL_FAST(row0, x);
                         uint32_t p1 = IMAGE_GET_RGB565_PIXEL_FAST(row1, x);
-                        uint32_t r = __USAT((int32_t) (COLOR_RGB565_TO_R5(p0) - COLOR_RGB565_TO_R5(p1)), 5);
-                        uint32_t g = __USAT((int32_t) (COLOR_RGB565_TO_G6(p0) - COLOR_RGB565_TO_G6(p1)), 6);
-                        uint32_t b = __USAT((int32_t) (COLOR_RGB565_TO_B5(p0) - COLOR_RGB565_TO_B5(p1)), 5);
+                        uint32_t r = __USAT(((int32_t) COLOR_RGB565_TO_R5(p0)) - ((int32_t) COLOR_RGB565_TO_R5(p1)), 5);
+                        uint32_t g = __USAT(((int32_t) COLOR_RGB565_TO_G6(p0)) - ((int32_t) COLOR_RGB565_TO_G6(p1)), 6);
+                        uint32_t b = __USAT(((int32_t) COLOR_RGB565_TO_B5(p0)) - ((int32_t) COLOR_RGB565_TO_B5(p1)), 5);
                         IMAGE_PUT_RGB565_PIXEL_FAST(row0, x, COLOR_R5_G6_B5_TO_RGB565(r, g, b));
                     }
                 }
@@ -221,34 +234,41 @@ void imlib_rsub_line_op(int x, int x_end, int y_row, imlib_draw_row_data_t *data
             uint32_t *row1 = (uint32_t *) data->dst_row_override;
 
             if (!mask) {
-                #if (__ARM_ARCH > 6)
-                // Align to 32-bit boundary.
-                for (; (x % 32) && (x < x_end); x++) {
-                    uint32_t p0 = IMAGE_GET_BINARY_PIXEL_FAST(row0, x);
-                    uint32_t p1 = IMAGE_GET_BINARY_PIXEL_FAST(row1, x);
-                    uint32_t p = p1 > p0;
-                    IMAGE_PUT_BINARY_PIXEL_FAST(row0, x, p);
+                uint32_t n = x_end - x;
+                uint32_t unaligned = x % UINT32_T_BITS;
+
+                if (unaligned) {
+                    uint32_t unaligned_len = IM_MIN(UINT32_T_BITS - unaligned, n);
+                    uint32_t vp0 = vldr_binary_bits(row0, x, unaligned_len);
+                    uint32_t vp1 = vldr_binary_bits(row1, x, unaligned_len);
+                    vstr_binary_bits(row0, x, unaligned_len, vp1 & ~vp0);
+                    x += unaligned_len;
+                    n -= unaligned_len;
                 }
 
-                for (; (x_end - x) >= 32; x += 32) {
-                    uint32_t p0 = row0[x / 32];
-                    uint32_t p1 = row1[x / 32];
-                    row0[x / 32] = p1 & (~p0); // the same as p1 > p0 for all bits
+                if (UINT32_VECTOR_BITS > UINT32_T_BITS) {
+                    for (uint32_t i = x / UINT32_T_BITS; n >= UINT32_VECTOR_BITS;
+                         n -= UINT32_VECTOR_BITS, x += UINT32_VECTOR_BITS, i += UINT32_VECTOR_SIZE) {
+                        vstr_u32(row0 + i, vbic_u32(vldr_u32(row1 + i), vldr_u32(row0 + i)));
+                    }
                 }
-                #endif
 
-                for (; x < x_end; x++) {
-                    uint32_t p0 = IMAGE_GET_BINARY_PIXEL_FAST(row0, x);
-                    uint32_t p1 = IMAGE_GET_BINARY_PIXEL_FAST(row1, x);
-                    uint32_t p = p1 > p0;
-                    IMAGE_PUT_BINARY_PIXEL_FAST(row0, x, p);
+                for (uint32_t i = x / UINT32_T_BITS; n >= UINT32_T_BITS;
+                     n -= UINT32_T_BITS, x += UINT32_T_BITS, i++) {
+                    row0[i] = row1[i] & ~row0[i];
+                }
+
+                if (n) {
+                    uint32_t vp0 = vldr_binary_bits(row0, x, n);
+                    uint32_t vp1 = vldr_binary_bits(row1, x, n);
+                    vstr_binary_bits(row0, x, n, vp1 & ~vp0);
                 }
             } else {
                 for (; x < x_end; x++) {
                     if (image_get_mask_pixel(mask, x, y_row)) {
                         uint32_t p0 = IMAGE_GET_BINARY_PIXEL_FAST(row0, x);
                         uint32_t p1 = IMAGE_GET_BINARY_PIXEL_FAST(row1, x);
-                        uint32_t p = p1 > p0;
+                        uint32_t p = p1 & ~p0;
                         IMAGE_PUT_BINARY_PIXEL_FAST(row0, x, p);
                     }
                 }
@@ -260,26 +280,23 @@ void imlib_rsub_line_op(int x, int x_end, int y_row, imlib_draw_row_data_t *data
             uint8_t *row1 = (uint8_t *) data->dst_row_override;
 
             if (!mask) {
-                #if defined(ARM_MATH_DSP)
-                for (; (x_end - x) >= 4; x += 4) {
-                    uint32_t p0 = *((uint32_t *) (row0 + x));
-                    uint32_t p1 = *((uint32_t *) (row1 + x));
-                    *((uint32_t *) (row0 + x)) = __UQSUB8(p1, p0);
-                }
-                #endif
+                uint32_t n = x_end - x;
 
-                for (; x < x_end; x++) {
-                    uint32_t p0 = IMAGE_GET_GRAYSCALE_PIXEL_FAST(row0, x);
-                    uint32_t p1 = IMAGE_GET_GRAYSCALE_PIXEL_FAST(row1, x);
-                    uint32_t p = __USAT((int32_t) (p1 - p0), 8);
-                    IMAGE_PUT_GRAYSCALE_PIXEL_FAST(row0, x, p);
+                for (; n >= UINT8_VECTOR_SIZE; n -= UINT8_VECTOR_SIZE, x += UINT8_VECTOR_SIZE) {
+                    vstr_u8(row0 + x, vqsub_u8(vldr_u8(row1 + x), vldr_u8(row0 + x)));
+                }
+
+                if (n) {
+                    v128_predicate_t pred = vpredicate_8(n);
+                    v2x_rows_t data = vldr_u8_pred_x2((v2x_row_ptrs_t) {.p0.u8 = row0, .p1.u8 = row1}, x, pred);
+                    vstr_u8_pred(row0 + x, vqsub_u8(data.r1, data.r0), pred);
                 }
             } else {
                 for (; x < x_end; x++) {
                     if (image_get_mask_pixel(mask, x, y_row)) {
                         uint32_t p0 = IMAGE_GET_GRAYSCALE_PIXEL_FAST(row0, x);
                         uint32_t p1 = IMAGE_GET_GRAYSCALE_PIXEL_FAST(row1, x);
-                        uint32_t p = __USAT((int32_t) (p1 - p0), 8);
+                        uint32_t p = __USAT(((int32_t) p1) - ((int32_t) p0), 8);
                         IMAGE_PUT_GRAYSCALE_PIXEL_FAST(row0, x, p);
                     }
                 }
@@ -291,33 +308,39 @@ void imlib_rsub_line_op(int x, int x_end, int y_row, imlib_draw_row_data_t *data
             uint16_t *row1 = (uint16_t *) data->dst_row_override;
 
             if (!mask) {
-                #if defined(ARM_MATH_DSP)
-                for (; (x_end - x) >= 2; x += 2) {
-                    uint32_t p0 = *((uint32_t *) (row0 + x));
-                    uint32_t p1 = *((uint32_t *) (row1 + x));
-                    uint32_t r = __USAT16(__SSUB16((p1 >> 11) & 0x1f001f, (p0 >> 11) & 0x1f001f), 5);
-                    uint32_t g = __USAT16(__SSUB16((p1 >> 5) & 0x3f003f, (p0 >> 5) & 0x3f003f), 6);
-                    uint32_t b = __USAT16(__SSUB16(p1 & 0x1f001f, p0 & 0x1f001f), 5);
-                    *((uint32_t *) (row0 + x)) = COLOR_R5_G6_B5_TO_RGB565(r, g, b);
-                }
-                #endif
+                uint32_t n = x_end - x;
 
-                for (; x < x_end; x++) {
-                    uint32_t p0 = IMAGE_GET_RGB565_PIXEL_FAST(row0, x);
-                    uint32_t p1 = IMAGE_GET_RGB565_PIXEL_FAST(row1, x);
-                    uint32_t r = __USAT((int32_t) (COLOR_RGB565_TO_R5(p1) - COLOR_RGB565_TO_R5(p0)), 5);
-                    uint32_t g = __USAT((int32_t) (COLOR_RGB565_TO_G6(p1) - COLOR_RGB565_TO_G6(p0)), 6);
-                    uint32_t b = __USAT((int32_t) (COLOR_RGB565_TO_B5(p1) - COLOR_RGB565_TO_B5(p0)), 5);
-                    IMAGE_PUT_RGB565_PIXEL_FAST(row0, x, COLOR_R5_G6_B5_TO_RGB565(r, g, b));
+                for (; n >= UINT16_VECTOR_SIZE; n -= UINT16_VECTOR_SIZE, x += UINT16_VECTOR_SIZE) {
+                    vrgb_pixels_t p0 = vrgb_rgb565_to_pixels565(vldr_u16(row0 + x));
+                    vrgb_pixels_t p1 = vrgb_rgb565_to_pixels565(vldr_u16(row1 + x));
+                    vrgb_pixels_t p = {
+                        .r = vusat_s16_narrow_u8(vsub_s16(p1.r, p0.r), 5),
+                        .g = vusat_s16_narrow_u8(vsub_s16(p1.g, p0.g), 6),
+                        .b = vusat_s16_narrow_u8(vsub_s16(p1.b, p0.b), 5)
+                    };
+                    vstr_u16(row0 + x, vrgb_pixels565_to_rgb565(p));
+                }
+
+                if (n) {
+                    v128_predicate_t pred = vpredicate_16(n);
+                    v2x_rows_t data = vldr_u16_pred_x2((v2x_row_ptrs_t) {.p0.u16 = row0, .p1.u16 = row1}, x, pred);
+                    vrgb_pixels_t p0 = vrgb_rgb565_to_pixels565(data.r0);
+                    vrgb_pixels_t p1 = vrgb_rgb565_to_pixels565(data.r1);
+                    vrgb_pixels_t p = {
+                        .r = vusat_s16_narrow_u8(vsub_s16(p1.r, p0.r), 5),
+                        .g = vusat_s16_narrow_u8(vsub_s16(p1.g, p0.g), 6),
+                        .b = vusat_s16_narrow_u8(vsub_s16(p1.b, p0.b), 5)
+                    };
+                    vstr_u16_pred(row0 + x, vrgb_pixels565_to_rgb565(p), pred);
                 }
             } else {
                 for (; x < x_end; x++) {
                     if (image_get_mask_pixel(mask, x, y_row)) {
                         uint32_t p0 = IMAGE_GET_RGB565_PIXEL_FAST(row0, x);
                         uint32_t p1 = IMAGE_GET_RGB565_PIXEL_FAST(row1, x);
-                        uint32_t r = __USAT((int32_t) (COLOR_RGB565_TO_R5(p1) - COLOR_RGB565_TO_R5(p0)), 5);
-                        uint32_t g = __USAT((int32_t) (COLOR_RGB565_TO_G6(p1) - COLOR_RGB565_TO_G6(p0)), 6);
-                        uint32_t b = __USAT((int32_t) (COLOR_RGB565_TO_B5(p1) - COLOR_RGB565_TO_B5(p0)), 5);
+                        uint32_t r = __USAT(((int32_t) COLOR_RGB565_TO_R5(p1)) - ((int32_t) COLOR_RGB565_TO_R5(p0)), 5);
+                        uint32_t g = __USAT(((int32_t) COLOR_RGB565_TO_G6(p1)) - ((int32_t) COLOR_RGB565_TO_G6(p0)), 6);
+                        uint32_t b = __USAT(((int32_t) COLOR_RGB565_TO_B5(p1)) - ((int32_t) COLOR_RGB565_TO_B5(p0)), 5);
                         IMAGE_PUT_RGB565_PIXEL_FAST(row0, x, COLOR_R5_G6_B5_TO_RGB565(r, g, b));
                     }
                 }
@@ -342,20 +365,16 @@ void imlib_min_line_op(int x, int x_end, int y_row, imlib_draw_row_data_t *data)
             uint8_t *row1 = (uint8_t *) data->dst_row_override;
 
             if (!mask) {
-                #if defined(ARM_MATH_DSP)
-                for (; (x_end - x) >= 4; x += 4) {
-                    uint32_t p0 = *((uint32_t *) (row0 + x));
-                    uint32_t p1 = *((uint32_t *) (row1 + x));
-                    __USUB8(p0, p1);
-                    *((uint32_t *) (row0 + x)) = __SEL(p1, p0);
-                }
-                #endif
+                uint32_t n = x_end - x;
 
-                for (; x < x_end; x++) {
-                    uint32_t p0 = IMAGE_GET_GRAYSCALE_PIXEL_FAST(row0, x);
-                    uint32_t p1 = IMAGE_GET_GRAYSCALE_PIXEL_FAST(row1, x);
-                    uint32_t p = IM_MIN(p0, p1);
-                    IMAGE_PUT_GRAYSCALE_PIXEL_FAST(row0, x, p);
+                for (; n >= UINT8_VECTOR_SIZE; n -= UINT8_VECTOR_SIZE, x += UINT8_VECTOR_SIZE) {
+                    vstr_u8(row0 + x, vmin_u8(vldr_u8(row1 + x), vldr_u8(row0 + x)));
+                }
+
+                if (n) {
+                    v128_predicate_t pred = vpredicate_8(n);
+                    v2x_rows_t data = vldr_u8_pred_x2((v2x_row_ptrs_t) {.p0.u8 = row0, .p1.u8 = row1}, x, pred);
+                    vstr_u8_pred(row0 + x, vmin_u8(data.r1, data.r0), pred);
                 }
             } else {
                 for (; x < x_end; x++) {
@@ -374,27 +393,30 @@ void imlib_min_line_op(int x, int x_end, int y_row, imlib_draw_row_data_t *data)
             uint16_t *row1 = (uint16_t *) data->dst_row_override;
 
             if (!mask) {
-                #if defined(ARM_MATH_DSP)
-                for (; (x_end - x) >= 2; x += 2) {
-                    uint32_t p0 = *((uint32_t *) (row0 + x));
-                    uint32_t p1 = *((uint32_t *) (row1 + x));
-                    uint32_t p0_rb = p0 & 0xf81ff81f, p1_rb = p1 & 0xf81ff81f;
-                    __USUB8(p0_rb, p1_rb);
-                    uint32_t rb = __SEL(p1_rb, p0_rb);
-                    uint32_t p0_g = p0 & 0x07e007e0, p1_g = p1 & 0x07e007e0;
-                    __USUB16(p0_g, p1_g);
-                    uint32_t g = __SEL(p1_g, p0_g);
-                    *((uint32_t *) (row0 + x)) = rb | g;
-                }
-                #endif
+                uint32_t n = x_end - x;
 
-                for (; x < x_end; x++) {
-                    uint32_t p0 = IMAGE_GET_RGB565_PIXEL_FAST(row0, x);
-                    uint32_t p1 = IMAGE_GET_RGB565_PIXEL_FAST(row1, x);
-                    uint32_t r = IM_MIN(COLOR_RGB565_TO_R5(p0), COLOR_RGB565_TO_R5(p1));
-                    uint32_t g = IM_MIN(COLOR_RGB565_TO_G6(p0), COLOR_RGB565_TO_G6(p1));
-                    uint32_t b = IM_MIN(COLOR_RGB565_TO_B5(p0), COLOR_RGB565_TO_B5(p1));
-                    IMAGE_PUT_RGB565_PIXEL_FAST(row0, x, COLOR_R5_G6_B5_TO_RGB565(r, g, b));
+                for (; n >= UINT16_VECTOR_SIZE; n -= UINT16_VECTOR_SIZE, x += UINT16_VECTOR_SIZE) {
+                    v128_t p0 = vldr_u16(row0 + x);
+                    v128_t p1 = vldr_u16(row1 + x);
+                    v128_t r0_rb = vand_u32(p0, vdup_u16(0xf81f));
+                    v128_t r1_rb = vand_u32(p1, vdup_u16(0xf81f));
+                    v128_t r_rb = vmin_u8(r0_rb, r1_rb);
+                    v128_t r0_g = vand_u32(p0, vdup_u16(0x07e0));
+                    v128_t r1_g = vand_u32(p1, vdup_u16(0x07e0));
+                    v128_t r_g = vmin_u16(r0_g, r1_g);
+                    vstr_u16(row0 + x, vorr_u32(r_rb, r_g));
+                }
+
+                if (n) {
+                    v128_predicate_t pred = vpredicate_16(n);
+                    v2x_rows_t data = vldr_u16_pred_x2((v2x_row_ptrs_t) {.p0.u16 = row0, .p1.u16 = row1}, x, pred);
+                    v128_t r0_rb = vand_u32(data.r0, vdup_u16(0xf81f));
+                    v128_t r1_rb = vand_u32(data.r1, vdup_u16(0xf81f));
+                    v128_t r_rb = vmin_u8(r0_rb, r1_rb);
+                    v128_t r0_g = vand_u32(data.r0, vdup_u16(0x07e0));
+                    v128_t r1_g = vand_u32(data.r1, vdup_u16(0x07e0));
+                    v128_t r_g = vmin_u16(r0_g, r1_g);
+                    vstr_u16_pred(row0 + x, vorr_u32(r_rb, r_g), pred);
                 }
             } else {
                 for (; x < x_end; x++) {
@@ -429,20 +451,16 @@ void imlib_max_line_op(int x, int x_end, int y_row, imlib_draw_row_data_t *data)
             uint8_t *row1 = (uint8_t *) data->dst_row_override;
 
             if (!mask) {
-                #if defined(ARM_MATH_DSP)
-                for (; (x_end - x) >= 4; x += 4) {
-                    uint32_t p0 = *((uint32_t *) (row0 + x));
-                    uint32_t p1 = *((uint32_t *) (row1 + x));
-                    __USUB8(p0, p1);
-                    *((uint32_t *) (row0 + x)) = __SEL(p0, p1);
-                }
-                #endif
+                uint32_t n = x_end - x;
 
-                for (; x < x_end; x++) {
-                    uint32_t p0 = IMAGE_GET_GRAYSCALE_PIXEL_FAST(row0, x);
-                    uint32_t p1 = IMAGE_GET_GRAYSCALE_PIXEL_FAST(row1, x);
-                    uint32_t p = IM_MAX(p0, p1);
-                    IMAGE_PUT_GRAYSCALE_PIXEL_FAST(row0, x, p);
+                for (; n >= UINT8_VECTOR_SIZE; n -= UINT8_VECTOR_SIZE, x += UINT8_VECTOR_SIZE) {
+                    vstr_u8(row0 + x, vmax_u8(vldr_u8(row1 + x), vldr_u8(row0 + x)));
+                }
+
+                if (n) {
+                    v128_predicate_t pred = vpredicate_8(n);
+                    v2x_rows_t data = vldr_u8_pred_x2((v2x_row_ptrs_t) {.p0.u8 = row0, .p1.u8 = row1}, x, pred);
+                    vstr_u8_pred(row0 + x, vmax_u8(data.r1, data.r0), pred);
                 }
             } else {
                 for (; x < x_end; x++) {
@@ -461,27 +479,30 @@ void imlib_max_line_op(int x, int x_end, int y_row, imlib_draw_row_data_t *data)
             uint16_t *row1 = (uint16_t *) data->dst_row_override;
 
             if (!mask) {
-                #if defined(ARM_MATH_DSP)
-                for (; (x_end - x) >= 2; x += 2) {
-                    uint32_t p0 = *((uint32_t *) (row0 + x));
-                    uint32_t p1 = *((uint32_t *) (row1 + x));
-                    uint32_t p0_rb = p0 & 0xf81ff81f, p1_rb = p1 & 0xf81ff81f;
-                    __USUB8(p0_rb, p1_rb);
-                    uint32_t rb = __SEL(p0_rb, p1_rb);
-                    uint32_t p0_g = p0 & 0x07e007e0, p1_g = p1 & 0x07e007e0;
-                    __USUB16(p0_g, p1_g);
-                    uint32_t g = __SEL(p0_g, p1_g);
-                    *((uint32_t *) (row0 + x)) = rb | g;
-                }
-                #endif
+                uint32_t n = x_end - x;
 
-                for (; x < x_end; x++) {
-                    uint32_t p0 = IMAGE_GET_RGB565_PIXEL_FAST(row0, x);
-                    uint32_t p1 = IMAGE_GET_RGB565_PIXEL_FAST(row1, x);
-                    uint32_t r = IM_MAX(COLOR_RGB565_TO_R5(p0), COLOR_RGB565_TO_R5(p1));
-                    uint32_t g = IM_MAX(COLOR_RGB565_TO_G6(p0), COLOR_RGB565_TO_G6(p1));
-                    uint32_t b = IM_MAX(COLOR_RGB565_TO_B5(p0), COLOR_RGB565_TO_B5(p1));
-                    IMAGE_PUT_RGB565_PIXEL_FAST(row0, x, COLOR_R5_G6_B5_TO_RGB565(r, g, b));
+                for (; n >= UINT16_VECTOR_SIZE; n -= UINT16_VECTOR_SIZE, x += UINT16_VECTOR_SIZE) {
+                    v128_t p0 = vldr_u16(row0 + x);
+                    v128_t p1 = vldr_u16(row1 + x);
+                    v128_t r0_rb = vand_u32(p0, vdup_u16(0xf81f));
+                    v128_t r1_rb = vand_u32(p1, vdup_u16(0xf81f));
+                    v128_t r_rb = vmax_u8(r0_rb, r1_rb);
+                    v128_t r0_g = vand_u32(p0, vdup_u16(0x07e0));
+                    v128_t r1_g = vand_u32(p1, vdup_u16(0x07e0));
+                    v128_t r_g = vmax_u16(r0_g, r1_g);
+                    vstr_u16(row0 + x, vorr_u32(r_rb, r_g));
+                }
+
+                if (n) {
+                    v128_predicate_t pred = vpredicate_16(n);
+                    v2x_rows_t data = vldr_u16_pred_x2((v2x_row_ptrs_t) {.p0.u16 = row0, .p1.u16 = row1}, x, pred);
+                    v128_t r0_rb = vand_u32(data.r0, vdup_u16(0xf81f));
+                    v128_t r1_rb = vand_u32(data.r1, vdup_u16(0xf81f));
+                    v128_t r_rb = vmax_u8(r0_rb, r1_rb);
+                    v128_t r0_g = vand_u32(data.r0, vdup_u16(0x07e0));
+                    v128_t r1_g = vand_u32(data.r1, vdup_u16(0x07e0));
+                    v128_t r_g = vmax_u16(r0_g, r1_g);
+                    vstr_u16_pred(row0 + x, vorr_u32(r_rb, r_g), pred);
                 }
             } else {
                 for (; x < x_end; x++) {
@@ -516,28 +537,23 @@ void imlib_difference_line_op(int x, int x_end, int y_row, imlib_draw_row_data_t
             uint8_t *row1 = (uint8_t *) data->dst_row_override;
 
             if (!mask) {
-                #if defined(ARM_MATH_DSP)
-                for (; (x_end - x) >= 4; x += 4) {
-                    uint32_t p0 = *((uint32_t *) (row0 + x));
-                    uint32_t p1 = *((uint32_t *) (row1 + x));
-                    uint32_t sub0 = __USUB8(p0, p1);
-                    uint32_t sub1 = __USUB8(p1, p0);
-                    *((uint32_t *) (row0 + x)) = __SEL(sub1, sub0);
-                }
-                #endif
+                uint32_t n = x_end - x;
 
-                for (; x < x_end; x++) {
-                    uint32_t p0 = IMAGE_GET_GRAYSCALE_PIXEL_FAST(row0, x);
-                    uint32_t p1 = IMAGE_GET_GRAYSCALE_PIXEL_FAST(row1, x);
-                    uint32_t p = __USAD8(p0, p1);
-                    IMAGE_PUT_GRAYSCALE_PIXEL_FAST(row0, x, p);
+                for (; n >= UINT8_VECTOR_SIZE; n -= UINT8_VECTOR_SIZE, x += UINT8_VECTOR_SIZE) {
+                    vstr_u8(row0 + x, vabd_u8(vldr_u8(row1 + x), vldr_u8(row0 + x)));
+                }
+
+                if (n) {
+                    v128_predicate_t pred = vpredicate_8(n);
+                    v2x_rows_t data = vldr_u8_pred_x2((v2x_row_ptrs_t) {.p0.u8 = row0, .p1.u8 = row1}, x, pred);
+                    vstr_u8_pred(row0 + x, vabd_u8(data.r1, data.r0), pred);
                 }
             } else {
                 for (; x < x_end; x++) {
                     if (image_get_mask_pixel(mask, x, y_row)) {
                         uint32_t p0 = IMAGE_GET_GRAYSCALE_PIXEL_FAST(row0, x);
                         uint32_t p1 = IMAGE_GET_GRAYSCALE_PIXEL_FAST(row1, x);
-                        uint32_t p = __USAD8(p0, p1);
+                        uint32_t p = abs(((int32_t) p0) - ((int32_t) p1));
                         IMAGE_PUT_GRAYSCALE_PIXEL_FAST(row0, x, p);
                     }
                 }
@@ -549,38 +565,39 @@ void imlib_difference_line_op(int x, int x_end, int y_row, imlib_draw_row_data_t
             uint16_t *row1 = (uint16_t *) data->dst_row_override;
 
             if (!mask) {
-                #if defined(ARM_MATH_DSP)
-                for (; (x_end - x) >= 2; x += 2) {
-                    uint32_t p0 = *((uint32_t *) (row0 + x));
-                    uint32_t p1 = *((uint32_t *) (row1 + x));
-                    uint32_t p0_rb = p0 & 0xf81ff81f, p1_rb = p1 & 0xf81ff81f;
-                    uint32_t sub0 = __USUB8(p0_rb, p1_rb);
-                    uint32_t sub1 = __USUB8(p1_rb, p0_rb);
-                    uint32_t rb = __SEL(sub1, sub0);
-                    uint32_t p0_g = p0 & 0x07e007e0, p1_g = p1 & 0x07e007e0;
-                    sub0 = __USUB16(p0_g, p1_g);
-                    sub1 = __USUB16(p1_g, p0_g);
-                    uint32_t g = __SEL(sub1, sub0);
-                    *((uint32_t *) (row0 + x)) = rb | g;
-                }
-                #endif
+                uint32_t n = x_end - x;
 
-                for (; x < x_end; x++) {
-                    uint32_t p0 = IMAGE_GET_RGB565_PIXEL_FAST(row0, x);
-                    uint32_t p1 = IMAGE_GET_RGB565_PIXEL_FAST(row1, x);
-                    uint32_t r = __USAD8(COLOR_RGB565_TO_R5(p0), COLOR_RGB565_TO_R5(p1));
-                    uint32_t g = __USAD8(COLOR_RGB565_TO_G6(p0), COLOR_RGB565_TO_G6(p1));
-                    uint32_t b = __USAD8(COLOR_RGB565_TO_B5(p0), COLOR_RGB565_TO_B5(p1));
-                    IMAGE_PUT_RGB565_PIXEL_FAST(row0, x, COLOR_R5_G6_B5_TO_RGB565(r, g, b));
+                for (; n >= UINT16_VECTOR_SIZE; n -= UINT16_VECTOR_SIZE, x += UINT16_VECTOR_SIZE) {
+                    v128_t p0 = vldr_u16(row0 + x);
+                    v128_t p1 = vldr_u16(row1 + x);
+                    v128_t r0_rb = vand_u32(p0, vdup_u16(0xf81f));
+                    v128_t r1_rb = vand_u32(p1, vdup_u16(0xf81f));
+                    v128_t r_rb = vabd_u8(r0_rb, r1_rb);
+                    v128_t r0_g = vand_u32(p0, vdup_u16(0x07e0));
+                    v128_t r1_g = vand_u32(p1, vdup_u16(0x07e0));
+                    v128_t r_g = vabd_u16(r0_g, r1_g);
+                    vstr_u16(row0 + x, vorr_u32(r_rb, r_g));
+                }
+
+                if (n) {
+                    v128_predicate_t pred = vpredicate_16(n);
+                    v2x_rows_t data = vldr_u16_pred_x2((v2x_row_ptrs_t) {.p0.u16 = row0, .p1.u16 = row1}, x, pred);
+                    v128_t r0_rb = vand_u32(data.r0, vdup_u16(0xf81f));
+                    v128_t r1_rb = vand_u32(data.r1, vdup_u16(0xf81f));
+                    v128_t r_rb = vabd_u8(r0_rb, r1_rb);
+                    v128_t r0_g = vand_u32(data.r0, vdup_u16(0x07e0));
+                    v128_t r1_g = vand_u32(data.r1, vdup_u16(0x07e0));
+                    v128_t r_g = vabd_u16(r0_g, r1_g);
+                    vstr_u16_pred(row0 + x, vorr_u32(r_rb, r_g), pred);
                 }
             } else {
                 for (; x < x_end; x++) {
                     if (image_get_mask_pixel(mask, x, y_row)) {
                         uint32_t p0 = IMAGE_GET_RGB565_PIXEL_FAST(row0, x);
                         uint32_t p1 = IMAGE_GET_RGB565_PIXEL_FAST(row1, x);
-                        uint32_t r = __USAD8(COLOR_RGB565_TO_R5(p0), COLOR_RGB565_TO_R5(p1));
-                        uint32_t g = __USAD8(COLOR_RGB565_TO_G6(p0), COLOR_RGB565_TO_G6(p1));
-                        uint32_t b = __USAD8(COLOR_RGB565_TO_B5(p0), COLOR_RGB565_TO_B5(p1));
+                        uint32_t r = abs(((int32_t) COLOR_RGB565_TO_R5(p0)) - ((int32_t) COLOR_RGB565_TO_R5(p1)));
+                        uint32_t g = abs(((int32_t) COLOR_RGB565_TO_G6(p0)) - ((int32_t) COLOR_RGB565_TO_G6(p1)));
+                        uint32_t b = abs(((int32_t) COLOR_RGB565_TO_B5(p0)) - ((int32_t) COLOR_RGB565_TO_B5(p1)));
                         IMAGE_PUT_RGB565_PIXEL_FAST(row0, x, COLOR_R5_G6_B5_TO_RGB565(r, g, b));
                     }
                 }

--- a/src/omv/imlib/simd.h
+++ b/src/omv/imlib/simd.h
@@ -31,6 +31,20 @@
 #define UINT64_VECTOR_SIZE  (VECTOR_SIZE_BYTES / 8U)
 #endif
 
+#define INT8_VECTOR_BITS    (INT8_VECTOR_SIZE * 8U)
+#define UINT8_VECTOR_BITS   (UINT8_VECTOR_SIZE * 8U)
+
+#define INT16_VECTOR_BITS   (INT16_VECTOR_SIZE * 16U)
+#define UINT16_VECTOR_BITS  (UINT16_VECTOR_SIZE * 16U)
+
+#define INT32_VECTOR_BITS   (INT32_VECTOR_SIZE * 32U)
+#define UINT32_VECTOR_BITS  (UINT32_VECTOR_SIZE * 32U)
+
+#if (VECTOR_SIZE_BYTES >= 8)
+#define INT64_VECTOR_BITS   (INT64_VECTOR_SIZE * 64U)
+#define UINT64_VECTOR_BITS  (UINT64_VECTOR_SIZE * 64U)
+#endif
+
 #if (__ARM_ARCH >= 8)
 typedef int8x16_t  v128_s8_t;
 typedef uint8x16_t v128_u8_t;
@@ -129,7 +143,26 @@ static inline v128_predicate_t vpredicate_8(uint32_t n) {
     #if (__ARM_ARCH >= 8)
     return vctp8q(n);
     #else
-    return IM_MIN(n, UINT8_VECTOR_SIZE);
+    return (n < UINT8_VECTOR_SIZE) ? n : UINT8_VECTOR_SIZE;
+    #endif
+}
+
+// Use this for code that has a scalar fallback path to automatically remove predication
+// on architectures with small vector sizes where it can hurt performance...
+static inline uint32_t vpredicate_8_maybe(uint32_t n) {
+    #if (VECTOR_SIZE_BYTES > 4)
+    return vpredicate_8(n);
+    #else
+    (void) n;
+    return 4;
+    #endif
+}
+
+static inline uint32_t vpredicate_8_maybe_min_elements() {
+    #if (VECTOR_SIZE_BYTES > 4)
+    return 1;
+    #else
+    return 4;
     #endif
 }
 
@@ -137,7 +170,26 @@ static inline v128_predicate_t vpredicate_16(uint32_t n) {
     #if (__ARM_ARCH >= 8)
     return vctp16q(n);
     #else
-    return IM_MIN(n, UINT16_VECTOR_SIZE);
+    return (n < UINT16_VECTOR_SIZE) ? n : UINT16_VECTOR_SIZE;
+    #endif
+}
+
+// Use this for code that has a scalar fallback path to automatically remove predication
+// on architectures with small vector sizes where it can hurt performance...
+static inline uint32_t vpredicate_16_maybe(uint32_t n) {
+    #if (VECTOR_SIZE_BYTES > 4)
+    return vpredicate_16(n);
+    #else
+    (void) n;
+    return 2;
+    #endif
+}
+
+static inline uint32_t vpredicate_16_maybe_min_elements() {
+    #if (VECTOR_SIZE_BYTES > 4)
+    return 1;
+    #else
+    return 2;
     #endif
 }
 
@@ -145,8 +197,23 @@ static inline v128_predicate_t vpredicate_32(uint32_t n) {
     #if (__ARM_ARCH >= 8)
     return vctp32q(n);
     #else
-    return IM_MIN(n, UINT32_VECTOR_SIZE);
+    return (n < UINT32_VECTOR_SIZE) ? n : UINT32_VECTOR_SIZE;
     #endif
+}
+
+// Use this for code that has a scalar fallback path to automatically remove predication
+// on architectures with small vector sizes where it can hurt performance...
+static inline uint32_t vpredicate_32_maybe(uint32_t n) {
+    #if (VECTOR_SIZE_BYTES > 4)
+    return vpredicate_32(n);
+    #else
+    (void) n;
+    return 1;
+    #endif
+}
+
+static inline uint32_t vpredicate_32_maybe_min_elements() {
+    return 1;
 }
 
 #if (VECTOR_SIZE_BYTES >= 8)
@@ -154,7 +221,7 @@ static inline v128_predicate_t vpredicate_64(uint32_t n) {
     #if (__ARM_ARCH >= 8)
     return vctp64q(n);
     #else
-    return IM_MIN(n, UINT64_VECTOR_SIZE);
+    return (n < UINT64_VECTOR_SIZE) ? n : UINT64_VECTOR_SIZE;
     #endif
 }
 #endif
@@ -408,28 +475,28 @@ static inline v128_t vsxtb16_ror8(v128_t v0) {
 static inline v128_t vuxtb32(v128_t v0) {
     #if (__ARM_ARCH >= 8)
     return (v128_t) vmovlbq(v0.u16);
-    // #elif (__ARM_ARCH >= 7)
-    // return (v128_t) {
-    //     .u32 = { __UXTH(v0.u32[0]) }
-    // };
+    #elif (__ARM_ARCH >= 7)
+    return (v128_t) {
+        .u32 = { __UXTH(v0.u32[0]) }
+    };
     #else
-    v128_t r;
-    r.u32[0] = v0.u16[0];
-    return r;
+    return (v128_t) {
+        .u32 = { v0.u16[0] }
+    };
     #endif
 }
 
 static inline v128_t vsxtb32(v128_t v0) {
     #if (__ARM_ARCH >= 8)
     return (v128_t) vmovlbq(v0.s16);
-    // #elif (__ARM_ARCH >= 7)
-    // return (v128_t) {
-    //     .u32 = { __SXTH(v0.u32[0]) }
-    // };
+    #elif (__ARM_ARCH >= 7)
+    return (v128_t) {
+        .u32 = { __SXTH(v0.u32[0]) }
+    };
     #else
-    v128_t r;
-    r.s32[0] = v0.s16[0];
-    return r;
+    return (v128_t) {
+        .s32 = { v0.s16[0] }
+    };
     #endif
 }
 
@@ -493,38 +560,6 @@ static inline v128_t vpkhtb_ror8(v128_t v0, v128_t v1) {
     #endif
 }
 
-static inline v128_t vmov_u16_narrow_u8_lo(v128_t v0, v128_t v1) {
-    #if (__ARM_ARCH >= 8)
-    return (v128_t) vmovnbq(v0.u8, v1.u16);
-    #elif (__ARM_ARCH >= 7)
-    uint32_t t0 = v1.u32[0];
-    uint32_t t1 = __USUB8(0xFF00FF00, 0x00FF00FF); (void) t1;
-    return (v128_t) {
-        .u32 = { __SEL(v0.u32[0], t0) }
-    };
-    #else
-    return (v128_t) {
-        .u32 = { (v0.u32[0] & 0xFF00FF00) | (v1.u32[0] & 0x00FF00FF) }
-    };
-    #endif
-}
-
-static inline v128_t vmov_u16_narrow_u8_hi(v128_t v0, v128_t v1) {
-    #if (__ARM_ARCH >= 8)
-    return (v128_t) vmovntq(v0.u8, v1.u16);
-    #elif (__ARM_ARCH >= 7)
-    uint32_t t0 = v1.u32[0] << 8;
-    uint32_t t1 = __USUB8(0x00FF00FF, 0xFF00FF00); (void) t1;
-    return (v128_t) {
-        .u32 = { __SEL(v0.u32[0], t0) }
-    };
-    #else
-    return (v128_t) {
-        .u32 = { (v0.u32[0] & 0x00FF00FF) | ((v1.u32[0] << 8) & 0xFF00FF00) }
-    };
-    #endif
-}
-
 #if (__ARM_ARCH >= 8)
 #define vusat_s16_narrow_u8_lo(v0, v1, shift) ((v128_t) vqshrunbq_n_s16(v0.u8, v1.s16, shift))
 #else
@@ -560,6 +595,90 @@ static inline v128_t vusat_s16_narrow_u8_hi(v128_t v0, v128_t v1, uint32_t shift
     #endif
 }
 #endif
+
+// There's a software implementation of __USAT in the ARM CMSIS extension if needed
+#define usat_s16(x, bits) __USAT(x, bits)
+
+// There's a software implementation of __SSAT in the ARM CMSIS extension if needed
+#define ssat_s16(x, bits) __SSAT(x, bits)
+
+#if (__ARM_ARCH >= 8)
+#define vusat_s16_narrow_u8(v0, bits) \
+    ((v128_t) vshrq_n_u16(vqshluq_n_s16(v0.s16, 16 - bits), 16 - bits))
+#else
+static inline v128_t vusat_s16_narrow_u8(v128_t v0, uint32_t bits) {
+    // There's a software implementation of __USAT16 in the ARM CMSIS extension if needed
+    return (v128_t) {
+        .u32 = { __USAT16(v0.u32[0], bits) }
+    };
+}
+#endif
+
+#if (__ARM_ARCH >= 8)
+#define vusat_s16_narrow_u8_combine(v0, v1) \
+    ((v128_t) vqmovuntq_s16(vqmovunbq_s16(vuninitializedq_s16(), v0.s16), v1.s16))
+#else
+static inline v128_t vusat_s16_narrow_u8_combine(v128_t v0, v128_t v1) {
+    // There's a software implementation of __USAT16 in the ARM CMSIS extension if needed
+    return (v128_t) {
+        .u32 = { __USAT16(v0.u32[0], 8) | (__USAT16(v1.u32[0], 8) << 8) }
+    };
+}
+#endif
+
+#if (__ARM_ARCH >= 8)
+#define vmov_clean_u16_narrow_u8_combine(v0, v1) ((v128_t) vmovntq(v0.u8, v1.u16))
+#else
+static inline v128_t vmov_clean_u16_narrow_u8_combine(v128_t v0, v128_t v1) {
+    return (v128_t) {
+        .u32 = { v0.u32[0] | (v1.u32[0] << 8) }
+    };
+}
+#endif
+
+#if (__ARM_ARCH >= 8)
+#define vmov_dirty_u16_narrow_u8_combine(v0, v1) ((v128_t) vmovntq(v0.u8, v1.u16))
+#else
+static inline v128_t vmov_dirty_u16_narrow_u8_combine(v128_t v0, v128_t v1) {
+    return (v128_t) {
+        .u32 = { (v0.u32[0] & 0x00FF00FF) | ((v1.u32[0] & 0x00FF00FF) << 8) }
+    };
+}
+#endif
+
+static inline v128_t vcmpgesel_u8(v128_t v0, v128_t v1, v128_t v2, v128_t v3) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vpselq(v2.u8, v3.u8, vcmpcsq(v0.u8, v1.u8));
+    #elif (__ARM_ARCH >= 7)
+    uint32_t t = __USUB8(v0.u32[0], v1.u32[0]); (void) t;
+    return (v128_t) {
+        .u32 = { __SEL(v2.u32[0], v3.u32[0]) }
+    };
+    #else
+    v128_t r;
+    r.u8[0] = (v0.u8[0] >= v1.u8[0]) ? v2.u8[0] : v3.u8[0];
+    r.u8[1] = (v0.u8[1] >= v1.u8[1]) ? v2.u8[1] : v3.u8[1];
+    r.u8[2] = (v0.u8[2] >= v1.u8[2]) ? v2.u8[2] : v3.u8[2];
+    r.u8[3] = (v0.u8[3] >= v1.u8[3]) ? v2.u8[3] : v3.u8[3];
+    return r;
+    #endif
+}
+
+static inline v128_t vcmpgesel_u16(v128_t v0, v128_t v1, v128_t v2, v128_t v3) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vpselq(v2.u16, v3.u16, vcmpcsq(v0.u16, v1.u16));
+    #elif (__ARM_ARCH >= 7)
+    uint32_t t = __USUB16(v0.u32[0], v1.u32[0]); (void) t;
+    return (v128_t) {
+        .u32 = { __SEL(v2.u32[0], v3.u32[0]) }
+    };
+    #else
+    v128_t r;
+    r.u16[0] = (v0.u16[0] >= v1.u16[0]) ? v2.u16[0] : v3.u16[0];
+    r.u16[1] = (v0.u16[1] >= v1.u16[1]) ? v2.u16[1] : v3.u16[1];
+    return r;
+    #endif
+}
 
 #if (__ARM_ARCH >= 8)
 #define vget_u8(v0, n) vgetq_lane_u8(v0.u8, n)
@@ -705,7 +824,7 @@ static inline v128_t vset_s64(v128_t v0, uint32_t n, int64_t x) {
 #if (__ARM_ARCH >= 8)
 #define vdup_u8(x) ((v128_t) vdupq_n_u8(x))
 #else
-static inline v128_t vdup_u8(uint8_t x) {
+static inline v128_t vdup_u8(uint32_t x) {
     return (v128_t) {
         .u32 = { x * 0x01010101 }
     };
@@ -716,7 +835,7 @@ static inline v128_t vdup_u8(uint8_t x) {
 #if (__ARM_ARCH >= 8)
 #define vdup_s8(x) ((v128_t) vdupq_n_s8(x))
 #else
-static inline v128_t vdup_s8(int8_t x) {
+static inline v128_t vdup_s8(int32_t x) {
     return (v128_t) {
         .s32 = { (x & 0xFF) * 0x01010101 }
     };
@@ -727,7 +846,7 @@ static inline v128_t vdup_s8(int8_t x) {
 #if (__ARM_ARCH >= 8)
 #define vdup_u16(x) ((v128_t) vdupq_n_u16(x))
 #else
-static inline v128_t vdup_u16(uint16_t x) {
+static inline v128_t vdup_u16(uint32_t x) {
     return (v128_t) {
         .u32 = { x * 0x00010001 }
     };
@@ -738,10 +857,16 @@ static inline v128_t vdup_u16(uint16_t x) {
 #if (__ARM_ARCH >= 8)
 #define vdup_s16(x) ((v128_t) vdupq_n_s16(x))
 #else
-static inline v128_t vdup_s16(int16_t x) {
+static inline v128_t vdup_s16(int32_t x) {
+    #if (__ARM_ARCH >= 7)
+    return (v128_t) {
+        .s32 = { __PKHBT(x, x, 16) }
+    };
+    #else
     return (v128_t) {
         .s32 = { (x & 0xFFFF) * 0x00010001 }
     };
+    #endif
 }
 #endif
 
@@ -827,9 +952,154 @@ static inline v128_t vshlc(v128_t v0, uint32_t *reg, uint32_t n) {
 }
 #endif
 
+#if (__ARM_ARCH >= 8)
+#define vshlc0(v0, n) ({                    \
+        uint32_t reg = 0;                   \
+        ((v128_t) vshlcq(v0.u32, &reg, n)); \
+    })
+#else
+static inline v128_t vshlc0(v128_t v0, uint32_t n) {
+    return (v128_t) {
+        .u32 = { v0.u32[0] << n }
+    };
+}
+#endif
+
+static inline v128_t vadd_u8(v128_t v0, v128_t v1) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vaddq_u8(v0.u8, v1.u8);
+    #elif (__ARM_ARCH >= 7)
+    return (v128_t) {
+        .u32 = { __UADD8(v0.u32[0], v1.u32[0]) }
+    };
+    #else
+    return (v128_t) {
+        .u8 = v0.u8 + v1.u8
+    };
+    #endif
+}
+
+static inline v128_t vadd_s8(v128_t v0, v128_t v1) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vaddq_s8(v0.s8, v1.s8);
+    #elif (__ARM_ARCH >= 7)
+    return (v128_t) {
+        .u32 = { __SADD8(v0.u32[0], v1.u32[0]) }
+    };
+    #else
+    return (v128_t) {
+        .s8 = v0.s8 + v1.s8
+    };
+    #endif
+}
+
+static inline v128_t vqadd_u8(v128_t v0, v128_t v1) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vqaddq_u8(v0.u8, v1.u8);
+    #elif (__ARM_ARCH >= 7)
+    return (v128_t) {
+        .u32 = { __UQADD8(v0.u32[0], v1.u32[0]) }
+    };
+    #else
+    v128_t r;
+    int32_t u80 = v0.u8[0] + v1.u8[0];
+    r.u8[0] = (u80 > 255) ? 255 : u80;
+    int32_t u81 = v0.u8[1] + v1.u8[1];
+    r.u8[1] = (u81 > 255) ? 255 : u81;
+    int32_t u82 = v0.u8[2] + v1.u8[2];
+    r.u8[2] = (u82 > 255) ? 255 : u82;
+    int32_t u83 = v0.u8[3] + v1.u8[3];
+    r.u8[3] = (u83 > 255) ? 255 : u83;
+    return r;
+    #endif
+}
+
+static inline v128_t vqadd_s8(v128_t v0, v128_t v1) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vqaddq_s8(v0.s8, v1.s8);
+    #elif (__ARM_ARCH >= 7)
+    return (v128_t) {
+        .u32 = { __QADD8(v0.u32[0], v1.u32[0]) }
+    };
+    #else
+    v128_t r;
+    int32_t s80 = v0.s8[0] + v1.s8[0];
+    r.s8[0] = (s80 > 127) ? 127 : ((s80 < -128) ? -128 : s80);
+    int32_t s81 = v0.s8[1] + v1.s8[1];
+    r.s8[1] = (s81 > 127) ? 127 : ((s81 < -128) ? -128 : s81);
+    int32_t s82 = v0.s8[2] + v1.s8[2];
+    r.s8[2] = (s82 > 127) ? 127 : ((s82 < -128) ? -128 : s82);
+    int32_t s83 = v0.s8[3] + v1.s8[3];
+    r.s8[3] = (s83 > 127) ? 127 : ((s83 < -128) ? -128 : s83);
+    return r;
+    #endif
+}
+
+static inline v128_t vadd_u16(v128_t v0, v128_t v1) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vaddq_u16(v0.u16, v1.u16);
+    #elif (__ARM_ARCH >= 7)
+    return (v128_t) {
+        .u32 = { __UADD16(v0.u32[0], v1.u32[0]) }
+    };
+    #else
+    return (v128_t) {
+        .u16 = v0.u16 + v1.u16
+    };
+    #endif
+}
+
+static inline v128_t vadd_s16(v128_t v0, v128_t v1) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vaddq_s16(v0.s16, v1.s16);
+    #elif (__ARM_ARCH >= 7)
+    return (v128_t) {
+        .u32 = { __SADD16(v0.u32[0], v1.u32[0]) }
+    };
+    #else
+    return (v128_t) {
+        .s16 = v0.s16 + v1.s16
+    };
+    #endif
+}
+
+static inline v128_t vqadd_u16(v128_t v0, v128_t v1) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vqaddq_u16(v0.u16, v1.u16);
+    #elif (__ARM_ARCH >= 7)
+    return (v128_t) {
+        .u32 = { __UQADD16(v0.u32[0], v1.u32[0]) }
+    };
+    #else
+    v128_t r;
+    int32_t u160 = v0.u16[0] + v1.u16[0];
+    r.u16[0] = (u160 > 65535) ? 65535 : u160;
+    int32_t u161 = v0.u16[1] + v1.u16[1];
+    r.u16[1] = (u161 > 65535) ? 65535 : u161;
+    return r;
+    #endif
+}
+
+static inline v128_t vqadd_s16(v128_t v0, v128_t v1) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vqaddq_s16(v0.s16, v1.s16);
+    #elif (__ARM_ARCH >= 7)
+    return (v128_t) {
+        .u32 = { __QADD16(v0.u32[0], v1.u32[0]) }
+    };
+    #else
+    v128_t r;
+    int32_t s160 = v0.s16[0] + v1.s16[0];
+    r.s16[0] = (s160 > 32767) ? 32767 : ((s160 < -32768) ? -32768 : s160);
+    int32_t s161 = v0.s16[1] + v1.s16[1];
+    r.s16[1] = (s161 > 32767) ? 32767 : ((s161 < -32768) ? -32768 : s161);
+    return r;
+    #endif
+}
+
 static inline v128_t vadd_u32(v128_t v0, v128_t v1) {
     #if (__ARM_ARCH >= 8)
-    return (v128_t) vaddq(v0.u32, v1.u32);
+    return (v128_t) vaddq_u32(v0.u32, v1.u32);
     #else
     return (v128_t) {
         .u32 = v0.u32 + v1.u32
@@ -839,7 +1109,7 @@ static inline v128_t vadd_u32(v128_t v0, v128_t v1) {
 
 static inline v128_t vadd_s32(v128_t v0, v128_t v1) {
     #if (__ARM_ARCH >= 8)
-    return (v128_t) vaddq(v0.s32, v1.s32);
+    return (v128_t) vaddq_s32(v0.s32, v1.s32);
     #else
     return (v128_t) {
         .s32 = v0.s32 + v1.s32
@@ -849,7 +1119,7 @@ static inline v128_t vadd_s32(v128_t v0, v128_t v1) {
 
 static inline v128_t vsub_u8(v128_t v0, v128_t v1) {
     #if (__ARM_ARCH >= 8)
-    return (v128_t) vsubq(v0.u8, v1.u8);
+    return (v128_t) vsubq_u8(v0.u8, v1.u8);
     #elif (__ARM_ARCH >= 7)
     return (v128_t) {
         .u32 = { __USUB8(v0.u32[0], v1.u32[0]) }
@@ -863,7 +1133,7 @@ static inline v128_t vsub_u8(v128_t v0, v128_t v1) {
 
 static inline v128_t vsub_s8(v128_t v0, v128_t v1) {
     #if (__ARM_ARCH >= 8)
-    return (v128_t) vsubq(v0.s8, v1.s8);
+    return (v128_t) vsubq_s8(v0.s8, v1.s8);
     #elif (__ARM_ARCH >= 7)
     return (v128_t) {
         .u32 = { __SSUB8(v0.u32[0], v1.u32[0]) }
@@ -875,9 +1145,51 @@ static inline v128_t vsub_s8(v128_t v0, v128_t v1) {
     #endif
 }
 
+static inline v128_t vqsub_u8(v128_t v0, v128_t v1) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vqsubq_u8(v0.u8, v1.u8);
+    #elif (__ARM_ARCH >= 7)
+    return (v128_t) {
+        .u32 = { __UQSUB8(v0.u32[0], v1.u32[0]) }
+    };
+    #else
+    v128_t r;
+    int32_t u80 = v0.u8[0] - v1.u8[0];
+    r.u8[0] = (u80 < 0) ? 0 : u80;
+    int32_t u81 = v0.u8[1] - v1.u8[1];
+    r.u8[1] = (u81 < 0) ? 0 : u81;
+    int32_t u82 = v0.u8[2] - v1.u8[2];
+    r.u8[2] = (u82 < 0) ? 0 : u82;
+    int32_t u83 = v0.u8[3] - v1.u8[3];
+    r.u8[3] = (u83 < 0) ? 0 : u83;
+    return r;
+    #endif
+}
+
+static inline v128_t vqsub_s8(v128_t v0, v128_t v1) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vqsubq_s8(v0.s8, v1.s8);
+    #elif (__ARM_ARCH >= 7)
+    return (v128_t) {
+        .u32 = { __QSUB8(v0.u32[0], v1.u32[0]) }
+    };
+    #else
+    v128_t r;
+    int32_t s80 = v0.s8[0] - v1.s8[0];
+    r.s8[0] = (s80 > 127) ? 127 : ((s80 < -128) ? -128 : s80);
+    int32_t s81 = v0.s8[1] - v1.s8[1];
+    r.s8[1] = (s81 > 127) ? 127 : ((s81 < -128) ? -128 : s81);
+    int32_t s82 = v0.s8[2] - v1.s8[2];
+    r.s8[2] = (s82 > 127) ? 127 : ((s82 < -128) ? -128 : s82);
+    int32_t s83 = v0.s8[3] - v1.s8[3];
+    r.s8[3] = (s83 > 127) ? 127 : ((s83 < -128) ? -128 : s83);
+    return r;
+    #endif
+}
+
 static inline v128_t vsub_u16(v128_t v0, v128_t v1) {
     #if (__ARM_ARCH >= 8)
-    return (v128_t) vsubq(v0.u16, v1.u16);
+    return (v128_t) vsubq_u16(v0.u16, v1.u16);
     #elif (__ARM_ARCH >= 7)
     return (v128_t) {
         .u32 = { __USUB16(v0.u32[0], v1.u32[0]) }
@@ -891,7 +1203,7 @@ static inline v128_t vsub_u16(v128_t v0, v128_t v1) {
 
 static inline v128_t vsub_s16(v128_t v0, v128_t v1) {
     #if (__ARM_ARCH >= 8)
-    return (v128_t) vsubq(v0.s16, v1.s16);
+    return (v128_t) vsubq_s16(v0.s16, v1.s16);
     #elif (__ARM_ARCH >= 7)
     return (v128_t) {
         .u32 = { __SSUB16(v0.u32[0], v1.u32[0]) }
@@ -900,6 +1212,248 @@ static inline v128_t vsub_s16(v128_t v0, v128_t v1) {
     return (v128_t) {
         .s16 = v0.s16 - v1.s16
     };
+    #endif
+}
+
+static inline v128_t vqsub_u16(v128_t v0, v128_t v1) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vqsubq_u16(v0.u16, v1.u16);
+    #elif (__ARM_ARCH >= 7)
+    return (v128_t) {
+        .u32 = { __UQSUB16(v0.u32[0], v1.u32[0]) }
+    };
+    #else
+    v128_t r;
+    int32_t u160 = v0.u16[0] - v1.u16[0];
+    r.u16[0] = (u160 < 0) ? 0 : u160;
+    int32_t u161 = v0.u16[1] - v1.u16[1];
+    r.u16[1] = (u161 < 0) ? 0 : u161;
+    return r;
+    #endif
+}
+
+static inline v128_t vqsub_s16(v128_t v0, v128_t v1) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vqsubq_s16(v0.s16, v1.s16);
+    #elif (__ARM_ARCH >= 7)
+    return (v128_t) {
+        .u32 = { __QSUB16(v0.u32[0], v1.u32[0]) }
+    };
+    #else
+    v128_t r;
+    int32_t s160 = v0.s16[0] - v1.s16[0];
+    r.s16[0] = (s160 > 32767) ? 32767 : ((s160 < -32768) ? -32768 : s160);
+    int32_t s161 = v0.s16[1] - v1.s16[1];
+    r.s16[1] = (s161 > 32767) ? 32767 : ((s161 < -32768) ? -32768 : s161);
+    return r;
+    #endif
+}
+
+static inline v128_t vmin_u8(v128_t v0, v128_t v1) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vminq_u8(v0.u8, v1.u8);
+    #elif (__ARM_ARCH >= 7)
+    uint32_t t = __USUB8(v0.u32[0], v1.u32[0]); (void) t;
+    return (v128_t) {
+        .u32 = { __SEL(v1.u32[0], v0.u32[0]) }
+    };
+    #else
+    v128_t r;
+    r.u8[0] = (v0.u8[0] < v1.u8[0]) ? v0.u8[0] : v1.u8[0];
+    r.u8[1] = (v0.u8[1] < v1.u8[1]) ? v0.u8[1] : v1.u8[1];
+    r.u8[2] = (v0.u8[2] < v1.u8[2]) ? v0.u8[2] : v1.u8[2];
+    r.u8[3] = (v0.u8[3] < v1.u8[3]) ? v0.u8[3] : v1.u8[3];
+    return r;
+    #endif
+}
+
+static inline v128_t vmin_s8(v128_t v0, v128_t v1) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vminq_s8(v0.s8, v1.s8);
+    #elif (__ARM_ARCH >= 7)
+    uint32_t t = __SSUB8(v0.u32[0], v1.u32[0]); (void) t;
+    return (v128_t) {
+        .u32 = { __SEL(v1.u32[0], v0.u32[0]) }
+    };
+    #else
+    v128_t r;
+    r.s8[0] = (v0.s8[0] < v1.s8[0]) ? v0.s8[0] : v1.s8[0];
+    r.s8[1] = (v0.s8[1] < v1.s8[1]) ? v0.s8[1] : v1.s8[1];
+    r.s8[2] = (v0.s8[2] < v1.s8[2]) ? v0.s8[2] : v1.s8[2];
+    r.s8[3] = (v0.s8[3] < v1.s8[3]) ? v0.s8[3] : v1.s8[3];
+    return r;
+    #endif
+}
+
+static inline v128_t vmin_u16(v128_t v0, v128_t v1) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vminq_u16(v0.u16, v1.u16);
+    #elif (__ARM_ARCH >= 7)
+    uint32_t t = __USUB16(v0.u32[0], v1.u32[0]); (void) t;
+    return (v128_t) {
+        .u32 = { __SEL(v1.u32[0], v0.u32[0]) }
+    };
+    #else
+    v128_t r;
+    r.u16[0] = (v0.u16[0] < v1.u16[0]) ? v0.u16[0] : v1.u16[0];
+    r.u16[1] = (v0.u16[1] < v1.u16[1]) ? v0.u16[1] : v1.u16[1];
+    return r;
+    #endif
+}
+
+static inline v128_t vmin_s16(v128_t v0, v128_t v1) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vminq_s16(v0.s16, v1.s16);
+    #elif (__ARM_ARCH >= 7)
+    uint32_t t = __SSUB16(v0.u32[0], v1.u32[0]); (void) t;
+    return (v128_t) {
+        .u32 = { __SEL(v1.u32[0], v0.u32[0]) }
+    };
+    #else
+    v128_t r;
+    r.s16[0] = (v0.s16[0] < v1.s16[0]) ? v0.s16[0] : v1.s16[0];
+    r.s16[1] = (v0.s16[1] < v1.s16[1]) ? v0.s16[1] : v1.s16[1];
+    return r;
+    #endif
+}
+
+static inline v128_t vmax_u8(v128_t v0, v128_t v1) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vmaxq_u8(v0.u8, v1.u8);
+    #elif (__ARM_ARCH >= 7)
+    uint32_t t = __USUB8(v0.u32[0], v1.u32[0]); (void) t;
+    return (v128_t) {
+        .u32 = { __SEL(v0.u32[0], v1.u32[0]) }
+    };
+    #else
+    v128_t r;
+    r.u8[0] = (v0.u8[0] > v1.u8[0]) ? v0.u8[0] : v1.u8[0];
+    r.u8[1] = (v0.u8[1] > v1.u8[1]) ? v0.u8[1] : v1.u8[1];
+    r.u8[2] = (v0.u8[2] > v1.u8[2]) ? v0.u8[2] : v1.u8[2];
+    r.u8[3] = (v0.u8[3] > v1.u8[3]) ? v0.u8[3] : v1.u8[3];
+    return r;
+    #endif
+}
+
+static inline v128_t vax_s8(v128_t v0, v128_t v1) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vmaxq_s8(v0.s8, v1.s8);
+    #elif (__ARM_ARCH >= 7)
+    uint32_t t = __SSUB8(v0.u32[0], v1.u32[0]); (void) t;
+    return (v128_t) {
+        .u32 = { __SEL(v0.u32[0], v1.u32[0]) }
+    };
+    #else
+    v128_t r;
+    r.s8[0] = (v0.s8[0] > v1.s8[0]) ? v0.s8[0] : v1.s8[0];
+    r.s8[1] = (v0.s8[1] > v1.s8[1]) ? v0.s8[1] : v1.s8[1];
+    r.s8[2] = (v0.s8[2] > v1.s8[2]) ? v0.s8[2] : v1.s8[2];
+    r.s8[3] = (v0.s8[3] > v1.s8[3]) ? v0.s8[3] : v1.s8[3];
+    return r;
+    #endif
+}
+
+static inline v128_t vmax_u16(v128_t v0, v128_t v1) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vmaxq_u16(v0.u16, v1.u16);
+    #elif (__ARM_ARCH >= 7)
+    uint32_t t = __USUB16(v0.u32[0], v1.u32[0]); (void) t;
+    return (v128_t) {
+        .u32 = { __SEL(v0.u32[0], v1.u32[0]) }
+    };
+    #else
+    v128_t r;
+    r.u16[0] = (v0.u16[0] > v1.u16[0]) ? v0.u16[0] : v1.u16[0];
+    r.u16[1] = (v0.u16[1] > v1.u16[1]) ? v0.u16[1] : v1.u16[1];
+    return r;
+    #endif
+}
+
+static inline v128_t vmax_s16(v128_t v0, v128_t v1) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vmaxq_s16(v0.s16, v1.s16);
+    #elif (__ARM_ARCH >= 7)
+    uint32_t t = __SSUB16(v0.u32[0], v1.u32[0]); (void) t;
+    return (v128_t) {
+        .u32 = { __SEL(v0.u32[0], v1.u32[0]) }
+    };
+    #else
+    v128_t r;
+    r.s16[0] = (v0.s16[0] > v1.s16[0]) ? v0.s16[0] : v1.s16[0];
+    r.s16[1] = (v0.s16[1] > v1.s16[1]) ? v0.s16[1] : v1.s16[1];
+    return r;
+    #endif
+}
+
+static inline v128_t vabd_u8(v128_t v0, v128_t v1) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vabdq_u8(v0.u8, v1.u8);
+    #elif (__ARM_ARCH >= 7)
+    uint32_t t0 = __USUB8(v0.u32[0], v1.u32[0]);
+    uint32_t t1 = __USUB8(v1.u32[0], v0.u32[0]);
+    return (v128_t) {
+        .u32 = { __SEL(t1, t0) }
+    };
+    #else
+    v128_t r;
+    r.u8[0] = abs(v0.u8[0] - v1.u8[0]);
+    r.u8[1] = abs(v0.u8[1] - v1.u8[1]);
+    r.u8[2] = abs(v0.u8[2] - v1.u8[2]);
+    r.u8[3] = abs(v0.u8[3] - v1.u8[3]);
+    return r;
+    #endif
+}
+
+static inline v128_t vabd_s8(v128_t v0, v128_t v1) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vabdq_s8(v0.s8, v1.s8);
+    #elif (__ARM_ARCH >= 7)
+    uint32_t t0 = __SSUB8(v0.u32[0], v1.u32[0]);
+    uint32_t t1 = __SSUB8(v1.u32[0], v0.u32[0]);
+    return (v128_t) {
+        .u32 = { __SEL(t1, t0) }
+    };
+    #else
+    v128_t r;
+    r.s8[0] = abs(v0.s8[0] - v1.s8[0]);
+    r.s8[1] = abs(v0.s8[1] - v1.s8[1]);
+    r.s8[2] = abs(v0.s8[2] - v1.s8[2]);
+    r.s8[3] = abs(v0.s8[3] - v1.s8[3]);
+    return r;
+    #endif
+}
+
+static inline v128_t vabd_u16(v128_t v0, v128_t v1) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vabdq_u16(v0.u16, v1.u16);
+    #elif (__ARM_ARCH >= 7)
+    uint32_t t0 = __USUB16(v0.u32[0], v1.u32[0]);
+    uint32_t t1 = __USUB16(v1.u32[0], v0.u32[0]);
+    return (v128_t) {
+        .u32 = { __SEL(t1, t0) }
+    };
+    #else
+    v128_t r;
+    r.u16[0] = abs(v0.u16[0] - v1.u16[0]);
+    r.u16[1] = abs(v0.u16[1] - v1.u16[1]);
+    return r;
+    #endif
+}
+
+static inline v128_t vabd_s16(v128_t v0, v128_t v1) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vabdq_s16(v0.s16, v1.s16);
+    #elif (__ARM_ARCH >= 7)
+    uint32_t t0 = __SSUB16(v0.u32[0], v1.u32[0]);
+    uint32_t t1 = __SSUB16(v1.u32[0], v0.u32[0]);
+    return (v128_t) {
+        .u32 = { __SEL(t1, t0) }
+    };
+    #else
+    v128_t r;
+    r.s16[0] = abs(v0.s16[0] - v1.s16[0]);
+    r.s16[1] = abs(v0.s16[1] - v1.s16[1]);
+    return r;
     #endif
 }
 
@@ -1049,16 +1603,6 @@ static inline v128_t vlsr_u32(v128_t v0, uint32_t n) {
 }
 #endif
 
-static inline v128_t vand_u32(v128_t v0, v128_t v1) {
-    #if (__ARM_ARCH >= 8)
-    return (v128_t) vandq(v0.u32, v1.u32);
-    #else
-    return (v128_t) {
-        .u32 = v0.u32 & v1.u32
-    };
-    #endif
-}
-
 static inline v128_t vshl_u8(v128_t v0, v128_t v1) {
     #if (__ARM_ARCH >= 8)
     return (v128_t) vshlq(v0.u8, v1.s8);
@@ -1079,12 +1623,62 @@ static inline v128_t vshl_u16(v128_t v0, v128_t v1) {
     #endif
 }
 
+static inline v128_t vmvn_u32(v128_t v0) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vmvnq(v0.u32);
+    #else
+    return (v128_t) {
+        .u32 = ~v0.u32
+    };
+    #endif
+}
+
+static inline v128_t vmvn_s32(v128_t v0) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vmvnq(v0.s32);
+    #else
+    return (v128_t) {
+        .s32 = ~v0.s32
+    };
+    #endif
+}
+
+static inline v128_t vand_u32(v128_t v0, v128_t v1) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vandq(v0.u32, v1.u32);
+    #else
+    return (v128_t) {
+        .u32 = v0.u32 & v1.u32
+    };
+    #endif
+}
+
 static inline v128_t vand_s32(v128_t v0, v128_t v1) {
     #if (__ARM_ARCH >= 8)
     return (v128_t) vandq(v0.s32, v1.s32);
     #else
     return (v128_t) {
         .s32 = v0.s32 & v1.s32
+    };
+    #endif
+}
+
+static inline v128_t vbic_u32(v128_t v0, v128_t v1) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vbicq(v0.u32, v1.u32);
+    #else
+    return (v128_t) {
+        .u32 = v0.u32 & ~v1.u32
+    };
+    #endif
+}
+
+static inline v128_t vbic_s32(v128_t v0, v128_t v1) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vbicq(v0.s32, v1.s32);
+    #else
+    return (v128_t) {
+        .s32 = v0.s32 & ~v1.s32
     };
     #endif
 }
@@ -1105,6 +1699,26 @@ static inline v128_t vorr_s32(v128_t v0, v128_t v1) {
     #else
     return (v128_t) {
         .s32 = v0.s32 | v1.s32
+    };
+    #endif
+}
+
+static inline v128_t vorn_u32(v128_t v0, v128_t v1) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vornq(v0.u32, v1.u32);
+    #else
+    return (v128_t) {
+        .u32 = v0.u32 | ~v1.u32
+    };
+    #endif
+}
+
+static inline v128_t vorn_s32(v128_t v0, v128_t v1) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vornq(v0.s32, v1.s32);
+    #else
+    return (v128_t) {
+        .s32 = v0.s32 | ~v1.s32
     };
     #endif
 }
@@ -1131,7 +1745,7 @@ static inline v128_t veor_s32(v128_t v0, v128_t v1) {
 
 static inline v128_t vmul_u32(v128_t v0, v128_t v1) {
     #if (__ARM_ARCH >= 8)
-    return (v128_t) vmulq(v0.u32, v1.u32);
+    return (v128_t) vmulq_u32(v0.u32, v1.u32);
     #else
     return (v128_t) {
         .u32 = v0.u32 * v1.u32
@@ -1141,7 +1755,7 @@ static inline v128_t vmul_u32(v128_t v0, v128_t v1) {
 
 static inline v128_t vmul_s32(v128_t v0, v128_t v1) {
     #if (__ARM_ARCH >= 8)
-    return (v128_t) vmulq(v0.s32, v1.s32);
+    return (v128_t) vmulq_s32(v0.s32, v1.s32);
     #else
     return (v128_t) {
         .s32 = v0.s32 * v1.s32
@@ -1151,7 +1765,7 @@ static inline v128_t vmul_s32(v128_t v0, v128_t v1) {
 
 static inline v128_t vmla_u32(v128_t v0, v128_t v1, v128_t v2) {
     #if (__ARM_ARCH >= 8)
-    return (v128_t) vaddq(vmulq(v0.u32, v1.u32), v2.u32);
+    return (v128_t) vaddq_u32(vmulq_u32(v0.u32, v1.u32), v2.u32);
     #else
     return (v128_t) {
         .u32 = (v0.u32 * v1.u32) + v2.u32
@@ -1161,7 +1775,7 @@ static inline v128_t vmla_u32(v128_t v0, v128_t v1, v128_t v2) {
 
 static inline v128_t vmla_s32(v128_t v0, v128_t v1, v128_t v2) {
     #if (__ARM_ARCH >= 8)
-    return (v128_t) vaddq(vmulq(v0.s32, v1.s32), v2.s32);
+    return (v128_t) vaddq_s32(vmulq_s32(v0.s32, v1.s32), v2.s32);
     #else
     return (v128_t) {
         .s32 = (v0.s32 * v1.s32) + v2.s32
@@ -1192,6 +1806,10 @@ static inline v128_t vmul_n_u32(v128_t v0, uint32_t x) {
 static inline v128_t vmul_n_s16(v128_t v0, int16_t x) {
     #if (__ARM_ARCH >= 8)
     return (v128_t) vmulq_n_s16(v0.s16, x);
+    #elif (__ARM_ARCH >= 7)
+    return (v128_t) {
+        .u32 = { __PKHBT(__SMULBB(v0.u32[0], x), __SMULTB(v0.u32[0], x), 16) }
+    };
     #else
     return (v128_t) {
         .s16 = v0.s16 * x
@@ -1232,6 +1850,10 @@ static inline v128_t vmla_n_u32(v128_t v0, uint32_t x, v128_t v2) {
 static inline v128_t vmla_n_s16(v128_t v0, int16_t x, v128_t v2) {
     #if (__ARM_ARCH >= 8)
     return (v128_t) vmlaq_n_s16(v2.s16, v0.s16, x);
+    #elif (__ARM_ARCH >= 7)
+    return (v128_t) {
+        .u32 = { __SADD16(__PKHBT(__SMULBB(v0.u32[0], x), __SMULTB(v0.u32[0], x), 16), v2.u32[0]) }
+    };
     #else
     return (v128_t) {
         .s16 = (v0.s16 * x) + v2.s16
@@ -1299,20 +1921,72 @@ static inline v128_t vldr_u8_pred(const uint8_t *p, v128_predicate_t pred) {
     #if (__ARM_ARCH >= 8)
     return (v128_t) vldrbq_z_u8(p, pred);
     #else
-    v128_t v0;
-
     if (pred > 3) {
-        v0.u32[0] = *((const uint32_t *) p);
-    } else if (pred > 2) {
-        v0.u32[0] = *((const uint16_t *) p);
-        v0.u8[2] = p[2];
+        return (v128_t) {
+            .u32 = { *((const uint32_t *) p) }
+        };
     } else if (pred > 1) {
-        v0.u32[0] = *((const uint16_t *) p);
-    } else {
-        v0.u32[0] = p[0];
-    }
+        v128_t v0 = (v128_t) {
+            .u32 = { *((const uint16_t *) p) }
+        };
 
-    return v0;
+        if (pred > 2) {
+            v0.u8[2] = p[2];
+        }
+
+        return v0;
+    } else {
+        return (v128_t) {
+            .u32 = { p[0] }
+        };
+    }
+    #endif
+}
+
+static inline v2x_rows_t vldr_u8_pred_x2(v2x_row_ptrs_t row_ptrs, uint32_t x, v128_predicate_t pred) {
+    const uint8_t *p0 = row_ptrs.p0.u8 + x;
+    const uint8_t *p1 = row_ptrs.p1.u8 + x;
+    #if (__ARM_ARCH >= 8)
+    return (v2x_rows_t) {
+        .r0 = (v128_t) vldrbq_z_u8(p0, pred),
+        .r1 = (v128_t) vldrbq_z_u8(p1, pred)
+    };
+    #else
+    if (pred > 3) {
+        return (v2x_rows_t) {
+            .r0 = (v128_t) {
+                .u32 = { *((const uint32_t *) p0) }
+            },
+            .r1 = (v128_t) {
+                .u32 = { *((const uint32_t *) p1) }
+            }
+        };
+    } else if (pred > 1) {
+        v2x_rows_t v0 = {
+            .r0 = (v128_t) {
+                .u32 = { *((const uint16_t *) p0) }
+            },
+            .r1 = (v128_t) {
+                .u32 = { *((const uint16_t *) p1) }
+            }
+        };
+
+        if (pred > 2) {
+            v0.r0.u8[2] = p0[2];
+            v0.r1.u8[2] = p1[2];
+        }
+
+        return v0;
+    } else {
+        return (v2x_rows_t) {
+            .r0 = (v128_t) {
+                .u32 = { p0[0] }
+            },
+            .r1 = (v128_t) {
+                .u32 = { p1[0] }
+            }
+        };
+    }
     #endif
 }
 
@@ -1330,11 +2004,12 @@ static inline void vstr_u8_pred(uint8_t *p, v128_t v0, v128_predicate_t pred) {
     #else
     if (pred > 3) {
         *((uint32_t *) p) = v0.u32[0];
-    } else if (pred > 2) {
-        *((uint16_t *) p) = v0.u16[0];
-        p[2] = v0.u8[2];
     } else if (pred > 1) {
         *((uint16_t *) p) = v0.u16[0];
+
+        if (pred > 2) {
+            p[2] = v0.u8[2];
+        }
     } else {
         p[0] = v0.u8[0];
     }
@@ -1355,15 +2030,40 @@ static inline v128_t vldr_u16_pred(const uint16_t *p, v128_predicate_t pred) {
     #if (__ARM_ARCH >= 8)
     return (v128_t) vldrhq_z_u16(p, pred);
     #else
-    v128_t v0;
+    return (v128_t) {
+        .u32 = { (pred > 1) ? *((const uint32_t *) p) : p[0] }
+    };
+    #endif
+}
 
+static inline v2x_rows_t vldr_u16_pred_x2(v2x_row_ptrs_t row_ptrs, uint32_t x, v128_predicate_t pred) {
+    const uint16_t *p0 = row_ptrs.p0.u16 + x;
+    const uint16_t *p1 = row_ptrs.p1.u16 + x;
+    #if (__ARM_ARCH >= 8)
+    return (v2x_rows_t) {
+        .r0 = (v128_t) vldrhq_z_u16(p0, pred),
+        .r1 = (v128_t) vldrhq_z_u16(p1, pred)
+    };
+    #else
     if (pred > 1) {
-        v0.u32[0] = *((const uint32_t *) p);
+        return (v2x_rows_t) {
+            .r0 = (v128_t) {
+                .u32 = { *((const uint32_t *) p0) }
+            },
+            .r1 = (v128_t) {
+                .u32 = { *((const uint32_t *) p1) }
+            }
+        };
     } else {
-        v0.u32[0] = p[0];
+        return (v2x_rows_t) {
+            .r0 = (v128_t) {
+                .u32 = { p0[0] }
+            },
+            .r1 = (v128_t) {
+                .u32 = { p1[0] }
+            }
+        };
     }
-
-    return v0;
     #endif
 }
 
@@ -1391,17 +2091,33 @@ static inline v128_t vldr_u8_widen_u16_pred(uint8_t *p, v128_predicate_t pred) {
     #if (__ARM_ARCH >= 8)
     return (v128_t) vldrbq_z_u16(p, pred);
     #else
-    v128_t v0;
+    v128_t v0 = (v128_t) {
+        .u32 = { p[0] }
+    };
 
     if (pred > 1) {
-        v0.u32[0] = *((uint16_t *) p);
-        v0.u8[2] = v0.u8[1];
-        v0.u8[1] = 0;
-    } else {
-        v0.u32[0] = *p;
+        v0.u8[2] = p[1];
     }
 
     return v0;
+    #endif
+}
+
+static inline v128_t vldr_u32(const uint32_t *p) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vldrwq_u32(p);
+    #else
+    return (v128_t) {
+        .u32 = { *p }
+    };
+    #endif
+}
+
+static inline void vstr_u32(uint32_t *p, v128_t v0) {
+    #if (__ARM_ARCH >= 8)
+    vstrwq(p, v0.u32);
+    #else
+    *p = v0.u32[0];
     #endif
 }
 
@@ -1409,9 +2125,10 @@ static inline void vstr_u16_narrow_u8_pred(uint8_t *p, v128_t v0, v128_predicate
     #if (__ARM_ARCH >= 8)
     vstrbq_p_u16(p, v0.u16, pred);
     #else
-    *p = v0.u32[0];
+    p[0] = v0.u32[0];
+
     if (pred > 1) {
-        *((uint8_t *) (p + 1)) = v0.u8[2];
+        p[1] = v0.u8[2];
     }
     #endif
 }
@@ -1683,19 +2400,236 @@ static inline void vmemcpy_64(void *dest, void *src, size_t n) {
 }
 #endif
 
+// Turns a vector of partial sums into complete sums.
+//
+// [partial_accN, ..., partial_acc2, partial_acc1, acc0] -> [accN, ..., acc2, acc1, acc0]
+#if VECTOR_SIZE_BYTES >= 32
+#error "Unsupported vector size"
+#elif VECTOR_SIZE_BYTES >= 16
+#define vsum_up_s8(acc) ({         \
+        v128_t p = vshlc0(acc, 8); \
+        acc = vadd_s8(acc, p);     \
+        p = vshlc0(acc, 16);       \
+        acc = vadd_s8(acc, p);     \
+        p = vshlc0(acc, 32);       \
+        acc = vadd_s8(acc, p);     \
+        p = vshlc0(acc, 32);       \
+        p = vshlc0(p, 32);         \
+        vadd_s8(acc, p);           \
+    })
+// [p7,p6,p5,p4,p3,p2,p1,a0] + [p6,p5,p4,p3,p2,p1,a0,0] = [p7+p6,p6+p5,p5+p4,p4+p3,p3+p2,p2+p1,a1,a0]
+// [p7+p6,p6+p5,p5+p4,p4+p3,p3+p2,p2+p1,a1,a0] + [p5+p4,p4+p3,p3+p2,p2+p1,a1,a0,0,0] =
+// [p7+p6+p5+p4,p6+p5+p4+p3,p5+p4+p3+p2,p4+p3+p2+p1,a3,a2,a1,a0]
+// [p7+p6+p5+p4,p6+p5+p4+p3,p5+p4+p3+p2,p4+p3+p2+p1,a3,a2,a1,a0] + [a3,a2,a1,a0,0,0,0,0] =
+// [a7,a6,a5,a4,a3,a2,a1,a0]
+#define vsum_up_s16(acc) ({         \
+        v128_t p = vshlc0(acc, 16); \
+        acc = vadd_s16(acc, p);     \
+        p = vshlc0(acc, 32);        \
+        acc = vadd_s16(acc, p);     \
+        p = vshlc0(acc, 32);        \
+        p = vshlc0(p, 32);          \
+        vadd_s16(acc, p);           \
+    })
+// [pacc3, pacc2, pacc1, acc0] + [pacc2, pacc1, acc0, 0] = [pacc3 + pacc2, pacc2 + pacc1, acc1, acc0]
+// [pacc3 + pacc2, pacc2 + pacc1, acc1, acc0] + [acc1, acc0, 0, 0] = [acc3, acc2, acc1, acc0]
+#define vsum_up_s32(acc) ({         \
+        v128_t p = vshlc0(acc, 32); \
+        acc = vadd_s32(acc, p);     \
+        p = vshlc0(acc, 32);        \
+        p = vshlc0(p, 32);          \
+        vadd_s32(acc, p);           \
+    })
+#elif VECTOR_SIZE_BYTES >= 8
+// [p7,p6,p5,p4,p3,p2,p1,a0] + [p6,p5,p4,p3,p2,p1,a0,0] = [p7+p6,p6+p5,p5+p4,p4+p3,p3+p2,p2+p1,a1,a0]
+// [p7+p6,p6+p5,p5+p4,p4+p3,p3+p2,p2+p1,a1,a0] + [p5+p4,p4+p3,p3+p2,p2+p1,a1,a0,0,0] =
+// [p7+p6+p5+p4,p6+p5+p4+p3,p5+p4+p3+p2,p4+p3+p2+p1,a3,a2,a1,a0]
+// [p7+p6+p5+p4,p6+p5+p4+p3,p5+p4+p3+p2,p4+p3+p2+p1,a3,a2,a1,a0] + [a3,a2,a1,a0,0,0,0,0] =
+// [a7,a6,a5,a4,a3,a2,a1,a0]
+#define vsum_up_s8(acc) ({         \
+        v128_t p = vshlc0(acc, 8); \
+        acc = vadd_s8(acc, p);     \
+        p = vshlc0(acc, 16);       \
+        acc = vadd_s8(acc, p);     \
+        p = vshlc0(acc, 32);       \
+        vadd_s8(acc, p);           \
+    })
+// [pacc3, pacc2, pacc1, acc0] + [pacc2, pacc1, acc0, 0] = [pacc3 + pacc2, pacc2 + pacc1, acc1, acc0]
+// [pacc3 + pacc2, pacc2 + pacc1, acc1, acc0] + [acc1, acc0, 0, 0] = [acc3, acc2, acc1, acc0]
+#define vsum_up_s16(acc) ({         \
+        v128_t p = vshlc0(acc, 16); \
+        acc = vadd_s16(acc, p);     \
+        p = vshlc0(acc, 32);        \
+        vadd_s16(acc, p);           \
+    })
+// [pacc1, acc0] + [acc0, 0] = [acc1, acc0]
+#define vsum_up_s32(acc) ({         \
+        v128_t p = vshlc0(acc, 32); \
+        vadd_s32(acc, p);           \
+    })
+#elif VECTOR_SIZE_BYTES >= 4
+// [pacc3, pacc2, pacc1, acc0] + [pacc2, pacc1, acc0, 0] = [pacc3 + pacc2, pacc2 + pacc1, acc1, acc0]
+// [pacc3 + pacc2, pacc2 + pacc1, acc1, acc0] + [acc1, acc0, 0, 0] = [acc3, acc2, acc1, acc0]
+#define vsum_up_s8(acc) ({         \
+        v128_t p = vshlc0(acc, 8); \
+        acc = vadd_s8(acc, p);     \
+        p = vshlc0(acc, 16);       \
+        vadd_s8(acc, p);           \
+    })
+// [pacc1, acc0] + [acc0, 0] = [acc1, acc0]
+#define vsum_up_s16(acc) ({         \
+        v128_t p = vshlc0(acc, 16); \
+        vadd_s16(acc, p);           \
+    })
+// [acc0] = [acc0]
+#define vsum_up_s32(acc) ({ \
+        acc;                \
+    })
+#endif
+
+inline int32_t div_fast_setup_s16(int32_t div) {
+    return 65536 / div;
+}
+
+static inline int32_t div_fast_binary_s16(int32_t x, int32_t div) {
+    return (x * div) >= 32768;
+}
+
+static inline int32_t div_fast_s16(int32_t x, int32_t div) {
+    return (x * div) >> 16;
+}
+
+static inline int32_t div_fast_usat_s16(int32_t x, int32_t div, int32_t bits) {
+    // There's a software implementation of __USAT in the ARM CMSIS extension if needed
+    return __USAT_ASR(x * div, bits, 16);
+}
+
+static inline int32_t div_fast_ssat_s16(int32_t x, int32_t div, int32_t bits) {
+    // There's a software implementation of __USAT in the ARM CMSIS extension if needed
+    return __SSAT_ASR(x * div, bits, 16);
+}
+
+static inline v128_t vdiv_fast_setup_s16(int32_t div) {
+    #if (__ARM_ARCH >= 8)
+    return vdup_s16((div - 1) >> 1);
+    #else
+    return vdup_s32(div);
+    #endif
+}
+
+// General purpose fast division.
+//
+// v0 must be between -32,768 and 32,767.
+// div must be from vdiv_fast_setup_s16().
+static inline v128_t vdiv_fast_s16(v128_t v0, v128_t div) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vqrdmulhq_s16(v0.s16, div.s16);
+    #elif (__ARM_ARCH >= 7)
+    return (v128_t) {
+        .u32 = { __PKHBT(__SMULWB(div.u32[0], v0.u32[0]), __SMULWT(div.u32[0], v0.u32[0]), 16) }
+    };
+    #else
+    v128_t r = (v128_t) {
+        .s16 = { (div.s32[0] * v0.s16[0]) >> 16 }
+    };
+    r.s16[1] = (div.s32[0] * v0.s16[1]) >> 16;
+    return r;
+    #endif
+}
+
+static inline int64_t div_fast_setup_s32(int32_t div) {
+    return 4294967296LL / div;
+}
+
+static inline int32_t div_fast_binary_s32(int32_t x, int64_t div) {
+    return (((int64_t) x) * div) >= 2147483648LL;
+}
+
+static inline int32_t div_fast_s32(int32_t x, int64_t div) {
+    return (((int64_t) x) * div) >> 32;
+}
+
+static inline v128_t vdiv_fast_setup_s32(int64_t div) {
+    return vdup_s32((div - 1) >> 1);
+}
+
+// General purpose fast division.
+//
+// v0 must be between -2,147,483,648 and 2,147,483,647.
+// div must be from vdiv_fast_setup_s32().
+static inline v128_t vdiv_fast_s32(v128_t v0, v128_t div) {
+    #if (__ARM_ARCH >= 8)
+    return (v128_t) vqrdmulhq_s32(v0.s32, div.s32);
+    #else
+    return (v128_t) {
+        .u32 = { __SMMULR(v0.s32[0] << 1, div.s32[0]) }
+    };
+    #endif
+}
+
+// Loads up to 32 binary pixels from a 32-bit integer array.
+static inline uint32_t vldr_binary_bits(uint32_t *p, uint32_t x, uint32_t count) {
+    uint32_t index = x >> 5;
+    uint32_t offset = x & 0x1f;
+    uint32_t remaining = 32 - offset;
+    uint32_t min = (remaining < count) ? remaining : count;
+    uint32_t mask = (1 << min) - 1;
+
+    uint32_t v = p[index];
+    uint32_t bits = (v >> offset) & mask;
+
+    if (count > min) {
+        mask = (1 << (count - min)) - 1;
+
+        v = p[index + 1];
+        bits |= (v & mask) << min;
+    }
+
+    return bits;
+}
+
+// Stores up to 32 binary pixels into a 32-bit integer array.
+static inline void vstr_binary_bits(uint32_t *p, uint32_t x, uint32_t count, uint32_t bits) {
+    uint32_t index = x >> 5;
+    uint32_t offset = x & 0x1f;
+    uint32_t remaining = 32 - offset;
+    uint32_t min = (remaining < count) ? remaining : count;
+    uint32_t mask = (1 << min) - 1;
+
+    uint32_t v = p[index];
+    v = (v & ~(mask << offset)) | ((bits & mask) << offset);
+    p[index] = v;
+
+    if (count > min) {
+        mask = (1 << (count - min)) - 1;
+
+        v = p[index + 1];
+        v = (v & ~mask) | ((bits >> min) & mask);
+        p[index + 1] = v;
+    }
+}
+
 // In the case of vectors larger than 32-bits the pattern is repeated for every 32-bits.
 //
-// pixels.r = MSB [0, R1, 0, R0] LSB pixels where each pixel is 8-bits.
-// pixels.g = MSB [0, G1, 0, G0] LSB pixels where each pixel is 8-bits.
-// pixels.b = MSB [0, B1, 0, B0] LSB pixels where each pixel is 8-bits.
+// pixels.r = MSB [0, R1, 0, R0] LSB pixels where each pixel is 5-bits.
+// pixels.g = MSB [0, G1, 0, G0] LSB pixels where each pixel is 6-bits.
+// pixels.b = MSB [0, B1, 0, B0] LSB pixels where each pixel is 5-bits.
 //
-// Y == ((R * 38) + (G * 75) + (B * 15)) / 128
+// r5 to r8 scale = (r << 3) | (r >> 2) = 8.25 ~= 255/31
+// g6 to g8 scale = (g << 2) | (g >> 4) = 4.0625 ~= 255/63
+// b5 to b8 scale = (b << 3) | (b >> 2) = 8.25 ~= 255/31
+//
+// r -> 38 * 8.25 = 313.5 -> 313
+// g -> 75 * 4.0625 = 304.6875 -> 304
+// b -> 15 * 8.25 = 123.75 -> 123
+//
+// Y = ((R * 313) + (G * 304) + (B * 123)) / 128
 //
 // Returns 2x uint8_t Grayscale (MSB [garbage, G1, garbage, G0] LSB) pixels for every 32-bits.
-static inline v128_t vrgb_pixels_to_grayscale(vrgb_pixels_t pixels) {
-    pixels.r = vmul_n_u32(pixels.r, 38);
-    pixels.r = vmla_n_u32(pixels.g, 75, pixels.r);
-    pixels.r = vmla_n_u32(pixels.b, 15, pixels.r);
+static inline v128_t vrgb_pixels565_to_grayscale(vrgb_pixels_t pixels) {
+    pixels.r = vmul_n_u32(pixels.r, 313);
+    pixels.r = vmla_n_u32(pixels.g, 304, pixels.r);
+    pixels.r = vmla_n_u32(pixels.b, 123, pixels.r);
     return vlsr_u32(pixels.r, 7);
 }
 
@@ -1705,8 +2639,72 @@ static inline v128_t vrgb_pixels_to_grayscale(vrgb_pixels_t pixels) {
 // pixels.g = MSB [0, G1, 0, G0] LSB pixels where each pixel is 8-bits.
 // pixels.b = MSB [0, B1, 0, B0] LSB pixels where each pixel is 8-bits.
 //
+// Y == ((R * 38) + (G * 75) + (B * 15)) / 128
+//
+// Returns 2x uint8_t Grayscale (MSB [garbage, G1, garbage, G0] LSB) pixels for every 32-bits.
+static inline v128_t vrgb_pixels888_to_grayscale(vrgb_pixels_t pixels) {
+    pixels.r = vmul_n_u32(pixels.r, 38);
+    pixels.r = vmla_n_u32(pixels.g, 75, pixels.r);
+    pixels.r = vmla_n_u32(pixels.b, 15, pixels.r);
+    return vlsr_u32(pixels.r, 7);
+}
+
+// In the case of vectors larger than 32-bits the pattern is repeated for every 32-bits.
+//
+// 2x uint16_t RGB565 (MSB [RGB1, RGB0] LSB) pixels for every 32-bits.
+//
+// Returns pixels.r = MSB [0, R1, 0, R0] LSB pixels where each pixel is 5-bits.
+// Returns pixels.g = MSB [0, G1, 0, G0] LSB pixels where each pixel is 6-bits.
+// Returns pixels.b = MSB [0, B1, 0, B0] LSB pixels where each pixel is 5-bits.
+static inline vrgb_pixels_t vrgb_rgb565_to_pixels565(v128_t rgb565) {
+    vrgb_pixels_t pixels;
+    pixels.r = vand_u32(vlsr_u32(rgb565, 11), vdup_u16(0x1f));
+    pixels.g = vand_u32(vlsr_u32(rgb565, 5), vdup_u16(0x3f));
+    pixels.b = vand_u32(rgb565, vdup_u16(0x1f));
+    return pixels;
+}
+
+// In the case of vectors larger than 32-bits the pattern is repeated for every 32-bits.
+//
+// 2x uint16_t RGB565 (MSB [RGB1, RGB0] LSB) pixels for every 32-bits.
+//
+// Returns pixels.r = MSB [0, R1, 0, R0] LSB pixels where each pixel is 8-bits.
+// Returns pixels.g = MSB [0, G1, 0, G0] LSB pixels where each pixel is 8-bits.
+// Returns pixels.b = MSB [0, B1, 0, B0] LSB pixels where each pixel is 8-bits.
+static inline vrgb_pixels_t vrgb_rgb565_to_pixels888(v128_t rgb565) {
+    vrgb_pixels_t pixels;
+    pixels.r = vand_u32(vlsr_u32(rgb565, 8), vdup_u16(0xf8));
+    pixels.r = vorr_u32(pixels.r, vlsr_u32(pixels.r, 5));
+    pixels.g = vand_u32(vlsr_u32(rgb565, 3), vdup_u16(0xfc));
+    pixels.g = vorr_u32(pixels.g, vlsr_u32(pixels.g, 6));
+    pixels.b = vand_u32(vlsl_u32(rgb565, 3), vdup_u16(0xf8));
+    pixels.b = vorr_u32(pixels.b, vlsr_u32(pixels.b, 5));
+    return pixels;
+}
+
+// In the case of vectors larger than 32-bits the pattern is repeated for every 32-bits.
+//
+// pixels.r = MSB [0, R1, 0, R0] LSB pixels where each pixel is 5-bits.
+// pixels.g = MSB [0, G1, 0, G0] LSB pixels where each pixel is 6-bits.
+// pixels.b = MSB [0, B1, 0, B0] LSB pixels where each pixel is 5-bits.
+//
 // Returns 2x uint16_t RGB565 (MSB [RGB1, RGB0] LSB) pixels for every 32-bits.
-static inline v128_t vrgb_pixels_to_rgb565(vrgb_pixels_t pixels) {
+static inline v128_t vrgb_pixels565_to_rgb565(vrgb_pixels_t pixels) {
+    #if (__ARM_ARCH >= 8)
+    return vsli_u16(vsli_u16(pixels.b, pixels.g, 5), pixels.r, 11);
+    #else
+    return vorr_u32(vlsl_u32(pixels.r, 11), vorr_u32(vlsl_u32(pixels.g, 5), pixels.b));
+    #endif
+}
+
+// In the case of vectors larger than 32-bits the pattern is repeated for every 32-bits.
+//
+// pixels.r = MSB [0, R1, 0, R0] LSB pixels where each pixel is 8-bits.
+// pixels.g = MSB [0, G1, 0, G0] LSB pixels where each pixel is 8-bits.
+// pixels.b = MSB [0, B1, 0, B0] LSB pixels where each pixel is 8-bits.
+//
+// Returns 2x uint16_t RGB565 (MSB [RGB1, RGB0] LSB) pixels for every 32-bits.
+static inline v128_t vrgb_pixels888_to_rgb565(vrgb_pixels_t pixels) {
     #if (__ARM_ARCH >= 8)
     pixels.r = vlsr_u16(pixels.r, 3);
     pixels.g = vlsr_u16(pixels.g, 2);
@@ -1728,7 +2726,7 @@ static inline v128_t vrgb_pixels_to_rgb565(vrgb_pixels_t pixels) {
 //
 // Stores 2x GRAYSCALE pixels for every 32-bits.
 static inline void vrgb_pixels_store_grayscale(uint8_t *p, uint32_t x, vrgb_pixels_t pixels, v128_predicate_t pred) {
-    vstr_u16_narrow_u8_pred(p + x, vrgb_pixels_to_grayscale(pixels), pred);
+    vstr_u16_narrow_u8_pred(p + x, vrgb_pixels888_to_grayscale(pixels), pred);
 }
 
 // In the case of vectors larger than 32-bits the pattern is repeated for every 32-bits.
@@ -1739,7 +2737,7 @@ static inline void vrgb_pixels_store_grayscale(uint8_t *p, uint32_t x, vrgb_pixe
 //
 // Stores 2x RGB565 pixels for every 32-bits.
 static inline void vrgb_pixels_store_rgb565(uint16_t *p, uint32_t x, vrgb_pixels_t pixels, v128_predicate_t pred) {
-    vstr_u16_pred(p + x, vrgb_pixels_to_rgb565(pixels), pred);
+    vstr_u16_pred(p + x, vrgb_pixels888_to_rgb565(pixels), pred);
 }
 
 // In the case of vectors larger than 32-bits the pattern is repeated for every 32-bits.
@@ -1750,7 +2748,7 @@ static inline void vrgb_pixels_store_rgb565(uint16_t *p, uint32_t x, vrgb_pixels
 //
 // Stores 2x binary pixels for every 32-bits.
 static inline void vrgb_pixels_store_binary(uint32_t *p, uint32_t x, vrgb_pixels_t pixels, v128_predicate_t pred) {
-    v128_t binary = vand_u32(vlsr_u32(vrgb_pixels_to_grayscale(pixels), 7), vdup_u16(1));
+    v128_t binary = vand_u32(vlsr_u32(vrgb_pixels888_to_grayscale(pixels), 7), vdup_u16(1));
 
     // Turn the binary pixels that are in each 16-bit lane into a binary number which effectively
     // concatenates them all together.
@@ -1759,23 +2757,5 @@ static inline void vrgb_pixels_store_binary(uint32_t *p, uint32_t x, vrgb_pixels
     //
     // The signed version vmladav is used on purpose since it has access to __SMUAD on ARMv7.
     uint32_t bits = vmladav_s16(binary, vshl_u16(vdup_u16(1), vidup_u16(0, 1)));
-
-    uint32_t index = x >> 5;
-    uint32_t offset = x & 0x1f;
-    uint32_t remaining = 32 - offset;
-    uint32_t count = vpredicate_16_get_n(pred);
-    uint32_t min = (remaining < count) ? remaining : count;
-    uint32_t mask = (1 << min) - 1;
-
-    uint32_t v = p[index];
-    v = (v & ~(mask << offset)) | ((bits & mask) << offset);
-    p[index] = v;
-
-    if (count > min) {
-        mask = (1 << (count - min)) - 1;
-
-        v = p[index + 1];
-        v = (v & ~mask) | (bits & mask);
-        p[index + 1] = v;
-    }
+    vstr_binary_bits(p, x, vpredicate_16_get_n(pred), bits);
 }


### PR DESCRIPTION
Benchmarks here: https://docs.google.com/spreadsheets/d/1-FNVKCEr8-6UYs8MUm6wgsOt2c8ihJ2mg9QXKkG91os/edit?gid=1912947035#gid=1912947035

Helium performance doesn't make a huge difference here because of the line processing overhead in draw_image() that has yet to be opitmized.

Depends on https://github.com/openmv/openmv/pull/2417.