### PR TITLE
common/vospi: Set vospi bus CPOL=1 and CPHA=1.

### DIFF
--- a/src/omv/common/vospi.c
+++ b/src/omv/common/vospi.c
@@ -179,6 +179,8 @@ int vospi_init(uint32_t n_packets, void *buffer) {
     spi_config.bus_mode = OMV_SPI_BUS_RX;
     spi_config.datasize = 16;
     spi_config.baudrate = VOSPI_CLOCK_SPEED;
+    spi_config.clk_pol = OMV_SPI_CPOL_LOW;
+    spi_config.clk_pha = OMV_SPI_CPHA_2EDGE;
     spi_config.dma_flags = OMV_SPI_DMA_CIRCULAR | OMV_SPI_DMA_DOUBLE;
 
     if (omv_spi_init(&vospi.spi_bus, &spi_config) != 0) {

--- a/src/omv/modules/py_fir_lepton.c
+++ b/src/omv/modules/py_fir_lepton.c
@@ -263,6 +263,8 @@ int fir_lepton_init(omv_i2c_t *bus, int *w, int *h, int *refresh, int *resolutio
     spi_config.datasize = 16;
     spi_config.bus_mode = OMV_SPI_BUS_RX;
     spi_config.nss_enable = false;
+    spi_config.clk_pol = OMV_SPI_CPOL_LOW;
+    spi_config.clk_pha = OMV_SPI_CPHA_2EDGE;
     spi_config.dma_flags = OMV_SPI_DMA_CIRCULAR | OMV_SPI_DMA_DOUBLE;
     omv_spi_init(&spi_bus, &spi_config);
 

--- a/src/omv/ports/mimxrt/omv_portconfig.h
+++ b/src/omv/ports/mimxrt/omv_portconfig.h
@@ -114,8 +114,8 @@ typedef LPI2C_Type *omv_i2c_dev_t;
 #define OMV_SPI_BUS_RX          (1 << 1)
 #define OMV_SPI_BUS_TX_RX       (OMV_SPI_BUS_TX | OMV_SPI_BUS_RX)
 
-#define OMV_SPI_CPOL_LOW        (kLPSPI_ClockPolarityActiveLow)
-#define OMV_SPI_CPOL_HIGH       (kLPSPI_ClockPolarityActiveHigh)
+#define OMV_SPI_CPOL_LOW        (kLPSPI_ClockPolarityActiveHigh)
+#define OMV_SPI_CPOL_HIGH       (kLPSPI_ClockPolarityActiveLow)
 
 #define OMV_SPI_CPHA_1EDGE      (kLPSPI_ClockPhaseFirstEdge)
 #define OMV_SPI_CPHA_2EDGE      (kLPSPI_ClockPhaseSecondEdge)

--- a/src/omv/ports/mimxrt/omv_spi.c
+++ b/src/omv/ports/mimxrt/omv_spi.c
@@ -313,7 +313,7 @@ int omv_spi_default_config(omv_spi_config_t *config, uint32_t bus_id) {
     config->spi_mode = OMV_SPI_MODE_MASTER;
     config->bus_mode = OMV_SPI_BUS_TX_RX;
     config->bit_order = OMV_SPI_MSB_FIRST;
-    config->clk_pol = OMV_SPI_CPOL_HIGH;
+    config->clk_pol = OMV_SPI_CPOL_LOW;
     config->clk_pha = OMV_SPI_CPHA_1EDGE;
     config->nss_pol = OMV_SPI_NSS_LOW;
     config->nss_enable = true;


### PR DESCRIPTION
The MSB read via SPI on the RT1062 is corrupted for the FLIR Lepton unless.

```
spi_config.clk_pol = OMV_SPI_CPOL_LOW;
spi_config.clk_pha = OMV_SPI_CPHA_2EDGE;
```

OMV_SPI_CPOL_LOW-> clock idle low, active high-> CPOL=1
OMV_SPI_CPHA_2EDGE -> CPHA=1

The other following 15-bits come out okay.

On the STM32, `spi_config.clk_pha = OMV_SPI_CPHA_2EDGE` or `spi_config.clk_pha = OMV_SPI_CPHA_1EDGE` both work oddly enough.

![image](https://github.com/user-attachments/assets/1af66a41-059d-4cdf-95f6-1581295992ab)

CPHA=1 and CPOL=1 are the correct settings. So, we've been running with this wrong for years on the STM32.

....

Need to test some more stuff until this PR is ready.
