### PR TITLE
ports/all: Refactor CSI drivers.

### DIFF
--- a/common/omv_csi.c
+++ b/common/omv_csi.c
@@ -598,7 +598,7 @@ __weak int omv_csi_get_id() {
     return csi.chip_id;
 }
 
-__weak uint32_t omv_csi_get_xclk_frequency() {
+__weak uint32_t omv_csi_get_clk_frequency() {
     return OMV_CSI_ERROR_CTL_UNSUPPORTED;
 }
 

--- a/common/omv_csi.h
+++ b/common/omv_csi.h
@@ -390,7 +390,7 @@ int omv_csi_reset();
 int omv_csi_get_id();
 
 // Returns the xclk freq in hz.
-uint32_t omv_csi_get_xclk_frequency();
+uint32_t omv_csi_get_clk_frequency();
 
 // Returns the xclk freq in hz.
 int omv_csi_set_clk_frequency(uint32_t frequency);

--- a/drivers/sensors/genx320.c
+++ b/drivers/sensors/genx320.c
@@ -71,7 +71,7 @@
 #define EVENT_THRESHOLD_SIGMA           10
 
 #define EVT_CLK_MULTIPLIER              (2)
-#define EVT_CLK_FREQ                    (((omv_csi_get_xclk_frequency() * EVT_CLK_MULTIPLIER) + 500000) / 1000000)
+#define EVT_CLK_FREQ                    (((omv_csi_get_clk_frequency() * EVT_CLK_MULTIPLIER) + 500000) / 1000000)
 
 #define AFK_50_HZ                       (50)
 #define AFK_60_HZ                       (60)
@@ -236,7 +236,7 @@ static int set_framerate(omv_csi_t *csi, int framerate) {
     }
 
     int lines = ACTIVE_SENSOR_HEIGHT + VSYNC_CLOCK_CYCLES;
-    int clocks_per_frame = (omv_csi_get_xclk_frequency() * EVT_CLK_MULTIPLIER) / framerate;
+    int clocks_per_frame = (omv_csi_get_clk_frequency() * EVT_CLK_MULTIPLIER) / framerate;
     int hsync_clocks = (clocks_per_frame / lines) - ACTIVE_SENSOR_WIDTH;
 
     if (hsync_clocks <= 0) {

--- a/drivers/sensors/mt9m114.c
+++ b/drivers/sensors/mt9m114.c
@@ -476,7 +476,7 @@ static int reset(omv_csi_t *csi) {
     ret |= omv_i2c_writew2(&csi->i2c_bus, csi->slv_addr, 0x301A, reg | (1 << 9));
 
     ret |= omv_i2c_writew2(&csi->i2c_bus, csi->slv_addr, MT9M114_REG_CAM_SYSCTL_PLL_DIVIDER_M_N,
-                           (omv_csi_get_xclk_frequency() == OMV_MT9M114_CLK_FREQ)
+                           (omv_csi_get_clk_frequency() == OMV_MT9M114_CLK_FREQ)
             ? 0x120 // xclk=24MHz, m=32, n=1, csi=48MHz, bus=76.8MHz
             : 0x448); // xclk=25MHz, m=72, n=4, csi=45MHz, bus=72MHz
 
@@ -675,7 +675,7 @@ static int set_framesize(omv_csi_t *csi, omv_csi_framesize_t framesize) {
     ret |= omv_i2c_writew2(&csi->i2c_bus, csi->slv_addr, MT9M114_REG_SENSOR_CFG_Y_ADDR_END, sensor_he);
     ret |= omv_i2c_writew2(&csi->i2c_bus, csi->slv_addr, MT9M114_REG_SENSOR_CFG_X_ADDR_END, sensor_we);
 
-    int pixclk = (omv_csi_get_xclk_frequency() == OMV_MT9M114_CLK_FREQ) ? 48000000 : 45000000;
+    int pixclk = (omv_csi_get_clk_frequency() == OMV_MT9M114_CLK_FREQ) ? 48000000 : 45000000;
 
     ret |= omv_i2c_writew2(&csi->i2c_bus, csi->slv_addr, MT9M114_REG_SENSOR_CFG_PIXCLK, pixclk >> 16);
     ret |= omv_i2c_writew2(&csi->i2c_bus, csi->slv_addr, MT9M114_REG_SENSOR_CFG_PIXCLK + 2, pixclk);

--- a/drivers/sensors/mt9v0xx.c
+++ b/drivers/sensors/mt9v0xx.c
@@ -343,7 +343,7 @@ static int set_auto_exposure(omv_csi_t *csi, int enable, int exposure_us) {
     ret |= omv_i2c_readw(&csi->i2c_bus, csi->slv_addr, window_width, &row_time_0);
     ret |= omv_i2c_readw(&csi->i2c_bus, csi->slv_addr, horizontal_blanking, &row_time_1);
 
-    int clock = omv_csi_get_xclk_frequency();
+    int clock = omv_csi_get_clk_frequency();
 
     int exposure = IM_MIN(exposure_us, MICROSECOND_CLKS / 2) * (clock / MICROSECOND_CLKS);
     int row_time = row_time_0 + row_time_1;
@@ -389,7 +389,7 @@ static int get_exposure_us(omv_csi_t *csi, int *exposure_us) {
         ret |= omv_i2c_readw(&csi->i2c_bus, csi->slv_addr, fine_shutter_width_total, &int_pixels);
     }
 
-    int clock = omv_csi_get_xclk_frequency();
+    int clock = omv_csi_get_clk_frequency();
 
     if (reg & (context ? MT9V0X4_AEC_ENABLE_B : MT9V0XX_AEC_ENABLE)) {
         ret |= omv_i2c_readw(&csi->i2c_bus, csi->slv_addr, MT9V0XX_AEC_EXPOSURE_OUTPUT, &int_rows);

--- a/drivers/sensors/ov5640.c
+++ b/drivers/sensors/ov5640.c
@@ -1126,7 +1126,7 @@ static int calc_pclk_freq(uint8_t sc_pll_ctrl_0,
                           uint8_t sc_pll_ctrl_2,
                           uint8_t sc_pll_ctrl_3,
                           uint8_t sys_root_div) {
-    uint32_t pclk_freq = omv_csi_get_xclk_frequency();
+    uint32_t pclk_freq = omv_csi_get_clk_frequency();
     pclk_freq /= ((sc_pll_ctrl_3 & 0x10) != 0x00) ? 2 : 1;
     pclk_freq /= ((sc_pll_ctrl_0 & 0x0F) == 0x0A) ? 5 : 4; //camera has two MIPI lanes
     switch (sc_pll_ctrl_3 & 0x0F) {

--- a/ports/alif/omv_csi.c
+++ b/ports/alif/omv_csi.c
@@ -95,62 +95,6 @@ void omv_csi_init0() {
     omv_csi_set_frame_callback(NULL);
 }
 
-int omv_csi_init() {
-    int init_ret = 0;
-    CPI_Type *cpi = cpi_get_base_addr(&csi);
-
-    alif_hal_csi_init(cpi, 0);
-
-    #if defined(OMV_CSI_POWER_PIN)
-    omv_gpio_write(OMV_CSI_POWER_PIN, 0);
-    #endif
-
-    #if defined(OMV_CSI_RESET_PIN)
-    omv_gpio_write(OMV_CSI_RESET_PIN, 0);
-    #endif
-
-    // Reset the csi state
-    memset(&csi, 0, sizeof(omv_csi_t));
-
-    // Set default framebuffer
-    csi.fb = framebuffer_get(0);
-
-    // Set default snapshot function.
-    csi.snapshot = omv_csi_snapshot;
-
-    // Configure the CSI external clock.
-    if (omv_csi_set_clk_frequency(OMV_CSI_CLK_FREQUENCY) != 0) {
-        // Failed to initialize the csi clock.
-        return OMV_CSI_ERROR_TIM_INIT_FAILED;
-    }
-
-    // Detect and initialize the image csi.
-    if ((init_ret = omv_csi_probe_init(OMV_CSI_I2C_ID, OMV_CSI_I2C_SPEED)) != 0) {
-        // csi probe/init failed.
-        return init_ret;
-    }
-
-    // Configure the CSI interface.
-    if (omv_csi_config(OMV_CSI_CONFIG_INIT) != 0) {
-        // CSI config failed
-        return OMV_CSI_ERROR_CSI_INIT_FAILED;
-    }
-
-    // Set default color palette.
-    csi.color_palette = rainbow_table;
-
-    // Disable VSYNC IRQ and callback
-    omv_csi_set_vsync_callback(NULL);
-
-    // Disable Frame callback.
-    omv_csi_set_frame_callback(NULL);
-
-    // All good!
-    csi.detected = true;
-
-    return 0;
-}
-
 int omv_csi_config(omv_csi_config_t config) {
     if (config == OMV_CSI_CONFIG_INIT) {
         CPI_Type *cpi = cpi_get_base_addr(&csi);
@@ -449,6 +393,62 @@ int omv_csi_snapshot(omv_csi_t *csi, image_t *dst_image, uint32_t flags) {
         // Debayer frame.
         imlib_debayer_image_awb(dst_image, &src_image, false, r_stat, (gb_stat + gr_stat) / 2, b_stat);
     }
+    return 0;
+}
+
+int omv_csi_init() {
+    int init_ret = 0;
+    CPI_Type *cpi = cpi_get_base_addr(&csi);
+
+    alif_hal_csi_init(cpi, 0);
+
+    #if defined(OMV_CSI_POWER_PIN)
+    omv_gpio_write(OMV_CSI_POWER_PIN, 0);
+    #endif
+
+    #if defined(OMV_CSI_RESET_PIN)
+    omv_gpio_write(OMV_CSI_RESET_PIN, 0);
+    #endif
+
+    // Reset the csi state
+    memset(&csi, 0, sizeof(omv_csi_t));
+
+    // Set default framebuffer
+    csi.fb = framebuffer_get(0);
+
+    // Set default snapshot function.
+    csi.snapshot = omv_csi_snapshot;
+
+    // Configure the CSI external clock.
+    if (omv_csi_set_clk_frequency(OMV_CSI_CLK_FREQUENCY) != 0) {
+        // Failed to initialize the csi clock.
+        return OMV_CSI_ERROR_TIM_INIT_FAILED;
+    }
+
+    // Detect and initialize the image csi.
+    if ((init_ret = omv_csi_probe_init(OMV_CSI_I2C_ID, OMV_CSI_I2C_SPEED)) != 0) {
+        // csi probe/init failed.
+        return init_ret;
+    }
+
+    // Configure the CSI interface.
+    if (omv_csi_config(OMV_CSI_CONFIG_INIT) != 0) {
+        // CSI config failed
+        return OMV_CSI_ERROR_CSI_INIT_FAILED;
+    }
+
+    // Set default color palette.
+    csi.color_palette = rainbow_table;
+
+    // Disable VSYNC IRQ and callback
+    omv_csi_set_vsync_callback(NULL);
+
+    // Disable Frame callback.
+    omv_csi_set_frame_callback(NULL);
+
+    // All good!
+    csi.detected = true;
+
     return 0;
 }
 

--- a/ports/mimxrt/omv_csi.c
+++ b/ports/mimxrt/omv_csi.c
@@ -73,62 +73,6 @@ void omv_csi_init0() {
     omv_csi_set_frame_callback(NULL);
 }
 
-int omv_csi_init() {
-    int init_ret = 0;
-
-    mimxrt_hal_csi_init(CSI);
-
-    #if defined(OMV_CSI_POWER_PIN)
-    omv_gpio_write(OMV_CSI_POWER_PIN, 1);
-    #endif
-
-    #if defined(OMV_CSI_RESET_PIN)
-    omv_gpio_write(OMV_CSI_RESET_PIN, 1);
-    #endif
-
-    // Reset the csi state
-    memset(&csi, 0, sizeof(omv_csi_t));
-
-    // Set default framebuffer
-    csi.fb = framebuffer_get(0);
-
-    // Set default snapshot function.
-    // Some sensors need to call snapshot from init.
-    csi.snapshot = omv_csi_snapshot;
-
-    // Configure the csi external clock (XCLK).
-    if (omv_csi_set_clk_frequency(OMV_CSI_CLK_FREQUENCY) != 0) {
-        // Failed to initialize the csi clock.
-        return OMV_CSI_ERROR_TIM_INIT_FAILED;
-    }
-
-    // Detect and initialize the image sensor.
-    if ((init_ret = omv_csi_probe_init(OMV_CSI_I2C_ID, OMV_CSI_I2C_SPEED)) != 0) {
-        // Sensor probe/init failed.
-        return init_ret;
-    }
-
-    // Configure the CSI interface.
-    if (omv_csi_config(OMV_CSI_CONFIG_INIT) != 0) {
-        // CSI config failed
-        return OMV_CSI_ERROR_CSI_INIT_FAILED;
-    }
-
-    // Set default color palette.
-    csi.color_palette = rainbow_table;
-
-    // Disable VSYNC IRQ and callback
-    omv_csi_set_vsync_callback(NULL);
-
-    // Disable Frame callback.
-    omv_csi_set_frame_callback(NULL);
-
-    // All good!
-    csi.detected = true;
-
-    return 0;
-}
-
 int omv_csi_config(omv_csi_config_t config) {
     if (config == OMV_CSI_CONFIG_INIT) {
         CSI_Reset(CSI);
@@ -207,7 +151,7 @@ int omv_csi_set_clk_frequency(uint32_t frequency) {
     return 0;
 }
 
-uint32_t omv_csi_get_xclk_frequency() {
+uint32_t omv_csi_get_clk_frequency() {
     return 24000000 / (CLOCK_GetDiv(kCLOCK_CsiDiv) + 1);
 }
 
@@ -587,3 +531,59 @@ int omv_csi_snapshot(omv_csi_t *csi, image_t *image, uint32_t flags) {
     return 0;
 }
 #endif
+
+int omv_csi_init() {
+    int init_ret = 0;
+
+    mimxrt_hal_csi_init(CSI);
+
+    #if defined(OMV_CSI_POWER_PIN)
+    omv_gpio_write(OMV_CSI_POWER_PIN, 1);
+    #endif
+
+    #if defined(OMV_CSI_RESET_PIN)
+    omv_gpio_write(OMV_CSI_RESET_PIN, 1);
+    #endif
+
+    // Reset the csi state
+    memset(&csi, 0, sizeof(omv_csi_t));
+
+    // Set default framebuffer
+    csi.fb = framebuffer_get(0);
+
+    // Set default snapshot function.
+    // Some sensors need to call snapshot from init.
+    csi.snapshot = omv_csi_snapshot;
+
+    // Configure the csi external clock (XCLK).
+    if (omv_csi_set_clk_frequency(OMV_CSI_CLK_FREQUENCY) != 0) {
+        // Failed to initialize the csi clock.
+        return OMV_CSI_ERROR_TIM_INIT_FAILED;
+    }
+
+    // Detect and initialize the image sensor.
+    if ((init_ret = omv_csi_probe_init(OMV_CSI_I2C_ID, OMV_CSI_I2C_SPEED)) != 0) {
+        // Sensor probe/init failed.
+        return init_ret;
+    }
+
+    // Configure the CSI interface.
+    if (omv_csi_config(OMV_CSI_CONFIG_INIT) != 0) {
+        // CSI config failed
+        return OMV_CSI_ERROR_CSI_INIT_FAILED;
+    }
+
+    // Set default color palette.
+    csi.color_palette = rainbow_table;
+
+    // Disable VSYNC IRQ and callback
+    omv_csi_set_vsync_callback(NULL);
+
+    // Disable Frame callback.
+    omv_csi_set_frame_callback(NULL);
+
+    // All good!
+    csi.detected = true;
+
+    return 0;
+}


### PR DESCRIPTION
No functional changes, just moving functions and code around to make #2691 more readable.

Note that `omv_csi_get_clk_frequency` was overridden using the wrong name in alif port.