### PR TITLE
modules/py_csi_ng: Support custom frame size.

### DIFF
--- a/common/omv_csi.c
+++ b/common/omv_csi.c
@@ -77,51 +77,50 @@ typedef struct _i2c_dev {
 
 // Sensor frame size/resolution table.
 uint16_t resolution[][2] = {
-    {0,    0   },
-    {0,    0   },    /* Custom set by drivers */
+    [OMV_CSI_FRAMESIZE_INVALID]     = {0,    0},
+    [OMV_CSI_FRAMESIZE_CUSTOM]      = {0,    0},
     // C/SIF Resolutions
-    {88,   72  },    /* QQCIF     */
-    {176,  144 },    /* QCIF      */
-    {352,  288 },    /* CIF       */
-    {88,   60  },    /* QQSIF     */
-    {176,  120 },    /* QSIF      */
-    {352,  240 },    /* SIF       */
+    [OMV_CSI_FRAMESIZE_QQCIF]       = {88,   72},
+    [OMV_CSI_FRAMESIZE_QCIF]        = {176,  144},
+    [OMV_CSI_FRAMESIZE_CIF]         = {352,  288},
+    [OMV_CSI_FRAMESIZE_QQSIF]       = {88,   60},
+    [OMV_CSI_FRAMESIZE_QSIF]        = {176,  120},
+    [OMV_CSI_FRAMESIZE_SIF]         = {352,  240},
     // VGA Resolutions
-    {40,   30  },    /* QQQQVGA   */
-    {80,   60  },    /* QQQVGA    */
-    {160,  120 },    /* QQVGA     */
-    {320,  240 },    /* QVGA      */
-    {640,  480 },    /* VGA       */
-    {30,   20  },    /* HQQQQVGA  */
-    {60,   40  },    /* HQQQVGA   */
-    {120,  80  },    /* HQQVGA    */
-    {240,  160 },    /* HQVGA     */
-    {480,  320 },    /* HVGA      */
-    // FFT Resolutions
-    {64,   32  },    /* 64x32     */
-    {64,   64  },    /* 64x64     */
-    {128,  64  },    /* 128x64    */
-    {128,  128 },    /* 128x128   */
-    // Himax Resolutions
-    {160,  160 },    /* 160x160   */
-    {320,  320 },    /* 320x320   */
+    [OMV_CSI_FRAMESIZE_QQQQVGA]     = {40,   30},
+    [OMV_CSI_FRAMESIZE_QQQVGA]      = {80,   60},
+    [OMV_CSI_FRAMESIZE_QQVGA]       = {160,  120},
+    [OMV_CSI_FRAMESIZE_QVGA]        = {320,  240},
+    [OMV_CSI_FRAMESIZE_VGA]         = {640,  480},
+    [OMV_CSI_FRAMESIZE_HQQQQVGA]    = {30,   20},
+    [OMV_CSI_FRAMESIZE_HQQQVGA]     = {60,   40},
+    [OMV_CSI_FRAMESIZE_HQQVGA]      = {120,  80},
+    [OMV_CSI_FRAMESIZE_HQVGA]       = {240,  160},
+    [OMV_CSI_FRAMESIZE_HVGA]        = {480,  320},
+    // TODO remove these when sensor is deprecated.
+    [OMV_CSI_FRAMESIZE_64X32]       = {64,   32},
+    [OMV_CSI_FRAMESIZE_64X64]       = {64,   64},
+    [OMV_CSI_FRAMESIZE_128X64]      = {128,  64},
+    [OMV_CSI_FRAMESIZE_128X128]     = {128,  128},
+    [OMV_CSI_FRAMESIZE_160X160]     = {160,  160},
+    [OMV_CSI_FRAMESIZE_320X320]     = {320,  320},
     // Other
-    {128,  160 },    /* LCD       */
-    {128,  160 },    /* QQVGA2    */
-    {720,  480 },    /* WVGA      */
-    {752,  480 },    /* WVGA2     */
-    {800,  600 },    /* SVGA      */
-    {1024, 768 },    /* XGA       */
-    {1280, 768 },    /* WXGA      */
-    {1280, 1024},    /* SXGA      */
-    {1280, 960 },    /* SXGAM     */
-    {1600, 1200},    /* UXGA      */
-    {1280, 720 },    /* HD        */
-    {1920, 1080},    /* FHD       */
-    {2560, 1440},    /* QHD       */
-    {2048, 1536},    /* QXGA      */
-    {2560, 1600},    /* WQXGA     */
-    {2592, 1944},    /* WQXGA2    */
+    [OMV_CSI_FRAMESIZE_LCD]         = {128,  160},
+    [OMV_CSI_FRAMESIZE_QQVGA2]      = {128,  160},
+    [OMV_CSI_FRAMESIZE_WVGA]        = {720,  480},
+    [OMV_CSI_FRAMESIZE_WVGA2]       = {752,  480},
+    [OMV_CSI_FRAMESIZE_SVGA]        = {800,  600},
+    [OMV_CSI_FRAMESIZE_XGA]         = {1024, 768},
+    [OMV_CSI_FRAMESIZE_WXGA]        = {1280, 768},
+    [OMV_CSI_FRAMESIZE_SXGA]        = {1280, 1024},
+    [OMV_CSI_FRAMESIZE_SXGAM]       = {1280, 960},
+    [OMV_CSI_FRAMESIZE_UXGA]        = {1600, 1200},
+    [OMV_CSI_FRAMESIZE_HD]          = {1280, 720},
+    [OMV_CSI_FRAMESIZE_FHD]         = {1920, 1080},
+    [OMV_CSI_FRAMESIZE_QHD]         = {2560, 1440},
+    [OMV_CSI_FRAMESIZE_QXGA]        = {2048, 1536},
+    [OMV_CSI_FRAMESIZE_WQXGA]       = {2560, 1600},
+    [OMV_CSI_FRAMESIZE_WQXGA2]      = {2592, 1944},
 };
 
 static omv_i2c_t csi_i2c;

--- a/drivers/sensors/hm01b0.c
+++ b/drivers/sensors/hm01b0.c
@@ -256,11 +256,6 @@ static int set_framesize(omv_csi_t *csi, omv_csi_framesize_t framesize) {
     uint16_t h = resolution[framesize][1];
 
     switch (framesize) {
-        case OMV_CSI_FRAMESIZE_320X320:
-            for (int i = 0; FULL_regs[i][0] && ret == 0; i++) {
-                ret |= omv_i2c_writeb2(csi->i2c, csi->slv_addr, FULL_regs[i][0], FULL_regs[i][1]);
-            }
-            break;
         case OMV_CSI_FRAMESIZE_QVGA:
             for (int i = 0; QVGA_regs[i][0] && ret == 0; i++) {
                 ret |= omv_i2c_writeb2(csi->i2c, csi->slv_addr, QVGA_regs[i][0], QVGA_regs[i][1]);
@@ -271,11 +266,18 @@ static int set_framesize(omv_csi_t *csi, omv_csi_framesize_t framesize) {
                 ret |= omv_i2c_writeb2(csi->i2c, csi->slv_addr, QQVGA_regs[i][0], QQVGA_regs[i][1]);
             }
             break;
-        default:
-            if (w > 320 || h > 320) {
+        case OMV_CSI_FRAMESIZE_CUSTOM:
+        case OMV_CSI_FRAMESIZE_320X320:
+            if (w != 320 || h != 320) {
                 ret = -1;
+                break;
             }
-
+            for (int i = 0; FULL_regs[i][0] && ret == 0; i++) {
+                ret |= omv_i2c_writeb2(csi->i2c, csi->slv_addr, FULL_regs[i][0], FULL_regs[i][1]);
+            }
+            break;
+        default:
+            ret = -1;
     }
 
     return ret;

--- a/modules/py_csi_ng.c
+++ b/modules/py_csi_ng.c
@@ -317,7 +317,22 @@ static mp_obj_t py_csi_framesize(size_t n_args, const mp_obj_t *args) {
         return mp_obj_new_int(self->csi->framesize);
     }
 
-    int error = omv_csi_set_framesize(self->csi, mp_obj_get_int(args[1]));
+    omv_csi_framesize_t framesize;
+
+    if (mp_obj_is_integer(args[1])) {
+        framesize = mp_obj_get_int(args[1]);
+    } else if (MP_OBJ_IS_TYPE(args[1], &mp_type_tuple)) {
+        mp_obj_t *arg_array;
+        mp_obj_get_array_fixed_n(args[1], 2, &arg_array);
+
+        framesize = OMV_CSI_FRAMESIZE_CUSTOM;
+        resolution[OMV_CSI_FRAMESIZE_CUSTOM][0] = mp_obj_get_int(arg_array[0]);
+        resolution[OMV_CSI_FRAMESIZE_CUSTOM][1] = mp_obj_get_int(arg_array[1]);
+    } else {
+        omv_csi_raise_error(OMV_CSI_ERROR_INVALID_ARGUMENT);
+    }
+
+    int error = omv_csi_set_framesize(self->csi, framesize);
     if (error != 0) {
         omv_csi_raise_error(error);
     }
@@ -1428,34 +1443,18 @@ static const mp_rom_map_elem_t globals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_NEGATIVE),        MP_ROM_INT(OMV_CSI_SDE_NEGATIVE) },  /* Negative image */
 
     // C/SIF Resolutions
-    { MP_ROM_QSTR(MP_QSTR_QQCIF),           MP_ROM_INT(OMV_CSI_FRAMESIZE_QQCIF) },    /* 88x72     */
     { MP_ROM_QSTR(MP_QSTR_QCIF),            MP_ROM_INT(OMV_CSI_FRAMESIZE_QCIF) },     /* 176x144   */
     { MP_ROM_QSTR(MP_QSTR_CIF),             MP_ROM_INT(OMV_CSI_FRAMESIZE_CIF) },      /* 352x288   */
-    { MP_ROM_QSTR(MP_QSTR_QQSIF),           MP_ROM_INT(OMV_CSI_FRAMESIZE_QQSIF) },    /* 88x60     */
     { MP_ROM_QSTR(MP_QSTR_QSIF),            MP_ROM_INT(OMV_CSI_FRAMESIZE_QSIF) },     /* 176x120   */
     { MP_ROM_QSTR(MP_QSTR_SIF),             MP_ROM_INT(OMV_CSI_FRAMESIZE_SIF) },      /* 352x240   */
     // VGA Resolutions
-    { MP_ROM_QSTR(MP_QSTR_QQQQVGA),         MP_ROM_INT(OMV_CSI_FRAMESIZE_QQQQVGA) },  /* 40x30     */
     { MP_ROM_QSTR(MP_QSTR_QQQVGA),          MP_ROM_INT(OMV_CSI_FRAMESIZE_QQQVGA) },   /* 80x60     */
     { MP_ROM_QSTR(MP_QSTR_QQVGA),           MP_ROM_INT(OMV_CSI_FRAMESIZE_QQVGA) },    /* 160x120   */
     { MP_ROM_QSTR(MP_QSTR_QVGA),            MP_ROM_INT(OMV_CSI_FRAMESIZE_QVGA) },     /* 320x240   */
     { MP_ROM_QSTR(MP_QSTR_VGA),             MP_ROM_INT(OMV_CSI_FRAMESIZE_VGA) },      /* 640x480   */
-    { MP_ROM_QSTR(MP_QSTR_HQQQQVGA),        MP_ROM_INT(OMV_CSI_FRAMESIZE_HQQQQVGA) }, /* 40x20     */
-    { MP_ROM_QSTR(MP_QSTR_HQQQVGA),         MP_ROM_INT(OMV_CSI_FRAMESIZE_HQQQVGA) },  /* 80x40     */
-    { MP_ROM_QSTR(MP_QSTR_HQQVGA),          MP_ROM_INT(OMV_CSI_FRAMESIZE_HQQVGA) },   /* 160x80    */
     { MP_ROM_QSTR(MP_QSTR_HQVGA),           MP_ROM_INT(OMV_CSI_FRAMESIZE_HQVGA) },    /* 240x160   */
     { MP_ROM_QSTR(MP_QSTR_HVGA),            MP_ROM_INT(OMV_CSI_FRAMESIZE_HVGA) },     /* 480x320   */
-    // FFT Resolutions
-    { MP_ROM_QSTR(MP_QSTR_B64X32),          MP_ROM_INT(OMV_CSI_FRAMESIZE_64X32) },    /* 64x32     */
-    { MP_ROM_QSTR(MP_QSTR_B64X64),          MP_ROM_INT(OMV_CSI_FRAMESIZE_64X64) },    /* 64x64     */
-    { MP_ROM_QSTR(MP_QSTR_B128X64),         MP_ROM_INT(OMV_CSI_FRAMESIZE_128X64) },   /* 128x64    */
-    { MP_ROM_QSTR(MP_QSTR_B128X128),        MP_ROM_INT(OMV_CSI_FRAMESIZE_128X128) },  /* 128x128   */
-    // Himax Resolutions
-    { MP_ROM_QSTR(MP_QSTR_B160X160),        MP_ROM_INT(OMV_CSI_FRAMESIZE_160X160) },  /* 160x160   */
-    { MP_ROM_QSTR(MP_QSTR_B320X320),        MP_ROM_INT(OMV_CSI_FRAMESIZE_320X320) },  /* 320x320   */
     // Other Resolutions
-    { MP_ROM_QSTR(MP_QSTR_LCD),             MP_ROM_INT(OMV_CSI_FRAMESIZE_LCD) },      /* 128x160   */
-    { MP_ROM_QSTR(MP_QSTR_QQVGA2),          MP_ROM_INT(OMV_CSI_FRAMESIZE_QQVGA2) },   /* 128x160   */
     { MP_ROM_QSTR(MP_QSTR_WVGA),            MP_ROM_INT(OMV_CSI_FRAMESIZE_WVGA) },     /* 720x480   */
     { MP_ROM_QSTR(MP_QSTR_WVGA2),           MP_ROM_INT(OMV_CSI_FRAMESIZE_WVGA2) },    /* 752x480   */
     { MP_ROM_QSTR(MP_QSTR_SVGA),            MP_ROM_INT(OMV_CSI_FRAMESIZE_SVGA) },     /* 800x600   */


### PR DESCRIPTION
When the `sensor` module is removed eventually, all of the `Bx` resolutions will be removed as well.