### PR TITLE
ports/stm32: Fix SystemClock_config() hard faulting.

### DIFF
--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -137,6 +137,9 @@ int main(void) {
     #endif
     bool first_soft_reset = true;
 
+    // Initialize SysTick.
+    HAL_InitTick(TICK_INT_PRIORITY);
+
     // Configure PLLs, oscillators, and system/peripheral clocks
     SystemClock_Config();
 


### PR DESCRIPTION
Tested on M4, M7, H7, H7P, N6.