### PR TITLE
boot: Add DFU partition delay setting.

### DIFF
--- a/boards/OPENMV_AE3/romfs.json
+++ b/boards/OPENMV_AE3/romfs.json
@@ -22,13 +22,7 @@
     },
     {
       "type": "tflite",
-      "path": "{TOP}/lib/models/yolo_v5_224_nano.tflite",
-      "alignment": 16,
-      "optimize": "Performance"
-    },
-    {
-      "type": "tflite",
-      "path": "{TOP}/lib/models/person_detect.tflite",
+      "path": "{TOP}/lib/models/yolo_v2_224_small.tflite",
       "alignment": 16,
       "optimize": "Performance"
     },

--- a/boot/include/port.h
+++ b/boot/include/port.h
@@ -68,6 +68,7 @@ typedef struct {
     uintptr_t start;
     uintptr_t limit;
     uint32_t attr;
+    uint32_t delay;
 } partition_t;
 
 typedef enum {

--- a/boot/src/common/dfu.c
+++ b/boot/src/common/dfu.c
@@ -46,13 +46,10 @@ void tud_dfu_detach_cb(void) {
 // or before tud_dfu_manifest_cb() (state=DFU_MANIFEST).
 uint32_t tud_dfu_get_timeout_cb(uint8_t itf, uint8_t state) {
     tud_dfu_detached = false;
+    const partition_t *p = &OMV_BOOT_DFU_PARTITIONS[itf];
 
     if (state == DFU_DNBUSY) {
-        if (itf < 3) {
-            return 0;
-        } else {
-            return 100;
-        }
+        return p->delay;
     } else if (state == DFU_MANIFEST) {
         return 0;
     }


### PR DESCRIPTION
Allows setting a custom delay for DFU partition. This should be set to ensure control transfers don't timeout if erasing the partition takes too long. By default, this is 0 for all partition types.

I did not check every possible flash type (we have boards with QSPI, OSPI, NOR and MRAM), but I think a default of 0 might be okay, as the slowest would be NOR (at around 2.5 seconds). For all SPI flashes, we do block erases (not sector not full erase). The recovery type/process for Everspin may need a little longer, though I don't remember it timing out

@kwagyeman Please check the boards and let me know which partitions need to have more delay, or just send a follow-up PR.

For all ST chips we use Program/erase parallelism = x32
STM32F427xx/STM32F429xx
![image](https://github.com/user-attachments/assets/c01efd69-ac78-49fe-ad4c-e31fcda50c65)


STM32F765xx STM32F767xx STM32F768Ax STM32F769xx:
![image](https://github.com/user-attachments/assets/996fcc9a-d547-41e3-a912-e74d1ec28a0f)

STM32H742xI/G STM32H743xI/G
![image](https://github.com/user-attachments/assets/44077301-e653-41a9-8e24-60832f5a9357)

W25Q256JV (4P):

![image](https://github.com/user-attachments/assets/acffc21a-8c32-4ec2-a096-2d786632e048)

Macronix OSPI (N6/AE3):
![image](https://github.com/user-attachments/assets/f0f3127a-73c5-41fa-aefe-a71455e9e8e2)

MRAM (AE3): Almost instantaneous.
