### PR TITLE
ports: Add GPU matrix support.

### DIFF
--- a/common/omv_gpu.h
+++ b/common/omv_gpu.h
@@ -50,5 +50,6 @@ int omv_gpu_draw_image(image_t *src_img,
                        int alpha,
                        const uint16_t *color_palette,
                        const uint8_t *alpha_palette,
-                       image_hint_t hint);
+                       image_hint_t hint,
+                       float *transform);
 #endif // __OMV_GPU_H__

--- a/drivers/sensors/lepton.c
+++ b/drivers/sensors/lepton.c
@@ -484,7 +484,7 @@ static int snapshot(omv_csi_t *csi, image_t *image, uint32_t flags) {
     imlib_draw_image(&fb_image, &temp, 0, 0, 1.0f, 1.0f, NULL, -1, 255,
                      (csi->pixformat == PIXFORMAT_RGB565) ? csi->color_palette : NULL, NULL,
                      IMAGE_HINT_BILINEAR | IMAGE_HINT_CENTER | IMAGE_HINT_SCALE_ASPECT_EXPAND,
-                     NULL, NULL, NULL);
+                     NULL, NULL, NULL, NULL);
 
     fb_alloc_free_till_mark();
     framebuffer_init_image(fb, image);

--- a/lib/imlib/apriltag.c
+++ b/lib/imlib/apriltag.c
@@ -11995,7 +11995,7 @@ void imlib_find_apriltags(list_t *out, image_t *ptr, rectangle_t *roi, apriltag_
     img.h = roi->h;
     img.pixfmt = PIXFORMAT_GRAYSCALE;
     img.data = fb_alloc(image_size(&img), FB_ALLOC_NO_HINT);
-    imlib_draw_image(&img, ptr, 0, 0, 1.f, 1.f, roi, -1, 255, NULL, NULL, 0, NULL, NULL, NULL);
+    imlib_draw_image(&img, ptr, 0, 0, 1.f, 1.f, roi, -1, 255, NULL, NULL, 0, NULL, NULL, NULL, NULL);
 
     image_u8_t im;
     im.width = roi->w;
@@ -12111,7 +12111,7 @@ void imlib_find_rects(list_t *out, image_t *ptr, rectangle_t *roi, uint32_t thre
     img.h = roi->h;
     img.pixfmt = PIXFORMAT_GRAYSCALE;
     img.data = fb_alloc(image_size(&img), FB_ALLOC_NO_HINT);
-    imlib_draw_image(&img, ptr, 0, 0, 1.f, 1.f, roi, -1, 255, NULL, NULL, 0, NULL, NULL, NULL);
+    imlib_draw_image(&img, ptr, 0, 0, 1.f, 1.f, roi, -1, 255, NULL, NULL, 0, NULL, NULL, NULL, NULL);
 
     image_u8_t im;
     im.width = roi->w;

--- a/lib/imlib/binary.c
+++ b/lib/imlib/binary.c
@@ -200,7 +200,8 @@ void imlib_binary(image_t *out, image_t *img, list_t *thresholds, bool invert, b
         dst_row_override = fb_alloc0(image_line_size(out), FB_ALLOC_CACHE_ALIGN);
     }
 
-    imlib_draw_image(out, &bmp, 0, 0, 1.0f, 1.0f, NULL, -1, 255, NULL, NULL, 0, callback, mask, dst_row_override);
+    imlib_draw_image(out, &bmp, 0, 0, 1.0f, 1.0f, NULL, -1, 255, NULL, NULL, 0,
+                     NULL, callback, mask, dst_row_override);
 
     if (dst_row_override) {
         fb_free(); // dst_row_override
@@ -1256,7 +1257,7 @@ static void imlib_hat(image_t *img, int ksize, int threshold, image_t *mask, bin
     op(&temp, ksize, threshold, mask);
     void *dst_row_override = fb_alloc0(image_line_size(img), FB_ALLOC_CACHE_ALIGN);
     imlib_draw_image(img, &temp, 0, 0, 1.0f, 1.0f, NULL, -1, 255, NULL, NULL, 0,
-                     imlib_difference_line_op, mask, dst_row_override);
+                     NULL, imlib_difference_line_op, mask, dst_row_override);
     fb_free(); // dst_row_override
     fb_free(); // temp.data
 }

--- a/lib/imlib/dmtx.c
+++ b/lib/imlib/dmtx.c
@@ -6016,7 +6016,7 @@ void imlib_find_datamatrices(list_t *out, image_t *ptr, rectangle_t *roi, int ef
         img.h = roi->h;
         img.pixfmt = PIXFORMAT_GRAYSCALE;
         img.data = grayscale_image;
-        imlib_draw_image(&img, ptr, 0, 0, 1.f, 1.f, roi, -1, 255, NULL, NULL, 0, NULL, NULL, NULL);
+        imlib_draw_image(&img, ptr, 0, 0, 1.f, 1.f, roi, -1, 255, NULL, NULL, 0, NULL, NULL, NULL, NULL);
     }
 
     umm_init_x(fb_avail());

--- a/lib/imlib/draw.c
+++ b/lib/imlib/draw.c
@@ -3056,7 +3056,7 @@ void imlib_draw_image(image_t *dst_img,
                                  (hint & (IMAGE_HINT_BILINEAR | IMAGE_HINT_BLACK_BACKGROUND));
 
         if (!omv_gpu_draw_image(src_img, &src_rect, dst_img, &dst_rect,
-                                alpha, color_palette, alpha_palette, gpu_hints)) {
+                                alpha, color_palette, alpha_palette, gpu_hints, NULL)) {
             goto exit_cleanup;
         }
     }

--- a/lib/imlib/framebuffer.c
+++ b/lib/imlib/framebuffer.c
@@ -290,8 +290,8 @@ void framebuffer_update_jpeg_buffer(image_t *src) {
                 dst.h = fast_floorf(src->h * scale);
                 if (image_size(&dst) <= max_size) {
                     imlib_draw_image(&dst, src, 0, 0, scale, scale, NULL, -1, 255, NULL, NULL,
-                                     IMAGE_HINT_BILINEAR | IMAGE_HINT_BLACK_BACKGROUND, NULL,
-                                     NULL, NULL);
+                                     IMAGE_HINT_BILINEAR | IMAGE_HINT_BLACK_BACKGROUND,
+                                     NULL, NULL, NULL, NULL);
                     compress = false;
                 }
             }

--- a/lib/imlib/imlib.h
+++ b/lib/imlib/imlib.h
@@ -1381,6 +1381,7 @@ void imlib_draw_image(image_t *dst_img,
                       const uint16_t *color_palette,
                       const uint8_t *alpha_palette,
                       image_hint_t hint,
+                      float *transform,
                       imlib_draw_row_callback_t callback,
                       void *callback_arg,
                       void *dst_row_override);

--- a/lib/imlib/lsd.c
+++ b/lib/imlib/lsd.c
@@ -2699,7 +2699,7 @@ void imlib_lsd_find_line_segments(list_t *out,
     img.h = roi->h;
     img.pixfmt = PIXFORMAT_GRAYSCALE;
     img.data = grayscale_image;
-    imlib_draw_image(&img, ptr, 0, 0, 1.f, 1.f, roi, -1, 255, NULL, NULL, 0, NULL, NULL, NULL);
+    imlib_draw_image(&img, ptr, 0, 0, 1.f, 1.f, roi, -1, 255, NULL, NULL, 0, NULL, NULL, NULL, NULL);
 
     umm_init_x(fb_avail());
 

--- a/lib/imlib/mjpeg.c
+++ b/lib/imlib/mjpeg.c
@@ -175,7 +175,7 @@ void mjpeg_write(FIL *fp, int width, int height, uint32_t *frames, uint32_t *byt
                 imlib_draw_image(&temp, img, center_x, center_y, scale, scale, roi,
                                  rgb_channel, alpha, color_palette, alpha_palette,
                                  (hint & (~IMAGE_HINT_CENTER)) | IMAGE_HINT_BLACK_BACKGROUND,
-                                 NULL, NULL, NULL);
+                                 NULL, NULL, NULL, NULL);
 
                 if (temp.w - p1.x) {
                     for (int i = p0.y; i < p1.y; i++) {

--- a/lib/imlib/qrcode.c
+++ b/lib/imlib/qrcode.c
@@ -2984,7 +2984,7 @@ void imlib_find_qrcodes(list_t *out, image_t *ptr, rectangle_t *roi)
     img.h = roi->h;
     img.pixfmt = PIXFORMAT_GRAYSCALE;
     img.data = grayscale_image;
-    imlib_draw_image(&img, ptr, 0, 0, 1.f, 1.f, roi, -1, 255, NULL, NULL, 0, NULL, NULL, NULL);
+    imlib_draw_image(&img, ptr, 0, 0, 1.f, 1.f, roi, -1, 255, NULL, NULL, 0, NULL, NULL, NULL, NULL);
 
     quirc_end(controller);
     list_init(out, sizeof(find_qrcodes_list_lnk_data_t));

--- a/lib/imlib/stats.c
+++ b/lib/imlib/stats.c
@@ -182,8 +182,8 @@ void imlib_get_similarity(image_t *img,
 
     void *dst_row_override = fb_alloc0(image_line_size(img), FB_ALLOC_CACHE_ALIGN);
     imlib_draw_image(img, other, x_start, y_start, x_scale, y_scale, roi,
-                     rgb_channel, alpha, color_palette, alpha_palette,
-                     hint, imlib_similarity_line_op, &state, dst_row_override);
+                     rgb_channel, alpha, color_palette, alpha_palette, hint,
+                     NULL, imlib_similarity_line_op, &state, dst_row_override);
 
     *avg = state.similarity_sum / blocks;
     *std = fast_sqrtf((state.similarity_sum_2 / blocks) - ((*avg) * (*avg)));

--- a/lib/imlib/zbar.c
+++ b/lib/imlib/zbar.c
@@ -8733,7 +8733,7 @@ void imlib_find_barcodes(list_t *out, image_t *ptr, rectangle_t *roi)
         img.h = roi->h;
         img.pixfmt = PIXFORMAT_GRAYSCALE;
         img.data = grayscale_image;
-        imlib_draw_image(&img, ptr, 0, 0, 1.f, 1.f, roi, -1, 255, NULL, NULL, 0, NULL, NULL, NULL);
+        imlib_draw_image(&img, ptr, 0, 0, 1.f, 1.f, roi, -1, 255, NULL, NULL, 0, NULL, NULL, NULL, NULL);
     }
 
     umm_init_x(fb_avail());

--- a/modules/py_csi_ng.c
+++ b/modules/py_csi_ng.c
@@ -224,7 +224,7 @@ static mp_obj_t py_csi_snapshot(size_t n_args, const mp_obj_t *pos_args, mp_map_
             image_t *other = py_helper_arg_to_image(args[ARG_image].u_obj, ARG_IMAGE_MUTABLE);
             fb_alloc_mark();
             imlib_draw_image(other, &image, 0, 0, 1.f, 1.f, NULL, -1, 255, NULL, NULL,
-                             IMAGE_HINT_SCALE_ASPECT_IGNORE, NULL, NULL, NULL);
+                             IMAGE_HINT_SCALE_ASPECT_IGNORE, NULL, NULL, NULL, NULL);
             fb_alloc_free_till_mark();
             return mp_const_none;
         }

--- a/modules/py_fir.c
+++ b/modules/py_fir.c
@@ -832,7 +832,7 @@ mp_obj_t py_fir_draw_ir(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_ar
 
     imlib_draw_image(dst_img, &src_img, args[ARG_x].u_int, args[ARG_y].u_int, x_scale, y_scale, &roi,
                      args[ARG_channel].u_int, args[ARG_alpha].u_int, color_palette, alpha_palette,
-                     args[ARG_hint].u_int, NULL, NULL, NULL);
+                     args[ARG_hint].u_int, NULL, NULL, NULL, NULL);
 
     fb_alloc_free_till_mark();
     return mp_const_none;
@@ -971,7 +971,8 @@ mp_obj_t py_fir_snapshot(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_a
 
     imlib_draw_image(&dst_img, &src_img, 0, 0, x_scale, y_scale, &roi,
                      args[ARG_channel].u_int, args[ARG_alpha].u_int, color_palette, alpha_palette,
-                     (args[ARG_hint].u_int & (~IMAGE_HINT_CENTER)) | IMAGE_HINT_BLACK_BACKGROUND, NULL, NULL, NULL);
+                     (args[ARG_hint].u_int & (~IMAGE_HINT_CENTER)) | IMAGE_HINT_BLACK_BACKGROUND,
+                     NULL, NULL, NULL, NULL);
 
     fb_alloc_free_till_mark();
 

--- a/modules/py_helper.h
+++ b/modules/py_helper.h
@@ -38,6 +38,7 @@ typedef enum py_helper_arg_image_flags {
 extern const mp_obj_fun_builtin_var_t py_func_unavailable_obj;
 image_t *py_helper_arg_to_image(const mp_obj_t arg, uint32_t flags);
 const void *py_helper_arg_to_palette(const mp_obj_t arg, uint32_t pixfmt);
+void *py_helper_arg_to_transform(const mp_obj_t arg);
 rectangle_t py_helper_arg_to_roi(const mp_obj_t arg, const image_t *img);
 void py_helper_arg_to_scale(const mp_obj_t arg_x_scale, const mp_obj_t arg_y_scale,
                             float *x_scale, float *y_scale);

--- a/modules/py_image.c
+++ b/modules/py_image.c
@@ -1114,7 +1114,7 @@ static mp_obj_t py_image_to(pixformat_t pixfmt, mp_rom_obj_t default_color_palet
                 temp.data = fb_alloc(image_size(&temp), FB_ALLOC_NO_HINT);
                 imlib_draw_image(&temp, src_img, 0, 0, x_scale, y_scale, &roi,
                                  args[ARG_channel].u_int, args[ARG_alpha].u_int, color_palette, alpha_palette,
-                                 args[ARG_hint].u_int, NULL, NULL, NULL);
+                                 args[ARG_hint].u_int, NULL, NULL, NULL, NULL);
             }
 
             if (((dst_img.pixfmt == PIXFORMAT_JPEG) &&
@@ -1155,7 +1155,7 @@ static mp_obj_t py_image_to(pixformat_t pixfmt, mp_rom_obj_t default_color_palet
         fb_alloc_mark();
         imlib_draw_image(&dst_img, src_img, 0, 0, x_scale, y_scale, &roi,
                          args[ARG_channel].u_int, args[ARG_alpha].u_int, color_palette, alpha_palette,
-                         args[ARG_hint].u_int, NULL, NULL, NULL);
+                         args[ARG_hint].u_int, NULL, NULL, NULL, NULL);
         fb_alloc_free_till_mark();
     }
 
@@ -1799,7 +1799,7 @@ static mp_obj_t py_image_line_op(size_t n_args, const mp_obj_t *pos_args, mp_map
 
     imlib_draw_image(image, other, args[ARG_x].u_int, args[ARG_y].u_int, x_scale, y_scale, &roi,
                      args[ARG_channel].u_int, args[ARG_alpha].u_int, color_palette, alpha_palette,
-                     args[ARG_hint].u_int, callback, mask, dst_row_override);
+                     args[ARG_hint].u_int, NULL, callback, mask, dst_row_override);
 
     fb_alloc_free_till_mark();
     return pos_args[0];

--- a/modules/py_spi_display.c
+++ b/modules/py_spi_display.c
@@ -247,7 +247,7 @@ static void spi_display_write(py_display_obj_t *self, image_t *src_img, int dst_
             // Transmits left/right parts already zeroed...
             imlib_draw_image(&dst_img, src_img, dst_x_start, dst_y_start,
                              x_scale, y_scale, roi, rgb_channel, alpha, color_palette, alpha_palette,
-                             hint | IMAGE_HINT_BLACK_BACKGROUND, spi_display_draw_image_cb, self, dst_img.data);
+                             hint | IMAGE_HINT_BLACK_BACKGROUND, NULL, spi_display_draw_image_cb, self, dst_img.data);
 
             // Zero the bottom rows
             if (p1.y < self->height) {
@@ -290,7 +290,7 @@ static void spi_display_write(py_display_obj_t *self, image_t *src_img, int dst_
 
             imlib_draw_image(&dst_img, src_img, dst_x_start, dst_y_start,
                              x_scale, y_scale, roi, rgb_channel, alpha, color_palette,
-                             alpha_palette, hint | IMAGE_HINT_BLACK_BACKGROUND, NULL, NULL, NULL);
+                             alpha_palette, hint | IMAGE_HINT_BLACK_BACKGROUND, NULL, NULL, NULL, NULL);
 
             if (self->width - p1.x) {
                 for (int i = p0.y; i < p1.y; i++) {

--- a/modules/py_tof.c
+++ b/modules/py_tof.c
@@ -479,7 +479,7 @@ mp_obj_t py_tof_draw_depth(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw
 
     imlib_draw_image(dst_img, &src_img, args[ARG_x].u_int, args[ARG_y].u_int, x_scale, y_scale, &roi,
                      args[ARG_channel].u_int, args[ARG_alpha].u_int, color_palette, alpha_palette,
-                     args[ARG_hint].u_int, NULL, NULL, NULL);
+                     args[ARG_hint].u_int, NULL, NULL, NULL, NULL);
 
     fb_alloc_free_till_mark();
     return mp_const_none;
@@ -584,7 +584,8 @@ mp_obj_t py_tof_snapshot(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_a
 
     imlib_draw_image(&dst_img, &src_img, 0, 0, x_scale, y_scale, &roi,
                      args[ARG_channel].u_int, args[ARG_alpha].u_int, color_palette, alpha_palette,
-                     (args[ARG_hint].u_int & (~IMAGE_HINT_CENTER)) | IMAGE_HINT_BLACK_BACKGROUND, NULL, NULL, NULL);
+                     (args[ARG_hint].u_int & (~IMAGE_HINT_CENTER)) | IMAGE_HINT_BLACK_BACKGROUND,
+                     NULL, NULL, NULL, NULL);
 
     fb_alloc_free_till_mark();
 

--- a/modules/py_tv.c
+++ b/modules/py_tv.c
@@ -634,7 +634,7 @@ static void spi_tv_display(image_t *src_img, int dst_x_start, int dst_y_start, f
             // Transmits left/right parts already zeroed...
             imlib_draw_image(&dst_img, src_img, dst_x_start, dst_y_start, x_scale, y_scale, roi,
                              rgb_channel, alpha, color_palette, alpha_palette, hint | IMAGE_HINT_BLACK_BACKGROUND,
-                             cb, NULL, dst_img.data);
+                             NULL, cb, NULL, dst_img.data);
 
             // Zero the bottom rows
             if (p1.y < TV_HEIGHT) {
@@ -677,7 +677,7 @@ static void spi_tv_display(image_t *src_img, int dst_x_start, int dst_y_start, f
 
                 imlib_draw_image(&dst_img, src_img, dst_x_start, dst_y_start, x_scale, y_scale, roi,
                                  rgb_channel, alpha, color_palette, alpha_palette, hint | IMAGE_HINT_BLACK_BACKGROUND,
-                                 NULL, NULL, NULL);
+                                 NULL, NULL, NULL, NULL);
 
                 if (TV_WIDTH - p1.x) {
                     for (int i = p0.y; i < p1.y; i++) {
@@ -718,7 +718,7 @@ static void spi_tv_display(image_t *src_img, int dst_x_start, int dst_y_start, f
 
                 imlib_draw_image(&dst_img, src_img, dst_x_start, dst_y_start, x_scale, y_scale, roi,
                                  rgb_channel, alpha, color_palette, alpha_palette, hint | IMAGE_HINT_BLACK_BACKGROUND,
-                                 NULL, NULL, NULL);
+                                 NULL, NULL, NULL, NULL);
 
                 if (TV_WIDTH - p1.x) {
                     for (int i = p0.y; i < p1.y; i++) {

--- a/ports/alif/omv_csi.c
+++ b/ports/alif/omv_csi.c
@@ -373,7 +373,7 @@ int alif_csi_snapshot(omv_csi_t *csi, image_t *dst_image, uint32_t flags) {
 
         rectangle_t srect = { fb->x, fb->y, fb->u, fb->v };
         rectangle_t drect = { 0, 0, fb->u, fb->v };
-        if (omv_gpu_draw_image(&src_cimage, &srect, &dst_cimage, &drect, 255, NULL, NULL, 0) != 0) {
+        if (omv_gpu_draw_image(&src_cimage, &srect, &dst_cimage, &drect, 255, NULL, NULL, 0, NULL) != 0) {
             return OMV_CSI_ERROR_IO_ERROR;
         }
     }

--- a/ports/alif/omv_gpu.c
+++ b/ports/alif/omv_gpu.c
@@ -131,8 +131,8 @@ int omv_gpu_draw_image(image_t *src_img,
                        const uint8_t *alpha_palette,
                        image_hint_t hint,
                        float *transform) {
-    // Belnding is not supported yet.
-    if (color_palette || alpha_palette) {
+    // Belnding is not supported yet and transformations are not supported.
+    if (color_palette || alpha_palette || transform) {
         return -1;
     }
     OMV_PROFILE_START();

--- a/ports/alif/omv_gpu.c
+++ b/ports/alif/omv_gpu.c
@@ -129,7 +129,8 @@ int omv_gpu_draw_image(image_t *src_img,
                        int alpha,
                        const uint16_t *color_palette,
                        const uint8_t *alpha_palette,
-                       image_hint_t hint) {
+                       image_hint_t hint,
+                       float *transform) {
     // Belnding is not supported yet.
     if (color_palette || alpha_palette) {
         return -1;

--- a/ports/stm32/modules/py_display.c
+++ b/ports/stm32/modules/py_display.c
@@ -448,7 +448,7 @@ static void display_write(py_display_obj_t *self, image_t *src_img, int dst_x_st
     if (!black) {
         imlib_draw_image(&dst_img, src_img, dst_x_start, dst_y_start,
                          x_scale, y_scale, roi, rgb_channel, 255, color_palette,
-                         alpha_palette, hint | IMAGE_HINT_BLACK_BACKGROUND, NULL, NULL, NULL);
+                         alpha_palette, hint | IMAGE_HINT_BLACK_BACKGROUND, NULL, NULL, NULL, NULL);
     }
 
     #ifdef __DCACHE_PRESENT

--- a/ports/stm32/omv_gpu.c
+++ b/ports/stm32/omv_gpu.c
@@ -120,6 +120,22 @@ int omv_gpu_draw_image(image_t *src_img,
         return -1;
     }
 
+    float dx0 = dst_rect->x;
+    float dy0 = dst_rect->y;
+    float dx1 = dst_rect->x + dst_rect->w;
+    float dy1 = dst_rect->y;
+    float dx2 = dst_rect->x + dst_rect->w;
+    float dy2 = dst_rect->y + dst_rect->h;
+    float dx3 = dst_rect->x;
+    float dy3 = dst_rect->y + dst_rect->h;
+
+    if (transform) {
+        nema_mat3x3_mul_vec(*((nema_matrix3x3_t *) transform), &dx0, &dy0);
+        nema_mat3x3_mul_vec(*((nema_matrix3x3_t *) transform), &dx1, &dy1);
+        nema_mat3x3_mul_vec(*((nema_matrix3x3_t *) transform), &dx2, &dy2);
+        nema_mat3x3_mul_vec(*((nema_matrix3x3_t *) transform), &dx3, &dy3);
+    }
+
     // Create command list.
     #if OMV_GPU_NEMA_MM_STATIC
     nema_buffer_t bo = {
@@ -157,9 +173,10 @@ int omv_gpu_draw_image(image_t *src_img,
     uint32_t dst_bf = (hint & IMAGE_HINT_BLACK_BACKGROUND) ? NEMA_BF_ZERO : NEMA_BF_INVSRCALPHA;
     nema_set_blend_blit(nema_blending_mode(NEMA_BF_SRCALPHA, dst_bf, blops));
     nema_set_const_color(nema_rgba(0, 0, 0, alpha));
-    nema_set_clip(dst_rect->x, dst_rect->y, dst_rect->w, dst_rect->h);
-    nema_blit_subrect_fit(dst_rect->x, dst_rect->y, dst_rect->w, dst_rect->h,
-                          src_rect->x, src_rect->y, src_rect->w, src_rect->h);
+    nema_set_clip(0, 0, dst_img->w, dst_img->h);
+    nema_enable_aa(true, true, true, true);
+    nema_blit_subrect_quad_fit(dx0, dy0, dx1, dy1, dx2, dy2, dx3, dy3,
+                               src_rect->x, src_rect->y, src_rect->w, src_rect->h);
 
     SCB_CleanInvalidateDCache_by_Addr(dst_img->data, image_size(dst_img));
     SCB_CleanDCache_by_Addr(src_img->data, image_size(src_img));
@@ -225,6 +242,11 @@ int omv_gpu_draw_image(image_t *src_img,
         return -1;
     }
     #endif
+
+    // DMA2D cannot do matrix transformations.
+    if (transform) {
+        return -1;
+    }
 
     DMA2D_HandleTypeDef dma2d = {
         .Instance = DMA2D,

--- a/ports/stm32/omv_gpu.c
+++ b/ports/stm32/omv_gpu.c
@@ -93,7 +93,8 @@ int omv_gpu_draw_image(image_t *src_img,
                        int alpha,
                        const uint16_t *color_palette,
                        const uint8_t *alpha_palette,
-                       image_hint_t hint) {
+                       image_hint_t hint,
+                       float *transform) {
     OMV_PROFILE_START();
 
     // GPU2D can only draw on RGB565/GRAYSCALE buffers.
@@ -191,7 +192,8 @@ int omv_gpu_draw_image(image_t *src_img,
                        int alpha,
                        const uint16_t *color_palette,
                        const uint8_t *alpha_palette,
-                       image_hint_t hint) {
+                       image_hint_t hint,
+                       float *transform) {
     OMV_PROFILE_START();
 
     // DMA2D can only draw on RGB565 buffers and the destination/source buffers must be accessible by DMA.


### PR DESCRIPTION
This PR adds initial matrix transformation support to draw image which can be used anywhere in the code.

Right now it just supports 2x3 affline matrices and 3x3 perspective transform matrices. However, I plan to expand support in the future for general purpose image remap transformation matrices which can be used for lens correction in the future (the CPU would handle this).

The code is written so that if the GPU can handle the operation it will. Otherwise, things fallback to the CPU based renderer. Note that I did not implement any of the CPU fallback path, so, draw_image will just ignore the `mat` argument if the GPU doesn't support it (and only the N6 has a GPU that can do this right now).


https://github.com/user-attachments/assets/b3e9a9f7-0fee-4401-a9f8-3ac22a19ef98

```
import sensor
import time
import image
from ulab import numpy as np
import math

sensor.reset()
sensor.set_pixformat(sensor.RGB565)
sensor.set_framesize(sensor.VGA)
clock = time.clock()

angle_deg = 0  # Start angle

while True:
    clock.tick()

    img = sensor.snapshot()
    small_img = img.scale(x_scale=0.75, y_scale=0.75, hint=image.BILINEAR, copy=True)

    # Rotation center (in dst image space)
    cx = img.width() / 2
    cy = img.height() / 2

    # Update angle
    angle_rad = math.radians(angle_deg)
    angle_deg = (angle_deg + 1) % 360  # increment rotation

    cos_t = math.cos(angle_rad)
    sin_t = math.sin(angle_rad)

    # 2x3 rotation matrix about center of large_img
    tx = cx - cos_t * cx + sin_t * cy
    ty = cy - sin_t * cx - cos_t * cy

    m = np.array([[cos_t, -sin_t, tx],
                  [sin_t,  cos_t, ty],
                  [0,  0, 1]])

    # Center position in destination (main image)
    x = (img.width() // 2) - (small_img.width() // 2)
    y = (img.height() // 2) - (small_img.height() // 2)

    # Draw rotated small_img in-place
    img.draw_image(small_img, x, y, transform=m)

    print(clock.fps())
```

https://github.com/user-attachments/assets/b948fb60-9a71-4678-91b7-dd5ca77a50a1

```
import time
import csi
import image
from ulab import numpy as np
import math

m = np.array([[ 0.8776188251549479, 0.02006060498589142, 38.14425632554175],
              [0.03851867279446007, 0.7883679987364723, 15.810020073591545],
              [0.0004941236255517049, -3.450005798236746e-05, 1.0]])

print(["0x%x"%i for i in csi.devices()])

alpha_pal = image.Image(256, 1, image.GRAYSCALE)
for i in range(256):
    alpha_pal[i] = int(math.pow((i / 255), 2) * 255)

csi0 = csi.CSI()
csi0.reset(hard=True)
csi0.pixformat(csi.RGB565)
csi0.framesize(csi.QVGA)

csi2 = csi.CSI(cid=csi.LEPTON)
csi2.reset(hard=False)
csi2.pixformat(csi.GRAYSCALE)
csi2.framesize(csi.QVGA)
csi2.ioctl(csi.IOCTL_LEPTON_SET_MODE, True, False)
csi2.ioctl(csi.IOCTL_LEPTON_SET_RANGE, 20.0, 40.0)

print(csi0, csi2)
clock = time.clock()

tmp = image.Image(csi0.width(), csi0.height(), csi0.pixformat())
img2 = image.Image(csi2.width(), csi2.height(), csi2.pixformat())

while True:
    clock.tick()
    img0 = csi0.snapshot()
    csi2.snapshot(update=False, blocking=False, image=img2)
    img0.draw_image(img2, 0, 0, transform=m, color_palette=image.PALETTE_IRONBOW,
                                       alpha_palette=alpha_pal,
                                       hint=image.BILINEAR)
    print(clock.fps())
```