### PR TITLE
common/omv_csi: Fix all sensors working on all boards.

### DIFF
--- a/boards/OPENMV3/omv_boardconfig.h
+++ b/boards/OPENMV3/omv_boardconfig.h
@@ -46,6 +46,7 @@
 #define OMV_OV7725_ENABLE                     (1)
 #define OMV_OV7725_PLL_CONFIG                 (0x81) // x6
 #define OMV_OV7725_BANDING                    (0x8F)
+#define OMV_OV7725_CLK_FREQ                   (9000000)
 
 // FIR drivers configuration.
 #define OMV_FIR_MLX90621_ENABLE               (1)

--- a/boards/OPENMV4/omv_boardconfig.h
+++ b/boards/OPENMV4/omv_boardconfig.h
@@ -62,6 +62,7 @@
 #define OMV_LEPTON_ENABLE                     (1)
 #define OMV_PAG7920_ENABLE                    (1)
 #define OMV_PAJ6100_ENABLE                    (1)
+#define OMV_PAJ6100_GLITCH_RECONFIG           (1)
 #define OMV_FROGEYE2020_ENABLE                (1)
 
 // FIR drivers configuration.

--- a/boards/OPENMV4P/omv_boardconfig.h
+++ b/boards/OPENMV4P/omv_boardconfig.h
@@ -48,6 +48,7 @@
 #define OMV_LEPTON_ENABLE                     (1)
 #define OMV_PAG7920_ENABLE                    (1)
 #define OMV_PAJ6100_ENABLE                    (1)
+#define OMV_PAJ6100_GLITCH_RECONFIG           (1)
 #define OMV_FROGEYE2020_ENABLE                (1)
 #define OMV_GENX320_EHC_ENABLE                (1)
 

--- a/drivers/sensors/paj6100.c
+++ b/drivers/sensors/paj6100.c
@@ -446,6 +446,11 @@ static int set_framesize(omv_csi_t *csi, omv_csi_framesize_t framesize) {
     lt_lockrange_out_ubound = (L_TARGET + AE_LOCK_RANGE_OUT) * w * h;
     lt_lockrange_out_lbound = (L_TARGET - AE_LOCK_RANGE_OUT) * w * h;
 
+    // PAJ6100 crashes CSI hardware unless we recongfigure it.
+    #if (OMV_PAJ6100_GLITCH_RECONFIG == 1)
+    csi->config(csi, OMV_CSI_CONFIG_INIT);
+    #endif // (OMV_PAJ6100_GLITCH_RECONFIG == 1)
+
     return 0;
 }
 


### PR DESCRIPTION
M4:
* OV7725 -> Works
* OV2640 -> Works

M7:
* OV7725 -> Works

H7:
* OV7725 -> Works
* OV2640 -> Works
* OV5640 -> Works
* MT9M114 -> Works
* MT9V034 -> Works
* Lepton -> Works
* Boson -> Not enabled
* GENX320 -> Not enabled
* PAG7920 -> Works
* PAG6100 -> Working in v4.5.2, broken in v4.5.3
* (spent 3 hours on trying to figure it out will continue in another PR - unrelated to dual csi stuff).

H7 Plus:
* OV7725 -> Works
* OV2640 -> Works
* OV5640 -> Works
* MT9M114 -> Works
* MT9V034 -> Works
* Lepton -> Works
* Boson -> Works (but not generally enabled)
* GENX320 -> Works
* PAG7920 -> Works
* PAG6100 -> Working in v4.5.2, broken in v4.5.3

RT1062:
* OV7725 -> Works
* OV2640 -> Works
* OV5640 -> Works
* MT9M114 -> Works
* MT9V034 -> Works
* Lepton -> Works
* Boson -> Works
* GENX320 -> Works
* PAG7920 -> Works
* PAG6100 -> Works

N6:
* OV7725 -> Works
* OV2640 -> Works
* OV5640 -> Works
* MT9M114 -> Works
* MT9V034 -> Works
* Lepton -> Works.
* Boson -> Works
* GENX320 -> Works
* PAG7920 -> Works
* PAG6100 -> Works
* PS5520 -> Works
* PAG7936 -> Works

AE3:
* PAG7936 -> Works.

ARDUINO NICLA:
* GC2145 -> Works

ARDUINO Portenta:
* HMB0360 -> Works

Arduino Giga:
* HMB0360 -> Works

Works well now.

```
import time
import csi
import image

print(["0x%x"%i for i in csi.devices()])

csi0 = csi.CSI()
csi0.reset(hard=True)
csi0.pixformat(csi.RGB565)
csi0.framesize(csi.QVGA)
csi0.framerate(120)

csi2 = csi.CSI(cid=csi.LEPTON)
csi2.reset(hard=False)
csi2.pixformat(csi.RGB565)
csi2.framesize(csi.QVGA)

clock = time.clock()
img2 = image.Image(csi2.width(), csi2.height(), csi2.pixformat())

while True:
    clock.tick()
    img0 = csi0.snapshot()
    csi2.snapshot(update=False, blocking=False, image=img2)
    img0.draw_image(img2, 160, 0, x_scale=0.5, y_scale=0.5)
```

For working with set_mode this works:

```
import time
import csi
import image

print(["0x%x"%i for i in csi.devices()])

csi0 = csi.CSI()
csi0.reset(hard=True)
csi0.pixformat(csi.RGB565)
csi0.framesize(csi.QVGA)
csi0.framerate(120)

csi2 = csi.CSI(cid=csi.LEPTON)
csi2.reset(hard=False)
csi2.pixformat(csi.RGB565)
csi2.framesize(csi.QVGA)

csi2.ioctl(csi.IOCTL_LEPTON_SET_MODE, True, False)
csi2.ioctl(csi.IOCTL_LEPTON_SET_RANGE, 10.0, 40.0)

# One non-blocking call is required with set_mode to get things running.
# spent 3 hours trying to figure out how to remove this and why
# but, can't seem to get rid of it. Without it, you just get a black image.
# debugging shows VOSPI bus is quiet.
csi2.snapshot(update=False, blocking=True)

clock = time.clock()
img2 = image.Image(csi2.width(), csi2.height(), csi2.pixformat())

while True:
    clock.tick()
    img0 = csi0.snapshot()
    csi2.snapshot(update=False, blocking=False, image=img2)
    img0.draw_image(img2, 160, 0, x_scale=0.5, y_scale=0.5)
    print(clock.fps())
```
