### PR TITLE
_boot.py: write unique_id to .openmv_disk.

### DIFF
--- a/scripts/libraries/_boot.py
+++ b/scripts/libraries/_boot.py
@@ -130,4 +130,8 @@ try:
 except Exception:
     create_file(".openmv_disk")
 
-del os, sys, vfs, fat, bdev, sdcard
+with open(".openmv_disk", "w") as f:
+    import machine
+    f.write("".join(f'{byte:02X}' for byte in machine.unique_id()))
+
+del os, sys, vfs, fat, bdev, sdcard, machine


### PR DESCRIPTION
When two OpenMV Cams are connected to the computer, OpenMV IDE cannot know the exact path.

After adding uniqueid to .openmv_disk file.

OpenMV IDE first gets the uniqueid through the serial port, and then can determine whether the path matches the connected OpenMV Cam.