### PR TITLE
modules/py_helper: Release the buffer used in set_to_framebuffer.

### DIFF
--- a/modules/py_helper.c
+++ b/modules/py_helper.c
@@ -619,4 +619,6 @@ void py_helper_set_to_framebuffer(image_t *img) {
 
     framebuffer_from_image(fb, img);
     img->data = buffer->data;
+
+    framebuffer_release(fb, FB_FLAG_FREE);
 }


### PR DESCRIPTION
The buffer used to copy an image must be released after, so it can be acquired later in equal_to_framebuffer.