### PR TITLE
Makefile: Suppress J-Link GDB server output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,7 @@ endif
 jlink:
 	setsid ${JLINK_GDB_SERVER} -speed ${JLINK_SPEED} -nogui \
         -if ${JLINK_INTERFACE} -halt -cpu cortex-m \
-		-device ${JLINK_DEVICE} -novd ${JLINK_SCRIPT} & \
+		-device ${JLINK_DEVICE} -novd ${JLINK_SCRIPT} >/dev/null 2>&1 & \
 	JLINK_PID=$$!; \
 	trap "kill $$JLINK_PID 2>/dev/null" EXIT; \
 	sleep 1 && jlink-gdb $(FW_DIR)/$(FIRMWARE).elf


### PR DESCRIPTION
Redirect J-Link GDB server stdout and stderr to /dev/null to prevent its output from mixing with GDB output in the terminal.