### PR TITLE
common/usbdbg: Flush data from unsupported commands.

### DIFF
--- a/common/usbdbg.c
+++ b/common/usbdbg.c
@@ -375,6 +375,9 @@ void usbdbg_data_out(uint32_t size, usbdbg_read_callback_t read_callback) {
         }
 
         default: /* error */
+            size = OMV_MIN(size, 512);
+            uint8_t byte_buffer[size];
+            read_callback(&byte_buffer, size);
             break;
     }
 }


### PR DESCRIPTION
The removal of unused USB commands that are still sent by the IDE causes tinyusb boards to crash on connect currently. Flushing the excess received bytes for unknown commands solves this issue.

The unused commands will still be removed in the IDE with an IDE release coming soon. But, this fix prevents breaking customer boards who are trying to use the Tools->Install Latest Development Firmware currently, and also customers who may not migrate to the latest IDE immediately.