### PR TITLE
imlib: Improve polling function.

### DIFF
--- a/lib/imlib/imlib.c
+++ b/lib/imlib/imlib.c
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include "py/obj.h"
 #include "py/runtime.h"
+#include "py/mphal.h"
 
 #include "font.h"
 #include "array.h"
@@ -39,6 +40,8 @@
 #ifdef IMLIB_ENABLE_GAMMA_LUT
 uint8_t gamma_table[256];
 #endif
+
+mp_uint_t imlib_last_poll_ms;
 
 void imlib_init() {
     #if (OMV_GPU_ENABLE == 1)
@@ -56,6 +59,15 @@ void imlib_deinit() {
     #if (OMV_JPEG_CODEC_ENABLE == 1)
     imlib_hardware_jpeg_deinit();
     #endif
+}
+
+void imlib_poll_events_handler(bool raise_exc) {
+    imlib_last_poll_ms = mp_hal_ticks_ms();
+    if (raise_exc) {
+        mp_event_handle_nowait();
+    } else {
+        mp_handle_pending_internal(MP_HANDLE_PENDING_CALLBACKS_ONLY);
+    }
 }
 
 #ifdef IMLIB_ENABLE_GAMMA_LUT

--- a/lib/imlib/imlib.h
+++ b/lib/imlib/imlib.h
@@ -45,6 +45,7 @@
 #include "omv_common.h"
 #include "omv_profiler.h"
 #include "py/runtime.h"
+#include "py/mphal.h"
 
 // Enables 38 TensorFlow Lite operators.
 #define IMLIB_TF_DEFAULT        (1)
@@ -117,12 +118,25 @@
 #define IM_DEG2RAD(x)            (((x) * IMLIB_PI) / 180.0f)
 #define IM_RAD2DEG(x)            (((x) * 180.0f) / IMLIB_PI)
 
-#define imlib_poll_events()                \
-    do {                                   \
-        static unsigned int _poll_ctr = 0; \
-        if (!(++_poll_ctr & 0x1F)) {       \
-            mp_event_handle_nowait();      \
-        }                                  \
+void imlib_poll_events_handler(bool raise_exc);
+extern mp_uint_t imlib_last_poll_ms;
+
+#ifndef IMLIB_POLL_INTERVAL_MS
+#define IMLIB_POLL_INTERVAL_MS  (10)
+#endif
+
+#define imlib_poll_events()                                      \
+    do {                                                         \
+        mp_uint_t _now = mp_hal_ticks_ms();                      \
+        if (_now - imlib_last_poll_ms >= IMLIB_POLL_INTERVAL_MS) \
+        imlib_poll_events_handler(true);                         \
+    } while (0)
+
+#define imlib_poll_events_noexc()                                \
+    do {                                                         \
+        mp_uint_t _now = mp_hal_ticks_ms();                      \
+        if (_now - imlib_last_poll_ms >= IMLIB_POLL_INTERVAL_MS) \
+        imlib_poll_events_handler(false);                        \
     } while (0)
 
 int imlib_ksize_to_n(int ksize);

--- a/lib/stai/stai_backend.c
+++ b/lib/stai/stai_backend.c
@@ -32,7 +32,7 @@
  */
 #include <string.h>
 #include <stdint.h>
-#include "imlib_config.h"
+#include "imlib.h"
 #include "omv_common.h"
 #include STM32_HAL_H
 
@@ -272,6 +272,7 @@ int ml_backend_run_inference(py_ml_model_obj_t *model) {
             nlr_buf_t nlr;
             if (nlr_push(&nlr) == 0) {
                 LL_ATON_OSAL_ENTER_CS();
+                imlib_poll_events();
                 mp_event_handle_nowait();
                 LL_ATON_OSAL_EXIT_CS();
                 nlr_pop();

--- a/ports/alif/alif_npu.c
+++ b/ports/alif/alif_npu.c
@@ -37,6 +37,7 @@
 #include "py/mphal.h"
 #include "py/runtime.h"
 
+#include "imlib.h"
 #include "alif_hal.h"
 #include "board_config.h"
 #include "ethosu_driver.h"
@@ -140,11 +141,11 @@ uint64_t ethosu_address_remap(uint64_t address, int index) {
 }
 
 void ethosu_inference_begin(struct ethosu_driver *drv, void *user_arg) {
-    mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_ONLY);
+    imlib_poll_events_noexc();
 }
 
 void ethosu_inference_end(struct ethosu_driver *drv, void *user_arg) {
-    mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_ONLY);
+    imlib_poll_events_noexc();
 }
 
 void ETHOSU_IRQ_HANDLER(void) {


### PR DESCRIPTION
Poll immediately when TinyUSB has pending events to keep USB responsive, otherwise poll at most once per ms. The interval is overridable via `IMLIB_POLL_INTERVAL_MS`.