### PR TITLE
ports/stm32/omv_gpu: Fix cache line clean size.

### DIFF
--- a/src/omv/ports/stm32/omv_gpu.c
+++ b/src/omv/ports/stm32/omv_gpu.c
@@ -295,7 +295,7 @@ int omv_gpu_draw_image(image_t *src_img,
 
         #if __DCACHE_PRESENT
         if (src_img->w == src_rect->w) {
-            SCB_CleanDCache_by_Addr(src16, src_rect->w * src_rect->h);
+            SCB_CleanDCache_by_Addr(src16, src_rect->w * src_rect->h * sizeof(uint16_t));
         } else {
             uint16_t *src16_tmp = src16;
             for (int i = 0; i < src_rect->h; i++) {


### PR DESCRIPTION
Found when helping to test GPU scaling.