### PR TITLE
imlib/fmath: Fix strict-aliasing violation in fast_expf.

### DIFF
--- a/lib/imlib/fmath.c
+++ b/lib/imlib/fmath.c
@@ -48,8 +48,13 @@ float fast_expf(float x) {
     // IEEE binary32 format
     e.e = (e.e - 1023 + 127) & 0xFF; // rebase
 
-    uint32_t packed = (e.s << 31) | (e.e << 23) | e.m << 3;
-    return *((float *) &packed);
+    union {
+        uint32_t u;
+        float f;
+    } packed;
+
+    packed.u = (e.s << 31) | (e.e << 23) | e.m << 3;
+    return packed.f;
 }
 
 /*

--- a/lib/imlib/imlib.mk
+++ b/lib/imlib/imlib.mk
@@ -79,7 +79,6 @@ IMLIB_SRC_C += \
     zbar.c \
 
 CFLAGS += -I$(TOP_DIR)/lib/imlib
-$(BUILD)/lib/imlib/fmath.o: override CFLAGS += -fno-strict-aliasing
 
 ifeq ($(CLANG_ENABLE),1)
 OMV_CLANG_OBJ = $(BUILD)/lib/imlib/bayer.o


### PR DESCRIPTION
GCC flags fast_expf() as a strict-aliasing violation, which is currently being masked for the entire file. 

I believe this PR fixes it in a clean fashion that should be no change in behaviour / size. 
