### PR TITLE
ports/stm32: Make usage of MDMA for jpeg compression conditional.

### DIFF
--- a/src/omv/ports/stm32/stm32_hal_msp.c
+++ b/src/omv/ports/stm32/stm32_hal_msp.c
@@ -771,7 +771,7 @@ void HAL_MspDeInit(void) {
 
 void MDMA_IRQHandler() {
     IRQ_ENTER(MDMA_IRQn);
-    #if (OMV_JPEG_CODEC_ENABLE == 1)
+    #if defined(OMV_MDMA_CHANNEL_JPEG_IN)
     extern void jpeg_mdma_irq_handler(void);
     jpeg_mdma_irq_handler();
     #endif


### PR DESCRIPTION
Allows using IT mode instead of DMA mode for jpeg compression. It mode is faster than non-IT mode since the processor can prepare the next MCU while the jpeg compressor is working.

Compression Performance on H7 Plus:
MDMA - VGA GRAYSCALE: 3.78ms - IT mode: 9ms
MDMA - VGA RGB565: 18.65ms - IT mode: 34.5ms

Decompression Performance on H7 Plus:
MDMA - VGA GRAYSCALE: 2.7ms - IT mode: 10.7ms
MDMA - VGA RGB565: 11.45ms - IT mode: 36ms



