### PR TITLE
bootloader: Set first partition's region as executable.

### DIFF
--- a/src/boot/src/common/mpu.c
+++ b/src/boot/src/common/mpu.c
@@ -100,7 +100,9 @@ __weak void port_mpu_init(void) {
 
     // Configure read-only MPU regions for boot partitions.
     for (size_t i = 0; i < OMV_BOOT_PARTITIONS_COUNT; i++) {
-        port_mpu_config(&OMV_BOOT_PARTITIONS[i], 1, 1, 1);
+        // Note first region is the bootloader's partition,
+        // which normally needs to be executable.
+        port_mpu_config(&OMV_BOOT_PARTITIONS[i], 1, 1, (i == 0));
     }
 }
 


### PR DESCRIPTION
If the first partition has a valid leave region, leave it as executable as it's typically used for the bootloader itself.