### PR TITLE
boards/OPENMV4: Lower OV5640 freq for 400 MHz STM32H7 boards.

### DIFF
--- a/boards/OPENMV4/omv_boardconfig.h
+++ b/boards/OPENMV4/omv_boardconfig.h
@@ -46,7 +46,7 @@
 #define OMV_OV2640_ENABLE                     (1)
 #define OMV_OV5640_ENABLE                     (1)
 #define OMV_OV5640_AF_ENABLE                  (1)
-#define OMV_OV5640_PLL_CTRL2                  (0x64)
+#define OMV_OV5640_PLL_CTRL2                  (0x54)
 #define OMV_OV5640_PLL_CTRL3                  (0x13)
 
 #define OMV_OV7725_ENABLE                     (1)


### PR DESCRIPTION
OpenMV H7 cameras are a mix of 400 MHz and 480 MHz H7 processors, where as all H7 Plus boards are 480 MHz capable H7 processors. We cannot run the OV5640 at the same speed of 80 MHz PIXCLK with 400 MHz CPUs, it needs to be reduced by the ratio of 400/480. For 480 MHz H7 units, this is slower than they could handle, but, not really a problem.