### PR TITLE
ports/alif: Clean up NPU driver.

### DIFF
--- a/ports/alif/alif_npu.c
+++ b/ports/alif/alif_npu.c
@@ -44,27 +44,17 @@
 #define ETHOSU_SEC_ENABLED      (1)
 #define ETHOSU_PRIV_ENABLED     (1)
 
-#define ETHOSU_CACHE_ALIGN      (16)
-//#define ETHOSU_CACHE_SIZE       (393216U)
 #define ETHOSU_CACHE_SIZE       (0)
+#define ETHOSU_CACHE_ALIGN      (16)
 
-#define ETHOSU_CACHE_SECTION    section(".bss.ethosu_cache")
-#define ETHOSU_CACHE_ATTRIBUTE  __attribute__((aligned(ETHOSU_CACHE_ALIGN), ETHOSU_CACHE_SECTION))
+#define ETHOSU_IRQ_NUMBER       LOCAL_NPU_IRQ_IRQn
+#define ETHOSU_IRQ_HANDLER      LOCAL_NPU_IRQHandler
+#define ETHOSU_BASE_ADDRESS     (void *) LOCAL_NPU_BASE
 
-#if CORE_M55_HP
-#define ETHOSU_IRQ_NUMBER       NPU_HP_IRQ_IRQn
-#define ETHOSU_IRQ_HANDLER      NPU_HP_IRQHandler
-#define ETHOSU_BASE_ADDRESS     (void *) NPU_HP_BASE
+#if (ETHOSU_CACHE_SIZE == 0)
+static uint8_t * ETHOSU_CACHE_BUFFER = NULL;
 #else
-#define ETHOSU_IRQ_NUMBER       NPU_HE_IRQ_IRQn
-#define ETHOSU_IRQ_HANDLER      NPU_HE_IRQHandler
-#define ETHOSU_BASE_ADDRESS     (void *) NPU_HE_BASE
-#endif
-
-#if (ETHOSU_CACHE_SIZE > 0)
-static uint8_t ETHOSU_CACHE_BUFFER[ETHOSU_CACHE_SIZE] ETHOSU_CACHE_ATTRIBUTE;
-#else
-static uint8_t *ETHOSU_CACHE_BUFFER = NULL;
+static uint8_t OMV_ATTR_SEC_ALIGN(ETHOSU_CACHE_BUFFER[ETHOSU_CACHE_SIZE], ".bss.sram0", ETHOSU_CACHE_ALIGN);
 #endif
 
 static struct ethosu_driver ethosu_driver;


### PR DESCRIPTION
Use portable Alif macros for NPU base, IRQ number and IRQ handler.