### PR TITLE
common: Add CRC HAL with hardware acceleration support.

### DIFF
--- a/common/common.mk
+++ b/common/common.mk
@@ -31,6 +31,7 @@ COMMON_SRC_C += \
     mutex.c \
     nosys_stubs.c \
     omv_csi.c \
+    omv_crc.c \
     pendsv.c \
     tinyusb_debug.c \
     trace.c \

--- a/common/omv_crc.c
+++ b/common/omv_crc.c
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2025 OpenMV, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include "omv_crc.h"
+
+__attribute__((weak)) void omv_crc_init(void) {
+
+}
+
+__attribute__((weak)) uint16_t omv_crc_calc(const void *buf, size_t size) {
+    const uint8_t *data = (const uint8_t *)buf;
+    uint16_t crc = 0xFFFF;
+    
+    for (size_t i = 0; i < size; i++) {
+        crc ^= (uint16_t)data[i] << 8;
+        
+        for (int j = 0; j < 8; j++) {
+            if (crc & 0x8000) {
+                crc = (crc << 1) ^ OMV_CRC16_POLY;
+            } else {
+                crc <<= 1;
+            }
+        }
+    }
+    
+    return crc;
+}

--- a/common/omv_crc.h
+++ b/common/omv_crc.h
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2025 OpenMV, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef __OMV_CRC_H__
+#define __OMV_CRC_H__
+#include <stdint.h>
+#include <stddef.h>
+
+// CRC-16-CCITT: X^16 + X^12 + X^5 + 1
+#define OMV_CRC16_POLY 0x1021
+
+void omv_crc_init(void);
+uint16_t omv_crc_calc(const void *buf, size_t size);
+
+#endif // __OMV_CRC_H__

--- a/lib/alif/alif.mk
+++ b/lib/alif/alif.mk
@@ -9,6 +9,7 @@
 
 HAL_SRC_C += \
 	drivers/source/adc.c \
+	drivers/source/crc.c \
 	drivers/source/dma_ctrl.c \
 	drivers/source/dma_op.c \
 	drivers/source/i2c.c \

--- a/ports/alif/omv_crc.c
+++ b/ports/alif/omv_crc.c
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2023-2024 OpenMV, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include "crc.h"
+#include "global_map.h"
+#include "omv_crc.h"
+
+#define CRC0 ((CRC_Type *)CRC0_BASE)
+
+static bool crc_initialized = false;
+
+void omv_crc_init(void) {
+    if (crc_initialized) {
+        return;
+    }
+    
+    crc_clear_config(CRC0);
+    
+    crc_enable_16bit_ccitt(CRC0);
+    
+    crc_initialized = true;
+}
+
+uint16_t omv_crc_calc(const void *buf, size_t size) {
+    omv_crc_init();
+    
+    if (size == 0) {
+        return 0xFFFF;
+    }
+    
+    crc_set_seed(CRC0, 0xFFFF);
+    crc_enable(CRC0);
+    
+    uint32_t crc_output = 0;
+    crc_calculate_16bit(CRC0, buf, size, &crc_output);
+    
+    return (uint16_t)(crc_output & 0xFFFF);
+}

--- a/ports/stm32/omv_crc.c
+++ b/ports/stm32/omv_crc.c
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2025 OpenMV, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include STM32_HAL_H
+#include "omv_crc.h"
+#include <stdbool.h>
+
+static CRC_HandleTypeDef hcrc = {0};
+static bool crc_initialized = false;
+
+void omv_crc_init(void) {
+    if (crc_initialized) {
+        return;
+    }
+
+    hcrc.Instance = CRC;
+    hcrc.Init.DefaultPolynomialUse = DEFAULT_POLYNOMIAL_DISABLE;
+    hcrc.Init.GeneratingPolynomial = OMV_CRC16_POLY;
+    hcrc.Init.CRCLength = CRC_POLYLENGTH_16B;
+    hcrc.Init.DefaultInitValueUse = DEFAULT_INIT_VALUE_DISABLE;
+    hcrc.Init.InitValue = 0xFFFF;
+    hcrc.Init.InputDataInversionMode = CRC_INPUTDATA_INVERSION_NONE;
+    hcrc.Init.OutputDataInversionMode = CRC_OUTPUTDATA_INVERSION_DISABLE;
+    hcrc.InputDataFormat = CRC_INPUTDATA_FORMAT_BYTES;
+
+    HAL_CRC_Init(&hcrc);
+    crc_initialized = true;
+}
+
+uint16_t omv_crc_calc(const void *buf, size_t size) {
+    omv_crc_init();
+
+    if (size == 0) {
+        return 0xFFFF;
+    }
+
+    uint32_t result = HAL_CRC_Calculate(&hcrc, (uint32_t *)buf, size);
+    return (uint16_t)(result & 0xFFFF);
+}


### PR DESCRIPTION
This PR implements a new CRC HAL for OpenMV, providing both software fallback and hardware-accelerated implementations across multiple ports.

Algorithm: CRC-16-CCITT with polynomial 0x1021 (X^16 + X^12 + X^5 + 1)
Initialization: 0xFFFF seed value
Processing: Byte-wise input with MSB-first bit ordering

  | Port | Implementation       | Hardware Unit                 |
  |----------|----------------------|-------------------------------|
  | STM32    | Hardware accelerated | STM32 CRC peripheral          |
  | Alif     | Hardware accelerated | CRC0 peripheral  |
  | MIMXRT   | Software fallback    | N/A (DCP CRC-32 incompatible) |
  | Others   | Software fallback    | Weak implementation           |
