### PR TITLE
Revert "common/mutex: Clear tid when releasing mutex"

### DIFF
--- a/common/mutex.c
+++ b/common/mutex.c
@@ -55,7 +55,6 @@ bool mutex_try_lock_fair(mutex_t *m, size_t tid) {
 
 void mutex_unlock(mutex_t *m, size_t tid) {
     if (atomic_load_explicit(&m->tid, memory_order_acquire) == tid) {
-        atomic_store_explicit(&m->tid, 0, memory_order_relaxed);
         atomic_flag_clear_explicit(&m->lock, memory_order_release);
     }
 }


### PR DESCRIPTION
This reverts commit bb5228856119585763905b13e2763173e49323bf.

Event though this fixes a deadlock in the new protocol, it actually breaks fair locking as one side could lock multiple times in a row.