### PR TITLE
ports/stm32: assert i2c not SPEED_FAST if not supported

### DIFF
--- a/src/omv/ports/stm32/omv_i2c.c
+++ b/src/omv/ports/stm32/omv_i2c.c
@@ -185,7 +185,7 @@ int omv_i2c_init(omv_i2c_t *i2c, uint32_t bus_id, uint32_t speed) {
     }
 
     #if !defined(IS_I2C_FASTMODEPLUS)
-        assert_param(speed != OMV_I2C_SPEED_FAST);
+    assert_param(speed != OMV_I2C_SPEED_FAST);
     #else
     if (speed == OMV_I2C_SPEED_FAST) {
         // Enable FAST mode plus.

--- a/src/omv/ports/stm32/omv_i2c.c
+++ b/src/omv/ports/stm32/omv_i2c.c
@@ -184,7 +184,9 @@ int omv_i2c_init(omv_i2c_t *i2c, uint32_t bus_id, uint32_t speed) {
         return -1;
     }
 
-    #if defined(IS_I2C_FASTMODEPLUS)
+    #if !defined(IS_I2C_FASTMODEPLUS)
+        assert_param(speed != OMV_I2C_SPEED_FAST);
+    #else
     if (speed == OMV_I2C_SPEED_FAST) {
         // Enable FAST mode plus.
         switch (bus_id) {
@@ -210,7 +212,7 @@ int omv_i2c_init(omv_i2c_t *i2c, uint32_t bus_id, uint32_t speed) {
             #endif
         }
     }
-    #endif
+    #endif // !defined(IS_I2C_FASTMODEPLUS)
 
     i2c->initialized = true;
     return 0;


### PR DESCRIPTION
Complements #2653. 

One more detail for #2652.
