### PR TITLE
imlib/draw: Fixed transpose on SDRAM-less boards.

### DIFF
--- a/src/omv/imlib/draw.c
+++ b/src/omv/imlib/draw.c
@@ -3144,8 +3144,14 @@ void imlib_draw_image(image_t *dst_img,
             t_src_img.data = src_img->data;
         }
 
+        // Query available on-chip RAM.
         uint32_t size;
         void *data = fb_alloc_all(&size, FB_ALLOC_PREFER_SPEED | FB_ALLOC_CACHE_ALIGN);
+        fb_free();
+
+        // Allocate a buffer to hold chunks of the transposed image while not using all of the on-chip RAM.
+        size = IM_MIN(size, image_size(&t_src_img));
+        data = fb_alloc(size, FB_ALLOC_PREFER_SPEED | FB_ALLOC_CACHE_ALIGN);
 
         // line_num stores how many lines we can do at a time with on-chip RAM.
         image_t temp = {.w = t_roi.w, .h = t_roi.h, .pixfmt = t_src_img.pixfmt};


### PR DESCRIPTION
When the omv_gpu driver was added for the STM32 it allocates a CLUT using fb_alloc. However, during transpose we allocate all RAM. So, the GPU driver call fails to allocate the RAM it needs for loading it's CLUT.

On SDRAM boards this error doesn't happen the fb_alloc_all call will only exhaust onchip SRAM.
