### PR TITLE
github: Disable broken boards.

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -46,8 +46,6 @@ jobs:
           - ARDUINO_PORTENTA_H7
           - ARDUINO_GIGA
           - ARDUINO_NICLA_VISION
-          - ARDUINO_NANO_RP2040_CONNECT
-          - ARDUINO_NANO_33_BLE_SENSE
         qemu: [false]
         profile: [0]
         artifacts: [true]


### PR DESCRIPTION
These boards are either already broken or will be broken very soon, and I can't maintain them anymore.