### PR TITLE
common: Add UMA fast stats.

### DIFF
--- a/common/umalloc.c
+++ b/common/umalloc.c
@@ -93,6 +93,7 @@ void uma_pool_add(void *mem, size_t size, uint32_t flags) {
     p->flags = flags;
     p->size = usable;
     p->free = usable;
+    p->persist = 0;
     p->peak = 0;
 }
 
@@ -170,11 +171,11 @@ void *uma_malloc(size_t size, uint32_t flags) {
         uma_fail();
     }
 
+    pool->free -= tlsf_block_size(ptr);
     if (flags & UMA_PERSIST) {
         tlsf_block_set_persist(ptr);
+        pool->persist += tlsf_block_size(ptr);
     }
-
-    pool->free -= tlsf_block_size(ptr);
     if ((pool->size - pool->free) > pool->peak) {
         pool->peak = pool->size - pool->free;
     }
@@ -207,11 +208,11 @@ void *uma_malign(size_t size, size_t align, uint32_t flags) {
         uma_fail();
     }
 
+    pool->free -= tlsf_block_size(ptr);
     if (flags & UMA_PERSIST) {
         tlsf_block_set_persist(ptr);
+        pool->persist += tlsf_block_size(ptr);
     }
-
-    pool->free -= tlsf_block_size(ptr);
     if ((pool->size - pool->free) > pool->peak) {
         pool->peak = pool->size - pool->free;
     }
@@ -230,6 +231,11 @@ void *uma_calloc(size_t size, uint32_t flags) {
 void *uma_realloc(void *ptr, size_t size, uint32_t flags) {
     if (!ptr) {
         return uma_malloc(size, flags);
+    }
+
+    if ((flags & UMA_PERSIST) || tlsf_block_is_persist(ptr)) {
+        // Well, we can, but there's no use use and it's much simple this way.
+        mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("can't realloc a persistent block"));
     }
 
     if (size == 0) {
@@ -287,10 +293,6 @@ void *uma_realloc(void *ptr, size_t size, uint32_t flags) {
         old_size = 0;   // for accounting
     }
 
-    if (flags & UMA_PERSIST) {
-        tlsf_block_set_persist(p);
-    }
-
     size_t new_size = tlsf_block_size(p);
     pool->free += (int) old_size - (int) new_size;
     if ((pool->size - pool->free) > pool->peak) {
@@ -306,6 +308,9 @@ void uma_free(void *ptr) {
     }
 
     uma_pool_t *pool = uma_pool_find(ptr, 0, 0);
+    if (tlsf_block_is_persist(ptr)) {
+        pool->persist -= tlsf_block_size(ptr);
+    }
     pool->free += tlsf_block_size(ptr);
     tlsf_free(pool->tlsf, ptr);
 }
@@ -348,6 +353,7 @@ void uma_transient_release(void) {
             uma_fail();
         }
         p->free = p->size;
+        p->persist = 0;
         p->peak = 0;
     }
 }
@@ -371,20 +377,16 @@ size_t uma_avail(uint32_t flags) {
 
 static void uma_block_walker(void *ptr, void *user) {
     uma_stats_t *s = (uma_stats_t *) user;
-    size_t size = tlsf_block_size(ptr);
     if (tlsf_block_is_free(ptr)) {
         s->free_count++;
-        s->free_bytes += size;
     } else if (tlsf_block_is_persist(ptr)) {
         s->persist_count++;
-        s->persist_bytes += size;
     } else {
         s->used_count++;
-        s->used_bytes += size;
     }
 }
 
-void uma_get_stats(int index, uma_stats_t *stats) {
+void uma_get_stats(int index, bool full, uma_stats_t *stats) {
     int start = 0, end = uma_num_pools;
 
     if (index >= 0 && index < uma_num_pools) {
@@ -395,7 +397,20 @@ void uma_get_stats(int index, uma_stats_t *stats) {
     memset(stats, 0, sizeof(*stats));
 
     for (int i = start; i < end; i++) {
-        tlsf_walk(uma_pools[i].tlsf, uma_block_walker, stats);
+        uma_pool_t *p = &uma_pools[i];
+        stats->free_bytes += p->free;
+        stats->used_bytes += p->size - p->free;
+        stats->persist_bytes += p->persist;
+    }
+
+    if (full) {
+        for (int i = start; i < end; i++) {
+            uma_pool_t *p = &uma_pools[i];
+            // It's not safe to walk transient pools
+            if (!(p->flags & UMA_TRANSIENT)) {
+                tlsf_walk(p->tlsf, uma_block_walker, stats);
+            }
+        }
     }
 
     if (end - start == 1) {
@@ -414,7 +429,7 @@ void uma_print_stats(int index) {
     for (int i = start; i < end; i++) {
         uma_pool_t *p = &uma_pools[i];
         uma_stats_t stats;
-        uma_get_stats(i, &stats);
+        uma_get_stats(i, true, &stats);
 
         printf("pool %d: base=0x%08lx size=%lu "
                "used=%lu(%lu) free=%lu(%lu) persist=%lu(%lu) "

--- a/common/umalloc.h
+++ b/common/umalloc.h
@@ -29,6 +29,7 @@
 #if !defined(LINKER_SCRIPT)
 #include <stdint.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #endif
 
 // Memory attributes (bits 0-7)
@@ -56,6 +57,7 @@ typedef struct {
     void *tlsf;
     size_t size;
     size_t free;
+    size_t persist;
     size_t peak;
     uintptr_t base;
     uintptr_t end;
@@ -88,7 +90,7 @@ void  uma_collect(void);
 size_t uma_avail(uint32_t flags);
 void uma_transient_acquire(void);
 void uma_transient_release(void);
-void uma_get_stats(int index, uma_stats_t *stats);
+void uma_get_stats(int index, bool full, uma_stats_t *stats);
 void uma_print_stats(int index);
 
 #endif // !LINKER_SCRIPT

--- a/modules/py_umalloc.c
+++ b/modules/py_umalloc.c
@@ -44,7 +44,7 @@ static MP_DEFINE_CONST_FUN_OBJ_0(py_umalloc_collect_obj, py_umalloc_collect);
 static mp_obj_t py_umalloc_stats(size_t n_args, const mp_obj_t *args) {
     int index = (n_args > 0) ? mp_obj_get_int(args[0]) : -1;
     uma_stats_t s;
-    uma_get_stats(index, &s);
+    uma_get_stats(index, true, &s);
     mp_obj_t tuple[7] = {
         mp_obj_new_int(s.used_count),
         mp_obj_new_int(s.free_count),

--- a/modules/unittests/umalloc.c
+++ b/modules/unittests/umalloc.c
@@ -295,7 +295,7 @@ static MP_DEFINE_CONST_FUN_OBJ_0(test_uma_collect_mixed_obj, test_uma_collect_mi
 // Test that stats reflect allocations.
 static mp_obj_t test_uma_stats(void) {
     uma_stats_t s;
-    uma_get_stats(-1, &s);
+    uma_get_stats(-1, true, &s);
     if (s.used_count != 0) {
         return mp_const_false;
     }
@@ -304,7 +304,7 @@ static mp_obj_t test_uma_stats(void) {
     void *b = uma_malloc(200, 0);
     void *c = uma_malloc(300, 0);
 
-    uma_get_stats(-1, &s);
+    uma_get_stats(-1, true, &s);
     if (s.used_count != 3) {
         uma_free(a);
         uma_free(b);
@@ -316,7 +316,7 @@ static mp_obj_t test_uma_stats(void) {
     uma_free(b);
     uma_free(c);
 
-    uma_get_stats(-1, &s);
+    uma_get_stats(-1, true, &s);
     if (s.used_count != 0) {
         return mp_const_false;
     }
@@ -331,14 +331,14 @@ static mp_obj_t test_uma_collect_stats(void) {
     uma_malloc(200, 0);
 
     uma_stats_t s;
-    uma_get_stats(-1, &s);
+    uma_get_stats(-1, true, &s);
     if (s.used_count != 2) {
         return mp_const_false;
     }
 
     uma_collect();
 
-    uma_get_stats(-1, &s);
+    uma_get_stats(-1, true, &s);
     if (s.used_count != 0) {
         return mp_const_false;
     }
@@ -655,7 +655,7 @@ static MP_DEFINE_CONST_FUN_OBJ_0(test_uma_pool_dtcm_strict_fail_obj, test_uma_po
 // Test that realloc with UMA_CACHE preserves alignment when the block relocates.
 static mp_obj_t test_uma_realloc_aligned(void) {
     // Allocate a cache-aligned block.
-    void *aligned = uma_malloc(128, UMA_CACHE | UMA_PERSIST);
+    void *aligned = uma_malloc(128, UMA_CACHE);
     if (!aligned || (uintptr_t) aligned % OMV_CACHE_LINE_SIZE != 0) {
         uma_free(aligned);
         return mp_const_false;
@@ -668,17 +668,16 @@ static mp_obj_t test_uma_realloc_aligned(void) {
         return mp_const_false;
     }
 
-    // Realloc to a larger size WITH UMA_CACHE. The blocker prevents
-    // in-place resize, forcing relocation — alignment must be preserved.
-    void *moved = uma_realloc(aligned, 256, UMA_CACHE | UMA_PERSIST);
+    // Realloc to a larger size. The blocker prevents in-place resize,
+    // forcing relocation - alignment must be preserved.
+    void *moved = uma_realloc(aligned, 256, UMA_CACHE);
     if (!moved) {
         uma_free(blocker);
         return mp_const_false;
     }
 
     bool pass = (moved != aligned
-                 && (uintptr_t) moved % OMV_CACHE_LINE_SIZE == 0
-                 && tlsf_block_is_persist(moved));
+                 && (uintptr_t) moved % OMV_CACHE_LINE_SIZE == 0);
 
     uma_free(moved);
     uma_free(blocker);


### PR DESCRIPTION
- Track persistent allocs manually via pool->persist field.
- Add bool full parameter to uma_get_stats:
  False -> use tracked vars (no block counts).
  True -> walk (non-transient) pools for block counts.

Note that walking transient pools is not safe as they may be in use at the time they're walked, or their contents might be overwritten and not reset yet.