### PR TITLE
lib/stm32: Disable small size single buffer DMA mode.

### DIFF
--- a/lib/stm32/n6/src/stm32n6xx_hal_dcmi.c
+++ b/lib/stm32/n6/src/stm32n6xx_hal_dcmi.c
@@ -418,7 +418,7 @@ HAL_StatusTypeDef HAL_DCMI_Start_DMA(DCMI_HandleTypeDef *hdcmi, uint32_t DCMI_Mo
   /* Length should be converted to number of bytes */
   tmp_length = tmp_length * 4U;
 
-  if (tmp_length <= 0xFFFFU)
+  if (tmp_length <= 0)
   {
     /* Continuoues Mode */
     /* Enable the DMA Stream */


### PR DESCRIPTION
The N6 crashes if you try to capture an image that's less than 64KB in size using any parallel bus sensor using `HAL_DCMI_Start_DMA`. The reason is that the HAL switches modes from the circular buffer linked list DMA to the non-circular buffer linked list DMA. Oddly, if you call with a size larger than 64KB first, the other path is taken in the HAL... which, after being executed once... prevents the smaller-sized path from crashing. So, more issues with linked list initialization in the HAL.

This commit just disables the single buffer path entirely as it's not needed and the crash no-longer happens.

Just capture an image at QQVGA to see the issue with any parallel sensor from cold boot.