### PR TITLE
drivers/cyw4343: Fix BT firmware file.

### DIFF
--- a/src/drivers/cyw4343/firmware/cyw4343_btfw.h
+++ b/src/drivers/cyw4343/firmware/cyw4343_btfw.h
@@ -1,2 +1,2 @@
-#define CYW43_BT_FW_LEN   (35182)
-const uintptr_t bt_fw_data = (uintptr_t) CYW43_BT_FIRMWARE_ADDRESS;
+const size_t btfw_len = 35182;
+const uint8_t *btfw_data = (const uint8_t *) CYW43_BT_FIRMWARE_ADDRESS;


### PR DESCRIPTION
Update the CYW43 to work with the new CYW43 BTHCI UART backend.