### PR TITLE
common/vospi: Set vospi bus CPOL=1 and CPHA=1.

### DIFF
--- a/src/omv/boards/OPENMV_RT1060/omv_boardconfig.h
+++ b/src/omv/boards/OPENMV_RT1060/omv_boardconfig.h
@@ -187,7 +187,6 @@
 // FIR Lepton
 #define OMV_FIR_LEPTON_I2C_BUS          (OMV_FIR_I2C_ID)
 #define OMV_FIR_LEPTON_I2C_BUS_SPEED    (OMV_FIR_I2C_SPEED)
-#define OMV_FIR_LEPTON_RX_CLK_DIV       (8)
 
 #define OMV_FIR_LEPTON_SPI_BUS          (OMV_SPI3_ID)
 #define OMV_FIR_LEPTON_MOSI_PIN         (&omv_pin_LPSPI3_MOSI)

--- a/src/omv/common/vospi.c
+++ b/src/omv/common/vospi.c
@@ -179,6 +179,8 @@ int vospi_init(uint32_t n_packets, void *buffer) {
     spi_config.bus_mode = OMV_SPI_BUS_RX;
     spi_config.datasize = 16;
     spi_config.baudrate = VOSPI_CLOCK_SPEED;
+    spi_config.clk_pol = OMV_SPI_CPOL_HIGH;
+    spi_config.clk_pha = OMV_SPI_CPHA_2EDGE;
     spi_config.dma_flags = OMV_SPI_DMA_CIRCULAR | OMV_SPI_DMA_DOUBLE;
 
     if (omv_spi_init(&vospi.spi_bus, &spi_config) != 0) {

--- a/src/omv/modules/py_fir_lepton.c
+++ b/src/omv/modules/py_fir_lepton.c
@@ -254,11 +254,7 @@ int fir_lepton_init(omv_i2c_t *bus, int *w, int *h, int *refresh, int *resolutio
     omv_spi_config_t spi_config;
     omv_spi_default_config(&spi_config, OMV_FIR_LEPTON_SPI_BUS);
 
-    #if OMV_FIR_LEPTON_RX_CLK_DIV
-    spi_config.baudrate = VOSPI_CLOCK_SPEED / OMV_FIR_LEPTON_RX_CLK_DIV;
-    #else
     spi_config.baudrate = VOSPI_CLOCK_SPEED;
-    #endif
 
     spi_config.datasize = 16;
     spi_config.bus_mode = OMV_SPI_BUS_RX;

--- a/src/omv/modules/py_fir_lepton.c
+++ b/src/omv/modules/py_fir_lepton.c
@@ -263,6 +263,8 @@ int fir_lepton_init(omv_i2c_t *bus, int *w, int *h, int *refresh, int *resolutio
     spi_config.datasize = 16;
     spi_config.bus_mode = OMV_SPI_BUS_RX;
     spi_config.nss_enable = false;
+    spi_config.clk_pol = OMV_SPI_CPOL_HIGH;
+    spi_config.clk_pha = OMV_SPI_CPHA_2EDGE;
     spi_config.dma_flags = OMV_SPI_DMA_CIRCULAR | OMV_SPI_DMA_DOUBLE;
     omv_spi_init(&spi_bus, &spi_config);
 

--- a/src/omv/ports/mimxrt/omv_portconfig.h
+++ b/src/omv/ports/mimxrt/omv_portconfig.h
@@ -114,8 +114,8 @@ typedef LPI2C_Type *omv_i2c_dev_t;
 #define OMV_SPI_BUS_RX          (1 << 1)
 #define OMV_SPI_BUS_TX_RX       (OMV_SPI_BUS_TX | OMV_SPI_BUS_RX)
 
-#define OMV_SPI_CPOL_LOW        (kLPSPI_ClockPolarityActiveLow)
-#define OMV_SPI_CPOL_HIGH       (kLPSPI_ClockPolarityActiveHigh)
+#define OMV_SPI_CPOL_LOW        (kLPSPI_ClockPolarityActiveHigh)
+#define OMV_SPI_CPOL_HIGH       (kLPSPI_ClockPolarityActiveLow)
 
 #define OMV_SPI_CPHA_1EDGE      (kLPSPI_ClockPhaseFirstEdge)
 #define OMV_SPI_CPHA_2EDGE      (kLPSPI_ClockPhaseSecondEdge)

--- a/src/omv/ports/mimxrt/omv_spi.c
+++ b/src/omv/ports/mimxrt/omv_spi.c
@@ -313,7 +313,7 @@ int omv_spi_default_config(omv_spi_config_t *config, uint32_t bus_id) {
     config->spi_mode = OMV_SPI_MODE_MASTER;
     config->bus_mode = OMV_SPI_BUS_TX_RX;
     config->bit_order = OMV_SPI_MSB_FIRST;
-    config->clk_pol = OMV_SPI_CPOL_HIGH;
+    config->clk_pol = OMV_SPI_CPOL_LOW;
     config->clk_pha = OMV_SPI_CPHA_1EDGE;
     config->nss_pol = OMV_SPI_NSS_LOW;
     config->nss_enable = true;


### PR DESCRIPTION
Fixes: https://github.com/openmv/openmv/issues/2485

1. Fixes swapped clock polarity names for the RT1062.
2.  The FLIR Lepton needs:

```
spi_config.clk_pol = OMV_SPI_CPOL_HIGH;
spi_config.clk_pha = OMV_SPI_CPHA_2EDGE;
```

![image](https://github.com/user-attachments/assets/0f32caaf-7789-4ade-885c-5baf51f98c02)

On the STM32... we've been running for years with:

```
config->clk_pol = OMV_SPI_CPOL_LOW;
config->clk_pha = OMV_SPI_CPHA_1EDGE;
```

However, things work with the new settings, too... weirdly enough on the STM32.

...

Need to test VOSPI/FIR  thoroughly on both boards and all SPI IMXRT devices before this is ready.



