### PR TITLE
ports/all: Refactor CSI port init.

### DIFF
--- a/common/omv_csi.h
+++ b/common/omv_csi.h
@@ -400,6 +400,9 @@ void omv_csi_init0();
 // Initializes CSI struct with default ops.
 int omv_csi_init();
 
+// Implemented by ports to set the default CSI ops.
+int omv_csi_ops_init(omv_csi_t *csi);
+
 // Return CSI instance.
 // If id == -1, return the main csi, otherwise look up csi by chip-id.
 omv_csi_t *omv_csi_get(int id);

--- a/ports/alif/alif_hal.c
+++ b/ports/alif/alif_hal.c
@@ -103,6 +103,11 @@ void alif_hal_init(void) {
     // Configure and enable USB IRQs.
     NVIC_ClearPendingIRQ(USB_IRQ_IRQn);
     NVIC_SetPriority(USB_IRQ_IRQn, IRQ_PRI_USB);
+
+    #if MICROPY_PY_CSI
+    // Enable CSI clock and configure pins.
+    alif_hal_csi_init(OMV_CSI_BASE);
+    #endif
 }
 
 int alif_hal_i2c_init(uint32_t bus_id) {
@@ -364,14 +369,15 @@ int alif_hal_pdm_deinit(uint32_t pdm_id) {
     return 0;
 }
 
-int alif_hal_csi_init(CPI_Type *cpi, uint32_t mode) {
-    if (mode == 0) {
+int alif_hal_csi_init(CPI_Type *cpi) {
+    // Enable CPI clock.
+    if (cpi == ((CPI_Type *) CPI_BASE)) {
         enable_cpi_periph_clk();
     } else {
         enable_lpcpi_periph_clk();
     }
 
-    // Configure camera sensor interface pins
+    // Configure CPI pins.
     omv_gpio_config(OMV_CSI_D0_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_HIGH, -1);
     omv_gpio_config(OMV_CSI_D1_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_HIGH, -1);
     omv_gpio_config(OMV_CSI_D2_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_HIGH, -1);
@@ -386,18 +392,6 @@ int alif_hal_csi_init(CPI_Type *cpi, uint32_t mode) {
     omv_gpio_config(OMV_CSI_PXCLK_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_HIGH, -1);
     omv_gpio_config(OMV_CSI_MXCLK_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_HIGH, -1);
 
-    // Configure DCMI GPIOs
-    #if defined(OMV_CSI_RESET_PIN)
-    omv_gpio_config(OMV_CSI_RESET_PIN, OMV_GPIO_MODE_OUTPUT, OMV_GPIO_PULL_DOWN, OMV_GPIO_SPEED_LOW, -1);
-    #endif
-    #if defined(OMV_CSI_FSYNC_PIN)
-    omv_gpio_config(OMV_CSI_FSYNC_PIN, OMV_GPIO_MODE_OUTPUT, OMV_GPIO_PULL_DOWN, OMV_GPIO_SPEED_LOW, -1);
-    #endif
-    #if defined(OMV_CSI_POWER_PIN)
-    omv_gpio_config(OMV_CSI_POWER_PIN, OMV_GPIO_MODE_OUTPUT, OMV_GPIO_PULL_UP, OMV_GPIO_SPEED_LOW, -1);
-    #endif
-
-    NVIC_SetPriority(CAM_IRQ_IRQn, IRQ_PRI_CSI);
     return 0;
 }
 

--- a/ports/alif/alif_hal.h
+++ b/ports/alif/alif_hal.h
@@ -40,5 +40,5 @@ int alif_hal_spi_init(uint32_t bus_id, bool nss_enable, uint32_t nss_pol);
 int alif_hal_spi_deinit(uint32_t bus_id);
 int alif_hal_pdm_init(uint32_t pdm_id);
 int alif_hal_pdm_deinit(uint32_t pdm_id);
-int alif_hal_csi_init(CPI_Type *cpi, uint32_t mode);
+int alif_hal_csi_init(CPI_Type *cpi);
 #endif //__ALIF_HAL_H__

--- a/ports/mimxrt/mimxrt_hal.c
+++ b/ports/mimxrt/mimxrt_hal.c
@@ -107,6 +107,11 @@ void mimxrt_hal_init() {
     edma_config_t edma_config = {0};
     EDMA_GetDefaultConfig(&edma_config);
     EDMA_Init(DMA0, &edma_config);
+
+    #if MICROPY_PY_CSI
+    // Enable CSI clock and configure pins.
+    mimxrt_hal_csi_init(CSI);
+    #endif
 }
 
 void mimxrt_hal_bootloader() {
@@ -118,9 +123,10 @@ void mimxrt_hal_bootloader() {
 }
 
 int mimxrt_hal_csi_init(CSI_Type *inst) {
+    // Enable CSI clock.
     CLOCK_EnableClock(kCLOCK_Csi);
 
-    // Configure DCMI pins.
+    // Configure CSI pins.
     omv_gpio_config(OMV_CSI_D0_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
     omv_gpio_config(OMV_CSI_D1_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
     omv_gpio_config(OMV_CSI_D2_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
@@ -134,20 +140,6 @@ int mimxrt_hal_csi_init(CSI_Type *inst) {
     omv_gpio_config(OMV_CSI_HSYNC_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
     omv_gpio_config(OMV_CSI_VSYNC_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
     omv_gpio_config(OMV_CSI_PXCLK_PIN, OMV_GPIO_MODE_ALT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_MED, -1);
-
-    // Configure DCMI GPIOs
-    #if defined(OMV_CSI_RESET_PIN)
-    omv_gpio_config(OMV_CSI_RESET_PIN, OMV_GPIO_MODE_OUTPUT, OMV_GPIO_PULL_DOWN, OMV_GPIO_SPEED_LOW, -1);
-    #endif
-    #if defined(OMV_CSI_FSYNC_PIN)
-    omv_gpio_config(OMV_CSI_FSYNC_PIN, OMV_GPIO_MODE_OUTPUT, OMV_GPIO_PULL_DOWN, OMV_GPIO_SPEED_LOW, -1);
-    #endif
-    #if defined(OMV_CSI_POWER_PIN)
-    omv_gpio_config(OMV_CSI_POWER_PIN, OMV_GPIO_MODE_OUTPUT, OMV_GPIO_PULL_UP, OMV_GPIO_SPEED_LOW, -1);
-    #endif
-
-    // Configure IRQ priority.
-    NVIC_SetPriority(CSI_IRQn, IRQ_PRI_CSI);
 
     return 0;
 }

--- a/ports/rp2/main.c
+++ b/ports/rp2/main.c
@@ -179,14 +179,21 @@ soft_reset:
 
     fb_alloc_init0();
     framebuffer_init0();
+    #if MICROPY_PY_CSI
+    omv_csi_init0();
+    #endif
 
     #if MICROPY_PY_FIR
     py_fir_init0();
     #endif // MICROPY_PY_FIR
 
     #if MICROPY_PY_CSI
-    if (omv_csi_init() != 0) {
-        printf("csi init failed!\n");
+    // Initialize the csi.
+    if (first_soft_reset) {
+        int ret = omv_csi_init();
+        if (ret != 0 && ret != OMV_CSI_ERROR_ISC_UNDETECTED) {
+            __fatal_error("Failed to init the CSI");
+        }
     }
     #endif
 

--- a/ports/rp2/omv_csi.c
+++ b/ports/rp2/omv_csi.c
@@ -68,6 +68,18 @@ static void dma_irq_handler() {
 
 static int rp2_csi_config(omv_csi_t *csi, omv_csi_config_t config) {
     if (config == OMV_CSI_CONFIG_INIT) {
+        // PIXCLK
+        gpio_init(OMV_CSI_PXCLK_PIN);
+        gpio_set_dir(OMV_CSI_PXCLK_PIN, GPIO_IN);
+
+        // HSYNC
+        gpio_init(OMV_CSI_HSYNC_PIN);
+        gpio_set_dir(OMV_CSI_HSYNC_PIN, GPIO_IN);
+
+        // VSYNC
+        gpio_init(OMV_CSI_VSYNC_PIN);
+        gpio_set_dir(OMV_CSI_VSYNC_PIN, GPIO_IN);
+
         // Install new DMA IRQ handler.
         irq_set_enabled(OMV_CSI_DMA_IRQ, false);
 
@@ -213,76 +225,10 @@ static int rp2_csi_snapshot(omv_csi_t *csi, image_t *image, uint32_t flags) {
     return 0;
 }
 
-int omv_csi_init() {
-    int init_ret = 0;
-    static omv_i2c_t i2c;
-
-    // PIXCLK
-    gpio_init(OMV_CSI_PXCLK_PIN);
-    gpio_set_dir(OMV_CSI_PXCLK_PIN, GPIO_IN);
-
-    // HSYNC
-    gpio_init(OMV_CSI_HSYNC_PIN);
-    gpio_set_dir(OMV_CSI_HSYNC_PIN, GPIO_IN);
-
-    // VSYNC
-    gpio_init(OMV_CSI_VSYNC_PIN);
-    gpio_set_dir(OMV_CSI_VSYNC_PIN, GPIO_IN);
-
-    #if defined(OMV_CSI_POWER_PIN)
-    gpio_init(OMV_CSI_POWER_PIN);
-    gpio_set_dir(OMV_CSI_POWER_PIN, GPIO_OUT);
-    gpio_pull_down(OMV_CSI_POWER_PIN);
-    gpio_put(OMV_CSI_POWER_PIN, 1);
-    #endif
-
-    #if defined(OMV_CSI_RESET_PIN)
-    gpio_init(OMV_CSI_RESET_PIN);
-    gpio_set_dir(OMV_CSI_RESET_PIN, GPIO_OUT);
-    gpio_pull_up(OMV_CSI_RESET_PIN);
-    gpio_put(OMV_CSI_RESET_PIN, 1);
-    #endif
-
-    // Initialize the CSIs using this driver's ops as defaults,
-    // which can be overridden by sensor drivers during probe.
-    for (size_t i=0; i<OMV_CSI_MAX_DEVICES; i++) {
-        omv_csi_t *csi = &csi_all[i];
-
-        memset(csi, 0, sizeof(omv_csi_t));
-        csi->i2c = &i2c;
-        csi->fb = framebuffer_get(-1);
-        csi->abort = rp2_csi_abort;
-        csi->config = rp2_csi_config;
-        csi->snapshot = rp2_csi_snapshot;
-        csi->color_palette = rainbow_table;
-    }
-
-    // Configure the csi external clock (XCLK).
-    if (omv_csi_set_clk_frequency(OMV_CSI_CLK_FREQUENCY) != 0) {
-        // Failed to initialize the csi clock.
-        return OMV_CSI_ERROR_TIM_INIT_FAILED;
-    }
-
-    // Initialize the camera bus.
-    omv_i2c_init(&i2c, OMV_CSI_I2C_ID, OMV_CSI_I2C_SPEED);
-
-    // Detect and initialize the image sensor.
-    if ((init_ret = omv_csi_probe(&i2c)) != 0) {
-        // Sensor probe/init failed.
-        return init_ret;
-    }
-
-    // Configure the DCMI interface.
-    for (size_t i=0; i<OMV_CSI_MAX_DEVICES; i++) {
-        omv_csi_t *csi = &csi_all[i];
-
-        if (omv_csi_config(csi, OMV_CSI_CONFIG_INIT) != 0) {
-            return OMV_CSI_ERROR_CSI_INIT_FAILED;
-        }
-    }
-
-    // Clear fb_enabled flag.
-    JPEG_FB()->enabled = 0;
+int omv_csi_ops_init(omv_csi_t *csi) {
+    csi->abort = rp2_csi_abort;
+    csi->config = rp2_csi_config;
+    csi->snapshot = rp2_csi_snapshot;
     return 0;
 }
 #endif // MICROPY_PY_CSI

--- a/ports/stm32/stm32_hal_msp.c
+++ b/ports/stm32/stm32_hal_msp.c
@@ -271,16 +271,6 @@ void HAL_MspInit(void) {
     OMV_AXI_QOS_LTDC_W_SET(OMV_AXI_QOS_LTDC_W_PRI);
     #endif
 
-    #if defined(OMV_CSI_RESET_PIN)
-    omv_gpio_config(OMV_CSI_RESET_PIN, OMV_GPIO_MODE_OUTPUT, OMV_GPIO_PULL_DOWN, OMV_GPIO_SPEED_LOW, -1);
-    #endif
-    #if defined(OMV_CSI_FSYNC_PIN)
-    omv_gpio_config(OMV_CSI_FSYNC_PIN, OMV_GPIO_MODE_OUTPUT, OMV_GPIO_PULL_DOWN, OMV_GPIO_SPEED_LOW, -1);
-    #endif
-    #if defined(OMV_CSI_POWER_PIN)
-    omv_gpio_config(OMV_CSI_POWER_PIN, OMV_GPIO_MODE_OUTPUT, OMV_GPIO_PULL_UP, OMV_GPIO_SPEED_LOW, -1);
-    #endif
-
     #if defined(OMV_FIR_LEPTON_RESET_PIN)
     omv_gpio_config(OMV_FIR_LEPTON_RESET_PIN, OMV_GPIO_MODE_OUTPUT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_LOW, -1);
     omv_gpio_write(OMV_FIR_LEPTON_RESET_PIN, 0);


### PR DESCRIPTION
* Removes duplicate CSI initialization code (almost identical in every port).
* Makes it easier to make changes in the future (e.g., decouple the clock).
* `omv_csi_init` is still completely replaceable.

Notes:
* One change from old code, made all control pins `PULL_NONE`, just doesn't make much sense to select one pull or the other.
* Some ports require the IP clock to generate the external clock, so those have to initialize CSI earlier.
* There was an extra `csi->detected=True` in alif port, probably due to duplicate code, copy&paste this is no longer needed, it's done in common code.

While at it, nrf and rp2 were missing `csi_init0` (still unknown though if they actually work). Tested the rest of the ports (imxrt, stm, alif).