### PR TITLE
common/csi: Decouple the clock from main CSI state.

### DIFF
--- a/boards/OPENMV_AE3/omv_boardconfig.h
+++ b/boards/OPENMV_AE3/omv_boardconfig.h
@@ -273,7 +273,7 @@ extern unsigned char OMV_BOARD_UID_ADDR[12];    // Unique address.
 
 // Camera interface
 #define OMV_CSI_BASE                    ((CPI_Type *) CPI_BASE)
-#define OMV_CSI_CLK_FREQUENCY           (12000000)
+#define OMV_CSI_CLK_FREQUENCY           (24000000)
 
 #define OMV_CSI_D0_PIN                  (&omv_pin_CSI_D0)
 #define OMV_CSI_D1_PIN                  (&omv_pin_CSI_D1)

--- a/boards/OPENMV_N6/omv_boardconfig.h
+++ b/boards/OPENMV_N6/omv_boardconfig.h
@@ -265,7 +265,7 @@
 
 // Camera Interface
 #define OMV_CSI_CLK_SOURCE                  (OMV_CSI_CLK_SOURCE_TIM)
-#define OMV_CSI_CLK_FREQUENCY               (12000000)
+#define OMV_CSI_CLK_FREQUENCY               (24000000)
 #define OMV_CSI_TIM                         (TIM1)
 #define OMV_CSI_TIM_PIN                     (&omv_pin_E9_TIM1)
 #define OMV_CSI_TIM_CHANNEL                 (TIM_CHANNEL_1)

--- a/common/omv_csi.h
+++ b/common/omv_csi.h
@@ -291,6 +291,17 @@ typedef struct _omv_csi_callback_t {
 typedef int (*omv_csi_snapshot_t)
     (omv_csi_t *csi, image_t *image, uint32_t flags);
 
+typedef struct _omv_clk omv_clk_t;
+
+typedef struct _omv_clk {
+    uint32_t freq;
+    #ifdef OMV_CSI_CLK_PORT_BITS
+    OMV_CSI_CLK_PORT_BITS
+    #endif
+    uint32_t (*get_freq) (omv_clk_t *csi);
+    int (*set_freq) (omv_clk_t *csi, uint32_t freq);
+} omv_clk_t;
+
 typedef struct _omv_csi {
     uint32_t chip_id;           // Sensor ID 32 bits.
     uint8_t slv_addr;           // Sensor I2C slave address.
@@ -339,10 +350,11 @@ typedef struct _omv_csi {
     bool auto_rotation;         // Rotate Image Automatically
     bool detected;              // Set to true when the sensor is initialized.
     bool power_on;              // Set to true when the sensor is active.
-    uint32_t clk_hz;            // Clock frequency requested by the driver.
 
     omv_i2c_t *i2c;             // SCCB/I2C bus.
     framebuffer_t *fb;          // Frame buffer pointer
+    omv_clk_t *clk;             // Clock controller.
+    uint32_t clk_hz;            // Clock freqeuency request by this CSI.
 
     #ifdef OMV_CSI_PORT_BITS
     // Additional port-specific members like device base pointer,
@@ -429,10 +441,10 @@ int omv_csi_reset(omv_csi_t *csi, bool hard);
 int omv_csi_get_id(omv_csi_t *csi);
 
 // Returns the xclk freq in hz.
-uint32_t omv_csi_get_clk_frequency();
+uint32_t omv_csi_get_clk_frequency(omv_csi_t *csi, bool nominal);
 
 // Returns the xclk freq in hz.
-int omv_csi_set_clk_frequency(uint32_t frequency);
+int omv_csi_set_clk_frequency(omv_csi_t *csi, uint32_t frequency);
 
 // Return true if the sensor was detected and initialized.
 bool omv_csi_is_detected(omv_csi_t *csi);

--- a/drivers/sensors/genx320.c
+++ b/drivers/sensors/genx320.c
@@ -70,7 +70,8 @@
 #define EVENT_THRESHOLD_SIGMA           10
 
 #define EVT_CLK_MULTIPLIER              (2)
-#define EVT_CLK_FREQ                    (((omv_csi_get_clk_frequency() * EVT_CLK_MULTIPLIER) + 500000) / 1000000)
+#define EVT_CLK_FREQ \
+    (((omv_csi_get_clk_frequency(csi, false) * EVT_CLK_MULTIPLIER) + 500000) / 1000000)
 
 #define AFK_50_HZ                       (50)
 #define AFK_60_HZ                       (60)
@@ -235,7 +236,7 @@ static int set_framerate(omv_csi_t *csi, int framerate) {
     }
 
     int lines = ACTIVE_SENSOR_HEIGHT + VSYNC_CLOCK_CYCLES;
-    int clocks_per_frame = (omv_csi_get_clk_frequency() * EVT_CLK_MULTIPLIER) / framerate;
+    int clocks_per_frame = (omv_csi_get_clk_frequency(csi, false) * EVT_CLK_MULTIPLIER) / framerate;
     int hsync_clocks = (clocks_per_frame / lines) - ACTIVE_SENSOR_WIDTH;
 
     if (hsync_clocks <= 0) {

--- a/drivers/sensors/mt9m114.c
+++ b/drivers/sensors/mt9m114.c
@@ -476,7 +476,7 @@ static int reset(omv_csi_t *csi) {
     ret |= omv_i2c_writew2(csi->i2c, csi->slv_addr, 0x301A, reg | (1 << 9));
 
     ret |= omv_i2c_writew2(csi->i2c, csi->slv_addr, MT9M114_REG_CAM_SYSCTL_PLL_DIVIDER_M_N,
-                           (omv_csi_get_clk_frequency() == OMV_MT9M114_CLK_FREQ)
+                           (omv_csi_get_clk_frequency(csi, true) == OMV_MT9M114_CLK_FREQ)
             ? 0x120 // xclk=24MHz, m=32, n=1, csi=48MHz, bus=76.8MHz
             : 0x448); // xclk=25MHz, m=72, n=4, csi=45MHz, bus=72MHz
 
@@ -675,7 +675,7 @@ static int set_framesize(omv_csi_t *csi, omv_csi_framesize_t framesize) {
     ret |= omv_i2c_writew2(csi->i2c, csi->slv_addr, MT9M114_REG_SENSOR_CFG_Y_ADDR_END, sensor_he);
     ret |= omv_i2c_writew2(csi->i2c, csi->slv_addr, MT9M114_REG_SENSOR_CFG_X_ADDR_END, sensor_we);
 
-    int pixclk = (omv_csi_get_clk_frequency() == OMV_MT9M114_CLK_FREQ) ? 48000000 : 45000000;
+    int pixclk = (omv_csi_get_clk_frequency(csi, true) == OMV_MT9M114_CLK_FREQ) ? 48000000 : 45000000;
 
     ret |= omv_i2c_writew2(csi->i2c, csi->slv_addr, MT9M114_REG_SENSOR_CFG_PIXCLK, pixclk >> 16);
     ret |= omv_i2c_writew2(csi->i2c, csi->slv_addr, MT9M114_REG_SENSOR_CFG_PIXCLK + 2, pixclk);

--- a/drivers/sensors/mt9v0xx.c
+++ b/drivers/sensors/mt9v0xx.c
@@ -342,7 +342,7 @@ static int set_auto_exposure(omv_csi_t *csi, int enable, int exposure_us) {
     ret |= omv_i2c_readw(csi->i2c, csi->slv_addr, window_width, &row_time_0);
     ret |= omv_i2c_readw(csi->i2c, csi->slv_addr, horizontal_blanking, &row_time_1);
 
-    int clock = omv_csi_get_clk_frequency();
+    int clock = omv_csi_get_clk_frequency(csi, false);
 
     int exposure = IM_MIN(exposure_us, MICROSECOND_CLKS / 2) * (clock / MICROSECOND_CLKS);
     int row_time = row_time_0 + row_time_1;
@@ -388,7 +388,7 @@ static int get_exposure_us(omv_csi_t *csi, int *exposure_us) {
         ret |= omv_i2c_readw(csi->i2c, csi->slv_addr, fine_shutter_width_total, &int_pixels);
     }
 
-    int clock = omv_csi_get_clk_frequency();
+    int clock = omv_csi_get_clk_frequency(csi, false);
 
     if (reg & (context ? MT9V0X4_AEC_ENABLE_B : MT9V0XX_AEC_ENABLE)) {
         ret |= omv_i2c_readw(csi->i2c, csi->slv_addr, MT9V0XX_AEC_EXPOSURE_OUTPUT, &int_rows);

--- a/drivers/sensors/ov5640.c
+++ b/drivers/sensors/ov5640.c
@@ -1120,12 +1120,13 @@ static int get_gain_db(omv_csi_t *csi, float *gain_db) {
     return ret;
 }
 
-static int calc_pclk_freq(uint8_t sc_pll_ctrl_0,
+static int calc_pclk_freq(omv_csi_t *csi,
+                          uint8_t sc_pll_ctrl_0,
                           uint8_t sc_pll_ctrl_1,
                           uint8_t sc_pll_ctrl_2,
                           uint8_t sc_pll_ctrl_3,
                           uint8_t sys_root_div) {
-    uint32_t pclk_freq = omv_csi_get_clk_frequency();
+    uint32_t pclk_freq = omv_csi_get_clk_frequency(csi, false);
     pclk_freq /= ((sc_pll_ctrl_3 & 0x10) != 0x00) ? 2 : 1;
     pclk_freq /= ((sc_pll_ctrl_0 & 0x0F) == 0x0A) ? 5 : 4; //camera has two MIPI lanes
     switch (sc_pll_ctrl_3 & 0x0F) {
@@ -1171,7 +1172,7 @@ static int set_auto_exposure(omv_csi_t *csi, int enable, int exposure_us) {
         uint16_t hts = (hts_h << 8) | hts_l;
         uint16_t vts = (vts_h << 8) | vts_l;
 
-        int pclk_freq = calc_pclk_freq(spc0, spc1, spc2, spc3, sysrootdiv);
+        int pclk_freq = calc_pclk_freq(csi, spc0, spc1, spc2, spc3, sysrootdiv);
         int clocks_per_us = pclk_freq / 1000000;
         int exposure = __USAT((exposure_us * clocks_per_us) / hts, 16);
 
@@ -1214,7 +1215,7 @@ static int get_exposure_us(omv_csi_t *csi, int *exposure_us) {
 
     aec = IM_MIN(aec, vts);
 
-    int pclk_freq = calc_pclk_freq(spc0, spc1, spc2, spc3, sysrootdiv);
+    int pclk_freq = calc_pclk_freq(csi, spc0, spc1, spc2, spc3, sysrootdiv);
     int clocks_per_us = pclk_freq / 1000000;
     *exposure_us = (aec * hts) / clocks_per_us;
 

--- a/ports/mimxrt/omv_csi.c
+++ b/ports/mimxrt/omv_csi.c
@@ -104,11 +104,11 @@ static int imx_csi_abort(omv_csi_t *csi, bool fifo_flush, bool in_irq) {
     return 0;
 }
 
-uint32_t omv_csi_get_clk_frequency() {
+static uint32_t imx_clk_get_frequency(omv_clk_t *clk) {
     return 24000000 / (CLOCK_GetDiv(kCLOCK_CsiDiv) + 1);
 }
 
-int omv_csi_set_clk_frequency(uint32_t frequency) {
+static int imx_clk_set_frequency(omv_clk_t *clk, uint32_t frequency) {
     if (frequency >= 24000000) {
         CLOCK_SetDiv(kCLOCK_CsiDiv, 0);
     } else if (frequency >= 12000000) {
@@ -504,9 +504,15 @@ int imx_csi_snapshot(omv_csi_t *csi, image_t *image, uint32_t flags) {
 }
 
 int omv_csi_ops_init(omv_csi_t *csi) {
+    // Set CSI ops.
     csi->abort = imx_csi_abort;
     csi->config = imx_csi_config;
     csi->snapshot = imx_csi_snapshot;
+
+    // Set CSI clock ops.
+    csi->clk->freq = OMV_CSI_CLK_FREQUENCY;
+    csi->clk->set_freq = imx_clk_set_frequency;
+    csi->clk->get_freq = imx_clk_get_frequency;
     return 0;
 }
 #endif // MICROPY_PY_CSI

--- a/ports/nrf/omv_csi.c
+++ b/ports/nrf/omv_csi.c
@@ -94,11 +94,11 @@ static int nrf_csi_config(omv_csi_t *csi, omv_csi_config_t config) {
     return 0;
 }
 
-uint32_t omv_csi_get_clk_frequency() {
+static uint32_t nrf_clk_get_frequency(omv_clk_t *clk) {
     return OMV_CSI_CLK_FREQUENCY;
 }
 
-int omv_csi_set_clk_frequency(uint32_t frequency) {
+static int nrf_clk_set_frequency(omv_clk_t *clk, uint32_t frequency) {
     nrf_gpio_cfg_output(OMV_CSI_MXCLK_PIN);
 
     // Generates 16 MHz signal using I2S peripheral
@@ -207,7 +207,14 @@ static int nrf_csi_snapshot(omv_csi_t *csi, image_t *image, uint32_t flags) {
 }
 
 int omv_csi_ops_init(omv_csi_t *csi) {
+    // Set CSI ops.
     csi->config = nrf_csi_config;
     csi->snapshot = nrf_csi_snapshot;
+
+
+    // Set CSI clock ops.
+    csi->clk->freq = OMV_CSI_CLK_FREQUENCY;
+    csi->clk->set_freq = nrf_clk_set_frequency;
+    csi->clk->get_freq = nrf_clk_get_frequency;
     return 0;
 }

--- a/ports/rp2/omv_csi.c
+++ b/ports/rp2/omv_csi.c
@@ -119,7 +119,11 @@ static int rp2_csi_abort(omv_csi_t *csi, bool fifo_flush, bool in_irq) {
     return 0;
 }
 
-int omv_csi_set_clk_frequency(uint32_t frequency) {
+static uint32_t rp2_clk_get_frequency(omv_clk_t *clk) {
+    return OMV_CSI_CLK_FREQUENCY;
+}
+
+static int rp2_clk_set_frequency(omv_clk_t *clk, uint32_t frequency) {
     uint32_t p = 4;
 
     // Allocate pin to the PWM
@@ -226,9 +230,15 @@ static int rp2_csi_snapshot(omv_csi_t *csi, image_t *image, uint32_t flags) {
 }
 
 int omv_csi_ops_init(omv_csi_t *csi) {
+    // Set CSI ops.
     csi->abort = rp2_csi_abort;
     csi->config = rp2_csi_config;
     csi->snapshot = rp2_csi_snapshot;
+
+    // Set CSI clock ops.
+    csi->clk->freq = OMV_CSI_CLK_FREQUENCY;
+    csi->clk->set_freq = rp2_clk_set_frequency;
+    csi->clk->get_freq = rp2_clk_get_frequency;
     return 0;
 }
 #endif // MICROPY_PY_CSI

--- a/ports/stm32/omv_portconfig.h
+++ b/ports/stm32/omv_portconfig.h
@@ -137,19 +137,24 @@ typedef I2C_HandleTypeDef *omv_i2c_dev_t;
 #define OMV_CSI_PORT_BITS_MDMA
 #endif
 
+
 #if defined(STM32N6)
 #define OMV_CSI_PORT_BITS          \
     struct {                       \
-        TIM_HandleTypeDef tim;     \
         DCMIPP_HandleTypeDef dcmi; \
     };
 #else
 #define OMV_CSI_PORT_BITS        \
     struct {                     \
-        TIM_HandleTypeDef tim;   \
         DMA_HandleTypeDef dma;   \
         DCMI_HandleTypeDef dcmi; \
         OMV_CSI_PORT_BITS_MDMA   \
     };
 #endif
+
+#define OMV_CSI_CLK_PORT_BITS      \
+    struct {                       \
+        TIM_HandleTypeDef tim;     \
+    };
+
 #endif // __OMV_PORTCONFIG_H__


### PR DESCRIPTION
This patch decouples the clock from the main CSI state, further separating the CSI instance from the port's CSI driver. Additionally, it allows CSIs to use different clocks, in theory, though they must first be detected somehow in order to switch clocks.

As a side effect of sharing the clock, set_frequency will be called more frequently (the default call plus once per CSI). However, the frequency is now checked, and the clock is only reconfigured if the new frequency exceeds a configurable tolerance.

Finally, get_clk_frequency now accepts a boolean to return either the exact clock frequency, for sensors that require it, or the nominal frequency.

Note that sensor drivers should be checked to see which ones require the exact clock and which require the nominal clock. I best guessed them for now.

Tested imxrt, alif, stm32.