### PR TITLE
scripts/libraries: Remove forced scale to fit in the ML library.

### DIFF
--- a/scripts/examples/03-Machine-Learning/00-TensorFlow/blazeface_detector.py
+++ b/scripts/examples/03-Machine-Learning/00-TensorFlow/blazeface_detector.py
@@ -14,6 +14,8 @@ csi0 = csi.CSI()
 csi0.reset()
 csi0.pixformat(csi.RGB565)
 csi0.framesize(csi.VGA)
+
+# BlazeFace requires a square image for the best results.
 csi0.window((400, 400))
 
 # Load built-in face detection model

--- a/scripts/examples/03-Machine-Learning/00-TensorFlow/blazepalm_detection.py
+++ b/scripts/examples/03-Machine-Learning/00-TensorFlow/blazepalm_detection.py
@@ -16,6 +16,8 @@ csi0 = csi.CSI()
 csi0.reset()
 csi0.pixformat(csi.RGB565)
 csi0.framesize(csi.VGA)
+
+# BlazePalm requires a square image for the best results.
 csi0.window((400, 400))
 
 # Load built-in palm detection model

--- a/scripts/examples/03-Machine-Learning/00-TensorFlow/face_landmarks_multi_face.py
+++ b/scripts/examples/03-Machine-Learning/00-TensorFlow/face_landmarks_multi_face.py
@@ -18,6 +18,9 @@ csi0 = csi.CSI()
 csi0.reset()
 csi0.pixformat(csi.RGB565)
 csi0.framesize(csi.VGA)
+
+# BlazeFace requires a square image for the best results.
+# FaceLandmarks works with non-square images from BlazeFace crops.
 csi0.window((400, 400))
 
 # Load built-in face detection model

--- a/scripts/examples/03-Machine-Learning/00-TensorFlow/face_landmarks_single_face.py
+++ b/scripts/examples/03-Machine-Learning/00-TensorFlow/face_landmarks_single_face.py
@@ -18,6 +18,9 @@ csi0 = csi.CSI()
 csi0.reset()
 csi0.pixformat(csi.RGB565)
 csi0.framesize(csi.VGA)
+
+# BlazeFace requires a square image for the best results.
+# FaceLandmarks works with non-square images from BlazeFace crops.
 csi0.window((400, 400))
 
 # Load built-in face detection model

--- a/scripts/examples/03-Machine-Learning/00-TensorFlow/hand_landmarks_multi_hand.py
+++ b/scripts/examples/03-Machine-Learning/00-TensorFlow/hand_landmarks_multi_hand.py
@@ -18,6 +18,9 @@ csi0 = csi.CSI()
 csi0.reset()
 csi0.pixformat(csi.RGB565)
 csi0.framesize(csi.VGA)
+
+# BlazePalm requires a square image for the best results.
+# HandLandmarks works with non-square images from BlazePalm crops.
 csi0.window((400, 400))
 
 # Load built-in palm detection model

--- a/scripts/examples/03-Machine-Learning/00-TensorFlow/hand_landmarks_single_hand.py
+++ b/scripts/examples/03-Machine-Learning/00-TensorFlow/hand_landmarks_single_hand.py
@@ -18,6 +18,9 @@ csi0 = csi.CSI()
 csi0.reset()
 csi0.pixformat(csi.RGB565)
 csi0.framesize(csi.VGA)
+
+# BlazePalm requires a square image for the best results.
+# HandLandmarks works with non-square images from BlazePalm crops.
 csi0.window((400, 400))
 
 # Load built-in palm detection model

--- a/scripts/examples/03-Machine-Learning/00-TensorFlow/movenet_singlepose_detection.py
+++ b/scripts/examples/03-Machine-Learning/00-TensorFlow/movenet_singlepose_detection.py
@@ -16,7 +16,6 @@ csi0 = csi.CSI()
 csi0.reset()
 csi0.pixformat(csi.RGB565)
 csi0.framesize(csi.VGA)
-csi0.window((400, 400))
 
 # Load built-in pose detection model
 model = ml.Model("/rom/movenet_singlepose_192.tflite", postprocess=MoveNet(threshold=0.4))

--- a/scripts/examples/03-Machine-Learning/00-TensorFlow/yolo_lc_person_detector.py
+++ b/scripts/examples/03-Machine-Learning/00-TensorFlow/yolo_lc_person_detector.py
@@ -16,7 +16,6 @@ csi0 = csi.CSI()
 csi0.reset()
 csi0.pixformat(csi.RGB565)
 csi0.framesize(csi.VGA)
-csi0.window((400, 400))
 
 # Load built-in person detection model
 model = ml.Model("/rom/yolo_lc_192.tflite", postprocess=YoloLC(threshold=0.4))

--- a/scripts/examples/03-Machine-Learning/00-TensorFlow/yolo_v2_detector.py
+++ b/scripts/examples/03-Machine-Learning/00-TensorFlow/yolo_v2_detector.py
@@ -22,7 +22,6 @@ csi0 = csi.CSI()
 csi0.reset()
 csi0.pixformat(csi.RGB565)
 csi0.framesize(csi.VGA)
-csi0.window((400, 400))
 
 # Load YOLO V2 model from ROM FS.
 model = ml.Model("/rom/<model_file_name>", postprocess=YoloV2(threshold=0.4))

--- a/scripts/examples/03-Machine-Learning/00-TensorFlow/yolo_v5_detector.py
+++ b/scripts/examples/03-Machine-Learning/00-TensorFlow/yolo_v5_detector.py
@@ -22,7 +22,6 @@ csi0 = csi.CSI()
 csi0.reset()
 csi0.pixformat(csi.RGB565)
 csi0.framesize(csi.VGA)
-csi0.window((400, 400))
 
 # Load YOLO V5 model from ROM FS.
 model = ml.Model("/rom/<model_file_name>", postprocess=YoloV5(threshold=0.4))

--- a/scripts/examples/03-Machine-Learning/00-TensorFlow/yolo_v8_detector.py
+++ b/scripts/examples/03-Machine-Learning/00-TensorFlow/yolo_v8_detector.py
@@ -18,7 +18,6 @@ csi0 = csi.CSI()
 csi0.reset()
 csi0.pixformat(csi.RGB565)
 csi0.framesize(csi.VGA)
-csi0.window((400, 400))
 
 # Load YOLO V8 model from ROM FS.
 model = ml.Model("/rom/yolov8n_192.tflite", postprocess=YoloV8(threshold=0.4))

--- a/scripts/libraries/ml/ml-core/ml/preprocessing.py
+++ b/scripts/libraries/ml/ml-core/ml/preprocessing.py
@@ -72,7 +72,7 @@ class Normalization:
         img = image.Image(w, h, pixfmt, buffer=memoryview(buffer)[offset:])
 
         # Copy and scale (if needed) the input image to the input buffer.
-        hints = image.BILINEAR | image.CENTER | image.SCALE_ASPECT_EXPAND | image.BLACK_BACKGROUND
+        hints = image.BILINEAR | image.CENTER | image.SCALE_ASPECT_IGNORE | image.BLACK_BACKGROUND
         img.draw_image(self._image, 0, 0, roi=self.roi, hint=hints)
 
         # Convert the image in-place into an ndarray input tensor.

--- a/scripts/libraries/ml/ml-core/ml/utils.py
+++ b/scripts/libraries/ml/ml-core/ml/utils.py
@@ -134,20 +134,18 @@ class NMS:
 
         x_scale = self.roi[2] / float(self.window_w)
         y_scale = self.roi[3] / float(self.window_h)
-        scale = min(x_scale, y_scale)
-        x_offset = ((self.roi[2] - (self.window_w * scale)) / 2) + self.roi[0]
-        y_offset = ((self.roi[3] - (self.window_h * scale)) / 2) + self.roi[1]
+        x_offset = ((self.roi[2] - (self.window_w * x_scale)) / 2) + self.roi[0]
+        y_offset = ((self.roi[3] - (self.window_h * y_scale)) / 2) + self.roi[1]
 
         for i in range(len(output_boxes)):
-            output_boxes[i][0] = int((output_boxes[i][0] * scale) + x_offset)
-            output_boxes[i][1] = int((output_boxes[i][1] * scale) + y_offset)
-            output_boxes[i][2] = int(output_boxes[i][2] * scale)
-            output_boxes[i][3] = int(output_boxes[i][3] * scale)
+            output_boxes[i][0] = int((output_boxes[i][0] * x_scale) + x_offset)
+            output_boxes[i][1] = int((output_boxes[i][1] * y_scale) + y_offset)
+            output_boxes[i][2] = int(output_boxes[i][2] * x_scale)
+            output_boxes[i][3] = int(output_boxes[i][3] * y_scale)
             keypoints = output_boxes[i][6]
             if keypoints is not None:
-                keypoints[:, :2] *= scale
-                keypoints[:, 0] += x_offset
-                keypoints[:, 1] += y_offset
+                keypoints[:, 0] = (keypoints[:, 0] * x_scale) + x_offset
+                keypoints[:, 1] = (keypoints[:, 1] * y_scale) + y_offset
 
         # Create a list per class with (rect, score) tuples.
 

--- a/scripts/unittest/tests/ml_blazeface.py
+++ b/scripts/unittest/tests/ml_blazeface.py
@@ -9,14 +9,17 @@ def unittest(data_path, temp_path):
     from ml.postprocessing.mediapipe import BlazeFace
 
     img = image.Image(data_path + "/faces.bmp", copy_to_fb=True)
+    # BlazeFace requires square input, so crop the center of the image.
+    s = min(img.width(), img.height())
+    img = img.crop(roi=((img.width() - s) // 2, (img.height() - s) // 2, s, s))
     model = ml.Model(data_path + "/blazeface_front_128.tflite", postprocess=BlazeFace(threshold=0.4))
     output = model.predict([img])
 
     expected = [
-        ([140, 14, 46, 46], 0.7783118),
-        ([234, 157, 34, 34], 0.6603524),
-        ([66, 97, 38, 38], 0.6350756),
-        ([234, 2, 40, 40], 0.5184602),
+        ([76, 14, 48, 48], 0.796841),
+        ([163, 155, 36, 36], 0.7004726),
+        ([170, 2, 40, 40], 0.5),
+        ([4, 97, 36, 36], 0.5),
     ]
 
     if len(output) != len(expected):

--- a/scripts/unittest/tests/ml_face_landmarks.py
+++ b/scripts/unittest/tests/ml_face_landmarks.py
@@ -11,16 +11,19 @@ def unittest(data_path, temp_path):
     from ml.postprocessing.mediapipe import FaceLandmarks
 
     img = image.Image(data_path + "/faces.bmp", copy_to_fb=True)
+    # BlazeFace requires square input, so crop the center of the image.
+    s = min(img.width(), img.height())
+    img = img.crop(roi=((img.width() - s) // 2, (img.height() - s) // 2, s, s))
 
     # First detect a face.
     face_detection = ml.Model(data_path + "/blazeface_front_128.tflite", postprocess=BlazeFace(threshold=0.4))
     faces = face_detection.predict([img])
 
     expected_rects = [
-        ([140, 14, 46, 46], 0.7783118),
-        ([234, 157, 34, 34], 0.6603524),
-        ([66, 97, 38, 38], 0.6350756),
-        ([234, 2, 40, 40], 0.5184602),
+        ([76, 14, 48, 48], 0.796841),
+        ([163, 155, 36, 36], 0.7004726),
+        ([170, 2, 40, 40], 0.5),
+        ([4, 97, 36, 36], 0.5),
     ]
 
     if len(faces) != len(expected_rects):
@@ -41,7 +44,7 @@ def unittest(data_path, temp_path):
         return False
 
     r, score, keypoints = marks[0]
-    if r != [141, 3, 46, 57]:
+    if r != [74, 0, 50, 61]:
         return False
     if keypoints.shape != (468, 3):
         return False

--- a/scripts/unittest/tests/ml_fomo.py
+++ b/scripts/unittest/tests/ml_fomo.py
@@ -9,11 +9,14 @@ def unittest(data_path, temp_path):
     from ml.postprocessing.edgeimpulse import Fomo
 
     img = image.Image(data_path + "/faces.bmp", copy_to_fb=True)
+    # FOMO requires square input, so crop the center of the image.
+    s = min(img.width(), img.height())
+    img = img.crop(roi=((img.width() - s) // 2, (img.height() - s) // 2, s, s))
     model = ml.Model(data_path + "/fomo_face_detection.tflite", postprocess=Fomo(threshold=0.4))
     output = model.predict([img])
 
     return output[1] == [
-        ([149, 17, 31, 31], 0.6796876),
-        ([194, 198, 31, 31], 0.6289064),
-        ([64, 17, 25, 31], 0.4453126),
+        ([130, 85, 31, 31], 0.9375),
+        ([85, 17, 31, 31], 0.875),
+        ([130, 198, 31, 31], 0.4257813),
     ]

--- a/scripts/unittest/tests/ml_hand_landmarks.py
+++ b/scripts/unittest/tests/ml_hand_landmarks.py
@@ -11,6 +11,9 @@ def unittest(data_path, temp_path):
     from ml.postprocessing.mediapipe import HandLandmarks
 
     img = image.Image(data_path + "/hand.bmp", copy_to_fb=True)
+    # BlazePalm requires square input, so crop the center of the image.
+    s = min(img.width(), img.height())
+    img = img.crop(roi=((img.width() - s) // 2, (img.height() - s) // 2, s, s))
 
     # First detect a palm.
     palm_detection = ml.Model(data_path + "/palm_detection_full_192.tflite", postprocess=BlazePalm(threshold=0.4))
@@ -34,7 +37,7 @@ def unittest(data_path, temp_path):
 
     # Should have at least one hand with 21 keypoints.
     r, score, keypoints = hands[0][0]
-    if r != [-6, 50, 319, 362]:
+    if r != [14, 48, 285, 364]:
         return False
     if keypoints.shape != (21, 3):
         return False


### PR DESCRIPTION
Image processing and NMS inside the ML library no longer scale to expand.

Instead, it just stretches. This works well for all YOLO like models and keypoint regressors.

Examples now directly control the w/h of the image passed into the model without any effects from the ML library.

For models like BlazeFace/Palm, these work better with a square crop.

https://github.com/user-attachments/assets/ea209486-b0df-461a-a778-9138db65b166

