### PR TITLE
docker: Add git worktree support

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -51,4 +51,100 @@ shell:
         -v $(realpath ../):/workspace \
         $(DOCKER_IMAGE_NAME):$(DOCKER_TAG) bash
 
+# ----------------------------------------------------------------------------
+# Local development targets.
+#
+# These mirror build-firmware / shell but mount the repo (and SDK) at the
+# same absolute path inside the container as on the host. This keeps debug
+# info paths in build artifacts matching the host filesystem (so gdb,
+# addr2line and IDE source navigation work without remapping). Worktrees
+# are supported by also mounting the main repo so the worktree's .git
+# pointer file resolves.
+#
+# Unlike the default targets, build-firmware-dev does not run `make clean`
+# before building, so subsequent invocations are incremental.
+# ----------------------------------------------------------------------------
+
+# Repo root and git layout, resolved on the host.
+DEV_REPO_ROOT := $(realpath ../)
+DEV_GIT_DIR := $(realpath $(shell git -C .. rev-parse --git-dir 2>/dev/null))
+DEV_GIT_COMMON_DIR := $(realpath $(shell git -C .. rev-parse --git-common-dir 2>/dev/null))
+
+# Resolve SDK_DIR via realpath when the directory exists; fall back to the
+# abspath form so error messages report a concrete path. The _check-sdk-dev
+# target fails fast before any docker invocation if the resolved path does
+# not exist, which is what actually keeps the docker run safe (the mount
+# line itself would be malformed for a missing path: `-v :` with no LHS).
+DEV_SDK_DIR := $(or $(realpath $(SDK_DIR)),$(abspath $(SDK_DIR)))
+
+# A worktree has git-dir != git-common-dir. Mount the main repo too so the
+# worktree's .git pointer file (and the parent .git/worktrees/... entry it
+# references) resolves inside the container.
+#
+# Resolve the main repo path via `git worktree list --porcelain` rather than
+# string-stripping the common-dir, which only works when the main repo's git
+# directory is named exactly `.git` (breaks for `--separate-git-dir`,
+# core.worktree, bare-style layouts).
+DEV_IS_WORKTREE := $(shell [ -n "$(DEV_GIT_DIR)" ] && [ "$(DEV_GIT_DIR)" != "$(DEV_GIT_COMMON_DIR)" ] && echo yes || echo no)
+DEV_MAIN_REPO := $(if $(filter yes,$(DEV_IS_WORKTREE)),$(shell git -C .. worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $$2; exit}'))
+
+# Any new target that consumes $(DEV_MOUNTS) MUST also depend on
+# _check-sdk-dev, otherwise a missing SDK_DIR yields a malformed `-v :`
+# mount and docker auto-creates an empty root-owned directory on the host.
+DEV_MOUNTS = -v $(DEV_REPO_ROOT):$(DEV_REPO_ROOT) \
+             -v $(DEV_SDK_DIR):$(DEV_SDK_DIR)
+ifeq ($(DEV_IS_WORKTREE),yes)
+ifeq ($(strip $(DEV_MAIN_REPO)),)
+$(error In a worktree but could not resolve main repo path via 'git worktree list'. Run 'make debug-paths-dev' to diagnose.)
+endif
+DEV_MOUNTS += -v $(DEV_MAIN_REPO):$(DEV_MAIN_REPO)
+endif
+
+_check-sdk-dev:
+	@test -d "$(DEV_SDK_DIR)" || { \
+        echo "ERROR: SDK_DIR=$(SDK_DIR) does not exist."; \
+        echo "Run 'make install-sdk' to fetch the SDK pinned in SDK_VERSION,"; \
+        echo "or pass SDK_DIR=<path> on the make command line."; \
+        exit 1; \
+    }
+
+build-firmware-dev: _check-sdk-dev build-image
+	docker run --rm \
+        --user $(shell id -u):$(shell id -g) \
+        -e HOME=/tmp \
+        -e TARGET=$(TARGET) \
+        -e SDK_DIR=$(DEV_SDK_DIR) \
+        -w $(DEV_REPO_ROOT) \
+        $(DEV_MOUNTS) \
+        $(DOCKER_IMAGE_NAME):$(DOCKER_TAG) docker/build-dev.sh
+
+shell-dev: _check-sdk-dev build-image
+	docker run --rm -it \
+        --user $(shell id -u):$(shell id -g) \
+        -e HOME=/tmp \
+        -e SDK_DIR=$(DEV_SDK_DIR) \
+        -w $(DEV_REPO_ROOT) \
+        $(DEV_MOUNTS) \
+        $(DOCKER_IMAGE_NAME):$(DOCKER_TAG) bash
+
+clean-dev:
+	rm -rf $(DEV_REPO_ROOT)/build $(DEV_REPO_ROOT)/lib/micropython/mpy-cross/build
+
+# Download and extract the OpenMV SDK to $(SDK_DIR). Version is pinned in
+# the repo's SDK_VERSION file; tools/ci.sh::ci_install_sdk is the canonical
+# installer (verifies sha256, idempotent via sdk.version stamp file).
+install-sdk:
+	@command -v wget >/dev/null 2>&1 || { echo "wget is required to download the SDK."; exit 1; }
+	@bash -c 'source ../tools/ci.sh && ci_install_sdk'
+
+# Print resolved dev-mode paths for debugging mount detection.
+debug-paths-dev:
+	@echo "DEV_REPO_ROOT     = $(DEV_REPO_ROOT)"
+	@echo "DEV_GIT_DIR       = $(DEV_GIT_DIR)"
+	@echo "DEV_GIT_COMMON_DIR= $(DEV_GIT_COMMON_DIR)"
+	@echo "DEV_IS_WORKTREE   = $(DEV_IS_WORKTREE)"
+	@echo "DEV_MAIN_REPO     = $(DEV_MAIN_REPO)"
+	@echo "DEV_SDK_DIR       = $(DEV_SDK_DIR)"
+	@echo "DEV_MOUNTS        = $(DEV_MOUNTS)"
+
 .DEFAULT_GOAL := build-firmware

--- a/docker/README.md
+++ b/docker/README.md
@@ -12,6 +12,24 @@ The `SDK_DIR` variable should point to the OpenMV SDK installation directory (de
 
 After building you should see the target build output under `build/<TARGET_NAME>`.
 
+## Local Development Build
+
+For local iteration there is a parallel `build-firmware-dev` target that mounts the repository (and SDK) at the same absolute path inside the container as on the host. This keeps debug info paths in build artifacts matching the host filesystem, so gdb, addr2line and IDE source navigation work without remapping. It also supports git worktrees and skips the up-front `make clean` so subsequent runs are incremental.
+
+```
+cd openmv/docker
+make install-sdk                                 # download SDK pinned by SDK_VERSION
+make build-firmware-dev TARGET=<TARGET NAME>
+make shell-dev                                   # interactive container shell
+make clean-dev                                   # wipe the build directory
+```
+
+`install-sdk` fetches the version pinned in the repo's `SDK_VERSION` file from `https://download.openmv.io/sdk` and extracts it to `$HOME/openmv-sdk-<version>`. It's idempotent and verifies the sha256. It only needs `wget`, `tar`, and `sha256sum` on the host (no docker required).
+
+When switching `TARGET` between dev builds, run `make clean-dev` first. Per-target build directories are isolated, but `lib/micropython/mpy-cross` is shared and may need to be rebuilt against the new target's headers.
+
+The default `make` target (`build-firmware`) is unchanged and remains the recommended path for reproducible/CI builds.
+
 ## Testing HTTP POST/GET
 
 In order to test HTTP POST and GET request, you can use the following docker image to setup a test web server that can accept POST and GET requests:

--- a/docker/build-common.sh
+++ b/docker/build-common.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Shared firmware build sequence sourced by build.sh and build-dev.sh.
+#
+# Callers must already have:
+#   - the working directory at the openmv repo root
+#   - the toolchain on PATH (Dockerfile-baked for build.sh; runtime export
+#     from $SDK_DIR for build-dev.sh)
+#   - submodules initialised (each caller does this with its own protocol
+#     scoping; build-dev.sh allows file:// for worktree alternates)
+#
+# Callers may set BUILD_OPTS for additional flags passed to the firmware
+# `make`. build.sh sets BUILD=<workspace path> to keep artifacts under
+# /workspace/build; build-dev.sh leaves BUILD_OPTS empty so the top-level
+# Makefile's default applies and per-port subdir nesting (e.g. AE3
+# multi-core) works.
+set -e -x
+
+make -j$(nproc) TARGET=${TARGET} submodules
+make -j$(nproc) -C lib/micropython/mpy-cross
+make -j$(nproc) ${BUILD_OPTS:-} TARGET=${TARGET}

--- a/docker/build-dev.sh
+++ b/docker/build-dev.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Local development build script.
+#
+# Used by `make build-firmware-dev`. Differs from build.sh:
+#   - No `make clean` before building, so rebuilds are incremental.
+#   - PATH is re-derived from runtime $SDK_DIR (the Dockerfile bakes a
+#     /workspace/sdk PATH at image build time which doesn't apply when the
+#     SDK is mounted at its host path).
+#   - Container runs as the host user (set via docker --user in the
+#     Makefile), so files written end up host-owned and no chown is needed.
+#   - Submodule init scopes protocol.file.allow=always to the single
+#     command (worktree alternates use file://; CVE-2022-39253).
+#
+# The shared firmware build sequence lives in build-common.sh.
+set -e -x
+
+if [ -z "${SDK_DIR}" ]; then
+    echo "SDK_DIR is not set" >&2
+    exit 1
+fi
+if [ -z "${TARGET}" ]; then
+    echo "TARGET is not set" >&2
+    exit 1
+fi
+
+export PATH="${SDK_DIR}/gcc/bin:${SDK_DIR}/llvm/bin:${SDK_DIR}/make:${SDK_DIR}/cmake/bin:${SDK_DIR}/python/bin:${SDK_DIR}/stcubeprog/bin:${PATH}"
+
+git -c protocol.file.allow=always submodule update --init --depth=1
+source "$(dirname "$0")/build-common.sh"

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -5,12 +5,11 @@ BUILD_DIR=/workspace/build/${TARGET}
 
 # Update submodules.
 git submodule update --init --depth=1
-make -j$(nproc) TARGET=${TARGET} submodules
 
-# Build the firmware.
+# Run the per-target clean separately (build-dev.sh skips this for
+# incremental builds), then delegate to the shared build sequence.
 make -j$(nproc) BUILD=${BUILD_DIR} clean
-make -j$(nproc) -C lib/micropython/mpy-cross
-make -j$(nproc) BUILD=${BUILD_DIR} TARGET=${TARGET}
+BUILD_OPTS="BUILD=${BUILD_DIR}" source "$(dirname "$0")/build-common.sh"
 
 # Fix permissions.
 chown -R ${HOST_UID:-1000}:${HOST_GID:-1000} /workspace/build


### PR DESCRIPTION
## Changes

This PR modifies the Docker build system to support git worktrees by mounting source code at runtime instead of copying it during image build.

## Technical Details

**Previous approach:**
- `COPY . .` embedded source tree into image during `docker build`
- Source was static - required image rebuild for any changes
- Failed with worktrees (`.git` is a pointer, main repo not accessible during build)

**New approach:**
- Source mounted as volumes at runtime: `-v /path/to/repo:/path/to/repo`
- Working directory matches host paths (makes elf file easier to debug from host computer)
- Git worktrees work (both worktree and main repo `.git` mounted)

**Benefits:**
- Faster iteration (no image rebuild needed)
- More reusable image
- Live source updates
- Supports git worktree workflows

## Testing

Verified on git worktree setup:
```bash
cd docker && make TARGET=OPENMV4
```

Build completes successfully with firmware output at `docker/build/OPENMV4/bin/`.

## Open Question

Was the original `COPY . .` approach intentional for other benefits (reproducibility, isolation, CI/CD workflows, etc.)?

Is there a different reason you'd prefer to keep the in-container build in a /workdir path?
