### PR TITLE
lib/micropython: Update RT1062 USB ID and buffers.

### DIFF
--- a/boards/OPENMV_RT1060/omv_boardconfig.h
+++ b/boards/OPENMV_RT1060/omv_boardconfig.h
@@ -83,7 +83,7 @@
 #define OMV_GC_BLOCK0_MEMORY            OCRM2   // Extra GC block 0.
 #define OMV_GC_BLOCK0_SIZE              (64K)
 #define OMV_GC_BLOCK1_MEMORY            DTCM    // Main GC block
-#define OMV_GC_BLOCK1_SIZE              (288K)
+#define OMV_GC_BLOCK1_SIZE              (272K)
 #define OMV_GC_BLOCK2_MEMORY            DRAM    // Extra GC block 1.
 #define OMV_GC_BLOCK2_SIZE              (8M)
 #define OMV_RAMFUNC_MEMORY              ITCM2   // RAM code memory.


### PR DESCRIPTION
* Update RT1062 USB ID from the FOSS one to our private VID:PID.
* Increase USB buffer sizes for faster CDC transfer.