### PR TITLE
sensors/GenX320: Adding IOCTL to control Anti-Flicker filter (AFK).

### DIFF
--- a/scripts/examples/01-Camera/03-Event-Cameras/02-Genx320/genx320_grayscale_set_afk.py
+++ b/scripts/examples/01-Camera/03-Event-Cameras/02-Genx320/genx320_grayscale_set_afk.py
@@ -1,0 +1,29 @@
+# This work is licensed under the MIT license.
+# Copyright (c) 2013-2024 OpenMV LLC. All rights reserved.
+# https://github.com/openmv/openmv/blob/master/LICENSE
+#
+# This example shows off using the GenX320 event sensor from Prophesee and controlling
+# AntiFlicKer (AFK) filter bloc in the GenX320 digital pipeline.
+# AFK allows to detect periodic changes of given frequencies in the scene and filter them out.
+
+import sensor
+import time
+
+sensor.reset()
+sensor.set_pixformat(sensor.GRAYSCALE)  # Must always be grayscale.
+sensor.set_framesize(sensor.B320X320)  # Must always be 320x320.
+sensor.set_framerate(100)
+
+# Enables AFK filter to remove periodic data in the frequency range from 130Hz to 160Hz
+sensor.ioctl(sensor.IOCTL_GENX320_SET_AFK, 1, 130, 160)
+# Disables AFK filter
+# sensor.ioctl(sensor.IOCTL_GENX320_SET_AFK, 0)
+
+clock = time.clock()
+
+while True:
+    clock.tick()
+
+    img = sensor.snapshot()
+
+    print(clock.fps())

--- a/src/drivers/genx320/include/psee_genx320.h
+++ b/src/drivers/genx320/include/psee_genx320.h
@@ -205,7 +205,7 @@ typedef enum {
 } AFK_StatusTypeDef;
 
 /**
- * @brief EHC State structures definition
+ * @brief AFK State structures definition
  */
 typedef enum {
     AFK_STATE_RESET     = 0x00U,
@@ -214,7 +214,7 @@ typedef enum {
 } AFK_StateTypeDef;
 
 /**
- * @brief EHC Statistics structures definition
+ * @brief AFK Statistics structures definition
  */
 typedef enum {
 	AFK_STATS_RESET     = 0x00U,
@@ -266,27 +266,27 @@ typedef enum {
  * @brief EHC Algo structures definition
  */
 typedef enum {
-    EHC_ALGO_DIFF3D     = 0x00U,  
-    EHC_ALGO_HISTO3D    = 0x01U,  
-    EHC_ALGO_RESET      = 0x02U,  
+    EHC_ALGO_DIFF3D     = 0x00U,
+    EHC_ALGO_HISTO3D    = 0x01U,
+    EHC_ALGO_RESET      = 0x02U,
 } EHC_AlgoTypeDef;
 
 /**
  * @brief EHC Trigger structures definition
  */
 typedef enum {
-    EHC_TRIGGER_EVENT_RATE          = 0x00U,         
+    EHC_TRIGGER_EVENT_RATE          = 0x00U,
     EHC_TRIGGER_INTEGRATION_PERIOD  = 0x01U,
-    EHC_TRIGGER_RESET               = 0x02U,  
+    EHC_TRIGGER_RESET               = 0x02U,
 } EHC_TriggerTypeDef;
 
 /**
  * @brief EHC Padding structures definition
  */
 typedef enum {
-    EHC_WITHOUT_PADDING = 0x00U, 
-    EHC_WITH_PADDING    = 0x01U,    
-    EHC_PADDING_RESET   = 0x02U,  
+    EHC_WITHOUT_PADDING = 0x00U,
+    EHC_WITH_PADDING    = 0x01U,
+    EHC_PADDING_RESET   = 0x02U,
 } EHC_PaddingTypeDef;
 
 /**

--- a/src/drivers/genx320/src/psee_genx320.c
+++ b/src/drivers/genx320/src/psee_genx320.c
@@ -1644,7 +1644,7 @@ static void psee_sram_powerdown(GenX320_ModulesTypeDef module) {
     case STC:
         psee_sensor_read(SRAM_PD0, &sram_pd0);
         psee_sensor_write(SRAM_PD0, sram_pd0 |           /*!< Previous State of SRAM_PD0 */
-                                        SRAM_PD0_STC0_PD /*!< SRAM's Power Down Register : 1 - EHC's SRAM cuts in powerdown */
+                                        SRAM_PD0_STC0_PD /*!< SRAM's Power Down Register : 1 - STC's SRAM cuts in powerdown */
         );
         break;
 
@@ -1785,7 +1785,7 @@ AFK_StatusTypeDef psee_afk_activate(AFK_HandleTypeDef *afk, uint16_t f_min, uint
     }
 
     /* Assert Clock Param */
-    if ((evt_clk_freq != 10) && (evt_clk_freq != 24) && (evt_clk_freq != 25) && (evt_clk_freq != 50)) {
+    if ((evt_clk_freq < 10) || (evt_clk_freq > 50)) {
         return AFK_CLK_ERROR;
     }
 

--- a/src/omv/common/omv_csi.h
+++ b/src/omv/common/omv_csi.h
@@ -220,7 +220,8 @@ typedef enum {
     OMV_CSI_IOCTL_HIMAX_OSC_ENABLE      = 0x1E | OMV_CSI_IOCTL_FLAGS_ABORT,
     OMV_CSI_IOCTL_GET_RGB_STATS         = 0x1F,
     OMV_CSI_IOCTL_GENX320_SET_BIASES    = 0x20,
-    OMV_CSI_IOCTL_GENX320_SET_BIAS      = 0x21
+    OMV_CSI_IOCTL_GENX320_SET_BIAS      = 0x21,
+    OMV_CSI_IOCTL_GENX320_SET_AFK       = 0x22
 } omv_csi_ioctl_t;
 
 typedef enum {

--- a/src/omv/modules/py_csi.c
+++ b/src/omv/modules/py_csi.c
@@ -1028,6 +1028,15 @@ static mp_obj_t py_omv_csi_ioctl(size_t n_args, const mp_obj_t *args) {
             }
             break;
         }
+        case OMV_CSI_IOCTL_GENX320_SET_AFK: {
+            if (n_args == 2) {
+                error = omv_csi_ioctl(request, mp_obj_get_int(args[1]));
+            } else if (n_args == 4) {
+                error = omv_csi_ioctl(request, mp_obj_get_int(args[1]), mp_obj_get_int(args[2]),
+                                      mp_obj_get_int(args[3]));
+            }
+            break;
+        }
         #endif // (OMV_GENX320_ENABLE == 1)
 
         default: {
@@ -1241,6 +1250,7 @@ static const mp_rom_map_elem_t globals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_GENX320_BIAS_FO),              MP_ROM_INT(OMV_CSI_GENX320_BIAS_FO)},
     { MP_ROM_QSTR(MP_QSTR_GENX320_BIAS_HPF),             MP_ROM_INT(OMV_CSI_GENX320_BIAS_HPF)},
     { MP_ROM_QSTR(MP_QSTR_GENX320_BIAS_REFR),            MP_ROM_INT(OMV_CSI_GENX320_BIAS_REFR)},
+    { MP_ROM_QSTR(MP_QSTR_IOCTL_GENX320_SET_AFK),        MP_ROM_INT(OMV_CSI_IOCTL_GENX320_SET_AFK)},
     #endif
 
     // Sensor functions

--- a/src/omv/sensors/genx320.c
+++ b/src/omv/sensors/genx320.c
@@ -84,7 +84,7 @@ static bool hot_pixels_disabled = false;
 static int32_t contrast = CONTRAST_DEFAULT;
 static int32_t brightness = BRIGHTNESS_DEFAULT;
 
-AFK_HandleTypeDef psee_afk;
+static AFK_HandleTypeDef psee_afk;
 
 static int reset(omv_csi_t *csi) {
     csi->color_palette = NULL;

--- a/src/omv/sensors/genx320.c
+++ b/src/omv/sensors/genx320.c
@@ -84,6 +84,8 @@ static bool hot_pixels_disabled = false;
 static int32_t contrast = CONTRAST_DEFAULT;
 static int32_t brightness = BRIGHTNESS_DEFAULT;
 
+AFK_HandleTypeDef psee_afk;
+
 static int reset(omv_csi_t *csi) {
     csi->color_palette = NULL;
 
@@ -129,8 +131,6 @@ static int reset(omv_csi_t *csi) {
                       RO_READOUT_CTRL_DROP_ON_FULL_EN);
 
     // Enable the Anti-FlicKering filter
-    AFK_HandleTypeDef psee_afk;
-
     if (psee_afk_init(&psee_afk) != AFK_OK) {
         return -1;
     }
@@ -524,6 +524,29 @@ static int ioctl(omv_csi_t *csi, int request, va_list ap) {
                 default: {
                     ret = -1;
                     break;
+                }
+            }
+            break;
+        }
+        // Controlling AFK filter
+        case OMV_CSI_IOCTL_GENX320_SET_AFK: {
+            int mode = va_arg(ap, int);
+            if (mode == 0) {
+                // Disable AFK
+                if (psee_afk_get_state(&psee_afk) != AFK_STATE_RESET) {
+                    if (psee_afk_deactivate(&psee_afk) != AFK_OK) {
+                        ret = -1;
+                    }
+                }
+            } else {
+                // Enable AFK
+                int freq_min = va_arg(ap, int);
+                int freq_max = va_arg(ap, int);
+                if (psee_afk_init(&psee_afk) != AFK_OK) {
+                    ret = -1;
+                }
+                if (psee_afk_activate(&psee_afk, freq_min, freq_max, EVT_CLK_FREQ) != AFK_OK) {
+                    ret = -1;
                 }
             }
             break;


### PR DESCRIPTION
This PR adds IOCTL for AFK (GenX320 AntiFlicker filter) allowing
* enable AFK with a new range of frequencies (useful for frequency filtering)
* disable AFK (as it is enabled by default and some users needs those filtered out frequencies)
* fixing typos and small cleaning

Tested on a LED (on top of https://github.com/openmv/openmv/pull/2614 ) and works well for filtering out given frequencies.