### PR TITLE
nema: Poll events in nema_wait_irq_cl.

### DIFF
--- a/ports/stm32/omv_gpu.c
+++ b/ports/stm32/omv_gpu.c
@@ -184,7 +184,7 @@ int omv_gpu_draw_image(image_t *src_img,
     HAL_ICACHE_WaitForInvalidateComplete();
 
     nema_cl_submit(&cl);
-    nema_cl_wait(&cl);
+    int ret = nema_cl_wait(&cl);
 
     #if !OMV_GPU_NEMA_MM_STATIC
     nema_cl_destroy(&cl);
@@ -195,7 +195,7 @@ int omv_gpu_draw_image(image_t *src_img,
     HAL_ICACHE_Invalidate_IT();
 
     SCB_InvalidateDCache_by_Addr(dst_img->data, image_size(dst_img));
-    return 0;
+    return ret;
 }
 #else
 int omv_gpu_draw_image(image_t *src_img,

--- a/ports/stm32/stm_nema.c
+++ b/ports/stm32/stm_nema.c
@@ -30,6 +30,7 @@
 
 #if (OMV_GPU_NEMA == 1)
 #include "py/mphal.h"
+#include "py/runtime.h"
 #include "irq.h"
 
 #include "omv_common.h"
@@ -38,6 +39,10 @@
 
 #ifndef OMV_GPU_NEMA_RING_SIZE
 #define OMV_GPU_NEMA_RING_SIZE 1024
+#endif
+
+#ifndef OMV_GPU_NEMA_TIMEOUT_MS
+#define OMV_GPU_NEMA_TIMEOUT_MS 500
 #endif
 
 volatile static int last_cl_id = -1;
@@ -85,8 +90,13 @@ int32_t nema_sys_init(void) {
 }
 
 int nema_wait_irq_cl(int cl_id) {
+    mp_uint_t tick_start = mp_hal_ticks_ms();
     while (last_cl_id < cl_id) {
-        __WFI();
+        mp_uint_t elapsed = mp_hal_ticks_ms() - tick_start;
+        if (elapsed >= OMV_GPU_NEMA_TIMEOUT_MS) {
+            return -1;
+        }
+        mp_event_wait_ms(OMV_GPU_NEMA_TIMEOUT_MS - elapsed);
     }
     return 0;
 }


### PR DESCRIPTION
nema_wait_irq_cl can block for a while causing the connection to be dropped. Use mp_event_wait_ms to service USB and other events while waiting, and return an error on timeout so the caller can fall back to software rendering.