### PR TITLE
drivers/sensors: Add lepton abort support.

### DIFF
--- a/common/vospi.c
+++ b/common/vospi.c
@@ -196,6 +196,11 @@ int vospi_deinit() {
     return omv_spi_deinit(&vospi.spi_bus);
 }
 
+int vospi_abort(void) {
+    vospi.flags &= ~VOSPI_FLAGS_CAPTURE;
+    return 0;
+}
+
 bool vospi_active(void) {
     return vospi.flags & VOSPI_FLAGS_CAPTURE;
 }

--- a/common/vospi.h
+++ b/common/vospi.h
@@ -28,6 +28,7 @@
 #include "framebuffer.h"
 int vospi_init(uint32_t n_packets, framebuffer_t *fb);
 int vospi_deinit();
+int vospi_abort(void);
 bool vospi_active(void);
 int vospi_snapshot(uint32_t timeout_ms);
 #endif // __VOSPI_H__

--- a/drivers/sensors/lepton.c
+++ b/drivers/sensors/lepton.c
@@ -493,6 +493,10 @@ static int snapshot(omv_csi_t *csi, image_t *image, uint32_t flags) {
     return 0;
 }
 
+static int lepton_abort(omv_csi_t *csi, bool fifo_flush, bool in_irq) {
+    return vospi_abort();
+}
+
 static int config(omv_csi_t *csi, omv_csi_config_t config) {
     if (config == OMV_CSI_CONFIG_INIT) {
         if (reset(csi) != 0) {
@@ -529,7 +533,7 @@ int lepton_init(omv_csi_t *csi) {
     csi->reset = reset;
     csi->sleep = sleep;
     csi->config = config;
-    csi->abort = NULL;
+    csi->abort = lepton_abort;
     csi->match = match;
     csi->snapshot = snapshot;
     csi->read_reg = read_reg;


### PR DESCRIPTION
Changing the resolution/pixformat between snapshots is now safe with the FLIR Lepton.