### PR TITLE
tools: Fix uncrustify union variable formatting

### DIFF
--- a/tools/uncrustify.cfg
+++ b/tools/uncrustify.cfg
@@ -2083,7 +2083,7 @@ nl_after_vbrace_close           = false    # true/false
 # Add or remove newline between the close brace and identifier,
 # as in 'struct { int a; } <here> b;'. Affects enumerations, unions and
 # structures. If set to ignore, uses nl_after_brace_close.
-nl_brace_struct_var             = ignore   # ignore/add/remove/force/not_defined
+nl_brace_struct_var             = remove  # ignore/add/remove/force/not_defined
 
 # Whether to alter newlines in '#define' macros.
 nl_define_macro                 = false    # true/false


### PR DESCRIPTION
Set nl_brace_struct_var = remove to keep union/struct variable declarations on the same line as the closing brace.