### PR TITLE
drivers/sensors: Remove OV5640 REV_Y special case.

### DIFF
--- a/boards/ARDUINO_PORTENTA_H7/omv_boardconfig.h
+++ b/boards/ARDUINO_PORTENTA_H7/omv_boardconfig.h
@@ -48,10 +48,6 @@
 #define OMV_OV5640_CLK_FREQ                 (12500000)
 #define OMV_OV5640_PLL_CTRL2                (0x7E)
 #define OMV_OV5640_PLL_CTRL3                (0x13)
-#define OMV_OV5640_REV_Y_CHECK              (0)
-#define OMV_OV5640_REV_Y_FREQ               (12500000)
-#define OMV_OV5640_REV_Y_CTRL2              (0x7E)
-#define OMV_OV5640_REV_Y_CTRL3              (0x13)
 
 #define OMV_HM01B0_ENABLE                   (1)
 #define OMV_HM0360_ENABLE                   (1)

--- a/boards/OPENMV4/omv_boardconfig.h
+++ b/boards/OPENMV4/omv_boardconfig.h
@@ -48,9 +48,6 @@
 #define OMV_OV5640_AF_ENABLE                  (1)
 #define OMV_OV5640_PLL_CTRL2                  (0x64)
 #define OMV_OV5640_PLL_CTRL3                  (0x13)
-#define OMV_OV5640_REV_Y_CHECK                (1)
-#define OMV_OV5640_REV_Y_CTRL2                (0x54)
-#define OMV_OV5640_REV_Y_CTRL3                (0x13)
 
 #define OMV_OV7725_ENABLE                     (1)
 #define OMV_OV7725_PLL_CONFIG                 (0x41) // x4

--- a/boards/OPENMV4P/omv_boardconfig.h
+++ b/boards/OPENMV4P/omv_boardconfig.h
@@ -34,9 +34,6 @@
 #define OMV_OV5640_AF_ENABLE                  (1)
 #define OMV_OV5640_PLL_CTRL2                  (0x64)
 #define OMV_OV5640_PLL_CTRL3                  (0x13)
-#define OMV_OV5640_REV_Y_CHECK                (1)
-#define OMV_OV5640_REV_Y_CTRL2                (0x54)
-#define OMV_OV5640_REV_Y_CTRL3                (0x13)
 
 #define OMV_OV7725_ENABLE                     (1)
 #define OMV_OV7725_PLL_CONFIG                 (0x41) // x4

--- a/boards/OPENMVPT/omv_boardconfig.h
+++ b/boards/OPENMVPT/omv_boardconfig.h
@@ -32,9 +32,6 @@
 #define OMV_OV5640_AF_ENABLE                    (1)
 #define OMV_OV5640_PLL_CTRL2                    (0x64)
 #define OMV_OV5640_PLL_CTRL3                    (0x13)
-#define OMV_OV5640_REV_Y_CHECK                  (1)
-#define OMV_OV5640_REV_Y_CTRL2                  (0x54)
-#define OMV_OV5640_REV_Y_CTRL3                  (0x13)
 
 // FIR drivers configuration.
 #define OMV_FIR_MLX90621_ENABLE                 (1)

--- a/boards/OPENMV_N6/omv_boardconfig.h
+++ b/boards/OPENMV_N6/omv_boardconfig.h
@@ -42,9 +42,6 @@
 #define OMV_OV5640_AF_ENABLE                (1)
 #define OMV_OV5640_PLL_CTRL2                (0x64)
 #define OMV_OV5640_PLL_CTRL3                (0x13)
-#define OMV_OV5640_REV_Y_CHECK              (1)
-#define OMV_OV5640_REV_Y_CTRL2              (0x54)
-#define OMV_OV5640_REV_Y_CTRL3              (0x13)
 
 #define OMV_MT9V0XX_ENABLE                  (1)
 #define OMV_LEPTON_ENABLE                   (1)

--- a/boards/OPENMV_RT1060/omv_boardconfig.h
+++ b/boards/OPENMV_RT1060/omv_boardconfig.h
@@ -29,9 +29,6 @@
 #define OMV_OV5640_AF_ENABLE            (1)
 #define OMV_OV5640_PLL_CTRL2            (0x64)
 #define OMV_OV5640_PLL_CTRL3            (0x13)
-#define OMV_OV5640_REV_Y_CHECK          (0)
-#define OMV_OV5640_REV_Y_CTRL2          (0x54)
-#define OMV_OV5640_REV_Y_CTRL3          (0x13)
 
 #define OMV_OV7725_ENABLE               (1)
 #define OMV_OV7725_PLL_CONFIG           (0x41)   // x4

--- a/common/omv_csi.c
+++ b/common/omv_csi.c
@@ -543,13 +543,6 @@ int omv_csi_probe(omv_i2c_t *i2c) {
             return OMV_CSI_ERROR_ISC_INIT_FAILED;
         }
 
-        // Special case for OV5640.
-        #if (OMV_OV5640_REV_Y_CHECK == 1)
-        if (csi->chip_id == OV5640_ID && HAL_GetREVID() < 0x2003) {
-            csi->clk_hz = OMV_OV5640_REV_Y_FREQ;
-        }
-        #endif
-
         // Sensors can change the clock's frequency or disable it
         // (with clk_hz=0). This is allowed only if the clock is
         // not shared (dev_count == 1) or if this is a main sensor.

--- a/drivers/sensors/ov5640.c
+++ b/drivers/sensors/ov5640.c
@@ -678,20 +678,6 @@ static int reset(omv_csi_t *csi) {
         int addr = (default_regs[i][0] << 8) | (default_regs[i][1] << 0);
         int data = default_regs[i][2];
 
-        #if (OMV_OV5640_REV_Y_CHECK == 1)
-        // Rev V (480 MHz / 20) -> 24 MHz PCLK / 3 * 100 = 800 MHz / 10 = 80 MHz PCLK.
-        // Rev Y (400 MHz / 16) -> 25 MHz PCLK / 3 * 84 = 700 MHz / 10 = 70 MHz PCLK.
-        if (HAL_GetREVID() < 0x2003) {
-            // Is this REV Y?
-            if (addr == SC_PLL_CONTRL2) {
-                data = OMV_OV5640_REV_Y_CTRL2;
-            }
-            if (addr == SC_PLL_CONTRL3) {
-                data = OMV_OV5640_REV_Y_CTRL3;
-            }
-        }
-        #endif
-
         ret |= omv_i2c_writeb2(csi->i2c, csi->slv_addr, addr, data);
     }
 

--- a/drivers/sensors/sensor_config.h
+++ b/drivers/sensors/sensor_config.h
@@ -22,9 +22,6 @@ extern int ov2640_init(omv_csi_t *csi);
 #ifndef OMV_OV5640_CLK_FREQ
 #define OMV_OV5640_CLK_FREQ     (24000000)
 #endif
-#ifndef OMV_OV5640_REV_Y_FREQ
-#define OMV_OV5640_REV_Y_FREQ   (25000000)
-#endif
 extern int ov5640_init(omv_csi_t *csi);
 
 #ifndef OMV_OV7670_CLK_FREQ


### PR DESCRIPTION
Tested on a Rev-Y board 400 MHz H7. It's not needed anymore. System works fine without it using OV5640.

I think this was added initially because the set_clk_freq code used to pick a higher freq than requested if it couldn't meet the target. However, after that bug was discovered and fixed this check is not necessary anymore.