### PR TITLE
imlib: Rework frame buffer management.

### DIFF
--- a/common/common.mk
+++ b/common/common.mk
@@ -38,6 +38,7 @@ COMMON_SRC_C += \
     unaligned_memcpy.c \
     usbdbg.c \
     vospi.c \
+    queue.c \
 
 CFLAGS += -I$(TOP_DIR)/common
 OMV_FIRM_OBJ += $(addprefix $(BUILD)/common/, $(COMMON_SRC_C:.c=.o))

--- a/common/fb_alloc.c
+++ b/common/fb_alloc.c
@@ -65,7 +65,7 @@ void fb_alloc_init0() {
 
 uint32_t fb_avail() {
     framebuffer_t *fb = framebuffer_get(0);
-    uint32_t temp = pointer - framebuffer_get_buffers_end(fb) - sizeof(uint32_t);
+    uint32_t temp = pointer - framebuffer_pool_end(fb) - sizeof(uint32_t);
     return (temp < sizeof(uint32_t)) ? 0 : temp;
 }
 
@@ -74,7 +74,7 @@ void fb_alloc_mark() {
     char *new_pointer = pointer - sizeof(uint32_t);
 
     // Check if allocation overwrites the framebuffer pixels
-    if (new_pointer < framebuffer_get_buffers_end(fb)) {
+    if (new_pointer < framebuffer_pool_end(fb)) {
         nlr_jump(MP_OBJ_TO_PTR(mp_obj_new_exception_msg(&mp_type_MemoryError,
                                                         MP_ERROR_TEXT("Out of fast frame buffer stack memory"))));
     }
@@ -154,7 +154,7 @@ void *fb_alloc(uint32_t size, int hints) {
     char *new_pointer = result - sizeof(uint32_t);
 
     // Check if allocation overwrites the framebuffer pixels
-    if (new_pointer < framebuffer_get_buffers_end(fb)) {
+    if (new_pointer < framebuffer_pool_end(fb)) {
         fb_alloc_fail();
     }
 
@@ -199,7 +199,7 @@ void *fb_alloc0(uint32_t size, int hints) {
 
 void *fb_alloc_all(uint32_t *size, int hints) {
     framebuffer_t *fb = framebuffer_get(0);
-    uint32_t temp = pointer - framebuffer_get_buffers_end(fb) - sizeof(uint32_t);
+    uint32_t temp = pointer - framebuffer_pool_end(fb) - sizeof(uint32_t);
 
     if (temp < sizeof(uint32_t)) {
         *size = 0;

--- a/common/fb_alloc.c
+++ b/common/fb_alloc.c
@@ -48,7 +48,7 @@ static char *pointer_overlay = &_fballoc_overlay_end;
 // Use fb_alloc_free_till_mark_permanent() instead.
 #define FB_PERMANENT_FLAG       0x2
 
-char *fb_alloc_stack_pointer() {
+char *fb_alloc_sp() {
     return pointer;
 }
 

--- a/common/fb_alloc.h
+++ b/common/fb_alloc.h
@@ -35,7 +35,7 @@
 #define OMV_ALLOC_ALIGNMENT     (OMV_CACHE_LINE_SIZE)
 #endif
 
-char *fb_alloc_stack_pointer();
+char *fb_alloc_sp();
 void fb_alloc_fail();
 void fb_alloc_init0();
 uint32_t fb_avail();

--- a/common/omv_common.h
+++ b/common/omv_common.h
@@ -46,6 +46,9 @@
 #define OMV_ALIGN_TO(x, alignment) \
     ((((uintptr_t)(x)) + (alignment) - 1) & ~((uintptr_t)((alignment) - 1)))
 
+#define OMV_ALIGN_DOWN(x, alignment) \
+    ((uintptr_t)(x) & ~((uintptr_t)(alignment) - 1))
+
 #ifdef OMV_DEBUG_PRINTF
 #define debug_printf(fmt, ...) \
     do { printf("%s(): " fmt, __func__, ##__VA_ARGS__);} while (0)

--- a/common/omv_csi.h
+++ b/common/omv_csi.h
@@ -550,7 +550,7 @@ int omv_csi_set_auto_rotation(omv_csi_t *csi, bool enable);
 bool omv_csi_get_auto_rotation(omv_csi_t *csi);
 
 // Set the number of virtual frame buffers.
-int omv_csi_set_framebuffers(omv_csi_t *csi, int count);
+int omv_csi_set_framebuffers(omv_csi_t *csi, size_t count, bool expand);
 
 // Drop the next frame to match the current frame rate.
 void omv_csi_throttle_framerate(omv_csi_t *csi);

--- a/common/queue.c
+++ b/common/queue.c
@@ -1,0 +1,190 @@
+/*
+ * SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2013-2024 OpenMV, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * Single-producer, single-consumer, lock-free bounded Queue.
+ *
+ * ARM processors have weak memory ordering and may reorder memory operations
+ * for performance. The compiler can also reorder operations. This queue uses
+ * acquire/release semantics to ensure proper synchronization between producer
+ * and consumer threads.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include "queue.h"
+
+void queue_init(queue_t **q, size_t capacity, void *buffer) {
+    if (!q || !buffer) {
+        return;
+    }
+    
+    *q = (queue_t *) buffer;
+    (*q)->capacity = capacity;
+    queue_flush(*q);
+}
+
+queue_t *queue_alloc(size_t capacity) {
+    if (capacity == 0) {
+        return NULL;
+    }
+    
+    void *buffer = malloc(queue_calc_size(capacity));
+    if (!buffer) {
+        return NULL;
+    }
+    
+    queue_t *q;
+    queue_init(&q, capacity, buffer);
+    return q;
+}
+
+void queue_destroy(queue_t *q) {
+    free(q);
+}
+
+void queue_flush(queue_t *q) {
+    if (!q) {
+        return;
+    }
+
+    #ifndef HAVE_STDATOMIC_H
+    q->head = 0;
+    q->tail = 0;
+    #else
+    atomic_store_explicit(&q->head, 0, memory_order_relaxed);
+    atomic_store_explicit(&q->tail, 0, memory_order_relaxed);
+    #endif
+}
+
+bool queue_push(queue_t *q, void *item) {
+    if (!q || !item) {
+        return false;
+    }
+    
+    #ifndef HAVE_STDATOMIC_H
+    size_t new_tail = (q->tail + 1) % (q->capacity + 1);
+
+    if (new_tail == q->head) {
+        return false; // Queue full
+    }
+    q->items[q->tail] = item;
+    q->tail = new_tail;
+    #else
+    size_t old_tail = atomic_load_explicit(&q->tail, memory_order_relaxed);
+    size_t new_tail = (old_tail + 1) % (q->capacity + 1);
+
+    // Ensure that the previous head is consumed.
+    if (new_tail == atomic_load_explicit(&q->head, memory_order_acquire)) {
+        return false; // Queue full
+    }
+
+    q->items[old_tail] = item;
+    // Release ensures the write completes before advancing tail
+    atomic_store_explicit(&q->tail, new_tail, memory_order_release);
+    #endif
+    
+    return true;
+}
+
+void *queue_pop(queue_t *q, bool peek) {
+    if (queue_is_empty(q)) {
+        return NULL;
+    }
+
+    #ifndef HAVE_STDATOMIC_H
+    void *item = q->items[q->head];
+    if (!peek) {
+        q->head = (q->head + 1) % (q->capacity + 1);
+    }
+    #else
+    size_t old_head = atomic_load_explicit(&q->head, memory_order_relaxed);
+    size_t new_head = (old_head + 1) % (q->capacity + 1);
+    void *item = q->items[old_head];
+
+    if (!peek) {
+        // Release ensures the read completes before advancing head
+        atomic_store_explicit(&q->head, new_head, memory_order_release);
+    }
+    #endif
+    
+    return item;
+}
+
+bool queue_is_empty(const queue_t *q) {
+    if (!q) {
+        return true;
+    }
+    
+    #ifndef HAVE_STDATOMIC_H
+    size_t head = q->head;
+    size_t tail = q->tail;
+    #else
+    // Ensure the current thread sees all prior updates to head and tail
+    size_t head = atomic_load_explicit(&q->head, memory_order_acquire);
+    size_t tail = atomic_load_explicit(&q->tail, memory_order_acquire);
+    #endif
+    return head == tail;
+}
+
+size_t queue_size(const queue_t *q) {
+    if (!q) {
+        return 0;
+    }
+    
+    #ifndef HAVE_STDATOMIC_H
+    size_t head = q->head;
+    size_t tail = q->tail;
+    #else
+    // Ensure the current thread sees all prior updates to head and tail
+    size_t head = atomic_load_explicit(&q->head, memory_order_acquire);
+    size_t tail = atomic_load_explicit(&q->tail, memory_order_acquire);
+    #endif
+    
+    // Calculate size considering the circular buffer
+    if (tail >= head) {
+        return tail - head;
+    } else {
+        return (q->capacity + 1) - head + tail;
+    }
+}
+
+// Swap the last item of q0 (tail - 1) with the first item of q1 (head).
+// Currently, this is only used for a special case in the framebuffer,
+// and it's only safe under very specific conditions.
+void *queue_swap(queue_t *q0, queue_t *q1) {
+    #ifndef HAVE_STDATOMIC_H
+    size_t tail = (q0->tail == 0) ? q0->capacity : q0->tail - 1;
+    size_t head = q1->head;
+    #else
+    size_t tail = atomic_load_explicit(&q0->tail, memory_order_acquire);
+    size_t head = atomic_load_explicit(&q1->head, memory_order_acquire);
+    tail = (tail == 0) ? q0->capacity : tail - 1;
+    #endif
+
+    void *item0 = q0->items[tail];
+    void *item1 = q1->items[head];
+
+    q0->items[tail] = item1;
+    q1->items[head] = item0;
+
+    return item0;
+}

--- a/common/queue.h
+++ b/common/queue.h
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2013-2024 OpenMV, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * Single-producer, single-consumer, lock-free bounded Queue.
+ */
+#ifndef __QUEUE_H__
+#define __QUEUE_H__
+
+#include <stddef.h>
+#include <stdbool.h>
+
+#if __STDC_VERSION__ < 201112L
+typedef size_t queue_index_t;
+#warning "Atomics not supported"
+#else
+#include <stdatomic.h>
+#define HAVE_STDATOMIC_H
+typedef atomic_size_t queue_index_t;
+#endif
+
+typedef struct {
+    size_t capacity;
+    queue_index_t head;
+    queue_index_t tail; // TODO pad with cache line if needed.
+    void *items[];
+} queue_t;
+
+// One extra slot is used to distinguish full from empty.
+#define queue_calc_size(capacity) \
+    (sizeof(queue_t) + ((capacity) + 1) * sizeof(void *))
+
+void queue_init(queue_t **q, size_t capacity, void *buffer);
+void queue_flush(queue_t *q);
+queue_t *queue_alloc(size_t capacity);
+void queue_destroy(queue_t *q);
+bool queue_is_empty(const queue_t *q);
+bool queue_push(queue_t *q, void *item);
+void *queue_pop(queue_t *q, bool peek);
+size_t queue_size(const queue_t *q);
+void *queue_swap(queue_t *q0, queue_t *q1);
+#endif // __QUEUE_H__

--- a/common/vospi.c
+++ b/common/vospi.c
@@ -28,6 +28,8 @@
 
 #include <stdint.h>
 #include <string.h>
+#include <stdio.h>
+
 #include "py/mphal.h"
 
 #include "vospi.h"
@@ -44,17 +46,17 @@
 
 #define VOSPI_BUFFER_SIZE           (VOSPI_PACKET_SIZE * 2) // 16-bits
 #define VOSPI_CLOCK_SPEED           20000000 // hz
-#define VOSPI_SYNC_MS               200 // ms
+#define VOSPI_SYNC_MS               250 // ms
 
-#define VOSPI_SPECIAL_PACKET        (20)
 #define VOSPI_DONT_CARE_PACKET      (0x0F00)
 #define VOSPI_HEADER_DONT_CARE(x)   (((x) & VOSPI_DONT_CARE_PACKET) == VOSPI_DONT_CARE_PACKET)
 #define VOSPI_HEADER_PID(id)        ((id) & 0x0FFF)
 #define VOSPI_HEADER_SID(id)        (((id) >> 12) & 0x7)
+#define VOSPI_IS_SPECIAL_PACKET(pid)    (vospi.lepton_3 && pid == 20)
 
 typedef enum {
-    VOSPI_FLAGS_CAPTURE = (1 << 0),
-    VOSPI_FLAGS_RESYNC  = (1 << 1),
+    VOSPI_FLAG_STREAM   = (1 << 0),
+    VOSPI_FLAG_CAPTURE  = (1 << 1),
 } vospi_flags_t;
 
 typedef struct _vospi_state {
@@ -67,24 +69,10 @@ typedef struct _vospi_state {
 } vospi_state_t;
 
 static vospi_state_t vospi;
-
 static uint16_t OMV_ATTR_SEC_ALIGN(vospi_buf[VOSPI_BUFFER_SIZE], OMV_VOSPI_DMA_BUFFER, OMV_DMA_ALIGNMENT);
-static void vospi_callback(omv_spi_t *spi, void *userdata, void *buf);
 
-static void vospi_resync() {
-    omv_spi_transfer_t spi_xfer = {
-        .rxbuf = vospi_buf,
-        .size = VOSPI_BUFFER_SIZE,
-        .flags = OMV_SPI_XFER_DMA,
-        .callback = vospi_callback,
-    };
-
-    mp_hal_delay_ms(VOSPI_SYNC_MS);
-    omv_spi_transfer_start(&vospi.spi_bus, &spi_xfer);
-}
-
-#if defined(OMV_ENABLE_VOSPI_CRC)
 static bool vospi_check_crc(const uint16_t *base) {
+    #if defined(OMV_ENABLE_VOSPI_CRC)
     int id = base[0];
     int packet_crc = base[1];
     int crc = ByteCRC16((id >> 8) & 0x0F, 0);
@@ -99,11 +87,14 @@ static bool vospi_check_crc(const uint16_t *base) {
     }
 
     return packet_crc == crc;
+    #else
+    return true;
+    #endif
 }
-#endif
 
-void vospi_callback(omv_spi_t *spi, void *userdata, void *buf) {
-    if (!(vospi.flags & VOSPI_FLAGS_CAPTURE)) {
+static void vospi_callback(omv_spi_t *spi, void *userdata, void *buf) {
+    if (!(vospi.flags & VOSPI_FLAG_CAPTURE) ||
+        !(vospi.flags & VOSPI_FLAG_STREAM)) {
         return;
     }
 
@@ -120,62 +111,58 @@ void vospi_callback(omv_spi_t *spi, void *userdata, void *buf) {
     int sid = VOSPI_HEADER_SID(id) - 1;
 
     // Discard packets with a pid != 0 when waiting for the first packet.
-    if ((vospi.pid == 0) && (pid != 0)) {
+    if (vospi.pid == 0 && pid != 0) {
         return;
     }
 
-    // Discard sidments with a sid != 0 when waiting for the first segment.
-    if (vospi.lepton_3 && (pid == VOSPI_SPECIAL_PACKET) && (vospi.sid == 0) && (sid != 0)) {
+    // Discard segments with a sid != 0 when waiting for the first segment.
+    if (VOSPI_IS_SPECIAL_PACKET(pid) && vospi.sid == 0 && sid != 0) {
         vospi.pid = 0;
         return;
     }
 
     // Are we in sync with the flir lepton?
-    if ((pid != vospi.pid)
-    #if defined(OMV_ENABLE_VOSPI_CRC)
-        || (!vospi_check_crc(base))
-    #endif
-        || (vospi.lepton_3 && (pid == VOSPI_SPECIAL_PACKET) && (sid != vospi.sid))) {
+    if (pid != vospi.pid ||
+        !vospi_check_crc(base) ||
+        (VOSPI_IS_SPECIAL_PACKET(pid) && sid != vospi.sid)) {
         vospi_abort();
-        vospi.flags |= VOSPI_FLAGS_CAPTURE;
         return;
     }
 
-    vbuffer_t *buffer = framebuffer_get_tail(vospi.fb, FB_PEEK);
+    vbuffer_t *buffer = framebuffer_acquire(vospi.fb, FB_FLAG_FREE | FB_FLAG_PEEK);
 
-    if (buffer) {
-        memcpy(((uint16_t *) buffer->data)
-               + (vospi.pid * VOSPI_PID_SIZE_PIXELS)
-               + (vospi.sid * VOSPI_SID_SIZE_PIXELS),
-               base + VOSPI_HEADER_WORDS, VOSPI_PID_SIZE_PIXELS * sizeof(uint16_t));
-
-        vospi.pid += 1;
-        if (vospi.pid == VOSPI_PIDS_PER_SID) {
-            vospi.pid = 0;
-
-            // For the FLIR Lepton 3 we have to receive all the pids in all the segments.
-            if (vospi.lepton_3) {
-                vospi.sid += 1;
-                if (vospi.sid == VOSPI_SIDS_PER_FRAME) {
-                    vospi.sid = 0;
-                    framebuffer_get_tail(vospi.fb, FB_NO_FLAGS);
-                }
-                // For the FLIR Lepton 1/2 we just have to receive all the pids.
-            } else {
-                framebuffer_get_tail(vospi.fb, FB_NO_FLAGS);
-            }
-        }
-    } else {
-        vospi.flags &= ~VOSPI_FLAGS_CAPTURE;
+    if (!buffer) {
+        vospi.flags &= ~VOSPI_FLAG_CAPTURE;
+        return;
     }
+
+    memcpy(((uint16_t *) buffer->data)
+           + (vospi.pid * VOSPI_PID_SIZE_PIXELS)
+           + (vospi.sid * VOSPI_SID_SIZE_PIXELS),
+           base + VOSPI_HEADER_WORDS, VOSPI_PID_SIZE_PIXELS * sizeof(uint16_t));
+
+    if (++vospi.pid == VOSPI_PIDS_PER_SID) {
+        vospi.pid = 0;
+
+        // For the FLIR Lepton 3 we have to receive all the pids in all the segments.
+        if (vospi.lepton_3) {
+            if (++vospi.sid == VOSPI_SIDS_PER_FRAME) {
+                vospi.sid = 0;
+                framebuffer_release(vospi.fb, FB_FLAG_FREE);
+            }
+            // For the FLIR Lepton 1/2 we just have to receive all the pids.
+        } else {
+            // Move the buffer from free queue -> used queue.
+            framebuffer_release(vospi.fb, FB_FLAG_FREE);
+        }
+    }
+    
 }
 
 int vospi_init(uint32_t n_packets, framebuffer_t *fb) {
     memset(&vospi, 0, sizeof(vospi_state_t));
-    vospi.lepton_3 = n_packets > VOSPI_PIDS_PER_SID;
     vospi.fb = fb;
-    // resync on first snapshot.
-    vospi.flags = VOSPI_FLAGS_RESYNC;
+    vospi.lepton_3 = n_packets > VOSPI_PIDS_PER_SID;
 
     omv_spi_config_t spi_config;
     omv_spi_default_config(&spi_config, OMV_CSI_SPI_ID);
@@ -194,50 +181,34 @@ int vospi_deinit() {
     return omv_spi_deinit(&vospi.spi_bus);
 }
 
+bool vospi_active(void) {
+    return vospi.flags & VOSPI_FLAG_CAPTURE;
+}
+
 int vospi_abort(void) {
-    vospi.flags &= ~VOSPI_FLAGS_CAPTURE;
+    vospi.flags = 0;
     int ret = omv_spi_transfer_abort(&vospi.spi_bus);
     vospi.pid = 0;
     vospi.sid = 0;
-    vospi.flags |= VOSPI_FLAGS_RESYNC;
     return ret;
 }
 
-bool vospi_active(void) {
-    return vospi.flags & VOSPI_FLAGS_CAPTURE;
-}
+void vospi_restart(void) {
+    omv_spi_transfer_t spi_xfer = {
+        .rxbuf = vospi_buf,
+        .size = VOSPI_BUFFER_SIZE,
+        .flags = OMV_SPI_XFER_DMA,
+        .callback = vospi_callback,
+    };
 
-int vospi_snapshot(uint32_t timeout_ms) {
-    framebuffer_free_current_buffer(vospi.fb);
+    // Resume streaming.
+    vospi.flags |= VOSPI_FLAG_CAPTURE;
 
-    if (!(vospi.flags & VOSPI_FLAGS_CAPTURE)) {
-        framebuffer_setup_buffers(vospi.fb);
-
-        // Restart counters to capture a new frame.
-        vospi.flags |= VOSPI_FLAGS_CAPTURE;
+    if (!(vospi.flags & VOSPI_FLAG_STREAM)) {
+        mp_hal_delay_ms(VOSPI_SYNC_MS);
+        omv_spi_transfer_start(&vospi.spi_bus, &spi_xfer);
+        vospi.flags |= VOSPI_FLAG_STREAM;
     }
 
-    // Snapshot start tick
-    mp_uint_t tick_start = mp_hal_ticks_ms();
-
-    do {
-        if (vospi.flags & VOSPI_FLAGS_RESYNC) {
-            vospi.flags &= ~VOSPI_FLAGS_RESYNC;
-            vospi_resync();
-        }
-
-        if (timeout_ms == 0) {
-            return -1;
-        }
-
-        if ((mp_hal_ticks_ms() - tick_start) > timeout_ms) {
-            vospi_abort();
-            return -1;
-        }
-
-        MICROPY_EVENT_POLL_HOOK
-    } while (!framebuffer_get_head(vospi.fb, FB_NO_FLAGS));
-
-    return 0;
 }
 #endif

--- a/common/vospi.h
+++ b/common/vospi.h
@@ -30,5 +30,5 @@ int vospi_init(uint32_t n_packets, framebuffer_t *fb);
 int vospi_deinit();
 int vospi_abort(void);
 bool vospi_active(void);
-int vospi_snapshot(uint32_t timeout_ms);
+void vospi_restart(void);
 #endif // __VOSPI_H__

--- a/lib/imlib/framebuffer.h
+++ b/lib/imlib/framebuffer.h
@@ -29,46 +29,91 @@
 #include "imlib.h"
 #include "mutex.h"
 #include "omv_common.h"
+#include "common/queue.h"
 
-// DMA Buffers need to be aligned by cache lines or 16 bytes.
-#ifndef __DCACHE_PRESENT
-#define FRAMEBUFFER_ALIGNMENT    16
-#else
-#define FRAMEBUFFER_ALIGNMENT    __SCB_DCACHE_LINE_SIZE
+#ifndef FRAMEBUFFER_ALIGNMENT
+#define FRAMEBUFFER_ALIGNMENT    OMV_CACHE_LINE_SIZE
 #endif
 
-typedef struct framebuffer {
-    int32_t x, y;
-    int32_t w, h;
-    int32_t u, v;
-    PIXFORMAT_STRUCT;
-    uint32_t raw_size;
-    uint32_t buff_size;
-    uint32_t n_buffers;
-    uint32_t frame_size;
-    int32_t head;
-    volatile int32_t tail;
-    bool check_head;
-    int32_t sampled_head;
-    bool dynamic;
-    OMV_ATTR_ALIGNED(uint8_t data[], FRAMEBUFFER_ALIGNMENT);
-} framebuffer_t;
+// TODO these should just be removed.
+#define framebuffer_get_width(fb)   (fb->w)
+#define framebuffer_get_height(fb)  (fb->h)
+#define framebuffer_get_depth(fb)   (fb->bpp)
+#define framebuffer_get_buffer_size(fb) (fb->buf_size)
 
+// If FB_FLAG_CHECK_LAST is set and this is the last buffer in
+// the free queue the release logic depends on the buffer mode:
+//
+// - Single/FIFO: The buffer is released.
+// - Double buffer: The buffer is not released.
+// - Triple buffer: The last used buffer is released first.
 typedef enum {
-    FB_NO_FLAGS   = (0 << 0),
-    FB_PEEK       = (1 << 0),   // If set, will not move the head/tail.
-    FB_INVALIDATE = (1 << 1),   // If set, invalidate the buffer on return.
+    FB_FLAG_NONE        = (1 << 0), // No special flags.
+    FB_FLAG_USED        = (1 << 1), // Acquire from used / Release to free.
+    FB_FLAG_FREE        = (1 << 2), // Acquire from free / Release to used.
+    FB_FLAG_PEEK        = (1 << 3), // Acquire a buffer and keep it in the queue.
+    FB_FLAG_CHECK_LAST  = (1 << 6), // Check if last buffer before releasing.
+    FB_FLAG_INVALIDATE  = (1 << 7), // Invalidate buffer when acquired/released.
 } framebuffer_flags_t;
 
+// The frame buffer memory is used for the following:
+//
+// - Buffer queues: If the number of video buffers exceeds 3.
+// - Video buffers: Consisting of a header followed by the buffer.
+// - Unused memory: Available for buffer expansion or fb_alloc.
+// - fb_alloc memory: Only for statically allocated frame buffers.
+//
+//              Dynamic Frame Buffer Memory Layout
+// raw_base      pool_start               pool_end        raw_end
+// ▼             ▼                        ▼                     ▼
+// ┌────────────────────────────────────────────────────────────┐
+// │ Queues¹ |    Frame Buffers Memory    |  Unused FB Memory²  │
+// └────────────────────────────────────────────────────────────┘
+//
+// For static frame buffers, fb_alloc uses a fixed end region and
+// may use the free space for transient allocations if available.
+//
+//              Static Frame Buffer Memory Layout
+// fb_start  pool_start  pool_end   fb_alloc_sp      fb_alloc_end
+// ▼         ▼           ▼          ▼                           ▼
+// ┌────────────────────────────────────────────────────────────┐
+// │ Queues¹ |  Buffers  | Unused FB Memory² |  Fixed FB Alloc  │
+// └────────────────────────────────────────────────────────────┘
+// ¹ Queues use frame buffer memory only if count > 3, otherwise
+//   they're statically allocated to keep small buffers in SRAM.
+//
+// ² Unused frame buffer space can be used to expand buffers up
+//   to the maximum available size (raw size minus queue size).
+typedef struct framebuffer {
+    int32_t x, y, w, h, u, v;
+    PIXFORMAT_STRUCT;
+    bool dynamic;       // Dynamically allocated or not.
+    bool expanded;      // True if buffers were expanded.
+    size_t raw_size;    // Raw buffer size and address.
+    char *raw_base;
+    size_t buf_size;    // Buffers size and count
+    size_t buf_count;
+    size_t frame_size;  // Actual frame size
+    queue_t *used_queue;
+    queue_t *free_queue;
+    // Static memory for small queues.
+    char raw_static[queue_calc_size(3) * 2];
+} framebuffer_t;
+
+// Drivers can add more flags:
+// VB_FLAG_EXAMPLE1  (VB_FLAG_LAST << 0)
+// VB_FLAG_EXAMPLE2  (VB_FLAG_LAST << 1)
+typedef enum {
+    VB_FLAG_NONE        = (1 << 0),
+    VB_FLAG_USED        = (1 << 1),
+    VB_FLAG_OVERFLOW    = (1 << 2),
+    VB_FLAG_LAST        = (1 << 3),
+} vbuffer_flags_t;
+
 typedef struct vbuffer {
-    // Used by snapshot code to figure out the jpeg size (bpp).
-    int32_t offset;
-    bool jpeg_buffer_overflow;
-    // Used internally by frame buffer code.
-    volatile bool waiting_for_data;
-    bool reset_state;
-    // Image data array.
-    OMV_ATTR_ALIGNED(uint8_t data[], FRAMEBUFFER_ALIGNMENT);
+    int32_t offset;     // Write offset into the buffer (used by some drivers).
+    uint32_t flags;     // Flags, see above.
+    OMV_ATTR_ALIGNED(uint8_t data[], FRAMEBUFFER_ALIGNMENT);    // Data.
 } vbuffer_t;
 
 typedef struct jpegbuffer {
@@ -76,33 +121,14 @@ typedef struct jpegbuffer {
     int32_t size;
     int32_t enabled;
     int32_t quality;
+    uint8_t *pixels;
     omv_mutex_t lock;
-    OMV_ATTR_ALIGNED(uint8_t pixels[], FRAMEBUFFER_ALIGNMENT);
 } jpegbuffer_t;
-
-extern jpegbuffer_t *jpegbuffer;
 
 void framebuffer_init0();
 
-framebuffer_t *framebuffer_get(size_t id);
-
-int32_t framebuffer_get_x(framebuffer_t *fb);
-int32_t framebuffer_get_y(framebuffer_t *fb);
-int32_t framebuffer_get_u(framebuffer_t *fb);
-int32_t framebuffer_get_v(framebuffer_t *fb);
-
-int32_t framebuffer_get_width(framebuffer_t *fb);
-int32_t framebuffer_get_height(framebuffer_t *fb);
-int32_t framebuffer_get_depth(framebuffer_t *fb);
-
-// Return the number of bytes in the current buffer.
-uint32_t framebuffer_get_buffer_size(framebuffer_t *fb);
-
-// Return the state of a buffer.
-vbuffer_t *framebuffer_get_buffer(framebuffer_t *fb, int32_t index);
-
 // Initializes a frame buffer instance.
-void framebuffer_init_fb(framebuffer_t *fb, size_t size, bool dynamic);
+void framebuffer_init(framebuffer_t *fb, void *buff, size_t size, bool dynamic);
 
 // Initializes an image from the frame buffer.
 void framebuffer_init_image(framebuffer_t *fb, image_t *img);
@@ -110,38 +136,46 @@ void framebuffer_init_image(framebuffer_t *fb, image_t *img);
 // Sets the frame buffer from an image.
 void framebuffer_init_from_image(framebuffer_t *fb, image_t *img);
 
-// Compress src image to the JPEG buffer if src is mutable, otherwise copy src to the JPEG buffer
-// if the src is JPEG and fits in the JPEG buffer, or encode and stream src image to the IDE if not.
-void framebuffer_update_jpeg_buffer(image_t *src);
-
-// Clear the framebuffer FIFO. If fifo_flush is true, reset and discard all framebuffers,
-// otherwise, retain the last frame in the fifo.
-void framebuffer_flush_buffers(framebuffer_t *fb, bool fifo_flush);
-
-// Set the number of virtual buffers in the frame buffer.
-// If n_buffers = -1 the number of virtual buffers will be set to 3 each  if possible.
-// If n_buffers = 1 the whole framebuffer is used. In this case, `frame_size` is ignored.
-int framebuffer_set_buffers(framebuffer_t *fb, int32_t n_buffers);
-
-// Call when done with the current vbuffer to mark it as free.
-void framebuffer_free_current_buffer(framebuffer_t *fb);
-
-// Call to do any heavy setup before frame capture.
-void framebuffer_setup_buffers(framebuffer_t *fb);
-
-// Sets the current frame buffer to the latest virtual frame buffer.
-// Returns the buffer if it is ready or NULL if not...
-// Pass FB_PEEK to get the next buffer but not take it.
-vbuffer_t *framebuffer_get_head(framebuffer_t *fb, framebuffer_flags_t flags);
-
-// Return the next vbuffer to store image data to or NULL if none.
-// Pass FB_PEEK to get the next buffer but not commit it.
-vbuffer_t *framebuffer_get_tail(framebuffer_t *fb, framebuffer_flags_t flags);
+// Return the static frame buffer instance.
+framebuffer_t *framebuffer_get(size_t id);
 
 // Returns a pointer to the end of the framebuffer(s).
-char *framebuffer_get_buffers_end(framebuffer_t *fb);
+char *framebuffer_pool_end(framebuffer_t *fb);
+
+// Clear the framebuffer FIFO.
+void framebuffer_flush(framebuffer_t *fb);
+
+// Change the number of buffers in the frame buffer.
+// If expand is true, the buffer size will expand to use all of the
+// available memory, otherwise it will equal the current frame size.
+int framebuffer_resize(framebuffer_t *fb, size_t count, bool expand);
+
+// Return true if free queue is not empty.
+bool framebuffer_writable(framebuffer_t *fb);
+
+// Return true if used queue is not empty.
+bool framebuffer_readable(framebuffer_t *fb);
+
+// FB_FLAG_USED: acquire buffer from used queue.
+// FB_FLAG_FREE: acquire buffer from free queue.
+vbuffer_t *framebuffer_acquire(framebuffer_t *fb, uint32_t flags);
+
+// FB_FLAG_USED: release buffer from used queue.
+// FB_FLAG_FREE: release buffer from free queue.
+// Note: Returns NULL if the buffer was Not released.
+vbuffer_t *framebuffer_release(framebuffer_t *fb, uint32_t flags);
+
+// Reset a vbuffer state.
+static inline void framebuffer_reset(vbuffer_t *buffer) {
+    memset(buffer, 0, offsetof(vbuffer_t, data));
+}
+
+// Compress src image to the JPEG buffer if src is mutable,
+// otherwise copy src to the JPEG buffer.
+void framebuffer_update_jpeg_buffer(image_t *src);
 
 // Use this macro to get a pointer to the JPEG buffer.
-#define JPEG_FB()    (jpegbuffer)
+extern jpegbuffer_t jpegbuffer;
+#define JPEG_FB()   (&jpegbuffer)
 
 #endif /* __FRAMEBUFFER_H__ */

--- a/modules/py_csi.c
+++ b/modules/py_csi.c
@@ -211,7 +211,7 @@ static mp_obj_t py_omv_csi_get_fb() {
     image_t image;
     omv_csi_t *csi = omv_csi_get(-1);
 
-    if (framebuffer_get_depth(csi->fb) < 0) {
+    if (csi->fb->bpp < 0) {
         return mp_const_none;
     }
 
@@ -229,7 +229,8 @@ static MP_DEFINE_CONST_FUN_OBJ_0(py_omv_csi_get_id_obj, py_omv_csi_get_id);
 static mp_obj_t py_omv_csi_get_frame_available() {
     omv_csi_t *csi = omv_csi_get(-1);
     framebuffer_t *fb = csi->fb;
-    return mp_obj_new_bool(fb->tail != fb->head);
+
+    return mp_obj_new_bool(framebuffer_readable(fb));
 }
 static MP_DEFINE_CONST_FUN_OBJ_0(py_omv_csi_get_frame_available_obj, py_omv_csi_get_frame_available);
 
@@ -378,10 +379,10 @@ static mp_obj_t py_omv_csi_get_windowing() {
         omv_csi_raise_error(OMV_CSI_ERROR_INVALID_FRAMESIZE);
     }
 
-    return mp_obj_new_tuple(4, (mp_obj_t []) {mp_obj_new_int(framebuffer_get_x(csi->fb)),
-                                              mp_obj_new_int(framebuffer_get_y(csi->fb)),
-                                              mp_obj_new_int(framebuffer_get_u(csi->fb)),
-                                              mp_obj_new_int(framebuffer_get_v(csi->fb))});
+    return mp_obj_new_tuple(4, (mp_obj_t []) {mp_obj_new_int(csi->fb->x),
+                                              mp_obj_new_int(csi->fb->y),
+                                              mp_obj_new_int(csi->fb->u),
+                                              mp_obj_new_int(csi->fb->v)});
 }
 static MP_DEFINE_CONST_FUN_OBJ_0(py_omv_csi_get_windowing_obj, py_omv_csi_get_windowing);
 
@@ -704,7 +705,7 @@ static mp_obj_t py_omv_csi_set_framebuffers(mp_obj_t count) {
     omv_csi_t *csi = omv_csi_get(-1);
     mp_int_t c = mp_obj_get_int(count);
 
-    if (c == csi->fb->n_buffers) {
+    if (c == csi->fb->buf_count) {
         return mp_const_none;
     }
 
@@ -712,7 +713,7 @@ static mp_obj_t py_omv_csi_set_framebuffers(mp_obj_t count) {
         omv_csi_raise_error(OMV_CSI_ERROR_INVALID_ARGUMENT);
     }
 
-    int error = omv_csi_set_framebuffers(csi, c);
+    int error = omv_csi_set_framebuffers(csi, c, false);
     if (error != 0) {
         omv_csi_raise_error(error);
     }
@@ -723,7 +724,7 @@ static MP_DEFINE_CONST_FUN_OBJ_1(py_omv_csi_set_framebuffers_obj, py_omv_csi_set
 
 static mp_obj_t py_omv_csi_get_framebuffers() {
     omv_csi_t *csi = omv_csi_get(-1);
-    return mp_obj_new_int(csi->fb->n_buffers);
+    return mp_obj_new_int(csi->fb->buf_count);
 }
 static MP_DEFINE_CONST_FUN_OBJ_0(py_omv_csi_get_framebuffers_obj, py_omv_csi_get_framebuffers);
 

--- a/modules/py_csi_ng.c
+++ b/modules/py_csi_ng.c
@@ -62,7 +62,6 @@ typedef struct _py_csi_obj_t {
     omv_csi_t *csi;
     mp_obj_t vsync_cb;
     mp_obj_t frame_cb;
-    framebuffer_t *fb; // Track dynamically allocated FBs.
 } py_csi_obj_t;
 
 const mp_obj_type_t py_csi_type;
@@ -123,7 +122,6 @@ static mp_obj_t py_csi_deinit(mp_obj_t self_in) {
 
     // Reset FB pointer (realloc'd in make_new).
     if (self->csi->fb->dynamic) {
-        self->fb = NULL;
         self->csi->fb = NULL;
     }
 
@@ -284,8 +282,9 @@ static MP_DEFINE_CONST_FUN_OBJ_1(py_csi_cid_obj, py_csi_cid);
 
 static mp_obj_t py_csi_readable(mp_obj_t self_in) {
     py_csi_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    vbuffer_t *head = framebuffer_get_head(self->csi->fb, FB_PEEK);
-    return mp_obj_new_bool(head != NULL);
+    framebuffer_t *fb = self->csi->fb;
+
+    return mp_obj_new_bool(framebuffer_readable(fb));
 }
 static MP_DEFINE_CONST_FUN_OBJ_1(py_csi_readable_obj, py_csi_readable);
 
@@ -355,10 +354,10 @@ static mp_obj_t py_csi_window(size_t n_args, const mp_obj_t *args) {
     }
 
     if (n_args == 1) {
-        return mp_obj_new_tuple(4, (mp_obj_t []) {mp_obj_new_int(framebuffer_get_x(self->csi->fb)),
-                                                  mp_obj_new_int(framebuffer_get_y(self->csi->fb)),
-                                                  mp_obj_new_int(framebuffer_get_u(self->csi->fb)),
-                                                  mp_obj_new_int(framebuffer_get_v(self->csi->fb))});
+        return mp_obj_new_tuple(4, (mp_obj_t []) {mp_obj_new_int(self->csi->fb->x),
+                                                  mp_obj_new_int(self->csi->fb->y),
+                                                  mp_obj_new_int(self->csi->fb->u),
+                                                  mp_obj_new_int(self->csi->fb->v)});
     }
 
     mp_obj_t *array;
@@ -750,19 +749,26 @@ static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(py_csi_auto_rotation_obj, 1, 2, py_cs
 static mp_obj_t py_csi_framebuffers(size_t n_args, const mp_obj_t *args) {
     py_csi_obj_t *self = MP_OBJ_TO_PTR(args[0]);
     framebuffer_t *fb = self->csi->fb;
+    bool expand = false;
 
     if (n_args == 1) {
-        return mp_obj_new_int(fb->n_buffers);
+        return mp_obj_new_int(fb->buf_count);
     }
 
     mp_int_t num = mp_obj_get_int(args[1]);
+
+    if (n_args == 3) {
+        expand = mp_obj_is_true(args[2]);
+    }
 
     if (num < 1) {
         omv_csi_raise_error(OMV_CSI_ERROR_INVALID_ARGUMENT);
     }
 
-    if (num != fb->n_buffers) {
-        int error = omv_csi_set_framebuffers(self->csi, num);
+    // Reconfigure the FB only if changing the number
+    // of buffers or reconfiguring the memory expansion.
+    if (fb->expanded != expand || num != fb->buf_count) {
+        int error = omv_csi_set_framebuffers(self->csi, num, expand);
         if (error != 0) {
             omv_csi_raise_error(error);
         }
@@ -770,7 +776,7 @@ static mp_obj_t py_csi_framebuffers(size_t n_args, const mp_obj_t *args) {
 
     return mp_const_none;
 }
-static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(py_csi_framebuffers_obj, 1, 2, py_csi_framebuffers);
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(py_csi_framebuffers_obj, 1, 3, py_csi_framebuffers);
 
 static mp_obj_t py_csi_special_effect(mp_obj_t self_in, mp_obj_t sde) {
     py_csi_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -1281,9 +1287,8 @@ mp_obj_t py_csi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, 
 
     if (csi->fb == NULL) {
         size_t fb_size = args[ARG_fb_size].u_int;
-        csi->fb = (framebuffer_t *) m_new(uint8_t, fb_size + sizeof(framebuffer_t));
-        framebuffer_init_fb(csi->fb, fb_size, true);
-        self->fb = csi->fb; // Track GC heap alloc
+        csi->fb = (framebuffer_t *) m_malloc(sizeof(framebuffer_t));
+        framebuffer_init(csi->fb, m_malloc(fb_size), fb_size, true);
     }
     
     #if MICROPY_PY_IMU

--- a/modules/py_csi_ng.c
+++ b/modules/py_csi_ng.c
@@ -1300,6 +1300,35 @@ mp_obj_t py_csi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, 
     return MP_OBJ_FROM_PTR(self);
 }
 
+static void py_csi_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    py_csi_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    omv_csi_t *csi = self->csi;
+
+    mp_printf(print, "CSI {\n");
+    mp_printf(print, "  Name                : %s\n", omv_csi_name(csi));
+    mp_printf(print, "  Chip ID             : 0x%04X\n", csi->chip_id);
+    mp_printf(print, "  Address             : 0x%02X\n", csi->slv_addr);
+    mp_printf(print, "  Powered On          : %s\n", csi->power_on ? "true" : "false");
+    mp_printf(print, "  Auxiliary           : %s\n", csi->auxiliary ? "true" : "false");
+    mp_printf(print, "  Raw Output          : %s\n", csi->raw_output ? "true" : "false");
+    if (csi->mipi_if) {
+        mp_printf(print, "  MIPI Bitrate        : %uMbps\n", csi->mipi_brate);
+    }
+    mp_printf(print, "  Frame Rate          : %d\n", csi->framerate);
+    mp_printf(print, "  Clock Frequency     : %luMHz\n", csi->clk_hz / 1000000);
+    mp_printf(print, "  Framebuffer {\n");
+    mp_printf(print, "    Dynamic           : %s\n", csi->fb->dynamic ? "true" : "false");
+    mp_printf(print, "    Expanded          : %s\n", csi->fb->expanded ? "true" : "false");
+    mp_printf(print, "    Raw Buffer Size   : %u\n", (unsigned) csi->fb->raw_size);
+    mp_printf(print, "    Raw Buffer Addr   : 0x%p\n", csi->fb->raw_base);
+    mp_printf(print, "    Frame Size        : %u\n", (unsigned) csi->fb->frame_size);
+    mp_printf(print, "    Vbuffer Size      : %u\n", (unsigned) csi->fb->buf_size);
+    mp_printf(print, "    Vbuffer Count     : %u\n", (unsigned) csi->fb->buf_count);
+    mp_printf(print, "    Used Queue Size   : %u\n", queue_size(csi->fb->used_queue));
+    mp_printf(print, "    Free Queue Size   : %u\n", queue_size(csi->fb->free_queue));
+    mp_printf(print, "  }\n}\n");
+}
+
 static const mp_rom_map_elem_t py_csi_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),            MP_ROM_QSTR(MP_QSTR_CSI) },
     { MP_ROM_QSTR(MP_QSTR___del__),             MP_ROM_PTR(&py_csi_deinit_obj) },
@@ -1351,6 +1380,7 @@ MP_DEFINE_CONST_OBJ_TYPE(
     MP_QSTR_CSI,
     MP_TYPE_FLAG_NONE,
     make_new, py_csi_make_new,
+    print, py_csi_print,
     locals_dict, &py_csi_locals_dict
     );
 

--- a/ports/alif/alif.mk
+++ b/ports/alif/alif.mk
@@ -92,10 +92,11 @@ CLANG_FLAGS = -fshort-enums \
               -DALIF_CMSIS_H=$(CMSIS_MCU_H) \
               $(filter-out -march% -fdisable-rtl%,$(CFLAGS))
 
-OMV_CFLAGS += -I$(TOP_DIR)/$(OMV_DIR)/$(COMMON_DIR)
-OMV_CFLAGS += -I$(TOP_DIR)/$(OMV_DIR)/modules/
-OMV_CFLAGS += -I$(TOP_DIR)/$(OMV_DIR)/ports/$(PORT)/
-OMV_CFLAGS += -I$(TOP_DIR)/$(OMV_DIR)/ports/$(PORT)/modules/
+OMV_CFLAGS += -I$(TOP_DIR)
+OMV_CFLAGS += -I$(TOP_DIR)/$(COMMON_DIR)
+OMV_CFLAGS += -I$(TOP_DIR)/modules/
+OMV_CFLAGS += -I$(TOP_DIR)/ports/$(PORT)/
+OMV_CFLAGS += -I$(TOP_DIR)/ports/$(PORT)/modules/
 OMV_CFLAGS += -I$(OMV_BOARD_CONFIG_DIR)
 
 MPY_CFLAGS += -I$(MP_BOARD_CONFIG_DIR)

--- a/ports/mimxrt/omv_portconfig.mk
+++ b/ports/mimxrt/omv_portconfig.mk
@@ -31,7 +31,7 @@ ROMFS_IMAGE := $(FW_DIR)/romfs.stamp
 ROMFS_CONFIG := $(OMV_BOARD_CONFIG_DIR)/romfs.json
 
 # Compiler Flags
-CFLAGS += -std=gnu99 \
+CFLAGS += -std=gnu11 \
           -Wall \
           -Werror \
           -Warray-bounds \
@@ -83,6 +83,7 @@ LDFLAGS = -mthumb \
           -Wl,-T$(BUILD)/$(LDSCRIPT).lds \
           -Wl,-Map=$(BUILD)/$(FIRMWARE).map
 
+OMV_CFLAGS += -I$(TOP_DIR)
 OMV_CFLAGS += -I$(TOP_DIR)/$(COMMON_DIR)
 OMV_CFLAGS += -I$(TOP_DIR)/modules
 OMV_CFLAGS += -I$(TOP_DIR)/ports/$(PORT)

--- a/ports/nrf/omv_portconfig.mk
+++ b/ports/nrf/omv_portconfig.mk
@@ -72,6 +72,7 @@ LDFLAGS = -mcpu=$(CPU) \
           -Wl,-Map=$(BUILD)/$(FIRMWARE).map \
           -Wl,-T$(BUILD)/$(LDSCRIPT).lds
 
+OMV_CFLAGS += -I$(TOP_DIR)
 OMV_CFLAGS += -I$(TOP_DIR)/$(COMMON_DIR)
 OMV_CFLAGS += -I$(TOP_DIR)/modules
 OMV_CFLAGS += -I$(TOP_DIR)/ports/$(PORT)

--- a/ports/rp2/omv_portconfig.cmake
+++ b/ports/rp2/omv_portconfig.cmake
@@ -122,6 +122,7 @@ target_sources(${MICROPY_TARGET} PRIVATE
     ${TOP_DIR}/common/umm_malloc.c
     ${TOP_DIR}/common/dma_alloc.c
     ${TOP_DIR}/common/unaligned_memcpy.c
+    ${TOP_DIR}/common/queue.c
 
     ${TOP_DIR}/drivers/sensors/ov2640.c
     ${TOP_DIR}/drivers/sensors/ov5640.c

--- a/ports/rp2/omv_portconfig.mk
+++ b/ports/rp2/omv_portconfig.mk
@@ -28,7 +28,7 @@ export CXX=
 
 # Note this overrides USER_C_MODULES.
 MPY_MKARGS += BOARD=$(TARGET) BUILD=$(BUILD)/rp2 USER_C_MODULES="" \
-              OMV_CMAKE=$(TOP_DIR)/$(OMV_DIR)/ports/$(PORT)/omv_portconfig.cmake
+              OMV_CMAKE=$(TOP_DIR)/ports/$(PORT)/omv_portconfig.cmake
 
 ###################################################
 all: $(OPENMV)


### PR DESCRIPTION
The main motivation for this work is to fix the FB double buffer issue, and possible race condition in triple buffer mode. However, as an added bonus, this also offers some optimization, code safety, new features and major cleanups.

---

* The frame buffer now uses two queues to manage the buffers: a free queue and a read queue. It juggles buffers between queues based on the operation and flags. The frame buffer code has been simplified a lot, since much of the complexity has been pushed out to the new queue component. It is also much more flexible now. For example, we could add a third queue if needed, or check the queue sizes and so on.

* The new SPSC lock-free queue component uses standard atomics and acquire and release semantics to ensure there are no issues with reordering by either the CPU or the compiler on current or future platforms. It is also generic enough to be used by other code and flexible enough to be allocated either dynamically using malloc or from a preallocated memory chunk.

* The frame buffer and JPEG buffer headers have been decoupled from their raw buffer memory and placed in SRAM. Additionally, when using three buffers or fewer, the new frame buffer queues are also placed in SRAM. Before this change, accessing fb->head, fb->tail, fb->buf_size, fb->w, etc. would all trigger DRAM accesses unless cached, but even then they could be evicted and accessed from DRAM again. Hopefully, this improves DRAM bandwidth usage, even on older cameras. I don’t know why I didn’t fix this earlier, I think it started with legacy cameras that lacked DRAM and just stayed that way. 

* 1, 2, 3 and N buffers all work, see tests below. Also, the FPS of the 2 buffers is now the same as the 3 buffers, just as expected. Furthermore, buffer expansion is supported on static and dynamic frame buffers. It's also possible to expand a single buffer or multiple buffers to use all the remaining FB memory (minus any fb_alloc'd memory, in the case of static frame buffers).

---

### Tests:

* Tested single, dual, triple CSIs with FLIR/VOSPI.
* Tested buffer expansion on static/dynamic FB with/without fb_alloc.
* Tested copy_to_fb by loading images.
* Tested on N6, 4P, RT1060.

### Frame buffer usage tests:

The following tests cover all cases. There's a 500ms delay after snapshot to see if the fb/queues behave as expected. For single and FIFO the capture stops. For 2 buffers, the producer holds on to the second buffer until the first one is released. Finally, for triple buffer mode, the producer alternates between the two free buffers.

```
// One buffer, stops.
snapshot buffer 0x91900020
next buffer 0x0

// 2 buffers:
snapshot buffer 0x91925840
next buffer 0x91900000

// 3 buffers:
snapshot buffer 0x9194b060
next buffer 0x91900000
next buffer 0x91925820
next buffer 0x91900000
next buffer 0x91925820

// > 3 buffers:
snapshot buffer 0x91900060
next buffer 0x91925860
next buffer 0x9194b080
next buffer 0x919708a0
next buffer 0x0
```