### PR TITLE
imlib/draw: Fix transpose fb_alloc.

### DIFF
--- a/src/omv/imlib/draw.c
+++ b/src/omv/imlib/draw.c
@@ -3135,14 +3135,8 @@ void imlib_draw_image(image_t *dst_img,
             t_src_img.data = src_img->data;
         }
 
-        // Query available on-chip RAM.
         uint32_t size;
         void *data = fb_alloc_all(&size, FB_ALLOC_PREFER_SPEED | FB_ALLOC_CACHE_ALIGN);
-        fb_free();
-
-        // Allocate a buffer to hold chunks of the transposed image while not using all of the on-chip RAM.
-        size = IM_MIN(size, image_size(&t_src_img));
-        data = fb_alloc(size, FB_ALLOC_PREFER_SPEED | FB_ALLOC_CACHE_ALIGN);
 
         // line_num stores how many lines we can do at a time with on-chip RAM.
         image_t temp = {.w = t_roi.w, .h = t_roi.h, .pixfmt = t_src_img.pixfmt};


### PR DESCRIPTION
Tested by simulating the Arduino Giga fb_alloc size using the OpenMV PT.

So the premise for the original reason for: https://github.com/openmv/openmv/pull/2534 is wrong which was to make a way to see how much ram was available for an aligned alloc.

fb_alloc_all when used with CACHE_ALIGN returns a different number than what fb_alloc() needs for CACHE_ALIGN to achieve the same thing.

These functions operate differently.

fb_alloc_all() grabs all memory, then algins the pointer, and then reduces the returned size to be some multiple of the alignment size.

fb_alloc() rounds up the alloc to a multiple of the CACHE_ALIGN size, then adds in padding bytes that allow it to do the pointer alignment. Then it does the alloc, and aligns the returned pointer.

Given the subtle behavior differences, these two methods will compute different results for how much memory they need. fb_alloc() computes a higher number since it increases the alloc size internally for the worst case since it hasn't performed the alloc yet, so it doesn't have the pointer offset to work with to be the most efficient.

`IM_MIN(size, image_size(&t_src_img));` was hiding this issue except in the case of low-memory (e.g. on the Arduino Giga).

...

Anyway, https://github.com/openmv/openmv/pull/2597 solves the original issue of changing from fb_alloc_all() to begin with. This PR was all that was required to fix the original issue of https://github.com/openmv/openmv/pull/2508.

So... this PR is just reverting the transpose code back to how it worked originally by reverting https://github.com/openmv/openmv/pull/2508.