### PR TITLE
sensors/genx320: Update ISSD sequence to increase frame rate.

### DIFF
--- a/src/drivers/genx320/src/genx320_issd_cpi_evt.c
+++ b/src/drivers/genx320/src/genx320_issd_cpi_evt.c
@@ -121,11 +121,24 @@ static const struct reg_op dcmi_init_seq[] = {
 	{.op = WRITE, .args = {.write = {0x111CUL, 0x03000074}} },	 // saphir/bias/bias_req_pu_lv0             Write fields: bias_en|bias_ctl
 	{.op = WRITE, .args = {.write = {0x1120UL, 0x010000A4}} },	 // saphir/bias/bias_sm_pdy_lv0             Write fields: bias_en|bias_ctl
 	{.op = WRITE, .args = {.write = {0x1208UL, 0x00000035}} },	 // saphir/bias/bgen_ctrl                   Write fields: burst_transfer_hv_bank_0|burst_transfer_lv_bank_0
-	{.op = WRITE, .args = {.write = {0x0000UL, 0x00000802}} }	 // saphir/roi_ctrl                         Write fields: roi_td_en
+	{.op = WRITE, .args = {.write = {0x0000UL, 0x00000802}} },	 // saphir/roi_ctrl                         Write fields: roi_td_en
+	{.op = WRITE, .args = {.write = {0x009008, 0x00000184}} },
+	{.op = WRITE, .args = {.write = {0x009008, 0x00010184}} },
+	{.op = WRITE, .args = {.write = {0x000200, 0x00000000}} },
+	{.op = WRITE, .args = {.write = {0x000214, 0x00000440}} },
+	{.op = WRITE, .args = {.write = {0x000214, 0x00000441}} },
+	{.op = WRITE, .args = {.write = {0x000204, 0x00000634}} },
+	{.op = WRITE, .args = {.write = {0x00020C, 0x00000061}} },
+	{.op = WRITE, .args = {.write = {0x000204, 0x00000635}} },
+	{.op = WRITE, .args = {.write = {0x000204, 0x00000637}} },
+	{.op = WRITE, .args = {.write = {0x000210, 0x00000C00}} },
+	{.op = WRITE, .args = {.write = {0x00B00C, 0x00000004}} },
+	{.op = WRITE, .args = {.write = {0x009008, 0x00000304}} },
+	{.op = WRITE, .args = {.write = {0x00004C, 0x00209600}} }
 };
 static const struct reg_op dcmi_start_seq[] = {
 	{.op = WRITE, .args = {.write = {0x9028UL, 0x00000000}} },	 // saphir/ro/ro_lp_ctrl                    Write fields: lp_output_disable
-	{.op = WRITE, .args = {.write = {0x9008UL, 0x000000A5}} },	 // saphir/ro/time_base_ctrl                Write fields: time_base_enable
+	{.op = WRITE, .args = {.write = {0x9008UL, 0x00000305}} },	 // saphir/ro/time_base_ctrl                Write fields: time_base_enable
 	{.op = DELAY, .args = {.delay = {1000}} },	 // us
 	{.op = WRITE, .args = {.write = {0x002CUL, 0x0022C724}} },	 // saphir/ro_td_ctrl                       Write fields: ro_td_ack_y_rstn|ro_td_arb_y_rstn|ro_td_addr_y_rstn|ro_td_sendreq_y_rstn
 	{.op = WRITE, .args = {.write = {0x0000UL, 0x00000C02}} },	 // saphir/roi_ctrl                         Write fields: roi_td_en|px_sw_rstn
@@ -136,7 +149,7 @@ static const struct reg_op dcmi_stop_seq[] = {
 	{.op = WRITE, .args = {.write = {0x002CUL, 0x00200624}} },	 // saphir/ro_td_ctrl                       Write fields: ro_td_ack_y_rstn|ro_td_arb_y_rstn|ro_td_addr_y_rstn|ro_td_sendreq_y_rstn
 	{.op = WRITE, .args = {.write = {0x9028UL, 0x00000002}} },	 // saphir/ro/ro_lp_ctrl                    Write fields: lp_output_disable|lp_keep_th
 	{.op = DELAY, .args = {.delay = {1000}} },	 // us
-	{.op = WRITE, .args = {.write = {0x9008UL, 0x000000A4}} },	 // saphir/ro/time_base_ctrl                Write fields: time_base_enable
+	{.op = WRITE, .args = {.write = {0x9008UL, 0x00000304}} },	 // saphir/ro/time_base_ctrl                Write fields: time_base_enable
 	{.op = WRITE, .args = {.write = {0x8000UL, 0x0001FFA2}} },	 // saphir/cpi/pipeline_control             Write fields: enable|drop_nbackpressure|hot_disable_enable
 	{.op = READ, .args = {.read = {0x8004UL, 0x00000002}} },	 // saphir/cpi/pipeline_status              Read fields: busy
 	{.op = DELAY, .args = {.delay = {1000}} }	 // us

--- a/src/drivers/genx320/src/genx320_issd_cpi_histo.c
+++ b/src/drivers/genx320/src/genx320_issd_cpi_histo.c
@@ -120,12 +120,25 @@ static const struct reg_op dcmi_init_seq[] = {
 	{.op = WRITE, .args = {.write = {0x111CUL, 0x03000074}} },	 // saphir/bias/bias_req_pu_lv0             Write fields: bias_en|bias_ctl
 	{.op = WRITE, .args = {.write = {0x1120UL, 0x010000A4}} },	 // saphir/bias/bias_sm_pdy_lv0             Write fields: bias_en|bias_ctl
 	{.op = WRITE, .args = {.write = {0x1208UL, 0x00000035}} },	 // saphir/bias/bgen_ctrl                   Write fields: burst_transfer_hv_bank_0|burst_transfer_lv_bank_0
-	{.op = WRITE, .args = {.write = {0x0000UL, 0x00000802}} }	 // saphir/roi_ctrl                         Write fields: roi_td_en
+	{.op = WRITE, .args = {.write = {0x0000UL, 0x00000802}} },	 // saphir/roi_ctrl                         Write fields: roi_td_en
+	{.op = WRITE, .args = {.write = {0x009008, 0x00000184}} },
+	{.op = WRITE, .args = {.write = {0x009008, 0x00010184}} },
+	{.op = WRITE, .args = {.write = {0x000200, 0x00000000}} },
+	{.op = WRITE, .args = {.write = {0x000214, 0x00000440}} },
+	{.op = WRITE, .args = {.write = {0x000214, 0x00000441}} },
+	{.op = WRITE, .args = {.write = {0x000204, 0x00000634}} },
+	{.op = WRITE, .args = {.write = {0x00020C, 0x00000061}} },
+	{.op = WRITE, .args = {.write = {0x000204, 0x00000635}} },
+	{.op = WRITE, .args = {.write = {0x000204, 0x00000637}} },
+	{.op = WRITE, .args = {.write = {0x000210, 0x00000C00}} },
+	{.op = WRITE, .args = {.write = {0x00B00C, 0x00000004}} },
+	{.op = WRITE, .args = {.write = {0x009008, 0x00000304}} },
+	{.op = WRITE, .args = {.write = {0x00004C, 0x00209600}} }
 };
 static const struct reg_op dcmi_start_seq[] = {
 	{.op = WRITE, .args = {.write = {0x8000UL, 0x0001FEA1}} },	 // saphir/cpi/pipeline_control
 	{.op = WRITE, .args = {.write = {0x9028UL, 0x00000000}} },	 // saphir/ro/ro_lp_ctrl                    Write fields: lp_output_disable
-	{.op = WRITE, .args = {.write = {0x9008UL, 0x000000A5}} },	 // saphir/ro/time_base_ctrl                Write fields: time_base_enable
+	{.op = WRITE, .args = {.write = {0x9008UL, 0x00000305}} },	 // saphir/ro/time_base_ctrl                Write fields: time_base_enable
 	{.op = DELAY, .args = {.delay = {1000}} },	 // us
 	{.op = WRITE, .args = {.write = {0x002CUL, 0x0022C724}} },	 // saphir/ro_td_ctrl                       Write fields: ro_td_ack_y_rstn|ro_td_arb_y_rstn|ro_td_addr_y_rstn|ro_td_sendreq_y_rstn
 	{.op = WRITE, .args = {.write = {0x0000UL, 0x00000C02}} },	 // saphir/roi_ctrl                         Write fields: roi_td_en|px_sw_rstn
@@ -136,7 +149,7 @@ static const struct reg_op dcmi_stop_seq[] = {
 	{.op = WRITE, .args = {.write = {0x002CUL, 0x00200624}} },	 // saphir/ro_td_ctrl                       Write fields: ro_td_ack_y_rstn|ro_td_arb_y_rstn|ro_td_addr_y_rstn|ro_td_sendreq_y_rstn
 	{.op = WRITE, .args = {.write = {0x9028UL, 0x00000002}} },	 // saphir/ro/ro_lp_ctrl                    Write fields: lp_output_disable|lp_keep_th
 	{.op = DELAY, .args = {.delay = {1000}} },	 // us
-	{.op = WRITE, .args = {.write = {0x9008UL, 0x000000A4}} },	 // saphir/ro/time_base_ctrl                Write fields: time_base_enable
+	{.op = WRITE, .args = {.write = {0x9008UL, 0x00000304}} },	 // saphir/ro/time_base_ctrl                Write fields: time_base_enable
 	{.op = WRITE, .args = {.write = {0x8000UL, 0x0001FFA2}} },	 // saphir/cpi/pipeline_control             Write fields: enable|drop_nbackpressure|hot_disable_enable
 	{.op = READ, .args = {.read = {0x8004UL, 0x00000002}} },	 // saphir/cpi/pipeline_status              Read fields: busy
 	{.op = DELAY, .args = {.delay = {1000}} }	 // us

--- a/src/omv/sensors/genx320.c
+++ b/src/omv/sensors/genx320.c
@@ -49,8 +49,12 @@
 #define ACTIVE_SENSOR_HEIGHT            (SENSOR_HEIGHT - BLANK_LINES)
 #define ACTIVE_SENSOR_SIZE              (ACTIVE_SENSOR_WIDTH * ACTIVE_SENSOR_HEIGHT)
 
-#define HSYNC_CLOCK_CYCLES              32
-#define VSYNC_CLOCK_CYCLES              32
+#ifdef OMV_GENX320_EHC_ENABLE
+#define HSYNC_CLOCK_CYCLES              880 // 320 + 880 = 1200 cycles -> ~122 FPS
+#else
+#define HSYNC_CLOCK_CYCLES              280 // 320 + 280 = 600 cycles
+#endif
+#define VSYNC_CLOCK_CYCLES              8
 
 #define CONTRAST_DEFAULT                16
 #define BRIGHTNESS_DEFAULT              128
@@ -66,8 +70,8 @@
 #define EVENT_THRESHOLD_TO_CALIBRATE    100000
 #define EVENT_THRESHOLD_SIGMA           10
 
-#define EVT_CLK_FREQ                    ((omv_csi_get_xclk_frequency() + 500000) / 1000000)
-#define EVT_SCALE_PERIOD(period)        (((period) * EVT_CLK_FREQ) / 10)
+#define EVT_CLK_MULTIPLIER              (2)
+#define EVT_CLK_FREQ                    (((omv_csi_get_xclk_frequency() * EVT_CLK_MULTIPLIER) + 500000) / 1000000)
 
 #define AFK_50_HZ                       (50)
 #define AFK_60_HZ                       (60)
@@ -115,6 +119,7 @@ static int reset(omv_csi_t *csi) {
 
     // Set EVT20 mode
     psee_sensor_write(EDF_CONTROL, 0);
+    #endif // (OMV_GENX320_EHC_ENABLE == 1)
 
     // Configure Packet and Frame sizes
     psee_sensor_write(CPI_PACKET_SIZE_CONTROL, ACTIVE_SENSOR_WIDTH);
@@ -122,7 +127,6 @@ static int reset(omv_csi_t *csi) {
                       HSYNC_CLOCK_CYCLES << CPI_PACKET_TIME_CONTROL_BLANKING_Pos);
     psee_sensor_write(CPI_FRAME_SIZE_CONTROL, ACTIVE_SENSOR_HEIGHT);
     psee_sensor_write(CPI_FRAME_TIME_CONTROL, VSYNC_CLOCK_CYCLES);
-    #endif // (OMV_GENX320_EHC_ENABLE == 1)
 
     // Enable dropping
     psee_sensor_write(RO_READOUT_CTRL, RO_READOUT_CTRL_DIGITAL_PIPE_EN |
@@ -166,7 +170,7 @@ static int reset(omv_csi_t *csi) {
     }
 
     if (psee_ehc_activate(&psee_ehc, EHC_ALGO_DIFF3D, 0, EHC_DIFF3D_N_BITS_SIZE,
-                          EVT_SCALE_PERIOD(INTEGRATION_DEF_PREIOD), EHC_WITHOUT_PADDING) != EHC_OK) {
+                          INTEGRATION_DEF_PREIOD, EHC_WITHOUT_PADDING) != EHC_OK) {
         return -1;
     }
     #else
@@ -231,7 +235,26 @@ static int set_framerate(omv_csi_t *csi, int framerate) {
         return -1;
     }
 
-    psee_sensor_write(EHC_INTEGRATION_PERIOD, EVT_SCALE_PERIOD(us));
+    int lines = ACTIVE_SENSOR_HEIGHT + VSYNC_CLOCK_CYCLES;
+    int clocks_per_frame = (omv_csi_get_xclk_frequency() * EVT_CLK_MULTIPLIER) / framerate;
+    int hsync_clocks = (clocks_per_frame / lines) - ACTIVE_SENSOR_WIDTH;
+
+    if (hsync_clocks <= 0) {
+        return -1;
+    }
+
+    // Disable any ongoing frame capture.
+    omv_csi_abort(true, false);
+
+    psee_sensor_write(EHC_INTEGRATION_PERIOD, us);
+    psee_sensor_write(CPI_PACKET_TIME_CONTROL, ACTIVE_SENSOR_WIDTH << CPI_PACKET_TIME_CONTROL_PERIOD_Pos |
+                      hsync_clocks << CPI_PACKET_TIME_CONTROL_BLANKING_Pos);
+
+    // Wait for the camera to settle
+    if (!csi->disable_delays) {
+        mp_hal_delay_ms(100);
+    }
+
     #endif // (OMV_GENX320_EHC_ENABLE == 1)
     return 0;
 }

--- a/src/omv/sensors/genx320.c
+++ b/src/omv/sensors/genx320.c
@@ -393,6 +393,12 @@ static void snapshot_post_process(image_t *image) {
 }
 
 static int snapshot(omv_csi_t *csi, image_t *image, uint32_t flags) {
+    #if (OMV_GENX320_EHC_ENABLE != 1)
+    if (csi->transpose) {
+        return OMV_CSI_ERROR_CAPTURE_FAILED;
+    }
+    #endif
+
     #if (OMV_GENX320_CAL_ENABLE == 1)
     if (!hot_pixels_disabled) {
         uint8_t *histogram = fb_alloc0(ACTIVE_SENSOR_SIZE, FB_ALLOC_NO_HINT);


### PR DESCRIPTION
Changes (from Prophesee):
* New ISSD Sequence increases 24MHz PCLK to 48MHz
* Time base is now setup on the sensor so you can pass arguments in 1MHz units versus needing to be scaled by the clock.

Changes (from OpenMV):
* Fixed the CPI Output control register setup so that defining HSYNC/VSYNC times work.

This PR is needed to increase the RT1062 frame rate: https://github.com/openmv/openmv/pull/2142. While debugging I noticed that the RT1062 drops 1-2 lines randomly every couple of frames leading to frame drops. As you decrease HSYNC lower than 240 the number of lines being dropped per frame starts to grow. By the time you get down to an HSYNC of 32, it's pretty much every other frame is missing lines, resulting in the frame rate being cut in half as our driver drops corrupt frames.

That said, all these frame rates are pointlessly high as you can't actually process 320x320 at above 50 FPS or so.

@nlyubova-psee 