### PR TITLE
imlib/bayer: Fix debayer bound predication.

### DIFF
--- a/src/omv/imlib/bayer.c
+++ b/src/omv/imlib/bayer.c
@@ -331,8 +331,8 @@ static inline v2x_row_ptrs_t vdebayer_quarter_rowptrs_init(const image_t *src, i
 }
 
 static inline v128_predicate_t vdebayer_load_pred(const image_t *src, int32_t x) {
-    // Load 1x to 4x 32-bit rows overlapping by 2 pixels. This creates a 6 pixel overlap.
-    return vpredicate_8(src->w - x + 6);
+    // Load 1x to 4x 32-bit rows overlapping by 2 pixels.
+    return vpredicate_8(src->w - x + (VBAYER_X_STRIDE - 2));
 }
 
 static inline v128_predicate_t vdebayer_store_pred(int32_t width, int32_t x) {
@@ -1393,7 +1393,7 @@ static void vdebayer_bggr_to_grayscale_awb(image_t *src, image_t *dst, image_t *
         vrgb_pixels_store_grayscale(p1, 0, vdebayer_apply_rb_gain(pixels1, red_gain, blue_gain), pred);
 
         int32_t x = VBAYER_X_STRIDE;
-        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x <= x_end; x += VBAYER_X_STRIDE) {
+        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x < x_end; x += VBAYER_X_STRIDE) {
             v4x_rows_t rows;
             rows.r0 = vldr_u32_gather_unaligned(rowptrs.p0.u8 + x, offsets);
             rows.r1 = vldr_u32_gather_unaligned(rowptrs.p1.u8 + x, offsets);
@@ -1436,7 +1436,7 @@ static void vdebayer_bggr_to_grayscale_awb(image_t *src, image_t *dst, image_t *
         vrgb_pixels_store_grayscale(p0, 0, vdebayer_apply_rb_gain(pixels0, red_gain, blue_gain), pred);
 
         int32_t x = VBAYER_X_STRIDE;
-        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x <= x_end; x += VBAYER_X_STRIDE) {
+        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x < x_end; x += VBAYER_X_STRIDE) {
             v4x_rows_t rows;
             rows.r0 = vldr_u32_gather_unaligned(rowptrs.p0.u8 + x, offsets);
             rows.r1 = vldr_u32_gather_unaligned(rowptrs.p1.u8 + x, offsets);
@@ -1481,7 +1481,7 @@ static void vdebayer_gbrg_to_grayscale_awb(image_t *src, image_t *dst, image_t *
         vrgb_pixels_store_grayscale(p1, 0, vdebayer_apply_rb_gain(pixels1, red_gain, blue_gain), pred);
 
         int32_t x = VBAYER_X_STRIDE;
-        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x <= x_end; x += VBAYER_X_STRIDE) {
+        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x < x_end; x += VBAYER_X_STRIDE) {
             v4x_rows_t rows;
             rows.r0 = vldr_u32_gather_unaligned(rowptrs.p0.u8 + x, offsets);
             rows.r1 = vldr_u32_gather_unaligned(rowptrs.p1.u8 + x, offsets);
@@ -1524,7 +1524,7 @@ static void vdebayer_gbrg_to_grayscale_awb(image_t *src, image_t *dst, image_t *
         vrgb_pixels_store_grayscale(p0, 0, vdebayer_apply_rb_gain(pixels0, red_gain, blue_gain), pred);
 
         int32_t x = VBAYER_X_STRIDE;
-        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x <= x_end; x += VBAYER_X_STRIDE) {
+        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x < x_end; x += VBAYER_X_STRIDE) {
             v4x_rows_t rows;
             rows.r0 = vldr_u32_gather_unaligned(rowptrs.p0.u8 + x, offsets);
             rows.r1 = vldr_u32_gather_unaligned(rowptrs.p1.u8 + x, offsets);
@@ -1567,7 +1567,7 @@ static void vdebayer_grbg_to_grayscale_awb(image_t *src, image_t *dst, image_t *
         vrgb_pixels_store_grayscale(p1, 0, vdebayer_apply_rb_gain(pixels1, red_gain, blue_gain), pred);
 
         int32_t x = VBAYER_X_STRIDE;
-        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x <= x_end; x += VBAYER_X_STRIDE) {
+        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x < x_end; x += VBAYER_X_STRIDE) {
             v4x_rows_t rows;
             rows.r0 = vldr_u32_gather_unaligned(rowptrs.p0.u8 + x, offsets);
             rows.r1 = vldr_u32_gather_unaligned(rowptrs.p1.u8 + x, offsets);
@@ -1610,7 +1610,7 @@ static void vdebayer_grbg_to_grayscale_awb(image_t *src, image_t *dst, image_t *
         vrgb_pixels_store_grayscale(p0, 0, vdebayer_apply_rb_gain(pixels0, red_gain, blue_gain), pred);
 
         int32_t x = VBAYER_X_STRIDE;
-        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x <= x_end; x += VBAYER_X_STRIDE) {
+        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x < x_end; x += VBAYER_X_STRIDE) {
             v4x_rows_t rows;
             rows.r0 = vldr_u32_gather_unaligned(rowptrs.p0.u8 + x, offsets);
             rows.r1 = vldr_u32_gather_unaligned(rowptrs.p1.u8 + x, offsets);
@@ -1653,7 +1653,7 @@ static void vdebayer_rggb_to_grayscale_awb(image_t *src, image_t *dst, image_t *
         vrgb_pixels_store_grayscale(p1, 0, vdebayer_apply_rb_gain(pixels1, red_gain, blue_gain), pred);
 
         int32_t x = VBAYER_X_STRIDE;
-        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x <= x_end; x += VBAYER_X_STRIDE) {
+        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x < x_end; x += VBAYER_X_STRIDE) {
             v4x_rows_t rows;
             rows.r0 = vldr_u32_gather_unaligned(rowptrs.p0.u8 + x, offsets);
             rows.r1 = vldr_u32_gather_unaligned(rowptrs.p1.u8 + x, offsets);
@@ -1696,7 +1696,7 @@ static void vdebayer_rggb_to_grayscale_awb(image_t *src, image_t *dst, image_t *
         vrgb_pixels_store_grayscale(p0, 0, vdebayer_apply_rb_gain(pixels0, red_gain, blue_gain), pred);
 
         int32_t x = VBAYER_X_STRIDE;
-        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x <= x_end; x += VBAYER_X_STRIDE) {
+        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x < x_end; x += VBAYER_X_STRIDE) {
             v4x_rows_t rows;
             rows.r0 = vldr_u32_gather_unaligned(rowptrs.p0.u8 + x, offsets);
             rows.r1 = vldr_u32_gather_unaligned(rowptrs.p1.u8 + x, offsets);
@@ -1739,7 +1739,7 @@ static void vdebayer_bggr_to_rgb565_awb(image_t *src, image_t *dst, image_t *buf
         vrgb_pixels_store_rgb565(p1, 0, vdebayer_apply_rb_gain(pixels1, red_gain, blue_gain), pred);
 
         int32_t x = VBAYER_X_STRIDE;
-        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x <= x_end; x += VBAYER_X_STRIDE) {
+        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x < x_end; x += VBAYER_X_STRIDE) {
             v4x_rows_t rows;
             rows.r0 = vldr_u32_gather_unaligned(rowptrs.p0.u8 + x, offsets);
             rows.r1 = vldr_u32_gather_unaligned(rowptrs.p1.u8 + x, offsets);
@@ -1782,7 +1782,7 @@ static void vdebayer_bggr_to_rgb565_awb(image_t *src, image_t *dst, image_t *buf
         vrgb_pixels_store_rgb565(p0, 0, vdebayer_apply_rb_gain(pixels0, red_gain, blue_gain), pred);
 
         int32_t x = VBAYER_X_STRIDE;
-        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x <= x_end; x += VBAYER_X_STRIDE) {
+        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x < x_end; x += VBAYER_X_STRIDE) {
             v4x_rows_t rows;
             rows.r0 = vldr_u32_gather_unaligned(rowptrs.p0.u8 + x, offsets);
             rows.r1 = vldr_u32_gather_unaligned(rowptrs.p1.u8 + x, offsets);
@@ -1825,7 +1825,7 @@ static void vdebayer_gbrg_to_rgb565_awb(image_t *src, image_t *dst, image_t *buf
         vrgb_pixels_store_rgb565(p1, 0, vdebayer_apply_rb_gain(pixels1, red_gain, blue_gain), pred);
 
         int32_t x = VBAYER_X_STRIDE;
-        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x <= x_end; x += VBAYER_X_STRIDE) {
+        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x < x_end; x += VBAYER_X_STRIDE) {
             v4x_rows_t rows;
             rows.r0 = vldr_u32_gather_unaligned(rowptrs.p0.u8 + x, offsets);
             rows.r1 = vldr_u32_gather_unaligned(rowptrs.p1.u8 + x, offsets);
@@ -1868,7 +1868,7 @@ static void vdebayer_gbrg_to_rgb565_awb(image_t *src, image_t *dst, image_t *buf
         vrgb_pixels_store_rgb565(p0, 0, vdebayer_apply_rb_gain(pixels0, red_gain, blue_gain), pred);
 
         int32_t x = VBAYER_X_STRIDE;
-        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x <= x_end; x += VBAYER_X_STRIDE) {
+        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x < x_end; x += VBAYER_X_STRIDE) {
             v4x_rows_t rows;
             rows.r0 = vldr_u32_gather_unaligned(rowptrs.p0.u8 + x, offsets);
             rows.r1 = vldr_u32_gather_unaligned(rowptrs.p1.u8 + x, offsets);
@@ -1911,7 +1911,7 @@ static void vdebayer_grbg_to_rgb565_awb(image_t *src, image_t *dst, image_t *buf
         vrgb_pixels_store_rgb565(p1, 0, vdebayer_apply_rb_gain(pixels1, red_gain, blue_gain), pred);
 
         int32_t x = VBAYER_X_STRIDE;
-        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x <= x_end; x += VBAYER_X_STRIDE) {
+        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x < x_end; x += VBAYER_X_STRIDE) {
             v4x_rows_t rows;
             rows.r0 = vldr_u32_gather_unaligned(rowptrs.p0.u8 + x, offsets);
             rows.r1 = vldr_u32_gather_unaligned(rowptrs.p1.u8 + x, offsets);
@@ -1954,7 +1954,7 @@ static void vdebayer_grbg_to_rgb565_awb(image_t *src, image_t *dst, image_t *buf
         vrgb_pixels_store_rgb565(p0, 0, vdebayer_apply_rb_gain(pixels0, red_gain, blue_gain), pred);
 
         int32_t x = VBAYER_X_STRIDE;
-        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x <= x_end; x += VBAYER_X_STRIDE) {
+        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x < x_end; x += VBAYER_X_STRIDE) {
             v4x_rows_t rows;
             rows.r0 = vldr_u32_gather_unaligned(rowptrs.p0.u8 + x, offsets);
             rows.r1 = vldr_u32_gather_unaligned(rowptrs.p1.u8 + x, offsets);
@@ -1997,7 +1997,7 @@ static void vdebayer_rggb_to_rgb565_awb(image_t *src, image_t *dst, image_t *buf
         vrgb_pixels_store_rgb565(p1, 0, vdebayer_apply_rb_gain(pixels1, red_gain, blue_gain), pred);
 
         int32_t x = VBAYER_X_STRIDE;
-        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x <= x_end; x += VBAYER_X_STRIDE) {
+        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x < x_end; x += VBAYER_X_STRIDE) {
             v4x_rows_t rows;
             rows.r0 = vldr_u32_gather_unaligned(rowptrs.p0.u8 + x, offsets);
             rows.r1 = vldr_u32_gather_unaligned(rowptrs.p1.u8 + x, offsets);
@@ -2040,7 +2040,7 @@ static void vdebayer_rggb_to_rgb565_awb(image_t *src, image_t *dst, image_t *buf
         vrgb_pixels_store_rgb565(p0, 0, vdebayer_apply_rb_gain(pixels0, red_gain, blue_gain), pred);
 
         int32_t x = VBAYER_X_STRIDE;
-        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x <= x_end; x += VBAYER_X_STRIDE) {
+        for (int32_t x_end = src->w - VBAYER_X_STRIDE; x < x_end; x += VBAYER_X_STRIDE) {
             v4x_rows_t rows;
             rows.r0 = vldr_u32_gather_unaligned(rowptrs.p0.u8 + x, offsets);
             rows.r1 = vldr_u32_gather_unaligned(rowptrs.p1.u8 + x, offsets);


### PR DESCRIPTION
Fixes debayer_awb() on the non-vectorized processors... https://github.com/openmv/openmv/issues/2425

I don't see the issue using the OV7725 with the AE3. Need to duplicate the error test setup.