### PR TITLE
framebuffer: Track FPS in stream frame header.

### DIFF
--- a/lib/imlib/framebuffer.c
+++ b/lib/imlib/framebuffer.c
@@ -263,6 +263,20 @@ void framebuffer_update_preview(image_t *src) {
     static int overflow_count = 0;
     framebuffer_t *fb = framebuffer_get(FB_STREAM_ID);
 
+    // Update FPS tracking (EMA of frame time in ms).
+    uint32_t now = mp_hal_ticks_ms();
+    if (fb->fps_last_ms) {
+        uint32_t delta = now - fb->fps_last_ms;
+        if (delta > 0) {
+            if (fb->fps_frame_time > 0.0f) {
+                fb->fps_frame_time = fb->fps_frame_time * 0.9f + delta * 0.1f;
+            } else {
+                fb->fps_frame_time = delta;
+            }
+        }
+    }
+    fb->fps_last_ms = now;
+
     // Check if the streaming buffer is disabled, image is NULL or format is not set.
     if (!fb->enabled || !src->data || src->pixfmt == PIXFORMAT_INVALID) {
         return;
@@ -365,6 +379,7 @@ exit_cleanup:
     header->pixfmt = fb->pixfmt;
     header->size = fb->is_compressed ? fb->size : fb->bpp;
     header->offset = sizeof(framebuffer_header_t);
+    header->fps = (fb->fps_frame_time > 0.0f) ? 1000.0f / fb->fps_frame_time : 0.0f;
 
     // Unlock the streaming buffer.
     if (overflow) {

--- a/lib/imlib/framebuffer.h
+++ b/lib/imlib/framebuffer.h
@@ -90,6 +90,8 @@ typedef struct framebuffer {
     queue_t *used_queue;    // Vbuffer used/read queue.
     queue_t *free_queue;    // Vbuffer free/write queue.
     char raw_static[queue_calc_size(3) * 2]; // Static memory for small queues.
+    uint32_t fps_last_ms;   // Timestamp of last preview update.
+    float fps_frame_time;   // Exponential moving average frame time in ms.
 } framebuffer_t;
 
 // Drivers can add more flags:
@@ -114,6 +116,7 @@ typedef struct __attribute__((packed)) framebuffer_header {
     uint32_t height;    // Frame height
     PIXFORMAT_STRUCT;   // Pixel format
     uint32_t offset;    // Data offset
+    float fps;          // Frames per second
     OMV_ATTR_ALIGNED(uint8_t data[], FRAMEBUFFER_ALIGNMENT);
 } framebuffer_header_t;
 


### PR DESCRIPTION
Add EMA-based frame time tracking to framebuffer_update_preview() and embed the computed FPS in the stream frame header, so the IDE can read it without requiring script-level clock boilerplate.