### PR TITLE
boards: Add missing romfs models and cascades.

### DIFF
--- a/boards/OPENMV_AE3/romfs.json
+++ b/boards/OPENMV_AE3/romfs.json
@@ -22,6 +22,12 @@
     },
     {
       "type": "tflite",
+      "path": "{TOP}/lib/models/person_detect.tflite",
+      "alignment": 16,
+      "optimize": "Performance"
+    },
+    {
+      "type": "tflite",
       "path": "{TOP}/lib/models/yolo_lc_192.tflite",
       "alignment": 16,
       "optimize": "Performance"

--- a/boards/OPENMV_N6/romfs.json
+++ b/boards/OPENMV_N6/romfs.json
@@ -10,6 +10,18 @@
     },
     {
       "type": "tflite",
+      "path": "{TOP}/lib/models/force_int_quant.tflite",
+      "alignment": 32,
+      "profile": "default"
+    },
+    {
+      "type": "tflite",
+      "path": "{TOP}/lib/models/person_detect.tflite",
+      "alignment": 32,
+      "profile": "default"
+    },
+    {
+      "type": "tflite",
       "path": "{TOP}/lib/models/yolo_lc_192.tflite",
       "alignment": 32,
       "profile": "default"
@@ -43,6 +55,21 @@
       "path": "{TOP}/lib/models/hand_landmarks_full_224.tflite",
       "alignment": 32,
       "profile": "default"
+    },
+    {
+      "type": "haar",
+      "path": "{TOP}/lib/haar/haarcascade_eye.xml",
+      "stages": 0
+    },
+    {
+      "type": "haar",
+      "path": "{TOP}/lib/haar/haarcascade_smile.xml",
+      "stages": 0
+    },
+    {
+      "type": "haar",
+      "path": "{TOP}/lib/haar/haarcascade_frontalface.xml",
+      "stages": 0
     }
     ]
   }


### PR DESCRIPTION
Realized these were missing on the N6 and then AE3 when testing https://github.com/openmv/openmv/pull/2949 against example scripts.