### PR TITLE
imlib/apriltag: Fix cache corruption.

### DIFF
--- a/lib/imlib/apriltag.c
+++ b/lib/imlib/apriltag.c
@@ -11994,7 +11994,7 @@ void imlib_find_apriltags(list_t *out, image_t *ptr, rectangle_t *roi, apriltag_
     img.w = roi->w;
     img.h = roi->h;
     img.pixfmt = PIXFORMAT_GRAYSCALE;
-    img.data = fb_alloc(image_size(&img), FB_ALLOC_NO_HINT);
+    img.data = fb_alloc(image_size(&img), FB_ALLOC_CACHE_ALIGN | FB_ALLOC_PREFER_SIZE);
     imlib_draw_image(&img, ptr, 0, 0, 1.f, 1.f, roi, -1, 255, NULL, NULL, 0, NULL, NULL, NULL, NULL);
 
     image_u8_t im;
@@ -12110,7 +12110,7 @@ void imlib_find_rects(list_t *out, image_t *ptr, rectangle_t *roi, uint32_t thre
     img.w = roi->w;
     img.h = roi->h;
     img.pixfmt = PIXFORMAT_GRAYSCALE;
-    img.data = fb_alloc(image_size(&img), FB_ALLOC_NO_HINT);
+    img.data = fb_alloc(image_size(&img), FB_ALLOC_CACHE_ALIGN | FB_ALLOC_PREFER_SIZE);
     imlib_draw_image(&img, ptr, 0, 0, 1.f, 1.f, roi, -1, 255, NULL, NULL, 0, NULL, NULL, NULL, NULL);
 
     image_u8_t im;


### PR DESCRIPTION
fb_alloc packs allocations tightly, so the stashed 4-byte size field can share a cache line with adjacent allocation data. In this case the data is the temporary image buffers which get passed to GPU and to `SCB_InvalidateDCache_by_Addr`, which aligns the address causing size writes to be lost.

This is one of the issues causing https://github.com/openmv/openmv/issues/3005. Note that currently the GPU buffer is actually in DTCM (uncacheable) but we can't move it to any other SRAM without this fix.