### PR TITLE
py_image: Fix corruption using to_ndarray() on grayscale images.

### DIFF
--- a/src/omv/modules/py_image.c
+++ b/src/omv/modules/py_image.c
@@ -845,7 +845,7 @@ static mp_obj_t py_image_to_ndarray(uint n_args, const mp_obj_t *pos_args, mp_ma
 
             int i = 0;
 
-            for (; i < len; i += 4) {
+            for (; i < (len - 3); i += 4) {
                 *((uint32_t *) (output_u8 + i)) = *((uint32_t *) (input_u8 + i)) ^ shift;
             }
 


### PR DESCRIPTION
Maybe fixes: https://github.com/openmv/openmv/issues/2469

This would corrupt the trailing 1-3 bytes of an allocation. However, allocations are multiples of 4 bytes. So, while this is a fix, I am not sure if it fixes the user error as the corrupted bytes would be at the tail of a heap block not in use.