### PR TITLE
scripts/examples: Fix IMXRT deepsleep and stop examples.

### DIFF
--- a/scripts/examples/50-OpenMV-Boards/50-IMXRT-Boards/80-Low-Power/deep_sleep.py
+++ b/scripts/examples/50-OpenMV-Boards/50-IMXRT-Boards/80-Low-Power/deep_sleep.py
@@ -34,7 +34,7 @@ sensor.shutdown(True)
 
 # Enable RTC interrupts every 30 seconds.
 # Note the camera will RESET after wakeup from Deepsleep Mode.
-rtc.wakeup(30000)
+rtc.alarm(rtc.ALARM0, 30000)
 
 # Enter Deepsleep Mode.
 machine.deepsleep()

--- a/scripts/examples/50-OpenMV-Boards/50-IMXRT-Boards/80-Low-Power/stop_mode.py
+++ b/scripts/examples/50-OpenMV-Boards/50-IMXRT-Boards/80-Low-Power/stop_mode.py
@@ -5,11 +5,10 @@
 # Stop Mode Example
 # This example demonstrates using the low-power Stop Mode.
 
-import pyb
 import machine
 
 # Create and init RTC object.
-rtc = pyb.RTC()
+rtc = machine.RTC()
 # (year, month, day[, hour[, minute[, second[, microsecond[, tzinfo]]]]])
 rtc.datetime((2014, 5, 1, 4, 13, 0, 0, 0))
 
@@ -17,8 +16,8 @@ rtc.datetime((2014, 5, 1, 4, 13, 0, 0, 0))
 print(rtc.datetime())
 
 # Enable RTC interrupts every 5 seconds.
-rtc.wakeup(5000)
+rtc.alarm(rtc.ALARM0, 5000)
 
 # Enter Stop Mode.
 # Note the IDE will disconnect.
-machine.sleep()
+machine.deepsleep()


### PR DESCRIPTION
Wrong API calls were used.

Tested fixes on RT1062.