### PR TITLE
boards/OPENMV_N6: Enable triple buffering for the N6 by default.

### DIFF
--- a/boards/OPENMV_N6/omv_boardconfig.h
+++ b/boards/OPENMV_N6/omv_boardconfig.h
@@ -249,7 +249,7 @@
 #define OMV_SPI_DISPLAY_RS_PIN              (&omv_pin_D13_GPIO)
 #define OMV_SPI_DISPLAY_RST_PIN             (&omv_pin_G13_GPIO)
 #define OMV_SPI_DISPLAY_BL_PIN              (&omv_pin_G0_GPIO)
-// TODO #define OMV_SPI_DISPLAY_TRIPLE_BUFFER       (1)
+#define OMV_SPI_DISPLAY_TRIPLE_BUFFER       (1)
 
 // CSI SPI bus
 #define OMV_CSI_SPI_ID                      (OMV_SPI5_ID)

--- a/ports/stm32/omv_portconfig.h
+++ b/ports/stm32/omv_portconfig.h
@@ -82,8 +82,13 @@ typedef const stm32_gpio_t *omv_gpio_t;
 // IRQ handlers, if this I2C is enabled in Micropython, or defined and handled in stm32_hal_msp.c.
 typedef I2C_HandleTypeDef *omv_i2c_dev_t;
 
+#if defined(STM32N6)
+#define OMV_I2C_MAX_8BIT_XFER   (65536U - 16U)
+#define OMV_I2C_MAX_16BIT_XFER  (32768U - 8U)
+#else
 #define OMV_I2C_MAX_8BIT_XFER   (65536U - 16U)
 #define OMV_I2C_MAX_16BIT_XFER  (65536U - 8U)
+#endif
 
 #define OMV_SPI_MODE_SLAVE     (SPI_MODE_SLAVE)
 #define OMV_SPI_MODE_MASTER    (SPI_MODE_MASTER)
@@ -104,8 +109,13 @@ typedef I2C_HandleTypeDef *omv_i2c_dev_t;
 #define OMV_SPI_NSS_LOW        (0)
 #define OMV_SPI_NSS_HIGH       (1)
 
+#if defined(STM32N6)
+#define OMV_SPI_MAX_8BIT_XFER  (65536U - 16U)
+#define OMV_SPI_MAX_16BIT_XFER (32768U - 8U)
+#else
 #define OMV_SPI_MAX_8BIT_XFER  (65536U - 16U)
 #define OMV_SPI_MAX_16BIT_XFER (65536U - 8U)
+#endif
 #define OMV_SPI_MAX_TIMEOUT    (HAL_MAX_DELAY)
 
 #if defined(STM32N6)

--- a/ports/stm32/stm_dma.c
+++ b/ports/stm32/stm_dma.c
@@ -352,6 +352,12 @@ int stm_dma_init(DMA_HandleTypeDef *dma_descr, void *dma_channel, uint32_t reque
     dma_init_done = !circular;
     #endif
 
+    #if defined(STM32N6)
+    if (stm_dma_sec_config(dma_descr) != HAL_OK) {
+        return -1;
+    }
+    #endif
+
     if (dma_init_done) {
         HAL_DMA_DeInit(dma_descr);
         if (HAL_DMA_Init(dma_descr) != HAL_OK) {
@@ -407,13 +413,17 @@ int stm_dma_ll_init(DMA_HandleTypeDef *dma_descr, DMA_QListTypeDef *dma_queue,
         return -1;
     }
 
+    return 0;
+}
+
+int stm_dma_sec_config(DMA_HandleTypeDef *dma_descr) {
     uint32_t chan_flags = DMA_CHANNEL_PRIV | DMA_CHANNEL_SEC |
                           DMA_CHANNEL_SRC_SEC | DMA_CHANNEL_DEST_SEC;
     if (HAL_DMA_ConfigChannelAttributes(dma_descr, chan_flags) != HAL_OK) {
         return -1;
     }
 
-    if (is_hp) {
+    if (stm_dma_is_hp_channel(dma_descr->Instance)) {
         DMA_IsolationConfigTypeDef isocfg = {
             .CidFiltering =  DMA_ISOLATION_ON,
             .StaticCid = DMA_CHANNEL_STATIC_CID_1,

--- a/ports/stm32/stm_dma.h
+++ b/ports/stm32/stm_dma.h
@@ -46,6 +46,7 @@ int stm_dma_init(DMA_HandleTypeDef *dma_descr, void *dma_channel, uint32_t reque
 #if defined(STM32N6)
 int stm_dma_ll_init(DMA_HandleTypeDef *dma_descr, DMA_QListTypeDef *dma_queue,
         DMA_NodeTypeDef *dma_nodes, size_t nodes_count, uint32_t ports);
+int stm_dma_sec_config(DMA_HandleTypeDef *dma_descr);
 #endif
 
 #ifdef OMV_MDMA_CHANNEL_DCMI_0


### PR DESCRIPTION
Needs https://github.com/openmv/micropython/pull/136.

DMA SPI transmit output works now on the N6 for the LCD and TV shield.

Regarding the max transfer size, the DMA controllers for the N6 always work in bytes when passing the length and have a limit of 64K for a block. So, the 16-bit size had to be halved.

Security config settings were also missing for DMA non-circular mode.