### PR TITLE
lib/stai: Fix event handling.

### DIFF
--- a/lib/stai/stai_backend.c
+++ b/lib/stai/stai_backend.c
@@ -264,12 +264,14 @@ int ml_backend_run_inference(py_ml_model_obj_t *model) {
         // Execute first/next runtime step
         ll_aton_rt_ret = LL_ATON_RT_RunEpochBlock(&state->nn_inst);
 
-        // Handle pending events (TinyUSB, OMV Protocol etc..)
-        mp_handle_pending_internal(MP_HANDLE_PENDING_CALLBACKS_ONLY);
-
-        // Wait for the next event
         if (ll_aton_rt_ret == LL_ATON_RT_WFE) {
+            // Epoch block is still running - wait for the NPU interrupt.
             LL_ATON_OSAL_WFE();
+        } else if (ll_aton_rt_ret == LL_ATON_RT_NO_WFE) {
+            // Epoch block finished and NPU is idle - handle pending events.
+            // Note MSC callbacks may erase/write the SPI flash, which exits
+            // (XIP) mode. It's only safe to handle events when the NPU is idle.
+            mp_handle_pending_internal(MP_HANDLE_PENDING_CALLBACKS_ONLY);
         }
     } while (ll_aton_rt_ret != LL_ATON_RT_DONE);
 


### PR DESCRIPTION
USB MSC callbacks may erase/write SPI flash, which requires exiting memory-mapped (XIP) mode on XSPI2. This conflicts with the NPU doing XIP reads from XSPI1 via the shared XSPI manager. Only run pending event handlers when RunEpochBlock returns NO_WFE, indicating the epoch block finished and the NPU is idle.