### PR TITLE
ports/stm32: Move display buffer into private SDRAM bank.

### DIFF
--- a/boards/OPENMVPT/board_config.h
+++ b/boards/OPENMVPT/board_config.h
@@ -117,11 +117,14 @@
 #define OMV_GC_BLOCK1_MEMORY                    DRAM    // Extra GC block 0.
 #define OMV_GC_BLOCK1_SIZE                      (8M)
 #define OMV_UMA_BLOCK0_MEMORY                   DRAM    // Default UMA pool.
-#define OMV_UMA_BLOCK0_SIZE                     (55M)
+#define OMV_UMA_BLOCK0_SIZE                     (39M)
 #define OMV_UMA_BLOCK0_FLAGS                    (0)
 #define OMV_UMA_BLOCK1_MEMORY                   SRAM0   // Fast UMA pool.
 #define OMV_UMA_BLOCK1_SIZE                     (496K)
 #define OMV_UMA_BLOCK1_FLAGS                    (UMA_FAST | UMA_DTCM)
+#define OMV_UMA_BLOCK2_MEMORY                   DRAM
+#define OMV_UMA_BLOCK2_SIZE                     (16M)
+#define OMV_UMA_BLOCK2_FLAGS                    (UMA_DISPLAY)
 #define OMV_MSC_BUF_SIZE                        (2K)    // USB MSC bot data
 #define OMV_LINE_BUF_SIZE                       (11 * 1024) // Image line buffer round(2592 * 2BPP * 2 buffers).
 #define OMV_VOSPI_DMA_BUFFER                    ".dma_buffer"
@@ -286,6 +289,7 @@
 #define OMV_RGB_DISPLAY_CLK_DISABLE()           __HAL_RCC_LTDC_CLK_DISABLE()
 #define OMV_RGB_DISPLAY_FORCE_RESET()           __HAL_RCC_LTDC_FORCE_RESET()
 #define OMV_RGB_DISPLAY_RELEASE_RESET()         __HAL_RCC_LTDC_RELEASE_RESET()
+#define OMV_RGB_DISPLAY_BUFFER_FLAGS            (UMA_STRICT | UMA_DISPLAY)
 
 #define OMV_RGB_DISPLAY_R0_PIN                  (&omv_pin_G13_LTDC)
 #define OMV_RGB_DISPLAY_R1_PIN                  (&omv_pin_A2_LTDC)

--- a/common/umalloc.h
+++ b/common/umalloc.h
@@ -39,6 +39,7 @@
 #define UMA_DMA_D2          (1 << 4)
 #define UMA_DMA_D3          (1 << 5)
 #define UMA_TRANSIENT       (1 << 6)
+#define UMA_DISPLAY         (1 << 7)
 #define UMA_MEM_ATTR_MASK   (0xFF)
 
 // Allocation flags (bits 8+)

--- a/ports/stm32/modules/py_display.c
+++ b/ports/stm32/modules/py_display.c
@@ -50,6 +50,10 @@
 #define OMV_DISPLAY_DISP_PIN OMV_RGB_DISPLAY_DISP_PIN
 #endif
 
+#ifndef OMV_RGB_DISPLAY_BUFFER_FLAGS
+#define OMV_RGB_DISPLAY_BUFFER_FLAGS (0)
+#endif
+
 typedef struct display_mode {
     uint32_t hactive;
     uint32_t vactive;
@@ -348,7 +352,7 @@ static void ltdc_init(py_display_obj_t *self, display_mode_t *dm) {
     uint32_t fb_size = dm->hactive * dm->vactive * sizeof(uint16_t);
 
     for (int i = 0; i < FRAMEBUFFER_COUNT; i++) {
-        self->framebuffers[i] = (uint16_t *) uma_calloc(fb_size, UMA_PERSIST | UMA_CACHE);
+        self->framebuffers[i] = (uint16_t *) uma_calloc(fb_size, UMA_PERSIST | UMA_CACHE | OMV_RGB_DISPLAY_BUFFER_FLAGS);
         display.framebuffer_layers[i].WindowX0 = 0;
         display.framebuffer_layers[i].WindowX1 = dm->hactive;
         display.framebuffer_layers[i].WindowY0 = 0;


### PR DESCRIPTION
For the longest the OpenMV PT has suffered from display stability issues were the screen would loose lock and flicker randomly. On debugging the issue I determined it was due to a FIFO underflow by the display controller which generated interrupts saying this.

The OpenMV PT becomes unstable due to the additional memory load caused by rendering the thermal color image from the FLIR Lepton on the regular image. Removing this rendering step makes the system stable... but, then there's no thermal overlay.

On further debugging, it was discovered the the display stability could be achieved by pushing the screen buffer allocation into its own SDRAM bank. However, with fballoc, this wasn't fixable in any pretty way.

Now thanks to umalloc, it's possible to create a private data pool for just the display controller so that it can receive the highest possible SDRAM bandwidth by having it's own private bank.

...

The Arduino Giga doesn't show any display stability issues compared to the OpenMV PT. Since it's not dealing with dual cameras and thermal overlay, the memory load is lower.