### PR TITLE
csi: remove enum to support preprocessor directives

### DIFF
--- a/src/omv/common/omv_csi.h
+++ b/src/omv/common/omv_csi.h
@@ -95,16 +95,14 @@
 
 #define OMV_CSI_TIMEOUT_MS      (3000)
 
+#define OMV_CSI_CLK_SOURCE_MCO  (0U)
+#define OMV_CSI_CLK_SOURCE_TIM  (1U)
+#define OMV_CSI_CLK_SOURCE_OSC  (2U)
+
 typedef enum {
     OMV_CSI_ACTIVE_LOW  = 0,
     OMV_CSI_ACTIVE_HIGH = 1
 } omv_csi_polarity_t;
-
-typedef enum {
-    OMV_CSI_CLK_SOURCE_MCO = 0U,
-    OMV_CSI_CLK_SOURCE_TIM = 1U,
-    OMV_CSI_CLK_SOURCE_OSC = 2U,
-} omv_csi_clk_source_t;
 
 typedef enum {
     OMV_CSI_CONFIG_INIT      = (1 << 0),


### PR DESCRIPTION
While adding a new port, I found that my `OMV_CSI_CLK_SOURCE` was not effective.  This was due to the value being defined as an `enum`, which is undefined during the preprocessor run.  This means that `OMV_CSI_CLK_SOURCE == OMV_CSI_CLK_SOURCE_TIM` was evaluating to `UNDEFINED == UNDEFINED`, always true.

Changing the `enum` to `#define`s to resolve this.