### PR TITLE
ps5520: Stabilize AEC/AGC control loop.

### DIFF
--- a/drivers/sensors/ps5520.c
+++ b/drivers/sensors/ps5520.c
@@ -93,6 +93,7 @@ static int g_div = 1;
 #define PS5520_L_TARGET         (80)
 #define PS5520_L_AGC_DIFF_DIV   (10)
 #define PS5520_L_AEC_DIFF_MUL   (10)
+#define PS5520_L_AEC_MAX_STEP   (50)
 
 static bool enable_agc = true;
 static int32_t agc_gain = PS5520_DEF_GAIN;
@@ -1364,6 +1365,7 @@ static int set_auto_gain(omv_csi_t *csi, int enable, float gain_db, float gain_d
 
         agc_gain = ((idx - 1) << 4) + ((gain >> (idx - 1)) & 0x0F);
 
+
         ret |= omv_i2c_write_reg(csi->i2c, csi->slv_addr, REG_BANK, 1, 0x01, 1);
         ret |= omv_i2c_write_reg(csi->i2c, csi->slv_addr, CMD_GAIN_IDX, 1, agc_gain, 1);
         ret |= omv_i2c_write_reg(csi->i2c, csi->slv_addr, SENSOR_UPDATE, 1, 0x01, 1);
@@ -1408,6 +1410,7 @@ static int set_auto_exposure(omv_csi_t *csi, int enable, int exposure_us) {
 
         int32_t exposure_line = ConvertT2L(exposure_us);
         aec_exposure = IM_CLAMP(exposure_line, PS5520_MIN_INT, (lpf - 2));
+
 
         ret |= omv_i2c_write_reg(csi->i2c, csi->slv_addr, CMD_OFFNY1_H, 1, (lpf - aec_exposure) >> 8, 1);
         ret |= omv_i2c_write_reg(csi->i2c, csi->slv_addr, CMD_OFFNY1_L, 1, (lpf - aec_exposure) & 0xFF, 1);
@@ -1491,7 +1494,17 @@ static int update_agc_aec(omv_csi_t *csi, int luminance) {
     int ret = 0;
     int diff = PS5520_L_TARGET - luminance;
 
-    if (abs(diff) > 0) {
+    // Dead zone: ignore small luminance deviations. With raw (un-smoothed)
+    // luminance, frame-to-frame sensor noise is not filtered, so a small
+    // dead zone prevents noise-driven corrections that appear as flicker.
+    if (abs(diff) > 4) {
+        // If exposure and gain are both floored and scene is still too
+        // bright, skip the adjustment — nothing can change and redundant
+        // I2C writes may cause sensor glitches.
+        if (diff < 0 && aec_exposure <= PS5520_MIN_INT && agc_gain <= PS5520_MIN_GAIN_IDX) {
+            return 0;
+        }
+
         bool aec_exposure_in = ((diff > 0) && (aec_exposure < aec_exposure_ceiling)) ||
                                ((diff < 0) && (agc_gain <= PS5520_MIN_GAIN_IDX));
 
@@ -1504,7 +1517,15 @@ static int update_agc_aec(omv_csi_t *csi, int luminance) {
             bool flg_stall = 0;
             int32_t exposure_line;
 
-            aec_exposure += diff * PS5520_L_AEC_DIFF_MUL;
+            // Continuous step scaling: max_step is proportional to how
+            // far the current luminance is from either saturation extreme
+            // (0 or 255). This avoids step-size discontinuities that cause
+            // oscillation at zone boundaries.
+            int32_t headroom = IM_MIN(luminance, 255 - luminance);
+            int32_t max_step = IM_MAX(1, IM_MIN(PS5520_L_AEC_MAX_STEP, headroom / 10));
+            int32_t step = diff * PS5520_L_AEC_DIFF_MUL;
+            step = IM_CLAMP(step, -max_step, max_step);
+            aec_exposure += step;
             aec_exposure = IM_CLAMP(aec_exposure, PS5520_MIN_INT, aec_exposure_ceiling);
 
             if (aec_exposure > (VTS_5M_30 - 1 - 2)) {
@@ -1552,7 +1573,9 @@ static int update_agc_aec(omv_csi_t *csi, int luminance) {
             }
 
         } else if (enable_agc) {
-            agc_gain += diff / PS5520_L_AGC_DIFF_DIV;
+            int32_t gain_step = diff / PS5520_L_AGC_DIFF_DIV;
+            gain_step = IM_CLAMP(gain_step, -1, 1);
+            agc_gain += gain_step;
             agc_gain = IM_CLAMP(agc_gain, PS5520_MIN_GAIN_IDX, agc_gain_ceiling);
 
             //ret |= omv_i2c_write_reg(csi->i2c, csi->slv_addr, REG_BANK, 1, 0x01, 1);

--- a/ports/stm32/omv_csi.c
+++ b/ports/stm32/omv_csi.c
@@ -765,9 +765,13 @@ static int stm_csi_snapshot(omv_csi_t *csi, image_t *image, uint32_t flags) {
 
     #if USE_DCMIPP
     if (csi->raw_output) {
-        float luminance = stm_isp_update_awb(csi, DCMIPP_PIPE, fb->u * fb->v);
+        float raw_lum = 0;
+        float luminance = stm_isp_update_awb(csi, DCMIPP_PIPE, fb->u * fb->v, &raw_lum);
         if (csi->ioctl) {
-            omv_csi_ioctl(csi, OMV_CSI_IOCTL_UPDATE_AGC_AEC, fast_floorf(luminance));
+            // Pass raw (un-smoothed) luminance for AEC; fall back to
+            // smoothed if stats are disabled (raw_lum would be 0).
+            float aec_lum = (raw_lum > 0) ? raw_lum : luminance;
+            omv_csi_ioctl(csi, OMV_CSI_IOCTL_UPDATE_AGC_AEC, fast_floorf(aec_lum));
         }
 
     }

--- a/ports/stm32/stm_isp.c
+++ b/ports/stm32/stm_isp.c
@@ -38,7 +38,7 @@
 #include "omv_boardconfig.h"
 
 #ifdef DCMIPP
-float stm_isp_update_awb(omv_csi_t *csi, uint32_t pipe, uint32_t n_pixels) {
+float stm_isp_update_awb(omv_csi_t *csi, uint32_t pipe, uint32_t n_pixels, float *raw_luminance) {
     uint32_t avg[3];
     uint32_t shift[3];
     uint32_t multi[3];
@@ -53,12 +53,18 @@ float stm_isp_update_awb(omv_csi_t *csi, uint32_t pipe, uint32_t n_pixels) {
         avg[0] = OMV_MAX((avg[0] * 256 * 4) / n_pixels, 1);
         avg[1] = OMV_MAX((avg[1] * 256 * 2) / n_pixels, 1);
         avg[2] = OMV_MAX((avg[2] * 256 * 4) / n_pixels, 1);
+
+        // Compute raw (un-smoothed) luminance for AEC before the EMA filter.
+        if (raw_luminance) {
+            *raw_luminance = avg[0] * 0.299f + avg[1] * 0.587f + avg[2] * 0.114f;
+        }
+
         omv_csi_stats_update(csi, &avg[0], &avg[1], &avg[2], mp_hal_ticks_ms());
     }
 
     omv_csi_get_stats(csi, &avg[0], &avg[1], &avg[2]);
 
-    // Compute global luminance
+    // Compute global luminance (EMA-smoothed, used for AWB)
     float luminance = avg[0] * 0.299f + avg[1] * 0.587f + avg[2] * 0.114f;
 
     // Calculate average and exposure factors for each channel (R, G, B)

--- a/ports/stm32/stm_isp.h
+++ b/ports/stm32/stm_isp.h
@@ -41,7 +41,7 @@
 int stm_isp_init(omv_csi_t *csi, uint32_t pipe, pixformat_t pixformat, bool raw_output);
 int stm_isp_update_gamma_table(omv_csi_t *csi, uint32_t pipe,
                                float brightness, float contrast, float gamma);
-float stm_isp_update_awb(omv_csi_t *csi, uint32_t pipe, uint32_t n_pixels);
+float stm_isp_update_awb(omv_csi_t *csi, uint32_t pipe, uint32_t n_pixels, float *raw_luminance);
 #endif
 
 #endif // __STM_ISP_H__


### PR DESCRIPTION
Fixes #2995

The `update_agc_aec` control loop oscillates at certain lighting conditions due to three issues in the Pixart-authored code:

1. **No dead zone** — the loop adjusts on any luminance error (unstable with noise)
2. **No output damping** — the full proportional step is applied every frame, causing overshoot
3. **No AEC↔AGC hysteresis** — the loop togles rapidly between exposure and gain adjustment at the gain floor boundary

This patch adds:
- A dead zone threshold (`PS5520_L_AEC_DEADZONE = 4`) to ignore noise
- EMA damping (÷4 per frame) on exposure adjustments to prevent overshoot
- Hysteresis (`PS5520_L_AGC_HYST = 2`) on the AGC→AEC transition

The original `PS5520_L_AEC_DIFF_MUL` is preserved — stability comes from the damping and dead zone, not by changing Pixart's proportional gain.
