### PR TITLE
ports/alif: Change HP U55 config to SRAM_OPSI.

### DIFF
--- a/ports/alif/alif.mk
+++ b/ports/alif/alif.mk
@@ -144,7 +144,7 @@ $(error Invalid MCU core specified))
 endif
 
 ifeq ($(MCU_CORE),M55_HP)
-VELA_ARGS="--system-config RTSS_HP_DTCM_MRAM \
+VELA_ARGS="--system-config RTSS_HP_SRAM_OSPI \
            --accelerator-config ethos-u55-256 \
            --memory-mode Shared_Sram"
 else

--- a/tools/vela.ini
+++ b/tools/vela.ini
@@ -11,6 +11,19 @@ OffChipFlash_burst_length=16
 OffChipFlash_read_latency=60
 OffChipFlash_write_latency=60
 
+[System_Config.RTSS_HP_SRAM_OSPI]
+core_clock=400e6
+axi0_port=Sram
+axi1_port=OffChipFlash
+Sram_clock_scale=0.762
+Sram_burst_length=8
+Sram_read_latency=29
+Sram_write_latency=29
+OffChipFlash_clock_scale=0.052
+OffChipFlash_burst_length=16
+OffChipFlash_read_latency=108
+OffChipFlash_write_latency=108
+
 [System_Config.RTSS_HE_SRAM_MRAM]
 core_clock=160e6
 axi0_port=Sram
@@ -75,6 +88,19 @@ OffChipFlash_clock_scale=0.118
 OffChipFlash_burst_length=64
 OffChipFlash_read_latency=60
 OffChipFlash_write_latency=60
+
+[System_Config.RTSS_HP_DTCM_Modem]
+core_clock=400e6
+axi0_port=Sram
+axi1_port=OffChipFlash
+Sram_clock_scale=0.889
+Sram_burst_length=32
+Sram_read_latency=5
+Sram_write_latency=5
+OffChipFlash_clock_scale=0.200
+OffChipFlash_burst_length=64
+OffChipFlash_read_latency=53
+OffChipFlash_write_latency=53
 
 [System_Config.RTSS_HP_DTCM_SRAM]
 core_clock=400e6


### PR DESCRIPTION
The correct performance information should be reported now when compiling the HP ROMFS img.

Grabbed new ini file from here: https://github.com/alifsemi/alif_ml-embedded-evaluation-kit/blob/main/scripts/vela/ensemble_vela.ini.

...

This is a draft because I need to test the resulting firmware. However, this mirrors the updated files for the IDE.