### PR TITLE
scripts: Add MoveNet Lightning pose estimation example and library

### DIFF
--- a/scripts/examples/03-Machine-Learning/00-TensorFlow/movenet_pose_estimation.py
+++ b/scripts/examples/03-Machine-Learning/00-TensorFlow/movenet_pose_estimation.py
@@ -1,0 +1,60 @@
+# This work is licensed under the MIT license.
+# Copyright (c) 2013-2025 OpenMV LLC. All rights reserved.
+# https://github.com/openmv/openmv/blob/master/LICENSE
+#
+# This example shows off Google's MoveNet Lightning pose estimation model.
+#
+# NOTE: This example requires an OpenMV Cam with an NPU like the AE3 or N6 to run real-time.
+
+import csi
+import time
+import ml
+from ml.postprocessing.movenet import MoveNetLightning
+
+# Initialize the sensor.
+csi0 = csi.CSI()
+csi0.reset()
+csi0.pixformat(csi.RGB565)
+csi0.framesize(csi.QVGA)
+csi0.window((192, 192))
+csi0.snapshot(time=2000)
+
+clock = time.clock()
+
+# Load MoveNet Lightning model with postprocessing.
+model = ml.Model(
+    "/rom/movenet_lightning_heatmaps_192_int8_pc.tflite",
+    postprocess=MoveNetLightning(threshold=0.3),
+)
+print(model)
+
+# COCO 17-keypoint skeleton connections.
+# Keypoints: 0 nose, 1 left_eye, 2 right_eye, 3 left_ear, 4 right_ear,
+# 5 left_shoulder, 6 right_shoulder, 7 left_elbow, 8 right_elbow,
+# 9 left_wrist, 10 right_wrist, 11 left_hip, 12 right_hip,
+# 13 left_knee, 14 right_knee, 15 left_ankle, 16 right_ankle
+skeleton_lines = [
+    (0, 1), (0, 2), (1, 3), (2, 4),
+    (5, 6), (5, 7), (7, 9), (6, 8), (8, 10),
+    (5, 11), (6, 12), (11, 12),
+    (11, 13), (13, 15), (12, 14), (14, 16),
+]
+
+while True:
+    clock.tick()
+    img = csi0.snapshot()
+
+    # predict() calls postprocess automatically.
+    # Returns a list of (rect, score, keypoints) tuples.
+    for r, score, keypoints in model.predict([img]):
+        # keypoints: ndarray (17, 2) in image coordinates.
+        # Index: 0 nose, 1 left_eye, 2 right_eye, 3 left_ear, 4 right_ear,
+        #        5 left_shoulder, 6 right_shoulder, 7 left_elbow, 8 right_elbow,
+        #        9 left_wrist, 10 right_wrist, 11 left_hip, 12 right_hip,
+        #        13 left_knee, 14 right_knee, 15 left_ankle, 16 right_ankle
+        ml.utils.draw_skeleton(
+            img, keypoints, skeleton_lines,
+            kp_color=(255, 0, 0), line_color=(0, 255, 0),
+        )
+
+    print(clock.fps(), "fps")

--- a/scripts/libraries/ml/ml-movenet/manifest.py
+++ b/scripts/libraries/ml/ml-movenet/manifest.py
@@ -1,0 +1,3 @@
+metadata(version="0.0.1")
+require("ml-core")
+package("ml")

--- a/scripts/libraries/ml/ml-movenet/ml/postprocessing/movenet.py
+++ b/scripts/libraries/ml/ml-movenet/ml/postprocessing/movenet.py
@@ -1,0 +1,88 @@
+# Copyright (C) 2026 OpenMV, LLC.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Any redistribution, use, or modification in source or binary form
+#    is done solely for personal benefit and not for any commercial
+#    purpose or for monetary gain. For commercial licensing options,
+#    please contact openmv@openmv.io
+#
+# THIS SOFTWARE IS PROVIDED BY THE LICENSOR AND COPYRIGHT OWNER "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE LICENSOR OR COPYRIGHT
+# OWNER BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from ml.utils import NMS, dequantize
+from ulab import numpy as np
+
+
+class MoveNetLightning:
+    """Post-processor for MoveNet Lightning/Thunder heatmap-based models.
+
+    The model outputs a single tensor of shape (1, h, w, k) where k is the
+    number of keypoints (17 for COCO pose). Each (h, w) slice is a heatmap
+    for one keypoint. The argmax of each heatmap gives the keypoint location.
+
+    Returns a list of ((x, y, w, h), score, keypoints) tuples via NMS,
+    where keypoints is an ndarray of shape (k, 2) in image coordinates.
+    """
+
+    def __init__(self, threshold=0.3):
+        self.threshold = threshold
+
+    def __call__(self, model, inputs, outputs):
+        ib, ih, iw, ic = model.input_shape[0]
+        nms = NMS(iw, ih, inputs[0].roi)
+
+        b, h, w, k = model.output_shape[0]
+        heatmaps = dequantize(model, outputs[0].reshape((h * w, k)), index=0)
+
+        arg_pred = np.argmax(heatmaps, axis=0)
+        val_pred = np.max(heatmaps, axis=0)
+
+        arg_y = arg_pred // w
+        arg_x = arg_pred - arg_y * w
+
+        # Normalized coordinates [0, 1]
+        pred_x = (arg_x + 0.5) / w
+        pred_y = (arg_y + 0.5) / h
+
+        # Build keypoints array in input image coordinates
+        keypoints = np.empty((k, 2))
+        keypoints[:, 0] = pred_x * iw
+        keypoints[:, 1] = pred_y * ih
+
+        # Average confidence of valid keypoints as the detection score
+        valid_kp_x = []
+        valid_kp_y = []
+        for i in range(k):
+            if val_pred[i] > self.threshold:
+                valid_kp_x.append(float(keypoints[i, 0]))
+                valid_kp_y.append(float(keypoints[i, 1]))
+
+        if not valid_kp_x:
+            return ()
+
+        score = float(np.sum(val_pred * (val_pred > self.threshold))) / len(valid_kp_x)
+
+        xmin = min(valid_kp_x)
+        ymin = min(valid_kp_y)
+        xmax = max(valid_kp_x)
+        ymax = max(valid_kp_y)
+
+        nms.add_bounding_box(xmin, ymin, xmax, ymax, score, 0, keypoints=keypoints)
+        return nms.get_bounding_boxes()[0]


### PR DESCRIPTION
## Summary
- Add MoveNet Lightning pose estimation example script with COCO 17-keypoint annotations
- Add MoveNet postprocessing library (`ml/postprocessing/movenet.py`)
- Include skeleton drawing with keypoint index comments for easy reference

## Test plan
- [x] Run `movenet_pose_estimation.py` on OpenMV Cam with NPU (AE3 or N6)
- [x] Verify keypoints are detected and skeleton is drawn correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)