### PR TITLE
drivers/sensors: Add aux flag to genx320 driver.

### DIFF
--- a/drivers/sensors/genx320.c
+++ b/drivers/sensors/genx320.c
@@ -736,6 +736,7 @@ int genx320_init(omv_csi_t *csi) {
     csi->set_hmirror = set_hmirror;
     csi->set_vflip = set_vflip;
     csi->ioctl = ioctl;
+    csi->auxiliary = 1;
 
     // Set csi flags
     csi->mono_bpp = sizeof(uint8_t);


### PR DESCRIPTION
One shot the hardware. :) Working on N6.

https://github.com/user-attachments/assets/0626a65e-6031-4816-88fe-54ddb97a92c4

(Note, was testing with without 3D printed mount which aligns the cameras).

```
import time
import csi
import image
from ulab import numpy as np
import math

print(["0x%x"%i for i in csi.devices()])

alpha_pal = image.Image(256, 1, image.GRAYSCALE)
for i in range(256):
    alpha_pal[i] = int(math.pow((i / 255), 2) * 255)

csi0 = csi.CSI()
csi0.reset(hard=True)
csi0.pixformat(csi.RGB565)
csi0.framesize(csi.QVGA)

csi2 = csi.CSI(cid=csi.GENX320)
csi2.reset(hard=False)
csi2.pixformat(csi.GRAYSCALE)
csi2.framesize((320, 320))
#csi2.ioctl(csi.IOCTL_LEPTON_SET_MODE, True, False)

print(csi0, csi2)
clock = time.clock()

tmp = image.Image(csi0.width(), csi0.height(), csi0.pixformat())
img2 = image.Image(csi2.width(), csi2.height(), csi2.pixformat())

while True:
    clock.tick()
    img0 = csi0.snapshot()
    csi2.snapshot(update=False, blocking=False, image=img2)
    img0.draw_image(img2, 0, 0, color_palette=image.PALETTE_IRONBOW,
                                       alpha_palette=alpha_pal,
                                       hint=image.BILINEAR)
    print(clock.fps())
```

