### PR TITLE
sensors/GenX320: Adding IOCTL to set Anti-Flicker filter (AFK).

### DIFF
--- a/src/drivers/genx320/include/psee_genx320.h
+++ b/src/drivers/genx320/include/psee_genx320.h
@@ -205,7 +205,7 @@ typedef enum {
 } AFK_StatusTypeDef;
 
 /**
- * @brief EHC State structures definition
+ * @brief AFK State structures definition
  */
 typedef enum {
     AFK_STATE_RESET     = 0x00U,
@@ -214,7 +214,7 @@ typedef enum {
 } AFK_StateTypeDef;
 
 /**
- * @brief EHC Statistics structures definition
+ * @brief AFK Statistics structures definition
  */
 typedef enum {
 	AFK_STATS_RESET     = 0x00U,
@@ -266,27 +266,27 @@ typedef enum {
  * @brief EHC Algo structures definition
  */
 typedef enum {
-    EHC_ALGO_DIFF3D     = 0x00U,  
-    EHC_ALGO_HISTO3D    = 0x01U,  
-    EHC_ALGO_RESET      = 0x02U,  
+    EHC_ALGO_DIFF3D     = 0x00U,
+    EHC_ALGO_HISTO3D    = 0x01U,
+    EHC_ALGO_RESET      = 0x02U,
 } EHC_AlgoTypeDef;
 
 /**
  * @brief EHC Trigger structures definition
  */
 typedef enum {
-    EHC_TRIGGER_EVENT_RATE          = 0x00U,         
+    EHC_TRIGGER_EVENT_RATE          = 0x00U,
     EHC_TRIGGER_INTEGRATION_PERIOD  = 0x01U,
-    EHC_TRIGGER_RESET               = 0x02U,  
+    EHC_TRIGGER_RESET               = 0x02U,
 } EHC_TriggerTypeDef;
 
 /**
  * @brief EHC Padding structures definition
  */
 typedef enum {
-    EHC_WITHOUT_PADDING = 0x00U, 
-    EHC_WITH_PADDING    = 0x01U,    
-    EHC_PADDING_RESET   = 0x02U,  
+    EHC_WITHOUT_PADDING = 0x00U,
+    EHC_WITH_PADDING    = 0x01U,
+    EHC_PADDING_RESET   = 0x02U,
 } EHC_PaddingTypeDef;
 
 /**

--- a/src/drivers/genx320/src/genx320_issd_cpi_evt.c
+++ b/src/drivers/genx320/src/genx320_issd_cpi_evt.c
@@ -121,11 +121,24 @@ static const struct reg_op dcmi_init_seq[] = {
 	{.op = WRITE, .args = {.write = {0x111CUL, 0x03000074}} },	 // saphir/bias/bias_req_pu_lv0             Write fields: bias_en|bias_ctl
 	{.op = WRITE, .args = {.write = {0x1120UL, 0x010000A4}} },	 // saphir/bias/bias_sm_pdy_lv0             Write fields: bias_en|bias_ctl
 	{.op = WRITE, .args = {.write = {0x1208UL, 0x00000035}} },	 // saphir/bias/bgen_ctrl                   Write fields: burst_transfer_hv_bank_0|burst_transfer_lv_bank_0
-	{.op = WRITE, .args = {.write = {0x0000UL, 0x00000802}} }	 // saphir/roi_ctrl                         Write fields: roi_td_en
+	{.op = WRITE, .args = {.write = {0x0000UL, 0x00000802}} },	 // saphir/roi_ctrl                         Write fields: roi_td_en
+	{.op = WRITE, .args = {.write = {0x009008, 0x00000184}} },
+	{.op = WRITE, .args = {.write = {0x009008, 0x00010184}} },
+	{.op = WRITE, .args = {.write = {0x000200, 0x00000000}} },
+	{.op = WRITE, .args = {.write = {0x000214, 0x00000440}} },
+	{.op = WRITE, .args = {.write = {0x000214, 0x00000441}} },
+	{.op = WRITE, .args = {.write = {0x000204, 0x00000634}} },
+	{.op = WRITE, .args = {.write = {0x00020C, 0x00000061}} },
+	{.op = WRITE, .args = {.write = {0x000204, 0x00000635}} },
+	{.op = WRITE, .args = {.write = {0x000204, 0x00000637}} },
+	{.op = WRITE, .args = {.write = {0x000210, 0x00000C00}} },
+	{.op = WRITE, .args = {.write = {0x00B00C, 0x00000004}} },
+	{.op = WRITE, .args = {.write = {0x009008, 0x00000304}} },
+	{.op = WRITE, .args = {.write = {0x00004C, 0x00209600}} }
 };
 static const struct reg_op dcmi_start_seq[] = {
 	{.op = WRITE, .args = {.write = {0x9028UL, 0x00000000}} },	 // saphir/ro/ro_lp_ctrl                    Write fields: lp_output_disable
-	{.op = WRITE, .args = {.write = {0x9008UL, 0x000000A5}} },	 // saphir/ro/time_base_ctrl                Write fields: time_base_enable
+	{.op = WRITE, .args = {.write = {0x9008UL, 0x00000305}} },	 // saphir/ro/time_base_ctrl                Write fields: time_base_enable
 	{.op = DELAY, .args = {.delay = {1000}} },	 // us
 	{.op = WRITE, .args = {.write = {0x002CUL, 0x0022C724}} },	 // saphir/ro_td_ctrl                       Write fields: ro_td_ack_y_rstn|ro_td_arb_y_rstn|ro_td_addr_y_rstn|ro_td_sendreq_y_rstn
 	{.op = WRITE, .args = {.write = {0x0000UL, 0x00000C02}} },	 // saphir/roi_ctrl                         Write fields: roi_td_en|px_sw_rstn
@@ -136,7 +149,7 @@ static const struct reg_op dcmi_stop_seq[] = {
 	{.op = WRITE, .args = {.write = {0x002CUL, 0x00200624}} },	 // saphir/ro_td_ctrl                       Write fields: ro_td_ack_y_rstn|ro_td_arb_y_rstn|ro_td_addr_y_rstn|ro_td_sendreq_y_rstn
 	{.op = WRITE, .args = {.write = {0x9028UL, 0x00000002}} },	 // saphir/ro/ro_lp_ctrl                    Write fields: lp_output_disable|lp_keep_th
 	{.op = DELAY, .args = {.delay = {1000}} },	 // us
-	{.op = WRITE, .args = {.write = {0x9008UL, 0x000000A4}} },	 // saphir/ro/time_base_ctrl                Write fields: time_base_enable
+	{.op = WRITE, .args = {.write = {0x9008UL, 0x00000304}} },	 // saphir/ro/time_base_ctrl                Write fields: time_base_enable
 	{.op = WRITE, .args = {.write = {0x8000UL, 0x0001FFA2}} },	 // saphir/cpi/pipeline_control             Write fields: enable|drop_nbackpressure|hot_disable_enable
 	{.op = READ, .args = {.read = {0x8004UL, 0x00000002}} },	 // saphir/cpi/pipeline_status              Read fields: busy
 	{.op = DELAY, .args = {.delay = {1000}} }	 // us

--- a/src/drivers/genx320/src/genx320_issd_cpi_histo.c
+++ b/src/drivers/genx320/src/genx320_issd_cpi_histo.c
@@ -120,12 +120,25 @@ static const struct reg_op dcmi_init_seq[] = {
 	{.op = WRITE, .args = {.write = {0x111CUL, 0x03000074}} },	 // saphir/bias/bias_req_pu_lv0             Write fields: bias_en|bias_ctl
 	{.op = WRITE, .args = {.write = {0x1120UL, 0x010000A4}} },	 // saphir/bias/bias_sm_pdy_lv0             Write fields: bias_en|bias_ctl
 	{.op = WRITE, .args = {.write = {0x1208UL, 0x00000035}} },	 // saphir/bias/bgen_ctrl                   Write fields: burst_transfer_hv_bank_0|burst_transfer_lv_bank_0
-	{.op = WRITE, .args = {.write = {0x0000UL, 0x00000802}} }	 // saphir/roi_ctrl                         Write fields: roi_td_en
+	{.op = WRITE, .args = {.write = {0x0000UL, 0x00000802}} },	 // saphir/roi_ctrl                         Write fields: roi_td_en
+	{.op = WRITE, .args = {.write = {0x009008, 0x00000184}} },
+	{.op = WRITE, .args = {.write = {0x009008, 0x00010184}} },
+	{.op = WRITE, .args = {.write = {0x000200, 0x00000000}} },
+	{.op = WRITE, .args = {.write = {0x000214, 0x00000440}} },
+	{.op = WRITE, .args = {.write = {0x000214, 0x00000441}} },
+	{.op = WRITE, .args = {.write = {0x000204, 0x00000634}} },
+	{.op = WRITE, .args = {.write = {0x00020C, 0x00000061}} },
+	{.op = WRITE, .args = {.write = {0x000204, 0x00000635}} },
+	{.op = WRITE, .args = {.write = {0x000204, 0x00000637}} },
+	{.op = WRITE, .args = {.write = {0x000210, 0x00000C00}} },
+	{.op = WRITE, .args = {.write = {0x00B00C, 0x00000004}} },
+	{.op = WRITE, .args = {.write = {0x009008, 0x00000304}} },
+	{.op = WRITE, .args = {.write = {0x00004C, 0x00209600}} }
 };
 static const struct reg_op dcmi_start_seq[] = {
 	{.op = WRITE, .args = {.write = {0x8000UL, 0x0001FEA1}} },	 // saphir/cpi/pipeline_control
 	{.op = WRITE, .args = {.write = {0x9028UL, 0x00000000}} },	 // saphir/ro/ro_lp_ctrl                    Write fields: lp_output_disable
-	{.op = WRITE, .args = {.write = {0x9008UL, 0x000000A5}} },	 // saphir/ro/time_base_ctrl                Write fields: time_base_enable
+	{.op = WRITE, .args = {.write = {0x9008UL, 0x00000305}} },	 // saphir/ro/time_base_ctrl                Write fields: time_base_enable
 	{.op = DELAY, .args = {.delay = {1000}} },	 // us
 	{.op = WRITE, .args = {.write = {0x002CUL, 0x0022C724}} },	 // saphir/ro_td_ctrl                       Write fields: ro_td_ack_y_rstn|ro_td_arb_y_rstn|ro_td_addr_y_rstn|ro_td_sendreq_y_rstn
 	{.op = WRITE, .args = {.write = {0x0000UL, 0x00000C02}} },	 // saphir/roi_ctrl                         Write fields: roi_td_en|px_sw_rstn
@@ -136,7 +149,7 @@ static const struct reg_op dcmi_stop_seq[] = {
 	{.op = WRITE, .args = {.write = {0x002CUL, 0x00200624}} },	 // saphir/ro_td_ctrl                       Write fields: ro_td_ack_y_rstn|ro_td_arb_y_rstn|ro_td_addr_y_rstn|ro_td_sendreq_y_rstn
 	{.op = WRITE, .args = {.write = {0x9028UL, 0x00000002}} },	 // saphir/ro/ro_lp_ctrl                    Write fields: lp_output_disable|lp_keep_th
 	{.op = DELAY, .args = {.delay = {1000}} },	 // us
-	{.op = WRITE, .args = {.write = {0x9008UL, 0x000000A4}} },	 // saphir/ro/time_base_ctrl                Write fields: time_base_enable
+	{.op = WRITE, .args = {.write = {0x9008UL, 0x00000304}} },	 // saphir/ro/time_base_ctrl                Write fields: time_base_enable
 	{.op = WRITE, .args = {.write = {0x8000UL, 0x0001FFA2}} },	 // saphir/cpi/pipeline_control             Write fields: enable|drop_nbackpressure|hot_disable_enable
 	{.op = READ, .args = {.read = {0x8004UL, 0x00000002}} },	 // saphir/cpi/pipeline_status              Read fields: busy
 	{.op = DELAY, .args = {.delay = {1000}} }	 // us

--- a/src/drivers/genx320/src/psee_genx320.c
+++ b/src/drivers/genx320/src/psee_genx320.c
@@ -1785,7 +1785,7 @@ AFK_StatusTypeDef psee_afk_activate(AFK_HandleTypeDef *afk, uint16_t f_min, uint
     }
 
     /* Assert Clock Param */
-    if ((evt_clk_freq != 10) && (evt_clk_freq != 24) && (evt_clk_freq != 25) && (evt_clk_freq != 50)) {
+    if ((evt_clk_freq < 10) || (evt_clk_freq > 50)) {
         return AFK_CLK_ERROR;
     }
 
@@ -2992,7 +2992,7 @@ STC_StatusTypeDef psee_stc_only_activate(STC_HandleTypeDef *stc, uint32_t stc_th
     }
 
     /* Assert Clock Param */
-    if ((evt_clk_freq != 10) && (evt_clk_freq != 24) && (evt_clk_freq != 25) && (evt_clk_freq != 50)) {
+    if ((evt_clk_freq < 10) || (evt_clk_freq > 50)) {
         return STC_CLK_ERROR;
     }
 
@@ -3083,7 +3083,7 @@ STC_StatusTypeDef psee_trail_only_activate(STC_HandleTypeDef *stc, uint32_t trai
     }
 
     /* Assert Clock Param */
-    if ((evt_clk_freq != 10) && (evt_clk_freq != 24) && (evt_clk_freq != 25) && (evt_clk_freq != 50)) {
+    if ((evt_clk_freq < 10) || (evt_clk_freq > 50)) {
         return STC_CLK_ERROR;
     }
 
@@ -3175,7 +3175,7 @@ STC_StatusTypeDef psee_stc_trail_activate(STC_HandleTypeDef *stc, uint32_t stc_t
     }
 
     /* Assert Clock Param */
-    if ((evt_clk_freq != 10) && (evt_clk_freq != 24) && (evt_clk_freq != 25) && (evt_clk_freq != 50)) {
+    if ((evt_clk_freq < 10) || (evt_clk_freq > 50)) {
         return STC_CLK_ERROR;
     }
 

--- a/src/omv/common/omv_csi.h
+++ b/src/omv/common/omv_csi.h
@@ -220,7 +220,8 @@ typedef enum {
     OMV_CSI_IOCTL_HIMAX_OSC_ENABLE      = 0x1E | OMV_CSI_IOCTL_FLAGS_ABORT,
     OMV_CSI_IOCTL_GET_RGB_STATS         = 0x1F,
     OMV_CSI_IOCTL_GENX320_SET_BIASES    = 0x20,
-    OMV_CSI_IOCTL_GENX320_SET_BIAS      = 0x21
+    OMV_CSI_IOCTL_GENX320_SET_BIAS      = 0x21,
+    OMV_CSI_IOCTL_GENX320_SET_AFK       = 0x22
 } omv_csi_ioctl_t;
 
 typedef enum {

--- a/src/omv/modules/py_csi.c
+++ b/src/omv/modules/py_csi.c
@@ -1028,6 +1028,15 @@ static mp_obj_t py_omv_csi_ioctl(uint n_args, const mp_obj_t *args) {
             }
             break;
         }
+        case OMV_CSI_IOCTL_GENX320_SET_AFK: {
+            if (n_args == 2) {
+                error = omv_csi_ioctl(request, mp_obj_get_int(args[1]));
+            } else if (n_args == 4) {
+                error = omv_csi_ioctl(request, mp_obj_get_int(args[1]), mp_obj_get_int(args[2]),
+                                               mp_obj_get_int(args[3]));
+            }
+            break;
+        }
         #endif // (OMV_GENX320_ENABLE == 1)
 
         default: {
@@ -1241,6 +1250,7 @@ static const mp_rom_map_elem_t globals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_GENX320_BIAS_FO),              MP_ROM_INT(OMV_CSI_GENX320_BIAS_FO)},
     { MP_ROM_QSTR(MP_QSTR_GENX320_BIAS_HPF),             MP_ROM_INT(OMV_CSI_GENX320_BIAS_HPF)},
     { MP_ROM_QSTR(MP_QSTR_GENX320_BIAS_REFR),            MP_ROM_INT(OMV_CSI_GENX320_BIAS_REFR)},
+    { MP_ROM_QSTR(MP_QSTR_IOCTL_GENX320_SET_AFK),        MP_ROM_INT(OMV_CSI_IOCTL_GENX320_SET_AFK)},
     #endif
 
     // Sensor functions

--- a/src/omv/sensors/genx320.c
+++ b/src/omv/sensors/genx320.c
@@ -88,6 +88,8 @@ static bool hot_pixels_disabled = false;
 static int32_t contrast = CONTRAST_DEFAULT;
 static int32_t brightness = BRIGHTNESS_DEFAULT;
 
+AFK_HandleTypeDef psee_afk;
+
 static int reset(omv_csi_t *csi) {
     csi->color_palette = NULL;
 
@@ -133,8 +135,6 @@ static int reset(omv_csi_t *csi) {
                       RO_READOUT_CTRL_DROP_ON_FULL_EN);
 
     // Enable the Anti-FlicKering filter
-    AFK_HandleTypeDef psee_afk;
-
     if (psee_afk_init(&psee_afk) != AFK_OK) {
         return -1;
     }
@@ -540,6 +540,33 @@ static int ioctl(omv_csi_t *csi, int request, va_list ap) {
                 }
                 case OMV_CSI_GENX320_BIAS_REFR: {
                     psee_sensor_set_bias(REFR, bias_value);
+                    break;
+                }
+                default: {
+                    ret = -1;
+                    break;
+                }
+            }
+            break;
+        }
+        // Controlling AFK filter
+        case OMV_CSI_IOCTL_GENX320_SET_AFK: {
+            int mode = va_arg(ap, int);
+            switch (mode) {
+                case 0: { // disable AFK
+                    if (psee_afk_get_state(&psee_afk) != AFK_STATE_RESET) {
+                        if (psee_afk_deactivate(&psee_afk) != AFK_OK)
+                            ret = -1;
+                    }
+                    break;
+                }
+                case 1: { // enable AFK
+                    int freq_min = va_arg(ap, int);
+                    int freq_max = va_arg(ap, int);
+                    if (psee_afk_init(&psee_afk) != AFK_OK)
+                        ret = -1;
+                    if (psee_afk_activate(&psee_afk, freq_min, freq_max, EVT_CLK_FREQ) != AFK_OK)
+                        ret = -1;
                     break;
                 }
                 default: {

--- a/src/omv/sensors/genx320.c
+++ b/src/omv/sensors/genx320.c
@@ -385,6 +385,12 @@ static void snapshot_post_process(image_t *image) {
 }
 
 static int snapshot(omv_csi_t *csi, image_t *image, uint32_t flags) {
+    #if (OMV_GENX320_EHC_ENABLE != 1)
+    if (csi->transpose) {
+        return OMV_CSI_ERROR_CAPTURE_FAILED;
+    }
+    #endif
+
     #if (OMV_GENX320_CAL_ENABLE == 1)
     if (!hot_pixels_disabled) {
         uint8_t *histogram = fb_alloc0(ACTIVE_SENSOR_SIZE, FB_ALLOC_NO_HINT);


### PR DESCRIPTION
This PR adds IOCTL for AFK (GenX320 AntiFlicker filter) allowing
* enable AFK with a new range of frequencies (useful for frequency filtering)
* disable AFK (as it is enabled by default and some users needs those filtered out frequencies)
* fixing typos and small cleaning