### PR TITLE
wasm: feat wasm port.

### DIFF
--- a/src/omv/boards/WASM/imlib_config.h
+++ b/src/omv/boards/WASM/imlib_config.h
@@ -1,0 +1,169 @@
+/*
+ * SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2013-2024 OpenMV, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * Image library configuration.
+ */
+#ifndef __IMLIB_CONFIG_H__
+#define __IMLIB_CONFIG_H__
+
+// Enable Image I/O
+#define IMLIB_ENABLE_IMAGE_IO
+
+// Enable Image File I/O
+#define IMLIB_ENABLE_IMAGE_FILE_IO
+
+// Enable LAB LUT
+#define IMLIB_ENABLE_LAB_LUT
+
+// Enable YUV LUT
+#define IMLIB_ENABLE_YUV_LUT
+
+// Enable ISP ops
+#define IMLIB_ENABLE_ISP_OPS
+
+// Enable binary ops
+#define IMLIB_ENABLE_BINARY_OPS
+
+// Enable math ops
+#define IMLIB_ENABLE_MATH_OPS
+
+// Enable flood_fill()
+#define IMLIB_ENABLE_FLOOD_FILL
+
+// Enable mean()
+#define IMLIB_ENABLE_MEAN
+
+// Enable median()
+#define IMLIB_ENABLE_MEDIAN
+
+// Enable mode()
+#define IMLIB_ENABLE_MODE
+
+// Enable midpoint()
+#define IMLIB_ENABLE_MIDPOINT
+
+// Enable morph()
+#define IMLIB_ENABLE_MORPH
+
+// Enable Gaussian
+#define IMLIB_ENABLE_GAUSSIAN
+
+// Enable Laplacian
+#define IMLIB_ENABLE_LAPLACIAN
+
+// Enable bilateral()
+#define IMLIB_ENABLE_BILATERAL
+
+// Enable linpolar()
+#define IMLIB_ENABLE_LINPOLAR
+
+// Enable logpolar()
+#define IMLIB_ENABLE_LOGPOLAR
+
+// Enable lens_corr()
+#define IMLIB_ENABLE_LENS_CORR
+
+// Enable rotation_corr()
+#define IMLIB_ENABLE_ROTATION_CORR
+
+// Enable phasecorrelate()
+#if defined(IMLIB_ENABLE_ROTATION_CORR)
+#define IMLIB_ENABLE_FIND_DISPLACEMENT
+#endif
+
+// Enable get_similarity()
+#define IMLIB_ENABLE_GET_SIMILARITY
+
+// Enable find_lines()
+#define IMLIB_ENABLE_FIND_LINES
+
+// Enable find_line_segments()
+#define IMLIB_ENABLE_FIND_LINE_SEGMENTS
+
+// Enable find_circles()
+#define IMLIB_ENABLE_FIND_CIRCLES
+
+// Enable find_rects()
+#define IMLIB_ENABLE_FIND_RECTS
+
+// Enable find_qrcodes() (14 KB)
+#define IMLIB_ENABLE_QRCODES
+
+// Enable find_apriltags() (64 KB)
+// #define IMLIB_ENABLE_APRILTAGS
+
+// Enable fine find_apriltags() - (8-way connectivity versus 4-way connectivity)
+#define IMLIB_ENABLE_FINE_APRILTAGS
+
+// Enable high res find_apriltags() - uses more RAM
+#define IMLIB_ENABLE_HIGH_RES_APRILTAGS
+
+// Enable find_datamatrices() (26 KB)
+#define IMLIB_ENABLE_DATAMATRICES
+
+// Enable find_barcodes() (42 KB)
+#define IMLIB_ENABLE_BARCODES
+
+// Enable find_features() and built-in Haar cascades. (75KBs)
+#define IMLIB_ENABLE_FEATURES
+#define IMLIB_ENABLE_FEATURES_BUILTIN_FACE_CASCADE
+#define IMLIB_ENABLE_FEATURES_BUILTIN_EYES_CASCADE
+
+// Enable CMSIS NN
+// #if !defined(CUBEAI)
+// #define IMLIB_ENABLE_CNN
+// #endif
+
+// // Enable Tensor Flow
+// #if !defined(CUBEAI)
+// #define IMLIB_ENABLE_TF (IMLIB_TF_FULLOPS)
+// #endif
+
+// Enable FAST (20+ KBs).
+// #define IMLIB_ENABLE_FAST
+
+// Enable find_template()
+#define IMLIB_FIND_TEMPLATE
+
+// Enable find_lbp()
+#define IMLIB_ENABLE_FIND_LBP
+
+// Enable find_keypoints()
+#define IMLIB_ENABLE_FIND_KEYPOINTS
+
+// Enable load, save and match descriptor
+#define IMLIB_ENABLE_DESCRIPTOR
+
+// Enable find_hog()
+// #define IMLIB_ENABLE_HOG
+
+// Enable selective_search()
+// #define IMLIB_ENABLE_SELECTIVE_SEARCH
+
+// Enable PNG encoder/decoder
+#define IMLIB_ENABLE_PNG_ENCODER
+#define IMLIB_ENABLE_PNG_DECODER
+
+// Stereo Imaging
+// #define IMLIB_ENABLE_STEREO_DISPARITY
+#endif //__IMLIB_CONFIG_H__

--- a/src/omv/boards/WASM/omv_boardconfig.h
+++ b/src/omv/boards/WASM/omv_boardconfig.h
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2013-2024 OpenMV, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * MicroPython board config.
+ */
+#ifndef __OMV_BOARDCONFIG_H__
+#define __OMV_BOARDCONFIG_H__
+
+// // JPEG configuration.
+#define OMV_JPEG_CODEC_ENABLE           (0)
+#define OMV_JPEG_QUALITY_LOW            (50)
+#define OMV_JPEG_QUALITY_HIGH           (90)
+#define OMV_JPEG_QUALITY_THRESHOLD      (320 * 240 * 2)
+
+// // UMM heap block size
+#define OMV_UMM_BLOCK_SIZE              256
+
+#define OMV_FB_MEMORY                   DRAM   // Framebuffer, fb_alloc
+#define OMV_FB_SIZE                     (64 * 1024 * 1024)        // FB memory: header + VGA/GS image
+#define OMV_FB_ALLOC_SIZE               (64 * 1024 * 1024)         // minimum fb alloc size
+#define OMV_JPEG_SIZE                   (2 * 1024 * 1024)  // IDE JPEG buffer (header + data).
+
+#endif //__OMV_BOARDCONFIG_H__

--- a/src/omv/boards/WASM/omv_boardconfig.mk
+++ b/src/omv/boards/WASM/omv_boardconfig.mk
@@ -1,0 +1,3 @@
+PORT=webassembly
+OMV_ENABLE_BL=0
+OMV_ENABLE_UVC=0

--- a/src/omv/common/mutex.c
+++ b/src/omv/common/mutex.c
@@ -29,6 +29,7 @@
  * CPUs the locking function is implemented with atomic access using disable/enable IRQs.
  */
 #include "mutex.h"
+#include CMSIS_MCU_H
 #include "cmsis_compiler.h"
 #include "py/mphal.h"
 

--- a/src/omv/ports/webassembly/cmsis_mcu.h
+++ b/src/omv/ports/webassembly/cmsis_mcu.h
@@ -1,0 +1,39 @@
+#ifndef __CMSIS_MCU_H__
+#define __CMSIS_MCU_H__
+
+#ifndef PI
+#define PI               3.14159265358979f
+#endif
+
+#ifndef M_PI
+#define M_PI             3.14159265f
+#define M_PI_2           1.57079632f
+#define M_PI_4           0.78539816f
+#endif
+
+#define typeof __typeof__
+
+inline void __builtin_arm_wfi() {
+};
+
+inline void __builtin_arm_dmb(uint32_t v) {
+};
+
+inline void __enable_irq() {
+};
+
+inline void __disable_irq() {
+};
+
+inline uint32_t __builtin_arm_rbit(uint32_t v) {
+    uint8_t sc = 31U;
+    uint32_t r = v;
+    for (v >>= 1U; v; v >>= 1U) {
+        r <<= 1U;
+        r |= v & 1U;
+        sc--;
+    }
+    return (r << sc);
+}
+
+#endif

--- a/src/omv/ports/webassembly/lib/oofatfs/ff.c
+++ b/src/omv/ports/webassembly/lib/oofatfs/ff.c
@@ -1,0 +1,90 @@
+/*
+ * SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2013-2024 OpenMV, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * FatFs Posix Wraper.
+ */
+#include "ff.h"
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdio.h>
+
+size_t f_size(FIL *fp) {
+    long current_pos = ftell(fp->file);
+    fseek(fp->file, 0, SEEK_END);
+    long size = ftell(fp->file);
+    fseek(fp->file, current_pos, SEEK_SET);
+    return size;
+}
+
+size_t f_tell(FIL *fp) {
+    return ftell(fp->file);
+}
+
+bool f_eof(FIL *fp) {
+    return feof(fp->file) != 0;
+}
+
+FRESULT f_lseek(FIL *fp, FSIZE_t ofs) {
+    fseek(fp->file, ofs, SEEK_SET);
+    return FR_OK;
+}
+
+FRESULT f_opendir(FATFS *fs, FF_DIR *dp, const TCHAR *path) {
+    return FR_DISK_ERR;
+}
+
+FRESULT f_truncate(FIL *fp) {
+    return FR_DISK_ERR;
+}
+
+FRESULT f_sync(FIL *fp) {
+    fflush(fp->file);
+    return FR_OK;
+}
+
+FRESULT f_open(FATFS *fs, FIL *fp, const TCHAR *path, BYTE mode) {
+    fp->file = fopen(path, mode == FA_READ ? "rb" : "wb");
+    if (fp->file == NULL) {
+        return FR_NO_FILE;
+    }
+    fp->flag = mode;
+    fseek(fp->file, 0, SEEK_SET);
+    return FR_OK;
+}
+
+FRESULT f_close(FIL *fp) {
+    if (fp->file) {
+        fclose(fp->file);
+    }
+    return FR_OK;
+}
+
+FRESULT f_read(FIL *fp, void *buff, UINT btr, UINT *br) {
+    *br = fread(buff, 1, btr, fp->file);
+    return FR_OK;
+}
+
+FRESULT f_write(FIL *fp, const void *buff, UINT btw, UINT *bw) {
+    *bw = fwrite(buff, 1, btw, fp->file);
+    return FR_OK;
+}

--- a/src/omv/ports/webassembly/lib/oofatfs/ff.h
+++ b/src/omv/ports/webassembly/lib/oofatfs/ff.h
@@ -1,0 +1,96 @@
+/*
+ * SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2013-2024 OpenMV, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * FatFs Posix Wraper.
+ */
+#ifndef FF_DEFINED
+#define FF_DEFINED
+
+#include <stdio.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+typedef char FF_DIR; // hack
+typedef char FILINFO; // hack
+typedef char FATFS; // hack
+typedef char DIR; // hack
+
+typedef char          TCHAR;
+typedef unsigned int  UINT;     /* int must be 16-bit or 32-bit */
+typedef unsigned char BYTE;     /* char must be 8-bit */
+typedef size_t        FSIZE_t;  /* char must be 8-bit */
+
+typedef enum {
+    FR_OK = 0,              /* (0) Succeeded */
+    FR_DISK_ERR,            /* (1) A hard error occurred in the low level disk I/O layer */
+    FR_INT_ERR,             /* (2) Assertion failed */
+    FR_NOT_READY,           /* (3) The physical drive cannot work */
+    FR_NO_FILE,             /* (4) Could not find the file */
+    FR_NO_PATH,             /* (5) Could not find the path */
+    FR_INVALID_NAME,        /* (6) The path name format is invalid */
+    FR_DENIED,              /* (7) Access denied due to prohibited access or directory full */
+    FR_EXIST,               /* (8) Access denied due to prohibited access */
+    FR_INVALID_OBJECT,      /* (9) The file/directory object is invalid */
+    FR_WRITE_PROTECTED,     /* (10) The physical drive is write protected */
+    FR_INVALID_DRIVE,       /* (11) The logical drive number is invalid */
+    FR_NOT_ENABLED,         /* (12) The volume has no work area */
+    FR_NO_FILESYSTEM,       /* (13) There is no valid FAT volume */
+    FR_MKFS_ABORTED,        /* (14) The f_mkfs() aborted due to any problem */
+    FR_TIMEOUT,             /* (15) Could not get a grant to access the volume within defined period */
+    FR_LOCKED,              /* (16) The operation is rejected according to the file sharing policy */
+    FR_NOT_ENOUGH_CORE,     /* (17) LFN working buffer could not be allocated */
+    FR_TOO_MANY_OPEN_FILES, /* (18) Number of open files > FF_FS_LOCK */
+    FR_INVALID_PARAMETER    /* (19) Given parameter is invalid */
+} FRESULT;
+
+// /* File access mode and open method flags (3rd argument of f_open) */
+#define FA_READ             0x01
+#define FA_WRITE            0x02
+#define FA_OPEN_EXISTING    0x00
+#define FA_CREATE_NEW       0x04
+#define FA_CREATE_ALWAYS    0x08
+#define FA_OPEN_ALWAYS      0x10
+#define FA_OPEN_APPEND      0x30
+
+typedef struct {
+    FILE *file;
+    BYTE flag;
+} FIL;
+
+size_t f_size(FIL *fp);
+size_t f_tell(FIL *fp);
+bool f_eof(FIL *fp);
+FRESULT f_open(FATFS *fs, FIL *fp, const TCHAR *path, BYTE mode);   /* Open or create a file */
+FRESULT f_close(FIL *fp);                                           /* Close an open file object */
+FRESULT f_read(FIL *fp, void *buff, UINT btr, UINT *br);            /* Read data from the file */
+FRESULT f_write(FIL *fp, const void *buff, UINT btw, UINT *bw);     /* Write data to the file */
+FRESULT f_lseek(FIL *fp, FSIZE_t ofs);                              /* Move file pointer of the file object */
+
+FRESULT f_opendir(FATFS *fs, FF_DIR *dp, const TCHAR *path);        /* Open a directory */
+FRESULT f_stat(FATFS *fs, const TCHAR *path, FILINFO *fno);         /* Get file status */
+FRESULT f_mkdir(FATFS *fs, const TCHAR *path);                      /* Create a sub directory */
+FRESULT f_unlink(FATFS *fs, const TCHAR *path);                     /* Delete an existing file or directory */
+FRESULT f_rename(FATFS *fs, const TCHAR *path_old, const TCHAR *path_new);  /* Rename/Move a file or directory */
+FRESULT f_truncate(FIL *fp);                                        /* Truncate the file */
+FRESULT f_sync(FIL *fp);                                            /* Flush cached data of the writing file */
+#endif

--- a/src/omv/ports/webassembly/omv_mpconfigport.h
+++ b/src/omv/ports/webassembly/omv_mpconfigport.h
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2013-2024 OpenMV, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * MicroPython port config.
+ */
+#include <mpconfigport.h>
+#define MICROPY_BANNER_NAME_AND_VERSION "OpenMV " OPENMV_GIT_TAG "; MicroPython " MICROPY_GIT_TAG

--- a/src/omv/ports/webassembly/omv_portconfig.mk
+++ b/src/omv/ports/webassembly/omv_portconfig.mk
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright (C) 2013-2024 OpenMV, LLC.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+CFLAGS_EXTMOD += -DCMSIS_MCU_H='<cmsis_mcu.h>'
+CFLAGS_EXTMOD += -I$(TOP_DIR)/hal/cmsis/include
+CFLAGS_EXTMOD += -I$(TOP_DIR)/$(OMV_DIR)/boards/$(TARGET)
+CFLAGS_EXTMOD += -I$(TOP_DIR)/$(OMV_DIR)/ports/$(PORT)
+CFLAGS_EXTMOD += -I$(TOP_DIR)/$(OMV_DIR)/ports/$(PORT)/lib/oofatfs
+CFLAGS_EXTMOD += -I$(TOP_DIR)/$(OMV_DIR)/modules
+CFLAGS_EXTMOD += -I$(TOP_DIR)/$(OMV_DIR)/imlib
+CFLAGS_EXTMOD += -I$(TOP_DIR)/$(OMV_DIR)/alloc
+CFLAGS_EXTMOD += -I$(TOP_DIR)/$(OMV_DIR)/common
+CFLAGS_EXTMOD += -I$(TOP_DIR)/$(MICROPY_DIR)/py
+CFLAGS_EXTMOD += -D__ARMCC_VERSION=6100100 -D__ARM_COMPAT_H
+
+
+SRC_EXTMOD_C += $(addprefix $(TOP_DIR)/$(MICROPY_DIR)/,\
+	extmod/modasyncio.c \
+	extmod/modbinascii.c \
+	extmod/modbtree.c \
+	extmod/modcryptolib.c \
+	extmod/moddeflate.c \
+	extmod/modframebuf.c \
+	extmod/modhashlib.c \
+	extmod/modheapq.c \
+	extmod/modjson.c \
+	extmod/modlwip.c \
+	extmod/modmachine.c \
+	extmod/modnetwork.c \
+	extmod/modonewire.c \
+	extmod/modopenamp.c \
+	extmod/modopenamp_remoteproc.c \
+	extmod/modopenamp_remoteproc_store.c \
+	extmod/modos.c \
+	extmod/modplatform.c\
+	extmod/modrandom.c \
+	extmod/modre.c \
+	extmod/modselect.c \
+	extmod/modsocket.c \
+	extmod/modtls_axtls.c \
+	extmod/modtls_mbedtls.c \
+	extmod/mbedtls/mbedtls_alt.c \
+	extmod/modtime.c \
+	extmod/moductypes.c \
+	extmod/modvfs.c \
+	extmod/modwebrepl.c \
+	extmod/modwebsocket.c \
+	extmod/os_dupterm.c \
+	extmod/vfs.c \
+	extmod/vfs_posix.c \
+	extmod/vfs_posix_file.c \
+	extmod/vfs_reader.c \
+	extmod/virtpin.c \
+	shared/libc/abort_.c \
+	shared/libc/printf.c \
+	)
+
+SRC_EXTMOD_C += $(addprefix $(TOP_DIR)/$(OMV_DIR)/,\
+	modules/py_clock.c \
+	modules/py_helper.c \
+	modules/py_image.c \
+	modules/py_imageio.c \
+	)
+
+SRC_THIRDPARTY_C += $(addprefix $(TOP_DIR)/$(OMV_DIR)/,\
+	ports/webassembly/lib/oofatfs/ff.c \
+	common/array.c \
+	common/file_utils.c \
+	common/mutex.c \
+	alloc/fb_alloc.c \
+	alloc/umm_malloc.c \
+	alloc/unaligned_memcpy.c \
+	alloc/xalloc.c \
+	)
+
+SRC_THIRDPARTY_C += $(addprefix $(TOP_DIR)/$(OMV_DIR)/imlib/,\
+	apriltag.c \
+	bayer.c \
+	binary.c \
+	blob.c \
+	bmp.c \
+	clahe.c \
+	collections.c \
+	dmtx.c \
+	draw.c \
+	edge.c \
+	eye.c \
+	fast.c \
+	fft.c \
+	filter.c \
+	fmath.c \
+	font.c \
+	framebuffer.c \
+	fsort.c \
+	gif.c \
+	haar.c \
+	hog.c \
+	hough.c \
+	imlib.c \
+	integral_mw.c \
+	integral.c \
+	isp.c \
+	jpegd.c \
+	jpege.c \
+	kmeans.c \
+	lab_tab.c \
+	lbp.c \
+	line.c \
+	lodepng.c \
+	lsd.c \
+	mathop.c \
+	mjpeg.c \
+	orb.c \
+	phasecorrelation.c \
+	png.c \
+	point.c \
+	ppm.c \
+	qrcode.c \
+	rainbow_tab.c \
+	rectangle.c \
+	selective_search.c \
+	sincos_tab.c \
+	stats.c \
+	stereo.c \
+	template.c \
+	xyz_tab.c \
+	yuv.c \
+	zbar.c \
+	)
+
+
+WASM_LD_S = $(TOP_DIR)/$(OMV_DIR)/ports/webassembly/wasm.ld.S
+WASM_LD_O = $(BUILD)/$(TARGET)/wasm.ld.o
+
+LDFLAGS_THIRDPARTY += $(WASM_LD_O)
+
+###################################################
+all: $(OPENMV)
+
+wasm.ld.o: $(WASM_LD_S)
+	mkdir -p $(BUILD)/$(TARGET)
+	emcc -c $(CFLAGS_EXTMOD) -o $(WASM_LD_O) $(WASM_LD_S)
+
+$(FIRMWARE):wasm.ld.o
+	$(MAKE) -C $(TOP_DIR)/$(MICROPY_DIR)/ports/$(PORT) BUILD=$(BUILD)/$(TARGET) min CFLAGS_EXTMOD="$(CFLAGS_EXTMOD)" SRC_EXTMOD_C="$(SRC_EXTMOD_C)" SRC_THIRDPARTY_C="$(SRC_THIRDPARTY_C)" LDFLAGS_THIRDPARTY="$(LDFLAGS_THIRDPARTY)"
+
+# This target generates the firmware image.
+$(OPENMV): $(FIRMWARE)
+	wasm-opt -Oz -o $(BUILD)/$(TARGET)/micropython.wasm $(BUILD)/$(TARGET)/micropython.wasm

--- a/src/omv/ports/webassembly/usbdbg.h
+++ b/src/omv/ports/webassembly/usbdbg.h
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2013-2024 OpenMV, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * USB debug support.
+ */
+#ifndef __USBDBG_H__
+#define __USBDBG_H__
+#include <stdbool.h>
+inline void usbdbg_set_irq_enabled(bool enabled) {
+}
+#endif

--- a/src/omv/ports/webassembly/wasm.ld.S
+++ b/src/omv/ports/webassembly/wasm.ld.S
@@ -1,0 +1,31 @@
+#include "omv_boardconfig.h"
+
+.global _fb_memory_start
+.global _fb_memory_end
+.global _fb_alloc_end
+.global _jpeg_memory_start
+.global _jpeg_memory_end
+
+.section .data, "", @
+_fb_memory_start:
+    .space OMV_FB_SIZE
+    .size _fb_memory_start, OMV_FB_SIZE
+
+_fb_memory_end = _fb_memory_start + OMV_FB_SIZE
+    .size _fb_memory_end, 0
+
+_fb_alloc_start:
+    .space OMV_FB_ALLOC_SIZE
+    .size _fb_alloc_start, OMV_FB_ALLOC_SIZE
+
+_fb_alloc_end = _fb_alloc_start + OMV_FB_ALLOC_SIZE
+    .size _fb_alloc_end, 0
+
+_jpeg_memory_start:
+    .space OMV_JPEG_SIZE
+    .size _jpeg_memory_start, OMV_JPEG_SIZE
+
+_jpeg_memory_end = _jpeg_memory_start + OMV_JPEG_SIZE
+    .size _jpeg_memory_end, 0
+
+.section .text, "", @


### PR DESCRIPTION
This is an draft PR that implements compiling openmv to wasm.
The main tasks are:
1. ff.c wraper.
2. cmsis.c wraper.
3. fb_alloc.c add ifndef OMV_FB_MEMORY.

# compile steps:
1. remove -Werror in `src/micropython/ports/webassembly/Makefile`. If this PR is approved, I will add an additional PR for the subrepository.

2. `make TARGET=WASM`

This will build micropython.wasm ans micropython.min.mjs.

3. `node build/WASM/micropython.min.mjs` will enter REPL.

