### PR TITLE
scripts/libraries: Add support for more yolo post-processing.

### DIFF
--- a/scripts/libraries/ml/ml/postprocessing.py
+++ b/scripts/libraries/ml/ml/postprocessing.py
@@ -100,11 +100,11 @@ class yolo_v2_postprocess:
             return e_x / np.sum(e_x, axis=1, keepdims=True)
 
         # Reshape the output to a 2D array
-        colum_outputs = outputs[0].reshape((oh * ow * self.anchors_len,
-                                            _YOLO_V2_CLASSES + class_count))
+        row_outputs = outputs[0].reshape((oh * ow * self.anchors_len,
+                                          _YOLO_V2_CLASSES + class_count))
 
         # Threshold all the scores
-        score_indices = sigmoid(colum_outputs[:, _YOLO_V2_SCORE])
+        score_indices = sigmoid(row_outputs[:, _YOLO_V2_SCORE])
         score_indices = np.nonzero(score_indices > self.threshold)
         if isinstance(score_indices, tuple):
             score_indices = score_indices[0]
@@ -112,7 +112,7 @@ class yolo_v2_postprocess:
             return _NO_DETECTION
 
         # Get the bounding boxes that have a valid score
-        bb = np.take(colum_outputs, score_indices, axis=0)
+        bb = np.take(row_outputs, score_indices, axis=0)
 
         # Extract rows, columns, and anchor indices
         bb_rows = score_indices // (ow * self.anchors_len)
@@ -169,10 +169,10 @@ class yolo_v5_postprocess:
         class_count = oc - _YOLO_V5_CLASSES
 
         # Reshape the output to a 2D array
-        colum_outputs = outputs[0].reshape((oh * ow, _YOLO_V5_CLASSES + class_count))
+        row_outputs = outputs[0].reshape((oh * ow, _YOLO_V5_CLASSES + class_count))
 
         # Threshold all the scores
-        score_indices = colum_outputs[:, _YOLO_V5_SCORE]
+        score_indices = row_outputs[:, _YOLO_V5_SCORE]
         score_indices = np.nonzero(score_indices > self.threshold)
         if isinstance(score_indices, tuple):
             score_indices = score_indices[0]
@@ -180,7 +180,7 @@ class yolo_v5_postprocess:
             return _NO_DETECTION
 
         # Get the bounding boxes that have a valid score
-        bb = np.take(colum_outputs, score_indices, axis=0)
+        bb = np.take(row_outputs, score_indices, axis=0)
 
         # Get the score information
         bb_scores = bb[:, _YOLO_V5_SCORE]

--- a/scripts/libraries/ml/ml/postprocessing.py
+++ b/scripts/libraries/ml/ml/postprocessing.py
@@ -105,9 +105,7 @@ class yolo_v2_postprocess:
 
         # Threshold all the scores
         score_indices = sigmoid(row_outputs[:, _YOLO_V2_SCORE])
-        score_indices = np.nonzero(score_indices > self.threshold)
-        if isinstance(score_indices, tuple):
-            score_indices = score_indices[0]
+        score_indices = np.nonzero(score_indices > self.threshold)[0]
         if not len(score_indices):
             return _NO_DETECTION
 
@@ -173,9 +171,7 @@ class yolo_v5_postprocess:
 
         # Threshold all the scores
         score_indices = row_outputs[:, _YOLO_V5_SCORE]
-        score_indices = np.nonzero(score_indices > self.threshold)
-        if isinstance(score_indices, tuple):
-            score_indices = score_indices[0]
+        score_indices = np.nonzero(score_indices > self.threshold)[0]
         if not len(score_indices):
             return _NO_DETECTION
 

--- a/scripts/libraries/ml/ml/postprocessing.py
+++ b/scripts/libraries/ml/ml/postprocessing.py
@@ -140,7 +140,7 @@ class yolo_v2_postprocess:
         h_rel = h_rel * ih
 
         nms = NMS(iw, ih, inputs[0].roi)
-        for i in range(len(bb)):
+        for i in range(bb.shape[0]):
             nms.add_bounding_box(x_center[i] - (w_rel[i] / 2),
                                  y_center[i] - (h_rel[i] / 2),
                                  x_center[i] + (w_rel[i] / 2),
@@ -198,7 +198,7 @@ class yolo_v5_postprocess:
         ymax = (y_center + h_rel) * ih
 
         nms = NMS(iw, ih, inputs[0].roi)
-        for i in range(len(bb)):
+        for i in range(bb.shape[0]):
             nms.add_bounding_box(xmin[i], ymin[i], xmax[i], ymax[i],
                                  bb_scores[i], bb_classes[i])
         return nms.get_bounding_boxes(threshold=self.nms_threshold, sigma=self.nms_sigma)

--- a/scripts/libraries/ml/ml/postprocessing.py
+++ b/scripts/libraries/ml/ml/postprocessing.py
@@ -206,3 +206,57 @@ class yolo_v5_postprocess:
             nms.add_bounding_box(xmin[i], ymin[i], xmax[i], ymax[i],
                                  bb_scores[i], bb_classes[i])
         return nms.get_bounding_boxes(threshold=self.nms_threshold, sigma=self.nms_sigma)
+
+
+class yolo_v8_postprocess:
+    _YOLO_V8_CX = const(0)
+    _YOLO_V8_CY = const(1)
+    _YOLO_V8_CW = const(2)
+    _YOLO_V8_CH = const(3)
+    _YOLO_V8_CLASSES = const(4)
+
+    def __init__(self, threshold=0.6, nms_threshold=0.1, nms_sigma=0.1):
+        self.threshold = threshold
+        self.nms_threshold = nms_threshold
+        self.nms_sigma = nms_sigma
+
+    def __call__(self, model, inputs, outputs):
+        oh, ow, oc = model.output_shape[0]
+        class_count = ow - _YOLO_V8_CLASSES
+
+        # Reshape the output to a 2D array
+        column_outputs = outputs[0].reshape((oh * (_YOLO_V8_CLASSES + class_count), oc))
+
+        # Threshold all the scores
+        score_indices = np.max(column_outputs[_YOLO_V8_CLASSES:, :], axis=0)
+        score_indices = np.nonzero(score_indices > self.threshold)[0]
+        if not len(score_indices):
+            return _NO_DETECTION
+
+        # Get the bounding boxes that have a valid score
+        bb = np.take(column_outputs, score_indices, axis=1)
+
+        # Get the score information
+        bb_scores = np.max(bb[_YOLO_V8_CLASSES:, :], axis=0)
+
+        # Get the class information
+        bb_classes = np.argmax(bb[_YOLO_V8_CLASSES:, :], axis=0)
+
+        # Compute the bounding box information
+        x_center = bb[_YOLO_V8_CX, :]
+        y_center = bb[_YOLO_V8_CY, :]
+        w_rel = bb[_YOLO_V8_CW, :] * 0.5
+        h_rel = bb[_YOLO_V8_CH, :] * 0.5
+
+        # Scale the bounding boxes to have enough integer precision for NMS
+        ib, ih, iw, ic = model.input_shape[0]
+        xmin = (x_center - w_rel) * iw
+        ymin = (y_center - h_rel) * ih
+        xmax = (x_center + w_rel) * iw
+        ymax = (y_center + h_rel) * ih
+
+        nms = NMS(iw, ih, inputs[0].roi)
+        for i in range(bb.shape[1]):
+            nms.add_bounding_box(xmin[i], ymin[i], xmax[i], ymax[i],
+                                 bb_scores[i], bb_classes[i])
+        return nms.get_bounding_boxes(threshold=self.nms_threshold, sigma=self.nms_sigma)

--- a/scripts/libraries/ml/ml/postprocessing.py
+++ b/scripts/libraries/ml/ml/postprocessing.py
@@ -64,6 +64,8 @@ class fomo_postprocess:
         return nms.get_bounding_boxes()
 
 
+# This is a lightweight version of the tiny yolo v2 object detection algorithm.
+# It was optimized to work well on embedded devices with limited computational resources.
 class yolo_v2_postprocess:
     _YOLO_V2_TX = const(0)
     _YOLO_V2_TY = const(1)
@@ -147,6 +149,19 @@ class yolo_v2_postprocess:
                                  y_center[i] + (h_rel[i] / 2),
                                  bb_scores[i], bb_classes[i])
         return nms.get_bounding_boxes(threshold=self.nms_threshold, sigma=self.nms_sigma)
+
+
+# This is a lightweight version of the YOLO (You Only Look Once) object detection algorithm.
+# It is designed to work well on embedded devices with limited computational resources.
+class yolo_lc_postprocess(yolo_v2_postprocess):
+    def __init__(self, threshold=0.6, anchors=None, nms_threshold=0.1, nms_sigma=0.1):
+        if anchors is None:
+            anchors = np.array([[0.076023, 0.258508],
+                                [0.163031, 0.413531],
+                                [0.234769, 0.702585],
+                                [0.427054, 0.715892],
+                                [0.748154, 0.857092]])
+        super().__init__(threshold, anchors, nms_threshold, nms_sigma)
 
 
 class yolo_v5_postprocess:


### PR DESCRIPTION
Adds support for yolov8 post-processing, yolo_lc which runs fast on the the AE3 and gets more than 1 FPS on the H7 Plus and RT1062. Leveraging YOLO networks based on ST's Model Zoo: https://github.com/STMicroelectronics/stm32ai-modelzoo/tree/main/object_detection

For YOLOV2, the anchors used apply the -st variants of the YOLOV2 network. The anchors to use for the non-ST ones are the anchors in the YOLO_LC class. Note that YOLO_LC is just a speed up variant of YOLOV2.

The SSD networks do not work with TFLite for Microcontrollers, they need the Tile operator which is not provided by libtflm.

YOLOX doesn't run on the AE3, you get an invoke error from the NPU. YOLOX does run on the H7P and RT1062, but, is slow. Mult-tensor output needs to be added for it to work on the N6. I tried to get YOLOX working on the H7P, but, the bounding boxes are way too small. They are in the right place though and follow me around. Leaving the code here for later use.

```
class yolo_x_postprocess:
    _YOLO_X_TX = const(0)
    _YOLO_X_TY = const(1)
    _YOLO_X_TW = const(2)
    _YOLO_X_TH = const(3)
    _YOLO_X_SCORE = const(4)
    _YOLO_X_CLASSES = const(5)

    def __init__(self, threshold=0.6, anchors=None, nms_threshold=0.1, nms_sigma=0.1):
        self.threshold = threshold
        self.anchors = anchors
        if self.anchors is None:
            self.anchors = np.array([[0.5, 0.5],
                                     [0.07, 0.25],
                                     [0.23, 0.7]])
        self.anchors_len = len(self.anchors)
        self.nms_threshold = nms_threshold
        self.nms_sigma = nms_sigma

    def postprocess(self, model, inputs, i, outputs):
        ob, oh, ow, oc = model.output_shape[i]
        class_count = (oc // self.anchors_len) - _YOLO_X_CLASSES

        def sigmoid(x):
            return 1.0 / (1.0 + np.exp(-x))

        def mod(a, b):
            return a - (b * (a // b))

        def softmax(x):
            e_x = np.exp(x - np.max(x, axis=1, keepdims=True))
            return e_x / np.sum(e_x, axis=1, keepdims=True)

        # Reshape the output to a 2D array
        row_outputs = outputs.reshape((oh * ow * self.anchors_len,
                                       _YOLO_X_CLASSES + class_count))

        # Threshold all the scores
        score_indices = sigmoid(row_outputs[:, _YOLO_X_SCORE])
        score_indices = np.nonzero(score_indices > self.threshold)[0]
        if not len(score_indices):
            return tuple(np.empty((1,)) for j in range(6))

        # Get the bounding boxes that have a valid score
        bb = np.take(row_outputs, score_indices, axis=0)

        # Extract rows, columns, and anchor indices
        bb_rows = score_indices // (ow * self.anchors_len)
        bb_cols = mod(score_indices // self.anchors_len, ow)
        bb_anchors = mod(score_indices, self.anchors_len)

        # Get the anchor box information
        bb_a_array = np.take(self.anchors, bb_anchors, axis=0)

        # Get the score information
        bb_scores = sigmoid(bb[:, _YOLO_X_SCORE])

        # Get the class information
        bb_classes = np.argmax(softmax(bb[:, _YOLO_X_CLASSES:]), axis=1)

        # Compute the bounding box information
        x_center = (bb_cols + sigmoid(bb[:, _YOLO_X_TX])) / ow
        y_center = (bb_rows + sigmoid(bb[:, _YOLO_X_TY])) / oh
        w_rel = ((bb_a_array[:, 0] * np.exp(bb[:, _YOLO_X_TW])) / ow) * 0.5
        h_rel = ((bb_a_array[:, 1] * np.exp(bb[:, _YOLO_X_TH])) / oh) * 0.5

        return x_center, y_center, w_rel, h_rel, bb_scores, bb_classes

    def __call__(self, model, inputs, outputs):
        processed_outputs = [self.postprocess(model, inputs, i, o) for i, o in enumerate(outputs)]
        x, y, w, h, s, c = [np.concatenate(a) for a in zip(*processed_outputs)]

        # Scale the bounding boxes to have enough integer precision for NMS
        ib, ih, iw, ic = model.input_shape[0]
        xmin = (x - w) * iw
        ymin = (y - h) * ih
        xmax = (x + w) * iw
        ymax = (y + h) * ih

        nms = NMS(iw, ih, inputs[0].roi)
        for i in range(s.shape[0]):
            nms.add_bounding_box(xmin[i], ymin[i], xmax[i], ymax[i], s[i], c[i])
        return nms.get_bounding_boxes(threshold=self.nms_threshold, sigma=self.nms_sigma)
```

YOLO LC on H7P

https://github.com/user-attachments/assets/ea780ec9-e466-4b8d-9a6e-731ee181b489

YOLO LC on AE3

https://github.com/user-attachments/assets/b691f6c1-5f37-47d5-9ab1-297a1c5b3704

YOLOV8 on AE3 - 224

https://github.com/user-attachments/assets/2ad29d8b-807d-4c7a-b941-269ae6d51b8f

YOLOV8 on N6 - 416

https://github.com/user-attachments/assets/7b20039f-1012-4896-a5e8-1921e3efea4c