### PR TITLE
boards: Add fixed sensor polarity configs.

### DIFF
--- a/boards/OPENMV2/omv_boardconfig.h
+++ b/boards/OPENMV2/omv_boardconfig.h
@@ -165,6 +165,8 @@
 #define OMV_CSI_RESET_PIN                     (&omv_pin_A10_GPIO)
 #define OMV_CSI_POWER_PIN                     (&omv_pin_B5_GPIO)
 
+#define OMV_CSI_POLARITY_CONFIG               { OMV_CSI_ACTIVE_HIGH, OMV_CSI_ACTIVE_LOW }
+
 // Physical I2C buses.
 
 // I2C bus 1

--- a/boards/OPENMV3/omv_boardconfig.h
+++ b/boards/OPENMV3/omv_boardconfig.h
@@ -165,6 +165,8 @@
 #define OMV_CSI_RESET_PIN                     (&omv_pin_A10_GPIO)
 #define OMV_CSI_POWER_PIN                     (&omv_pin_B5_GPIO)
 
+#define OMV_CSI_POLARITY_CONFIG               { OMV_CSI_ACTIVE_HIGH, OMV_CSI_ACTIVE_LOW }
+
 // Physical I2C buses.
 
 // I2C bus 1

--- a/boards/OPENMV_AE3/omv_boardconfig.h
+++ b/boards/OPENMV_AE3/omv_boardconfig.h
@@ -290,6 +290,8 @@ extern unsigned char OMV_BOARD_UID_ADDR[12];    // Unique address.
 #define OMV_CSI_RESET_PIN               (&omv_pin_CSI_RESET)
 #define OMV_CSI_POWER_PIN               (&omv_pin_CSI_POWER)
 
+#define OMV_CSI_POLARITY_CONFIG         { OMV_CSI_ACTIVE_LOW, OMV_CSI_ACTIVE_LOW }
+
 #define OMV_WL_POWER_PIN                (&omv_pin_WL_REG_ON)
 #define OMV_BT_POWER_PIN                (&omv_pin_BT_REG_ON)
 


### PR DESCRIPTION
Did the polarity audit. Here are the results:

```
{ OMV_CSI_ACTIVE_HIGH, OMV_CSI_ACTIVE_HIGH },
{ OMV_CSI_ACTIVE_HIGH, OMV_CSI_ACTIVE_LOW },
{ OMV_CSI_ACTIVE_LOW,  OMV_CSI_ACTIVE_HIGH },
{ OMV_CSI_ACTIVE_LOW,  OMV_CSI_ACTIVE_LOW },
```

-> Current,  all sensors work

```
{ OMV_CSI_ACTIVE_HIGH, OMV_CSI_ACTIVE_LOW },
{ OMV_CSI_ACTIVE_HIGH, OMV_CSI_ACTIVE_HIGH },
{ OMV_CSI_ACTIVE_LOW,  OMV_CSI_ACTIVE_LOW },
{ OMV_CSI_ACTIVE_LOW,  OMV_CSI_ACTIVE_HIGH },
```

Lepton1/Lepton3 work
MT9M114/MT9V034 works
PAG7920/PAJ6100 work
OV7725 works
OV2640/OV5640 work
GENX320 works
BOSON works
PAG7936 works
PS5520 works

all sensors work with this config too

```
{ OMV_CSI_ACTIVE_LOW,  OMV_CSI_ACTIVE_LOW },
{ OMV_CSI_ACTIVE_LOW,  OMV_CSI_ACTIVE_HIGH },
{ OMV_CSI_ACTIVE_HIGH, OMV_CSI_ACTIVE_LOW },
{ OMV_CSI_ACTIVE_HIGH, OMV_CSI_ACTIVE_HIGH },
```

BOSON causes camera panic!!! Guess sensor is never found.
GENX320 image is blank!!! Streams but no image.
OV2640/OV5640 work
OV7725 works
PAG7920/PAJ6100 work
MT9V034 snapshot timeout!!! Doesn't stream, but sensor is found.
MT9M114 works
Lepton1/Lepton3 work
PAG7936 works
PS5520 works

```
{ OMV_CSI_ACTIVE_LOW,  OMV_CSI_ACTIVE_HIGH },
{ OMV_CSI_ACTIVE_LOW,  OMV_CSI_ACTIVE_LOW },
{ OMV_CSI_ACTIVE_HIGH, OMV_CSI_ACTIVE_HIGH },
{ OMV_CSI_ACTIVE_HIGH, OMV_CSI_ACTIVE_LOW },
```

Lepton1/Lepton3 work
MT9M114 works
MT9V034 snapshot timeout!!! Doesn't stream, but sensor is found.
PAG7920/PAJ6100 work
OV7725 works
OV2640/OV5640 work
GENX320 image is blank!!! Streams but no image.
BOSON causes camera panic!!! Guess sensor is never found.
PAG7936 works
PS5520 works

...

Summary, it appears any of the modes that start off with PWDN active low cause an issue. For the MT9V034 and GENX320 it appears the wrong polarity of PWDN is locked in as these sensors respond to I2C traffic when powered down. For the BOSON, changing the polarity order just causes enumeration issues.

...

This PR contains the correct polarity settings for our other cameras with a fixed sensor loadout.


