### PR TITLE
ports/alif: Fully implement Alif GPU driver.

### DIFF
--- a/lib/imlib/draw.c
+++ b/lib/imlib/draw.c
@@ -3084,8 +3084,8 @@ void imlib_draw_image(image_t *dst_img,
         rectangle_t dst_rect = {
             .x = dst_x_start,
             .y = dst_y_start,
-            .w = dst_x_end - dst_rect.x,
-            .h = dst_y_end - dst_rect.y,
+            .w = dst_x_end - dst_x_start,
+            .h = dst_y_end - dst_y_start,
         };
 
         rectangle_t src_rect = {

--- a/ports/alif/omv_gpu.c
+++ b/ports/alif/omv_gpu.c
@@ -135,6 +135,22 @@ int omv_gpu_draw_image(image_t *src_img,
                        const uint8_t *alpha_palette,
                        image_hint_t hint,
                        float *transform) {
+    image_t src_copy;
+    image_t dst_copy;
+
+    // BAYER is 8-bpp; the GPU can only do a plain 1:1 crop/copy of it. Any
+    // scale/filter/mirror/flip/blend hint corrupts the raw mosaic, so alias
+    // to GRAYSCALE only for a hintless 1:1 blit; everything else falls to SW.
+    if (src_img->is_bayer && dst_img->is_bayer && hint == 0 &&
+        src_rect->w == dst_rect->w && src_rect->h == dst_rect->h) {
+        src_copy = *src_img;
+        src_copy.pixfmt = PIXFORMAT_GRAYSCALE;
+        src_img = &src_copy;
+        dst_copy = *dst_img;
+        dst_copy.pixfmt = PIXFORMAT_GRAYSCALE;
+        dst_img = &dst_copy;
+    }
+
     // GPU2D can only draw on RGB565/GRAYSCALE buffers.
     if (dst_img->pixfmt != PIXFORMAT_RGB565 && dst_img->pixfmt != PIXFORMAT_GRAYSCALE) {
         return -1;

--- a/ports/alif/omv_gpu.c
+++ b/ports/alif/omv_gpu.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 OpenMV, LLC.
+ * Copyright (C) 2023-2026 OpenMV, LLC.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,6 +42,7 @@
 #include "omv_gpu.h"
 
 static d2_device *dev;
+static d2_color CLUT_BUFFER[256];
 
 extern char _gpu_memory_start;
 extern char _gpu_memory_end;
@@ -89,16 +90,6 @@ int omv_gpu_init() {
         __fatal_error("Failed to init GPU hardware");
     }
 
-#if 0
-    d2_setblendmode(dev, d2_bm_alpha, d2_bm_one_minus_alpha);
-    d2_setalphamode(dev, d2_am_constant); // default in d2_newcontext
-    d2_setlinecap(dev, d2_lc_butt);
-    d2_setantialiasing(dev, 1);
-    d2_setblur(dev, 0);
-    d2_settextureoperation(dev, d2_to_one, d2_to_copy, d2_to_copy, d2_to_copy);
-    d2_setfillmode(dev, d2_fm_texture);
-    d2_settexturemode(dev, d2_tm_filter);
-#endif
     return 0;
 }
 
@@ -109,17 +100,30 @@ void omv_gpu_deinit() {
     }
 }
 
-static d2_u32 omv_gpu_pixfmt(uint32_t omv_pixfmt) {
+static void omv_gpu_load_clut(const uint16_t *color_palette, const uint8_t *alpha_palette) {
+    for (int i = 0; i < 256; i++) {
+        int r, g, b;
+        if (color_palette) {
+            int pixel = color_palette[i];
+            r = COLOR_RGB565_TO_R8(pixel);
+            g = COLOR_RGB565_TO_G8(pixel);
+            b = COLOR_RGB565_TO_B8(pixel);
+        } else {
+            r = g = b = i;
+        }
+        int a = alpha_palette ? alpha_palette[i] : 255;
+        CLUT_BUFFER[i] = a << 24 | r << 16 | g << 8 | b;
+    }
+}
+
+static d2_u32 omv_gpu_pixfmt(uint32_t omv_pixfmt, bool clut) {
     switch (omv_pixfmt) {
-        case PIXFORMAT_BINARY:
-            return d2_mode_alpha1;
-        case PIXFORMAT_BAYER_ANY:
         case PIXFORMAT_GRAYSCALE:
-            return d2_mode_alpha8;
+            return clut ? d2_mode_i8 | d2_mode_clut : d2_mode_alpha8;
         case PIXFORMAT_RGB565:
             return d2_mode_rgb565;
     }
-    mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("Pixel format is not supported"));
+    __builtin_unreachable();
 }
 
 int omv_gpu_draw_image(image_t *src_img,
@@ -131,8 +135,40 @@ int omv_gpu_draw_image(image_t *src_img,
                        const uint8_t *alpha_palette,
                        image_hint_t hint,
                        float *transform) {
-    // Blending, transformations, and TCM buffers are not supported.
-    if (color_palette || alpha_palette || transform) {
+    // GPU2D can only draw on RGB565/GRAYSCALE buffers.
+    if (dst_img->pixfmt != PIXFORMAT_RGB565 && dst_img->pixfmt != PIXFORMAT_GRAYSCALE) {
+        return -1;
+    }
+
+    // GPU can only blit grayscale destinations with a grayscale source.
+    if (dst_img->pixfmt == PIXFORMAT_GRAYSCALE &&
+        (src_img->pixfmt != PIXFORMAT_GRAYSCALE || alpha != 255 || color_palette || alpha_palette)) {
+        return -1;
+    }
+
+    // GPU2D can only read from RGB565 or GRAYSCALE buffers.
+    // If the source image is RGB565, it must not have a color or alpha palette.
+    if (src_img->pixfmt != PIXFORMAT_GRAYSCALE &&
+        (src_img->pixfmt != PIXFORMAT_RGB565 || color_palette || alpha_palette)) {
+        return -1;
+    }
+
+    // Transformations are not supported.
+    if (transform) {
+        return -1;
+    }
+
+    // In-place blits with mirror/flip are not supported.
+    if (src_img->data == dst_img->data && (hint & (IMAGE_HINT_HMIRROR | IMAGE_HINT_VFLIP))) {
+        return -1;
+    }
+
+    // Check GPU hardware limits (per dave2d driver).
+    if (src_img->w > 2048 || src_img->h > 1024 ||
+        src_rect->x > 1023 || src_rect->y > 1023 ||
+        dst_rect->w > 1023 || dst_rect->h > 1023 ||
+        dst_rect->x > 2047 || dst_rect->y > 2047 ||
+        ((src_img->h - 1) * src_img->w) >= (2 * 1024 * 1024)) {
         return -1;
     }
 
@@ -143,23 +179,48 @@ int omv_gpu_draw_image(image_t *src_img,
     err = d2_selectrenderbuffer(dev, rbuffer);
     OMV_GPU_CHECK_ERROR(err);
 
-    d2_u32 dst_pixfmt = omv_gpu_pixfmt(dst_img->pixfmt);
+    d2_u32 dst_pixfmt = omv_gpu_pixfmt(dst_img->pixfmt, false);
     err = d2_framebuffer(dev, (void *) LocalToGlobal(dst_img->data), dst_img->w, dst_img->w, dst_img->h, dst_pixfmt);
     OMV_GPU_CHECK_ERROR(err);
 
-    d2_u32 src_pixfmt = omv_gpu_pixfmt(src_img->pixfmt);
+    d2_u32 src_pixfmt = omv_gpu_pixfmt(src_img->pixfmt, dst_img->pixfmt == PIXFORMAT_RGB565);
     err = d2_setblitsrc(dev, (void *) LocalToGlobal(src_img->data), src_img->w, src_img->w, src_img->h, src_pixfmt);
+    OMV_GPU_CHECK_ERROR(err);
+
+    err = d2_setalpha(dev, alpha);
+    OMV_GPU_CHECK_ERROR(err);
+
+    err = d2_setalphamode(dev, d2_am_constant);
+    OMV_GPU_CHECK_ERROR(err);
+
+    err = d2_setblendmode(dev, d2_bm_alpha, hint & IMAGE_HINT_BLACK_BACKGROUND ?
+                          d2_bm_zero : d2_bm_one_minus_alpha);
     OMV_GPU_CHECK_ERROR(err);
 
     if (hint & IMAGE_HINT_BILINEAR) {
         blit_flags |= d2_bf_filter;
     }
 
-    if (src_pixfmt == d2_mode_alpha8 || dst_pixfmt == d2_mode_alpha8) {
-        blit_flags |= d2_bf_usealpha;
+    if (hint & IMAGE_HINT_HMIRROR) {
+        blit_flags |= d2_bf_mirroru;
     }
 
-    // Flush source image
+    if (hint & IMAGE_HINT_VFLIP) {
+        blit_flags |= d2_bf_mirrorv;
+    }
+
+    if (src_img->pixfmt == PIXFORMAT_GRAYSCALE) {
+        blit_flags |= d2_bf_usealpha;
+
+        if (dst_img->pixfmt == PIXFORMAT_RGB565) {
+            omv_gpu_load_clut(color_palette, alpha_palette);
+            err = d2_settexclut(dev, (void *) LocalToGlobal(CLUT_BUFFER));
+            OMV_GPU_CHECK_ERROR(err);
+        }
+    }
+
+    // Flush destination/source image
+    SCB_CleanInvalidateDCache_by_Addr(dst_img->data, image_size(dst_img));
     SCB_CleanDCache_by_Addr(src_img->data, image_size(src_img));
 
     // Copy source image to the framebuffer.
@@ -222,5 +283,3 @@ static void omv_gpu_check_error(uint32_t error, uint32_t line) {
 
     mp_raise_msg_varg(&mp_type_RuntimeError, (mp_rom_error_text_t) errors[error], line);
 }
-
-


### PR DESCRIPTION
Implements all modes the D/AVE GPU supports that we can use. RGB565 destination drawing fully supports all possible modes (except transforms). For grayscale destinations, only drawing grayscale images without alpha/colorPal/alphaPal is supported.

I tried to get a grayscale to grayscale drawing with alpha blending operational. It kinda worked, but the hardware seems to want to blend the two images even at 255 alpha, where one should be picked over the other.