### PR TITLE
imlib/draw: Enable GPU in-place cut-through.

### DIFF
--- a/src/omv/imlib/draw.c
+++ b/src/omv/imlib/draw.c
@@ -3061,19 +3061,19 @@ void imlib_draw_image(image_t *dst_img,
     size_t dst_img_row_bytes = image_size(dst_img) / dst_img->h;
 
     // Do we need to convert the image?
-    bool is_bayer_color_conversion = src_img->is_bayer && !dst_img->is_bayer;
-    bool is_yuv_color_conversion = src_img->is_yuv && !dst_img->is_yuv;
-    bool is_color_conversion = is_bayer_color_conversion || is_yuv_color_conversion;
+    bool is_bayer_conversion = src_img->is_bayer && !dst_img->is_bayer;
+    bool is_yuv_conversion = src_img->is_yuv && !dst_img->is_yuv;
+    bool is_bayer_yuv_conversion = is_bayer_conversion || is_yuv_conversion;
 
     // Force a deep copy if we cannot use the image in-place.
     bool need_deep_copy = (dst_img->data == src_img->data)
-                          && (is_scaling || (src_img_row_bytes < dst_img_row_bytes) || is_color_conversion);
+                          && (is_scaling || (src_img_row_bytes < dst_img_row_bytes) || is_bayer_yuv_conversion);
 
     // Force a deep copy if we are scaling.
-    bool is_color_conversion_scaling = is_color_conversion && is_scaling;
+    bool is_bayer_yuv_conversion_scaling = is_bayer_yuv_conversion && is_scaling;
 
     // Make a deep copy of the source image.
-    if (need_deep_copy || is_color_conversion_scaling || is_jpeg || is_png) {
+    if (need_deep_copy || is_bayer_yuv_conversion_scaling || is_jpeg || is_png) {
         new_src_img.w = src_img->w; // same width as source image
         new_src_img.h = src_img->h; // same height as source image
 

--- a/src/omv/imlib/draw.c
+++ b/src/omv/imlib/draw.c
@@ -2954,11 +2954,13 @@ void imlib_draw_image(image_t *dst_img,
     // top 16-bits = whole part, bottom 16-bits = fractional part.
 
     int dst_x_reset = (dst_delta_x < 0) ? (dst_x_end - 1) : dst_x_start;
-    long src_x_frac = fast_floorf(65536.0f / x_scale), src_x_frac_size = (src_x_frac + 0xFFFF) >> 16;
+    long src_x_frac = fast_floorf(65536.0f / x_scale);
+    long src_x_frac_size = (src_x_frac + 0xFFFF) >> 16;
     long src_x_accum_reset = fast_floorf((src_x_start << 16) / x_scale);
 
     int dst_y_reset = (dst_delta_y < 0) ? (dst_y_end - 1) : dst_y_start;
-    long src_y_frac = fast_floorf(65536.0f / y_scale), src_y_frac_size = (src_y_frac + 0xFFFF) >> 16;
+    long src_y_frac = fast_floorf(65536.0f / y_scale);
+    long src_y_frac_size = (src_y_frac + 0xFFFF) >> 16;
     long src_y_accum_reset = fast_floorf((src_y_start << 16) / y_scale);
 
     // Nearest Neighbor

--- a/src/omv/ports/stm32/omv_gpu.c
+++ b/src/omv/ports/stm32/omv_gpu.c
@@ -167,10 +167,14 @@ int omv_gpu_draw_image(image_t *src_img,
 
     #if __DCACHE_PRESENT
     // Ensures any cached writes to dst16 are flushed.
-    uint16_t *dst16_tmp = dst16;
-    for (int i = 0; i < dst_rect->h; i++) {
-        SCB_CleanInvalidateDCache_by_Addr(dst16_tmp, dst_rect->w * sizeof(uint16_t));
-        dst16_tmp += dst_img->w;
+    if (dst_img->w == dst_rect->w) {
+        SCB_CleanInvalidateDCache_by_Addr(dst16, dst_rect->w * dst_rect->h * sizeof(uint16_t));
+    } else {
+        uint16_t *dst16_tmp = dst16;
+        for (int i = 0; i < dst_rect->h; i++) {
+            SCB_CleanInvalidateDCache_by_Addr(dst16_tmp, dst_rect->w * sizeof(uint16_t));
+            dst16_tmp += dst_img->w;
+        }
     }
     #endif
 
@@ -181,10 +185,14 @@ int omv_gpu_draw_image(image_t *src_img,
         src = (uint32_t) src8;
 
         #if __DCACHE_PRESENT
-        uint8_t *src8_tmp = src8;
-        for (int i = 0; i < src_rect->h; i++) {
-            SCB_CleanDCache_by_Addr(src8_tmp, src_rect->w);
-            src8_tmp += src_img->w;
+        if (src_img->w == src_rect->w) {
+            SCB_CleanDCache_by_Addr(src8, src_rect->w * src_rect->h);
+        } else {
+            uint8_t *src8_tmp = src8;
+            for (int i = 0; i < src_rect->h; i++) {
+                SCB_CleanDCache_by_Addr(src8_tmp, src_rect->w);
+                src8_tmp += src_img->w;
+            }
         }
         #endif
     } else {
@@ -192,10 +200,14 @@ int omv_gpu_draw_image(image_t *src_img,
         src = (uint32_t) src16;
 
         #if __DCACHE_PRESENT
-        uint16_t *src16_tmp = src16;
-        for (int i = 0; i < src_rect->h; i++) {
-            SCB_CleanDCache_by_Addr(src16_tmp, src_rect->w * sizeof(uint16_t));
-            src16_tmp += src_img->w;
+        if (src_img->w == src_rect->w) {
+            SCB_CleanDCache_by_Addr(src16, src_rect->w * src_rect->h);
+        } else {
+            uint16_t *src16_tmp = src16;
+            for (int i = 0; i < src_rect->h; i++) {
+                SCB_CleanDCache_by_Addr(src16_tmp, src_rect->w * sizeof(uint16_t));
+                src16_tmp += src_img->w;
+            }
         }
         #endif
     }
@@ -213,10 +225,14 @@ int omv_gpu_draw_image(image_t *src_img,
 
     #if __DCACHE_PRESENT
     // Ensures any cached reads to dst16 are dropped.
-    dst16_tmp = dst16;
-    for (int i = 0; i < dst_rect->h; i++) {
-        SCB_InvalidateDCache_by_Addr(dst16_tmp, dst_rect->w * sizeof(uint16_t));
-        dst16_tmp += dst_img->w;
+    if (dst_img->w == dst_rect->w) {
+        SCB_InvalidateDCache_by_Addr(dst16, dst_rect->w * dst_rect->h * sizeof(uint16_t));
+    } else {
+        uint16_t *dst16_tmp = dst16;
+        for (int i = 0; i < dst_rect->h; i++) {
+            SCB_InvalidateDCache_by_Addr(dst16_tmp, dst_rect->w * sizeof(uint16_t));
+            dst16_tmp += dst_img->w;
+        }
     }
     #endif
 


### PR DESCRIPTION
Tested on the STM32H7. In-place image cropping performance with RGB565 (only operation in-place DMA2D supports) sees a massive boost going from 21ms to 2ms as the copy on the image is removed.

Tested on Alif, all instances of scaling down and/or cropping at the same time work. The copy overhead has been removed.

Scaling up on Alif seems to have issues. Without this PR with and with out-of-place buffers you get a corrupted image.