### PR TITLE
protocol: Fix race condition with locking.

### DIFF
--- a/protocol/omv_protocol_channel_profile.c
+++ b/protocol/omv_protocol_channel_profile.c
@@ -46,8 +46,17 @@ static size_t profile_channel_shape(const omv_protocol_channel_t *channel, size_
 }
 
 static int profile_channel_lock(const omv_protocol_channel_t *channel) {
+    mutex_t *lock = omv_profiler_lock();
+    if (!mutex_try_lock(lock, MUTEX_TID_IDE)) {
+        return -1;
+    }
+    // Size can be checked safetly after acquiring the lock.
     size_t size = channel->size(channel);
-    return size && mutex_try_lock(omv_profiler_lock(), MUTEX_TID_IDE) ? 0 : -1;
+    if (!size) {
+        mutex_unlock(lock, MUTEX_TID_IDE);
+        return -1;
+    }
+    return 0;
 }
 
 static int profile_channel_unlock(const omv_protocol_channel_t *channel) {

--- a/protocol/omv_protocol_channel_stream.c
+++ b/protocol/omv_protocol_channel_stream.c
@@ -40,9 +40,16 @@ static bool stream_channel_poll(const omv_protocol_channel_t *channel) {
 
 static int stream_channel_lock(const omv_protocol_channel_t *channel) {
     framebuffer_t *fb = framebuffer_get(FB_STREAM_ID);
+    if (!mutex_try_lock(&fb->lock, MUTEX_TID_IDE)) {
+        return -1;
+    }
+    // Size can be checked safetly after acquiring the lock.
     size_t size = channel->size(channel);
-    // Attempt locking only if the stream is ready.
-    return size && mutex_try_lock(&fb->lock, MUTEX_TID_IDE) ? 0 : -1;
+    if (!size) {
+        mutex_unlock(&fb->lock, MUTEX_TID_IDE);
+        return -1;
+    }
+    return 0;
 }
 
 static int stream_channel_unlock(const omv_protocol_channel_t *channel) {


### PR DESCRIPTION
On our older OpenMV Cams the usb protocol library runs USB interrupts. Which means that stream actions can happen while framebuffer_update_preview() is running in the main thread. On the OpenMV M4, it so happens that the stream checking size() while framebuffer_update_preview() is updating the header happens regularly causing a system crash.

The fix for this is to treat stream->size() as volatile until locked.

...

Did not notice the issue except on the old Cortex M4. 