### PR TITLE
drivers/sensors/lepton: Update lepton driver with asynchronous fb.

### DIFF
--- a/boards/ARDUINO_GIGA/omv_boardconfig.h
+++ b/boards/ARDUINO_GIGA/omv_boardconfig.h
@@ -141,8 +141,6 @@
 #define OMV_FB_OVERLAY_SIZE                 (448K)  // Fast fb_alloc memory size.
 #define OMV_JPEG_MEMORY                     DRAM    // JPEG buffer memory buffer.
 #define OMV_JPEG_SIZE                       (1M)    // IDE JPEG buffer (header + data).
-#define OMV_VOSPI_MEMORY                    DTCM    // VoSPI buffer memory.
-#define OMV_VOSPI_SIZE                      (38K)
 #define OMV_DMA_MEMORY                      SRAM3   // Misc DMA buffers memory.
 #define OMV_DMA_MEMORY_D1                   SRAM0   // Domain 1 DMA buffers.
 #define OMV_DMA_MEMORY_D2                   SRAM3   // Domain 2 DMA buffers.

--- a/boards/ARDUINO_PORTENTA_H7/omv_boardconfig.h
+++ b/boards/ARDUINO_PORTENTA_H7/omv_boardconfig.h
@@ -139,8 +139,6 @@
 #define OMV_FB_OVERLAY_SIZE                 (480K)  // Fast fb_alloc memory size.
 #define OMV_JPEG_MEMORY                     DRAM    // JPEG buffer memory buffer.
 #define OMV_JPEG_SIZE                       (1M)    // IDE JPEG buffer (header + data).
-#define OMV_VOSPI_MEMORY                    SRAM4   // VoSPI buffer memory.
-#define OMV_VOSPI_SIZE                      (38K)
 #define OMV_DMA_MEMORY                      SRAM3   // Misc DMA buffers memory.
 #define OMV_DMA_MEMORY_D1                   SRAM0   // Domain 1 DMA buffers.
 #define OMV_DMA_MEMORY_D2                   SRAM3   // Domain 2 DMA buffers.

--- a/boards/OPENMV4/omv_boardconfig.h
+++ b/boards/OPENMV4/omv_boardconfig.h
@@ -138,11 +138,9 @@
 #define OMV_FB_ALLOC_SIZE                     (80K) // minimum fb alloc size
 #define OMV_JPEG_MEMORY                       SRAM0 // JPEG buffer memory.
 #define OMV_JPEG_SIZE                         (32K) // IDE JPEG buffer (header + data).
-#define OMV_VOSPI_MEMORY                      SRAM4 // VoSPI buffer memory.
-#define OMV_VOSPI_SIZE                        (38K)
 #define OMV_DMA_MEMORY                        SRAM2 // Misc DMA buffers memory.
 #define OMV_GC_BLOCK0_MEMORY                  SRAM4 // Main GC block.
-#define OMV_GC_BLOCK0_SIZE                    (26K)
+#define OMV_GC_BLOCK0_SIZE                    (64K)
 #define OMV_GC_BLOCK1_MEMORY                  SRAM1 // Extra GC block 0.
 #define OMV_GC_BLOCK1_SIZE                    (267K)
 #define OMV_MSC_BUF_SIZE                      (2K)  // USB MSC bot data

--- a/boards/OPENMV4P/omv_boardconfig.h
+++ b/boards/OPENMV4P/omv_boardconfig.h
@@ -126,8 +126,6 @@
 #define OMV_FB_OVERLAY_SIZE                   (496K) // Fast fb_alloc memory size.
 #define OMV_JPEG_MEMORY                       DRAM   // JPEG buffer memory buffer.
 #define OMV_JPEG_SIZE                         (1M)   // IDE JPEG buffer (header + data).
-#define OMV_VOSPI_MEMORY                      SRAM4  // VoSPI buffer memory.
-#define OMV_VOSPI_SIZE                        (38K)
 #define OMV_DMA_MEMORY                        SRAM3  // Misc DMA buffers memory.
 #define OMV_DMA_MEMORY_D1                     SRAM0  // Domain 1 DMA buffers.
 #define OMV_DMA_MEMORY_D2                     SRAM3  // Domain 2 DMA buffers.

--- a/boards/OPENMVPT/omv_boardconfig.h
+++ b/boards/OPENMVPT/omv_boardconfig.h
@@ -117,8 +117,6 @@
 #define OMV_FB_OVERLAY_SIZE                     (496K)  // Fast fb_alloc memory size.
 #define OMV_JPEG_MEMORY                         DRAM    // JPEG buffer memory buffer.
 #define OMV_JPEG_SIZE                           (1M)    // IDE JPEG buffer (header + data).
-#define OMV_VOSPI_MEMORY                        SRAM4   // VoSPI buffer memory.
-#define OMV_VOSPI_SIZE                          (38K)
 #define OMV_DMA_MEMORY                          SRAM3   // DMA buffers memory.
 #define OMV_DMA_MEMORY_D1                       SRAM0   // Domain 1 DMA buffers.
 #define OMV_DMA_MEMORY_D2                       SRAM3   // Domain 2 DMA buffers.

--- a/boards/OPENMV_N6/omv_boardconfig.h
+++ b/boards/OPENMV_N6/omv_boardconfig.h
@@ -153,8 +153,6 @@
 #define OMV_FB_ALLOC_SIZE                   (11M)   // minimum fb_alloc size
 #define OMV_JPEG_MEMORY                     DRAM   // JPEG buffer memory buffer.
 #define OMV_JPEG_SIZE                       (1M)   // IDE JPEG buffer (header + data).
-#define OMV_VOSPI_MEMORY                    SRAM1  // VoSPI buffer memory.
-#define OMV_VOSPI_SIZE                      (64K)
 #define OMV_DMA_MEMORY                      SRAM1  // Misc DMA buffers memory.
 #define OMV_GC_BLOCK0_MEMORY                SRAM2  // Main GC block
 #define OMV_GC_BLOCK0_SIZE                  (1M)

--- a/boards/OPENMV_RT1060/omv_boardconfig.h
+++ b/boards/OPENMV_RT1060/omv_boardconfig.h
@@ -84,11 +84,9 @@
 #define OMV_FB_ALLOC_SIZE               (10M)   // minimum fb alloc size
 #define OMV_FB_OVERLAY_MEMORY           OCRM1   // Fast fb_alloc memory.
 #define OMV_FB_OVERLAY_SIZE             (512K)
-#define OMV_VOSPI_MEMORY                OCRM2   // VoSPI buffer memory.
-#define OMV_VOSPI_SIZE                  (38K)
 #define OMV_DMA_MEMORY                  DTCM    // Misc DMA buffers memory.
 #define OMV_GC_BLOCK0_MEMORY            OCRM2   // Extra GC block 0.
-#define OMV_GC_BLOCK0_SIZE              (26K)
+#define OMV_GC_BLOCK0_SIZE              (64K)
 #define OMV_GC_BLOCK1_MEMORY            DTCM    // Main GC block
 #define OMV_GC_BLOCK1_SIZE              (288K)
 #define OMV_GC_BLOCK2_MEMORY            DRAM    // Extra GC block 1.

--- a/common/common.ld.S
+++ b/common/common.ld.S
@@ -133,17 +133,6 @@ PROVIDE(__stack = __StackTop);
 } >OMV_JPEG_MEMORY
 #endif
 
-/* VOSPI framebuffer memory */
-#if defined(OMV_VOSPI_MEMORY)
-.vospi_memory (NOLOAD) :
-{
-  . = ALIGN(4);
-  _vospi_buf = .;
-  . = . + OMV_VOSPI_SIZE;
-  . = ALIGN(4);
-} >OMV_VOSPI_MEMORY
-#endif
-
 /* GPU memory */
 #if defined(OMV_GPU_MEMORY)
 .gpu_memory (NOLOAD) :

--- a/common/vospi.c
+++ b/common/vospi.c
@@ -60,7 +60,7 @@ typedef enum {
 typedef struct _vospi_state {
     int pid;
     int sid;
-    uint16_t *framebuffer;
+    framebuffer_t *fb;
     bool lepton_3;
     omv_spi_t spi_bus;
     volatile uint32_t flags;
@@ -143,33 +143,39 @@ void vospi_callback(omv_spi_t *spi, void *userdata, void *buf) {
         return;
     }
 
-    memcpy(vospi.framebuffer
-           + (vospi.pid * VOSPI_PID_SIZE_PIXELS)
-           + (vospi.sid * VOSPI_SID_SIZE_PIXELS),
-           base + VOSPI_HEADER_WORDS, VOSPI_PID_SIZE_PIXELS * sizeof(uint16_t));
+    vbuffer_t *buffer = framebuffer_get_tail(vospi.fb, FB_PEEK);
 
-    vospi.pid += 1;
-    if (vospi.pid == VOSPI_PIDS_PER_SID) {
-        vospi.pid = 0;
+    if (buffer) {
+        memcpy(((uint16_t *) buffer->data)
+               + (vospi.pid * VOSPI_PID_SIZE_PIXELS)
+               + (vospi.sid * VOSPI_SID_SIZE_PIXELS),
+               base + VOSPI_HEADER_WORDS, VOSPI_PID_SIZE_PIXELS * sizeof(uint16_t));
 
-        // For the FLIR Lepton 3 we have to receive all the pids in all the segments.
-        if (vospi.lepton_3) {
-            vospi.sid += 1;
-            if (vospi.sid == VOSPI_SIDS_PER_FRAME) {
-                vospi.sid = 0;
-                vospi.flags &= ~VOSPI_FLAGS_CAPTURE;
+        vospi.pid += 1;
+        if (vospi.pid == VOSPI_PIDS_PER_SID) {
+            vospi.pid = 0;
+
+            // For the FLIR Lepton 3 we have to receive all the pids in all the segments.
+            if (vospi.lepton_3) {
+                vospi.sid += 1;
+                if (vospi.sid == VOSPI_SIDS_PER_FRAME) {
+                    vospi.sid = 0;
+                    framebuffer_get_tail(vospi.fb, FB_NO_FLAGS);
+                }
+                // For the FLIR Lepton 1/2 we just have to receive all the pids.
+            } else {
+                framebuffer_get_tail(vospi.fb, FB_NO_FLAGS);
             }
-            // For the FLIR Lepton 1/2 we just have to receive all the pids.
-        } else {
-            vospi.flags &= ~VOSPI_FLAGS_CAPTURE;
         }
+    } else {
+        vospi.flags &= ~VOSPI_FLAGS_CAPTURE;
     }
 }
 
-int vospi_init(uint32_t n_packets, void *buffer) {
+int vospi_init(uint32_t n_packets, framebuffer_t *fb) {
     memset(&vospi, 0, sizeof(vospi_state_t));
     vospi.lepton_3 = n_packets > VOSPI_PIDS_PER_SID;
-    vospi.framebuffer = buffer;
+    vospi.fb = fb;
     // resync on first snapshot.
     vospi.flags = VOSPI_FLAGS_RESYNC;
 
@@ -189,9 +195,22 @@ int vospi_init(uint32_t n_packets, void *buffer) {
     return 0;
 }
 
+int vospi_deinit() {
+    omv_spi_transfer_abort(&vospi.spi_bus);
+    omv_spi_deinit(&vospi.spi_bus);
+    memset(&vospi, 0, sizeof(vospi_state_t));
+    return 0;
+}
+
 int vospi_snapshot(uint32_t timeout_ms) {
-    // Restart counters to capture a new frame.
-    vospi.flags |= VOSPI_FLAGS_CAPTURE;
+    framebuffer_free_current_buffer(vospi.fb);
+
+    if (!(vospi.flags & VOSPI_FLAGS_CAPTURE)) {
+        framebuffer_setup_buffers(vospi.fb);
+
+        // Restart counters to capture a new frame.
+        vospi.flags |= VOSPI_FLAGS_CAPTURE;
+    }
 
     // Snapshot start tick
     mp_uint_t tick_start = mp_hal_ticks_ms();
@@ -211,7 +230,7 @@ int vospi_snapshot(uint32_t timeout_ms) {
         }
 
         MICROPY_EVENT_POLL_HOOK
-    } while (vospi.flags & VOSPI_FLAGS_CAPTURE);
+    } while (!framebuffer_get_head(vospi.fb, FB_NO_FLAGS));
 
     return 0;
 }

--- a/common/vospi.h
+++ b/common/vospi.h
@@ -25,6 +25,8 @@
  */
 #ifndef __VOSPI_H__
 #define __VOSPI_H__
-int vospi_init(uint32_t n_packets, void *buffer);
+#include "framebuffer.h"
+int vospi_init(uint32_t n_packets, framebuffer_t *fb);
+int vospi_deinit();
 int vospi_snapshot(uint32_t timeout_ms);
 #endif // __VOSPI_H__

--- a/drivers/sensors/lepton.c
+++ b/drivers/sensors/lepton.c
@@ -202,7 +202,7 @@ static int ioctl(omv_csi_t *csi, int request, va_list ap) {
         }
         case OMV_CSI_IOCTL_LEPTON_GET_RESOLUTION: {
             int *resolution = va_arg(ap, int *);
-            *resolution = 14;
+            *resolution =  lepton.radiometry ? 16 : 14;
             break;
         }
         case OMV_CSI_IOCTL_LEPTON_RUN_COMMAND: {

--- a/drivers/sensors/lepton.c
+++ b/drivers/sensors/lepton.c
@@ -69,7 +69,6 @@ typedef struct lepton_state {
     LEP_CAMERA_PORT_DESC_T port;
 } lepton_state_t;
 
-extern uint16_t _vospi_buf[];
 static lepton_state_t lepton;
 
 static int lepton_reset(omv_csi_t *csi, bool measurement_mode, bool high_temp_mode);
@@ -359,8 +358,6 @@ static int lepton_reset(omv_csi_t *csi, bool measurement_mode, bool high_temp_mo
 }
 
 static int reset(omv_csi_t *csi) {
-    static bool vospi_initialized = false;
-
     memset(&lepton, 0, sizeof(lepton_state_t));
     lepton.min_temp = LEPTON_MIN_TEMP_DEFAULT;
     lepton.max_temp = LEPTON_MAX_TEMP_DEFAULT;
@@ -369,11 +366,9 @@ static int reset(omv_csi_t *csi) {
         return OMV_CSI_ERROR_CTL_FAILED;
     }
 
-    if (vospi_initialized == false) {
-        if (vospi_init(lepton.v_res, _vospi_buf) != 0) {
-            return OMV_CSI_ERROR_CTL_FAILED;
-        }
-        vospi_initialized = true;
+    vospi_deinit();
+    if (vospi_init(lepton.v_res, csi->fb) != 0) {
+        return OMV_CSI_ERROR_CTL_FAILED;
     }
 
     return 0;
@@ -382,10 +377,6 @@ static int reset(omv_csi_t *csi) {
 static int snapshot(omv_csi_t *csi, image_t *image, uint32_t flags) {
     framebuffer_t *fb = csi->fb;
     framebuffer_update_jpeg_buffer(fb);
-
-    if (fb->n_buffers != 1) {
-        framebuffer_set_buffers(fb, 1);
-    }
 
     if (csi->pixformat == PIXFORMAT_INVALID) {
         return OMV_CSI_ERROR_INVALID_PIXFORMAT;
@@ -399,15 +390,12 @@ static int snapshot(omv_csi_t *csi, image_t *image, uint32_t flags) {
         return OMV_CSI_ERROR_INVALID_FRAMESIZE;
     }
 
-    if (omv_csi_check_framebuffer_size(csi) == -1) {
+    if (resolution[csi->framesize][0] < lepton.h_res || resolution[csi->framesize][1] < lepton.v_res) {
         return OMV_CSI_ERROR_FRAMEBUFFER_OVERFLOW;
     }
 
-    framebuffer_free_current_buffer(fb);
-    vbuffer_t *buffer = framebuffer_get_tail(fb, FB_NO_FLAGS);
-
-    if (!buffer) {
-        return OMV_CSI_ERROR_FRAMEBUFFER_ERROR;
+    if (omv_csi_check_framebuffer_size(csi) == -1) {
+        return OMV_CSI_ERROR_FRAMEBUFFER_OVERFLOW;
     }
 
     for (int i = 0; i < LEPTON_SNAPSHOT_RETRY; i++) {
@@ -423,20 +411,18 @@ static int snapshot(omv_csi_t *csi, image_t *image, uint32_t flags) {
         }
     }
 
-    fb->w = fb->u;
-    fb->h = fb->v;
+    if (!csi->transpose) {
+        fb->w = fb->u;
+        fb->h = fb->v;
+    } else {
+        fb->w = fb->v;
+        fb->h = fb->u;
+    }
+
     fb->pixfmt = csi->pixformat;
 
-    framebuffer_init_image(fb, image);
-
-    float x_scale = resolution[csi->framesize][0] / ((float) lepton.h_res);
-    float y_scale = resolution[csi->framesize][1] / ((float) lepton.v_res);
-    // MAX == KeepAspectRationByExpanding - MIN == KeepAspectRatio
-    float scale = IM_MAX(x_scale, y_scale), scale_inv = 1.0f / scale;
-    int x_offset = (resolution[csi->framesize][0] - (lepton.h_res * scale)) / 2;
-    int y_offset = (resolution[csi->framesize][1] - (lepton.v_res * scale)) / 2;
-    // The code below upscales the source image to the requested frame size
-    // and then crops it to the window set by the user.
+    image_t fb_image; 
+    framebuffer_init_image(fb, &fb_image);
 
     LEP_SYS_FPA_TEMPERATURE_KELVIN_T kelvin;
     if (lepton.measurement_mode && (!lepton.radiometry)) {
@@ -444,60 +430,38 @@ static int snapshot(omv_csi_t *csi, image_t *image, uint32_t flags) {
             return OMV_CSI_ERROR_IO_ERROR;
         }
     }
+    
+    fb_alloc_mark();
+    image_t temp = {
+        .w = (!csi->transpose) ? lepton.h_res : lepton.v_res,
+        .h = (!csi->transpose) ? lepton.v_res : lepton.h_res,
+        .pixfmt = PIXFORMAT_GRAYSCALE,
+        .data = fb_alloc(lepton.h_res * lepton.v_res, FB_ALLOC_CACHE_ALIGN),
+    };
 
-    for (int y = y_offset, yy = fast_ceilf(lepton.v_res * scale) + y_offset; y < yy; y++) {
-        if ((fb->y <= y) && (y < (fb->y + fb->v))) {
-            // user window cropping
+    // When not in measurment mode set the min and max temperatures such that 0-255 values from the
+    // sensor, which are grayscale pixels 0-255, are not clipped when interpreted as Kelvin values.
+    float min = -273.15f; // in Celsius -> 0.0f in Kelvin
+    float max = -270.6f; // in Celsius -> 2.55f in Kelvin
 
-            uint16_t *row_ptr = _vospi_buf + (fast_floorf(y * scale_inv) * lepton.h_res);
-
-            for (int x = x_offset, xx = fast_ceilf(lepton.h_res * scale) + x_offset; x < xx; x++) {
-                if ((fb->x <= x) && (x < (fb->x + fb->u))) {
-                    // user window cropping
-
-                    // Value is the 14/16-bit value from the FLIR IR camera.
-                    // However, with AGC enabled only the bottom 8-bits are non-zero.
-                    int value = row_ptr[fast_floorf(x * scale_inv)];
-
-                    if (lepton.measurement_mode) {
-                        // Need to convert 14/16-bits to 8-bits ourselves...
-                        if (!lepton.radiometry) {
-                            value = (value - 8192) + kelvin;
-                        }
-                        float celsius = (value * 0.01f) - 273.15f;
-                        celsius = IM_CLAMP(celsius, lepton.min_temp, lepton.max_temp);
-                        value = __USAT(IM_DIV(((celsius - lepton.min_temp) * 255),
-                                              (lepton.max_temp - lepton.min_temp)), 8);
-                    }
-
-                    int t_x = x - fb->x;
-                    int t_y = y - fb->y;
-
-                    if (lepton.hmirror) {
-                        t_x = fb->u - t_x - 1;
-                    }
-                    if (lepton.vflip) {
-                        t_y = fb->v - t_y - 1;
-                    }
-
-                    switch (csi->pixformat) {
-                        case PIXFORMAT_GRAYSCALE: {
-                            IMAGE_PUT_GRAYSCALE_PIXEL(image, t_x, t_y, value & 0xFF);
-                            break;
-                        }
-                        case PIXFORMAT_RGB565: {
-                            IMAGE_PUT_RGB565_PIXEL(image, t_x, t_y, csi->color_palette[value & 0xFF]);
-                            break;
-                        }
-                        default: {
-                            break;
-                        }
-                    }
-                }
-            }
-        }
+    // When in measurment mode the lepton provides 14-bit or 16-bit values that must be clamped
+    // between the min and max temperatures in celsius and scaled to 0-255 values.
+    if (lepton.measurement_mode) {
+        min = lepton.min_temp;
+        max = lepton.max_temp;
     }
 
+    imlib_fill_image_from_lepton(&temp, lepton.h_res, lepton.v_res, (uint16_t *) fb_image.data, min, max,
+                                 false, (!lepton.measurement_mode) || lepton.radiometry, kelvin,
+                                 lepton.hmirror, lepton.vflip, csi->transpose);
+
+    imlib_draw_image(&fb_image, &temp, 0, 0, 1.0f, 1.0f, NULL, -1, 255,
+                     (csi->pixformat == PIXFORMAT_RGB565) ? csi->color_palette : NULL, NULL,
+                     IMAGE_HINT_BILINEAR | IMAGE_HINT_CENTER | IMAGE_HINT_SCALE_ASPECT_EXPAND,
+                     NULL, NULL, NULL);
+
+    fb_alloc_free_till_mark();
+    framebuffer_init_image(fb, image);
     return 0;
 }
 

--- a/lib/imlib/imlib.h
+++ b/lib/imlib/imlib.h
@@ -1187,6 +1187,9 @@ void imlib_deinit_all();
 // Generic Helper Functions
 void imlib_fill_image_from_float(image_t *img, int w, int h, float *data, float min, float max,
                                  bool mirror, bool flip, bool dst_transpose, bool src_transpose);
+void imlib_fill_image_from_lepton(image_t *img, int w, int h, uint16_t *data, float min, float max,
+                                  bool auto_range, bool radiometric, int kelvin_offset,
+                                  bool mirror, bool flip, bool transpose);
 
 // Bayer Image Processing
 pixformat_t imlib_bayer_shift(pixformat_t pixfmt, int x, int y, bool transpose);

--- a/modules/py_fir.c
+++ b/modules/py_fir.c
@@ -1089,9 +1089,10 @@ mp_obj_t py_fir_snapshot(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_a
         #if (OMV_FIR_LEPTON_ENABLE == 1)
         case FIR_LEPTON: {
             bool auto_range = args[ARG_scale].u_obj == mp_const_none;
-            fir_lepton_fill_image(&src_img, fir_width, fir_height, auto_range, min, max,
-                                  args[ARG_hmirror].u_bool, args[ARG_vflip].u_bool,
-                                  args[ARG_transpose].u_bool, args[ARG_timeout].u_int);
+            imlib_fill_image_from_lepton(&src_img, fir_width, fir_height,
+                                         fir_lepton_get_frame(args[ARG_timeout].u_int), min, max, auto_range,
+                                         fir_lepton_get_radiometry_enabled(), fir_lepton_get_temperature(),
+                                         args[ARG_hmirror].u_bool, args[ARG_vflip].u_bool, args[ARG_transpose].u_bool);
             break;
         }
         #endif

--- a/modules/py_fir_lepton.c
+++ b/modules/py_fir_lepton.c
@@ -390,7 +390,7 @@ int fir_lepton_init(omv_i2c_t *bus, int *w, int *h, int *refresh, int *resolutio
     fir_lepton_rad_en = rad == LEP_RAD_ENABLE;
     *w = flir_w;
     *h = flir_h;
-    *refresh = fir_lepton_3 ? 27 : 9;
+    *refresh = fir_lepton_3 ? 9 : 27;
     *resolution = fir_lepton_rad_en ? 16 : 14;
 
     #if defined(OMV_FIR_LEPTON_VSYNC_PIN)

--- a/modules/py_fir_lepton.c
+++ b/modules/py_fir_lepton.c
@@ -441,7 +441,7 @@ mp_obj_t fir_lepton_get_frame_available() {
     return mp_obj_new_bool(framebuffer_tail != framebuffer_head);
 }
 
-static const uint16_t *fir_lepton_get_frame(int timeout) {
+uint16_t *fir_lepton_get_frame(int timeout) {
     int sampled_framebuffer_tail = framebuffer_tail;
 
     if (timeout >= 0) {
@@ -464,7 +464,11 @@ static const uint16_t *fir_lepton_get_frame(int timeout) {
     return framebuffers[sampled_framebuffer_tail];
 }
 
-static int fir_lepton_get_temperature() {
+bool fir_lepton_get_radiometry_enabled() {
+    return fir_lepton_rad_en;
+}
+
+int fir_lepton_get_temperature() {
     LEP_SYS_FPA_TEMPERATURE_KELVIN_T kelvin;
 
     if (LEP_GetSysFpaTemperatureKelvin(&fir_lepton_handle, &kelvin) != LEP_OK) {
@@ -527,78 +531,6 @@ mp_obj_t fir_lepton_read_ir(int w, int h, bool mirror, bool flip, bool transpose
     tuple[2] = mp_obj_new_float(min);
     tuple[3] = mp_obj_new_float(max);
     return mp_obj_new_tuple(4, tuple);
-}
-
-void fir_lepton_fill_image(image_t *img, int w, int h, bool auto_range, float min, float max,
-                           bool mirror, bool flip, bool transpose, int timeout) {
-    int kelvin = fir_lepton_get_temperature();
-    const uint16_t *data = fir_lepton_get_frame(timeout);
-    int new_min;
-    int new_max;
-
-    if (auto_range) {
-        new_min = INT_MAX;
-        new_max = INT_MIN;
-
-        for (int i = 0, ii = w * h; i < ii; i++) {
-            int temp = data[i];
-
-            if (!fir_lepton_rad_en) {
-                temp = (temp - 8192) + kelvin;
-            }
-
-            if (temp < new_min) {
-                new_min = temp;
-            }
-
-            if (temp > new_max) {
-                new_max = temp;
-            }
-        }
-    } else {
-        float tmp = min;
-        min = (min < max) ? min : max;
-        max = (max > tmp) ? max : tmp;
-        new_min = fast_roundf((min + 273.15f) * 100.f); // to kelvin
-        new_max = fast_roundf((max + 273.15f) * 100.f); // to kelvin
-    }
-
-    float diff = 255.f / (new_max - new_min);
-    int w_1 = w - 1;
-    int h_1 = h - 1;
-
-    for (int y = 0; y < h; y++) {
-        int y_dst = flip ? (h_1 - y) : y;
-        const uint16_t *raw_row = data + (y * w);
-        uint8_t *row_pointer = ((uint8_t *) img->data) + (y_dst * w);
-        uint8_t *t_row_pointer = ((uint8_t *) img->data) + y_dst;
-
-        for (int x = 0; x < w; x++) {
-            int x_dst = mirror ? (w_1 - x) : x;
-            int raw = raw_row[x];
-
-            if (!fir_lepton_rad_en) {
-                raw = (raw - 8192) + kelvin;
-            }
-
-            if (raw < new_min) {
-                raw = new_min;
-            }
-
-            if (raw > new_max) {
-                raw = new_max;
-            }
-
-            int pixel = fast_roundf((raw - new_min) * diff);
-            pixel = __USAT(pixel, 8);
-
-            if (!transpose) {
-                row_pointer[x_dst] = pixel;
-            } else {
-                t_row_pointer[x_dst * h] = pixel;
-            }
-        }
-    }
 }
 
 void fir_lepton_trigger_ffc(int timeout) {

--- a/modules/py_fir_lepton.h
+++ b/modules/py_fir_lepton.h
@@ -31,9 +31,10 @@ void fir_lepton_register_vsync_cb(mp_obj_t cb);
 mp_obj_t fir_lepton_get_radiometry();
 void fir_lepton_register_frame_cb(mp_obj_t cb);
 mp_obj_t fir_lepton_get_frame_available();
+uint16_t *fir_lepton_get_frame(int timeout);
+bool fir_lepton_get_radiometry_enabled();
+int fir_lepton_get_temperature();
 mp_obj_t fir_lepton_read_ta();
 mp_obj_t fir_lepton_read_ir(int w, int h, bool mirror, bool flip, bool transpose, int timeout);
-void fir_lepton_fill_image(image_t *img, int w, int h, bool auto_range, float min, float max,
-                           bool mirror, bool flip, bool transpose, int timeout);
 void fir_lepton_trigger_ffc(int timeout);
 #endif // __PY_FIR_LEPTON_H__


### PR DESCRIPTION
This PR updates the FLIR Lepton driver to use multi-frame buffer architecture. This allows VOSPI to run in the background now, accumulating frames without blocking the main thread.

Now with the new multi-CSI architecture, `sensor.get_frame_available()` can be used to poll if a frame is available after the first snapshot starts the driver off, along with `sensor.get_framebuffer()`  to grab the thermal image in a non-blocking way.

Improvements to baseline:
* Transpose is now handled in addition to hmirror and vflip allowing for full image rotation.
* Legacy nearest neighbor code has been removed and replaced with bilinear image scaling which can leverage the GPU.
* Now that vospi writes directly to the frame buffers the legacy single vospi buffer can be free'd.

TODO:
* Need to do thorough testing on all ports using the Lepton (including N6).
* Update for use with multi-sensor PR for the N6.

