### PR TITLE
scripts/libraries: Simplify YOLO post-processing using keepdims.

### DIFF
--- a/scripts/libraries/ml/ml/postprocessing.py
+++ b/scripts/libraries/ml/ml/postprocessing.py
@@ -72,7 +72,7 @@ class yolo_v2_postprocess:
     _YOLO_V2_SCORE = const(4)
     _YOLO_V2_CLASSES = const(5)
 
-    def __init__(self, threshold=0.6, anchors=None):
+    def __init__(self, threshold=0.6, anchors=None, nms_threshold=0.1, nms_sigma=0.1):
         self.threshold = threshold
         if anchors is not None:
             self.anchors = anchors
@@ -83,6 +83,8 @@ class yolo_v2_postprocess:
                                      [5.55170, 9.30660],
                                      [9.72600, 11.1422]], dtype=np.float)
         self.anchors_len = len(self.anchors)
+        self.nms_threshold = nms_threshold
+        self.nms_sigma = nms_sigma
 
     def __call__(self, model, inputs, outputs):
         ob, oh, ow, oc = model.output_shape[0]
@@ -152,7 +154,7 @@ class yolo_v2_postprocess:
                                  x_center[i] + (w_rel[i] / 2),
                                  y_center[i] + (h_rel[i] / 2),
                                  bb_scores[i], bb_classes[i])
-        return nms.get_bounding_boxes()
+        return nms.get_bounding_boxes(threshold=self.nms_threshold, sigma=self.nms_sigma)
 
 
 class yolo_v5_postprocess:
@@ -163,8 +165,10 @@ class yolo_v5_postprocess:
     _YOLO_V5_SCORE = const(4)
     _YOLO_V5_CLASSES = const(5)
 
-    def __init__(self, threshold=0.6):
+    def __init__(self, threshold=0.6, nms_threshold=0.1, nms_sigma=0.1):
         self.threshold = threshold
+        self.nms_threshold = nms_threshold
+        self.nms_sigma = nms_sigma
 
     def __call__(self, model, inputs, outputs):
         oh, ow, oc = model.output_shape[0]
@@ -208,4 +212,4 @@ class yolo_v5_postprocess:
         for i in range(len(bb)):
             nms.add_bounding_box(xmin[i], ymin[i], xmax[i], ymax[i],
                                  bb_scores[i], bb_classes[i])
-        return nms.get_bounding_boxes()
+        return nms.get_bounding_boxes(threshold=self.nms_threshold, sigma=self.nms_sigma)

--- a/scripts/libraries/ml/ml/postprocessing.py
+++ b/scripts/libraries/ml/ml/postprocessing.py
@@ -74,14 +74,13 @@ class yolo_v2_postprocess:
 
     def __init__(self, threshold=0.6, anchors=None, nms_threshold=0.1, nms_sigma=0.1):
         self.threshold = threshold
-        if anchors is not None:
-            self.anchors = anchors
-        else:
+        self.anchors = anchors
+        if self.anchors is None:
             self.anchors = np.array([[0.98830, 3.36060],
                                      [2.11940, 5.37590],
                                      [3.05200, 9.13360],
                                      [5.55170, 9.30660],
-                                     [9.72600, 11.1422]], dtype=np.float)
+                                     [9.72600, 11.1422]])
         self.anchors_len = len(self.anchors)
         self.nms_threshold = nms_threshold
         self.nms_sigma = nms_sigma
@@ -97,8 +96,8 @@ class yolo_v2_postprocess:
             return a - (b * (a // b))
 
         def softmax(x):
-            e_x = np.exp(x - np.max(x))
-            return e_x / np.sum(e_x)
+            e_x = np.exp(x - np.max(x, axis=1, keepdims=True))
+            return e_x / np.sum(e_x, axis=1, keepdims=True)
 
         # Reshape the output to a 2D array
         colum_outputs = outputs[0].reshape((oh * ow * self.anchors_len,
@@ -121,18 +120,13 @@ class yolo_v2_postprocess:
         bb_anchors = mod(score_indices, self.anchors_len)
 
         # Get the anchor box information
-        bb_a_array = [self.anchors[i] for i in bb_anchors.tolist()]
-        bb_a_array = np.array(bb_a_array)
+        bb_a_array = np.take(self.anchors, bb_anchors, axis=0)
 
         # Get the score information
         bb_scores = sigmoid(bb[:, _YOLO_V2_SCORE])
 
         # Get the class information
-        bb_classes = []
-        for i in range(len(score_indices)):
-            s = softmax(bb[i, _YOLO_V2_CLASSES:])
-            bb_classes.append(np.argmax(s))
-        bb_classes = np.array(bb_classes, dtype=np.uint16)
+        bb_classes = np.argmax(softmax(bb[:, _YOLO_V2_CLASSES:]), axis=1)
 
         # Compute the bounding box information
         x_center = (bb_cols + sigmoid(bb[:, _YOLO_V2_TX])) / ow
@@ -192,8 +186,7 @@ class yolo_v5_postprocess:
         bb_scores = bb[:, _YOLO_V5_SCORE]
 
         # Get the class information
-        bb_classes = [np.argmax(bb[x, _YOLO_V5_CLASSES:]) for x in range(bb.shape[0])]
-        bb_classes = np.array(bb_classes, dtype=np.uint16)
+        bb_classes = np.argmax(bb[:, _YOLO_V5_CLASSES:], axis=1)
 
         # Compute the bounding box information
         x_center = bb[:, _YOLO_V5_CX]

--- a/src/omv/ports/mimxrt/omv_portconfig.mk
+++ b/src/omv/ports/mimxrt/omv_portconfig.mk
@@ -454,6 +454,7 @@ FIRM_OBJ += $(addprefix $(BUILD)/$(MICROPY_DIR)/modules/ulab/code/,\
 	numpy/stats.o                   \
 	numpy/transform.o               \
 	numpy/vector.o                  \
+	scipy/integrate/integrate.o     \
 	scipy/linalg/linalg.o           \
 	scipy/optimize/optimize.o       \
 	scipy/scipy.o                   \

--- a/src/omv/ports/nrf/omv_portconfig.mk
+++ b/src/omv/ports/nrf/omv_portconfig.mk
@@ -402,6 +402,7 @@ FIRM_OBJ += $(addprefix $(BUILD)/$(MICROPY_DIR)/modules/ulab/code/,\
 	numpy/stats.o                   \
 	numpy/transform.o               \
 	numpy/vector.o                  \
+	scipy/integrate/integrate.o     \
 	scipy/linalg/linalg.o           \
 	scipy/optimize/optimize.o       \
 	scipy/scipy.o                   \

--- a/src/omv/ports/rp2/omv_portconfig.cmake
+++ b/src/omv/ports/rp2/omv_portconfig.cmake
@@ -276,6 +276,7 @@ if(MICROPY_PY_ULAB)
         ${MICROPY_ULAB_DIR}/code/numpy/stats.c
         ${MICROPY_ULAB_DIR}/code/numpy/transform.c
         ${MICROPY_ULAB_DIR}/code/numpy/vector.c
+        ${MICROPY_ULAB_DIR}/code/scipy/integrate/integrate.c
         ${MICROPY_ULAB_DIR}/code/scipy/linalg/linalg.c
         ${MICROPY_ULAB_DIR}/code/scipy/optimize/optimize.c
         ${MICROPY_ULAB_DIR}/code/scipy/scipy.c

--- a/src/omv/ports/stm32/omv_portconfig.mk
+++ b/src/omv/ports/stm32/omv_portconfig.mk
@@ -478,6 +478,7 @@ FIRM_OBJ += $(addprefix $(BUILD)/$(MICROPY_DIR)/modules/ulab/code/,\
 	numpy/stats.o                   \
 	numpy/transform.o               \
 	numpy/vector.o                  \
+	scipy/integrate/integrate.o     \
 	scipy/linalg/linalg.o           \
 	scipy/optimize/optimize.o       \
 	scipy/scipy.o                   \


### PR DESCRIPTION
Update to ULAB 6.7.3.

Tested using YOLOV2 and YOLOV5 models.

The new scipy integrate code in ulab takes quite a bit of space though...

Fixes: https://github.com/openmv/openmv/issues/2547