### PR TITLE
ports/all: Fix MISO/MOSI pins being used in TX/RX only mode.

### DIFF
--- a/src/omv/ports/mimxrt/mimxrt_hal.c
+++ b/src/omv/ports/mimxrt/mimxrt_hal.c
@@ -194,7 +194,7 @@ int mimxrt_hal_i2c_init(uint32_t bus_id) {
     return 0;
 }
 
-int mimxrt_hal_spi_init(uint32_t bus_id, bool nss_enable, uint32_t nss_pol) {
+int mimxrt_hal_spi_init(uint32_t bus_id, bool nss_enable, uint32_t nss_pol, uint32_t bus_mode) {
     typedef struct {
         omv_gpio_t sclk_pin;
         omv_gpio_t miso_pin;
@@ -242,8 +242,12 @@ int mimxrt_hal_spi_init(uint32_t bus_id, bool nss_enable, uint32_t nss_pol) {
     }
 
     omv_gpio_config(spi_pins.sclk_pin, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
-    omv_gpio_config(spi_pins.miso_pin, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
-    omv_gpio_config(spi_pins.mosi_pin, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
+    if (bus_mode & OMV_SPI_BUS_RX) {
+        omv_gpio_config(spi_pins.miso_pin, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
+    }
+    if (bus_mode & OMV_SPI_BUS_TX) {
+        omv_gpio_config(spi_pins.mosi_pin, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
+    }
     if (nss_enable) {
         omv_gpio_config(spi_pins.ssel_pin, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_UP, OMV_GPIO_SPEED_MED, -1);
     } else {
@@ -257,7 +261,7 @@ int mimxrt_hal_spi_init(uint32_t bus_id, bool nss_enable, uint32_t nss_pol) {
     return 0;
 }
 
-int mimxrt_hal_spi_deinit(uint32_t bus_id) {
+int mimxrt_hal_spi_deinit(uint32_t bus_id, uint32_t bus_mode) {
     typedef struct {
         omv_gpio_t sclk_pin;
         omv_gpio_t miso_pin;
@@ -305,8 +309,12 @@ int mimxrt_hal_spi_deinit(uint32_t bus_id) {
     }
 
     omv_gpio_deinit(spi_pins.sclk_pin);
-    omv_gpio_deinit(spi_pins.miso_pin);
-    omv_gpio_deinit(spi_pins.mosi_pin);
+    if (bus_mode & OMV_SPI_BUS_RX) {
+        omv_gpio_deinit(spi_pins.miso_pin);
+    }
+    if (bus_mode & OMV_SPI_BUS_TX) {
+        omv_gpio_deinit(spi_pins.mosi_pin);
+    }
     omv_gpio_deinit(spi_pins.ssel_pin);
     return 0;
 }

--- a/src/omv/ports/mimxrt/mimxrt_hal.h
+++ b/src/omv/ports/mimxrt/mimxrt_hal.h
@@ -29,6 +29,6 @@ void mimxrt_hal_init();
 void mimxrt_hal_bootloader();
 int mimxrt_hal_csi_init(CSI_Type *inst);
 int mimxrt_hal_i2c_init(uint32_t bus_id);
-int mimxrt_hal_spi_init(uint32_t bus_id, bool nss_enable, uint32_t nss_pol);
-int mimxrt_hal_spi_deinit(uint32_t bus_id);
+int mimxrt_hal_spi_init(uint32_t bus_id, bool nss_enable, uint32_t nss_pol, uint32_t bus_mode);
+int mimxrt_hal_spi_deinit(uint32_t bus_id, uint32_t bus_mode);
 #endif //__MIMXRT_HAL_H__

--- a/src/omv/ports/mimxrt/omv_portconfig.h
+++ b/src/omv/ports/mimxrt/omv_portconfig.h
@@ -142,6 +142,7 @@ struct {                                                \
         lpspi_master_edma_handle_t descr_master_edma;   \
     };                                                  \
     lpspi_transfer_t xfer_descr;                        \
+    uint32_t bus_mode;                                  \
 };
 
 // omv_csi_t port-specific fields.

--- a/src/omv/ports/mimxrt/omv_spi.c
+++ b/src/omv/ports/mimxrt/omv_spi.c
@@ -234,6 +234,7 @@ int omv_spi_init(omv_spi_t *spi, omv_spi_config_t *config) {
     spi->inst = spi_descr->inst;
     spi->cs = spi_descr->cs;
     spi->dma_flags = config->dma_flags;
+    spi->bus_mode = config->bus_mode;
 
     lpspi_master_config_t spi_config;
     LPSPI_MasterGetDefaultConfig(&spi_config);
@@ -255,7 +256,7 @@ int omv_spi_init(omv_spi_t *spi, omv_spi_config_t *config) {
     spi->config_backup = spi_config;
 
     // Configure pins.
-    mimxrt_hal_spi_init(config->id, config->nss_enable, config->nss_pol);
+    mimxrt_hal_spi_init(config->id, config->nss_enable, config->nss_pol, config->bus_mode);
 
     LPSPI_MasterTransferCreateHandle(
         spi->inst,
@@ -294,7 +295,7 @@ int omv_spi_deinit(omv_spi_t *spi) {
             DMAMUX_DisableChannel(spi_descr->dma_descr_rx.dma_mux, spi->dma_descr_rx.channel);
         }
         LPSPI_Deinit(spi->inst);
-        mimxrt_hal_spi_deinit(spi->id);
+        mimxrt_hal_spi_deinit(spi->id, spi->bus_mode);
     }
     return 0;
 }

--- a/src/omv/ports/stm32/stm32_hal_msp.c
+++ b/src/omv/ports/stm32/stm32_hal_msp.c
@@ -491,8 +491,16 @@ void HAL_SPI_MspInit(SPI_HandleTypeDef *hspi) {
         omv_gpio_config(spi_pins.sclk_pin, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_DOWN, OMV_GPIO_SPEED_HIGH, -1);
     }
     #endif
-    omv_gpio_config(spi_pins.miso_pin, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_HIGH, -1);
-    omv_gpio_config(spi_pins.mosi_pin, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_HIGH, -1);
+    if (hspi->Init.Direction == SPI_DIRECTION_2LINES || hspi->Init.Direction == SPI_DIRECTION_2LINES_RXONLY) {
+        omv_gpio_config(spi_pins.miso_pin, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_HIGH, -1);
+    }
+    #if defined(STM32H7)
+    if (hspi->Init.Direction == SPI_DIRECTION_2LINES || hspi->Init.Direction == SPI_DIRECTION_2LINES_TXONLY) {
+    #else
+    if (hspi->Init.Direction == SPI_DIRECTION_2LINES || hspi->Init.Direction == SPI_DIRECTION_1LINE) {
+    #endif
+        omv_gpio_config(spi_pins.mosi_pin, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_HIGH, -1);
+    }
     if (hspi->Init.NSS != SPI_NSS_SOFT) {
         omv_gpio_config(spi_pins.ssel_pin, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_UP, OMV_GPIO_SPEED_HIGH, -1);
     } else {
@@ -583,8 +591,16 @@ void HAL_SPI_MspDeInit(SPI_HandleTypeDef *hspi) {
     }
 
     omv_gpio_deinit(spi_pins.sclk_pin);
-    omv_gpio_deinit(spi_pins.miso_pin);
-    omv_gpio_deinit(spi_pins.mosi_pin);
+    if (hspi->Init.Direction == SPI_DIRECTION_2LINES || hspi->Init.Direction == SPI_DIRECTION_2LINES_RXONLY) {
+        omv_gpio_deinit(spi_pins.miso_pin);
+    }
+    #if defined(STM32H7)
+    if (hspi->Init.Direction == SPI_DIRECTION_2LINES || hspi->Init.Direction == SPI_DIRECTION_2LINES_TXONLY) {
+    #else
+    if (hspi->Init.Direction == SPI_DIRECTION_2LINES || hspi->Init.Direction == SPI_DIRECTION_1LINE) {
+    #endif
+        omv_gpio_deinit(spi_pins.mosi_pin);
+    }
     // Deinited by omv_spi.c so as to not deinit the pin when HAL_SPI_MspDeInit is called
     // from deiniting the SPI bus from the machine or pyb module.
     // omv_gpio_deinit(spi_pins.ssel_pin);


### PR DESCRIPTION
Fixes: https://forums.openmv.io/t/when-the-display-library-of-the-lcd-expansion-board-is-used-the-p1-pin-cannot-be-used-normally/10519

Tested the LCD shield and FLIR Lepton on the H7 Plus and RT1062 and both devices work normally on each camera.