### PR TITLE
protocol: Run tud_task from PendSV dispatch.

### DIFF
--- a/common/micropy.mk
+++ b/common/micropy.mk
@@ -119,6 +119,9 @@ endif
 ifeq ($(MICROPY_PY_PROTOCOL), 1)
 MPY_CFLAGS += -DMICROPY_PY_PROTOCOL=1
 MPY_MKARGS += MICROPY_PY_PROTOCOL=1
+ifeq ($(OMV_USB_STACK_TINYUSB), 1)
+MPY_PENDSV_ENTRIES += PENDSV_DISPATCH_OMV_PROTOCOL,
+endif
 endif
 
 # +-----------------------------------------------------+

--- a/lib/stai/stai_backend.c
+++ b/lib/stai/stai_backend.c
@@ -44,6 +44,7 @@
 #include "py/gc.h"
 #include "py_ml.h"
 #include "umalloc.h"
+#include "omv_protocol.h"
 
 #include "ll_aton_runtime.h"
 #include "ll_aton_platform.h"
@@ -249,8 +250,6 @@ int ml_backend_run_inference(py_ml_model_obj_t *model) {
     LL_ATON_RT_RetValues_t ll_aton_rt_ret;
     ml_backend_state_t *state = (ml_backend_state_t *) model->state;
 
-    uma_transient_acquire();
-
     // Flush input buffers.
     for (size_t i = 0; i < model->inputs_size; i++) {
         const LL_Buffer_InfoTypeDef *buf = ll_aton_reloc_get_input_buffers_info(&state->nn_inst, i);
@@ -259,6 +258,10 @@ int ml_backend_run_inference(py_ml_model_obj_t *model) {
 
     LL_ATON_RT_RuntimeInit();
     LL_ATON_RT_Init_Network(&state->nn_inst);
+    uma_transient_acquire();
+
+    // Note MSC callbacks may erase/write the SPI flash, which exits XIP.
+    OMV_PROTOCOL_XIP_ENTER();
 
     do {
         // Execute first/next runtime step
@@ -267,13 +270,11 @@ int ml_backend_run_inference(py_ml_model_obj_t *model) {
         if (ll_aton_rt_ret == LL_ATON_RT_WFE) {
             // Epoch block is still running - wait for the NPU interrupt.
             LL_ATON_OSAL_WFE();
-        } else if (ll_aton_rt_ret == LL_ATON_RT_NO_WFE) {
-            // Epoch block finished and NPU is idle - handle pending events.
-            // Note MSC callbacks may erase/write the SPI flash, which exits
-            // (XIP) mode. It's only safe to handle events when the NPU is idle.
-            mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_ONLY);
         }
     } while (ll_aton_rt_ret != LL_ATON_RT_DONE);
+
+    // Note MSC callbacks may erase/write the SPI flash, which exits XIP.
+    OMV_PROTOCOL_XIP_EXIT();
 
     LL_ATON_RT_DeInit_Network(&state->nn_inst);
     LL_ATON_RT_RuntimeDeInit();

--- a/ports/alif/alif.mk
+++ b/ports/alif/alif.mk
@@ -149,7 +149,8 @@ LDFLAGS = -mthumb \
 
 ifeq ($(MCU_CORE),M55_HP)
 # Linker Flags
-LDFLAGS += -Wl,--wrap=mp_hal_stdio_poll \
+LDFLAGS += -Wl,--wrap=tud_task_ext \
+           -Wl,--wrap=mp_hal_stdio_poll \
            -Wl,--wrap=mp_hal_stdout_tx_strn
 endif
 

--- a/ports/alif/alif_npu.c
+++ b/ports/alif/alif_npu.c
@@ -40,6 +40,7 @@
 #include "alif_hal.h"
 #include "board_config.h"
 #include "ethosu_driver.h"
+#include "omv_protocol.h"
 
 #define ETHOSU_SEC_ENABLED      (1)
 #define ETHOSU_PRIV_ENABLED     (1)
@@ -140,11 +141,11 @@ uint64_t ethosu_address_remap(uint64_t address, int index) {
 }
 
 void ethosu_inference_begin(struct ethosu_driver *drv, void *user_arg) {
-    mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_ONLY);
+    OMV_PROTOCOL_XIP_ENTER();
 }
 
 void ethosu_inference_end(struct ethosu_driver *drv, void *user_arg) {
-    mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_ONLY);
+    OMV_PROTOCOL_XIP_EXIT();
 }
 
 void ETHOSU_IRQ_HANDLER(void) {

--- a/ports/alif/main.c
+++ b/ports/alif/main.c
@@ -237,6 +237,7 @@ soft_reset_exit:
     machine_pwm_deinit_all();
     machine_pin_irq_deinit();
     imlib_deinit();
+    omv_protocol_deinit();
     soft_timer_deinit();
     dma_deinit_all();
     gc_sweep_all();

--- a/ports/mimxrt/main.c
+++ b/ports/mimxrt/main.c
@@ -214,6 +214,7 @@ soft_reset:
     machine_i2s_deinit_all();
     #endif
     machine_pwm_deinit_all();
+    omv_protocol_deinit();
     soft_timer_deinit();
     imlib_deinit();
     gc_sweep_all();

--- a/ports/mimxrt/port_config.mk
+++ b/ports/mimxrt/port_config.mk
@@ -77,6 +77,7 @@ LDFLAGS = -mthumb \
           -mabi=aapcs-linux \
           -Wl,--print-memory-usage \
           -Wl,--gc-sections \
+          -Wl,--wrap=tud_task_ext \
           -Wl,--wrap=mp_hal_stdio_poll \
           -Wl,--wrap=mp_hal_stdout_tx_strn \
           -Wl,-T$(BUILD)/$(LDSCRIPT).lds \

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -407,6 +407,7 @@ soft_reset:
     py_audio_deinit();
     #endif
     imlib_deinit();
+    omv_protocol_deinit();
     soft_timer_deinit();
     #if MICROPY_HW_ENABLE_USB_RUNTIME_DEVICE && MICROPY_HW_TINYUSB_STACK
     mp_usbd_deinit();

--- a/ports/stm32/port_config.mk
+++ b/ports/stm32/port_config.mk
@@ -83,7 +83,8 @@ LDFLAGS = -mthumb \
           -Wl,-Map=$(BUILD)/$(FIRMWARE).map
 
 ifeq ($(OMV_USB_STACK_TINYUSB), 1)
-LDFLAGS += -Wl,--wrap=mp_hal_stdio_poll \
+LDFLAGS += -Wl,--wrap=tud_task_ext \
+           -Wl,--wrap=mp_hal_stdio_poll \
            -Wl,--wrap=mp_hal_stdout_tx_strn
 else
 LDFLAGS += -Wl,--wrap=usbd_cdc_control \

--- a/protocol/omv_protocol.c
+++ b/protocol/omv_protocol.c
@@ -113,10 +113,16 @@ int omv_protocol_init_default() {
 
     #endif // OMV_PROTOCOL_DEFAULT_CHANNELS
 
+    // Resume transport channel.
+    omv_protocol_resume();
+
     return 0;
 }
 
 void omv_protocol_deinit(void) {
+    // Suspend transport channel.
+    omv_protocol_suspend();
+
     // Deinitialize all channels (including transport at index 0)
     for (int i = 0; i < OMV_PROTOCOL_MAX_CHANNELS; i++) {
         if (ctx.channels[i] && ctx.channels[i]->deinit) {
@@ -149,6 +155,20 @@ void omv_protocol_reset(void) {
 bool omv_protocol_is_active(void) {
     const omv_protocol_channel_t *transport = omv_protocol_find_transport();
     return transport && transport->is_active(transport);
+}
+
+void omv_protocol_suspend(void) {
+    const omv_protocol_channel_t *transport = omv_protocol_find_transport();
+    if (transport && transport->suspend) {
+        transport->suspend(transport);
+    }
+}
+
+void omv_protocol_resume(void) {
+    const omv_protocol_channel_t *transport = omv_protocol_find_transport();
+    if (transport && transport->resume) {
+        transport->resume(transport);
+    }
 }
 
 bool omv_protocol_exec_script(void) {

--- a/protocol/omv_protocol.h
+++ b/protocol/omv_protocol.h
@@ -84,6 +84,21 @@
 #define OMV_PROTOCOL_EVENT_POLL()           mp_event_handle_nowait()
 #endif
 
+// XIP critical section macros. Suspend USB event processing before
+// entering XIP-dependent code (e.g., NPU inference), resume after.
+// EXIT drains any protocol task scheduled by resume's PendSV dispatch.
+#define OMV_PROTOCOL_XIP_ENTER()                             \
+    do {                                                     \
+        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_ONLY); \
+        omv_protocol_suspend();                              \
+    } while (0)
+
+#define OMV_PROTOCOL_XIP_EXIT()                              \
+    do {                                                     \
+        omv_protocol_resume();                               \
+        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_ONLY); \
+    } while (0)
+
 #define omv_protocol_check_timeout(start_ms, timeout) \
     ((OMV_PROTOCOL_TICKS_MS() - start_ms) > timeout)
 
@@ -375,6 +390,10 @@ void omv_protocol_deinit(void);
 
 // Helper function to check if the transport is active.
 bool omv_protocol_is_active(void);
+
+// Suspend/resume protocol background processing.
+void omv_protocol_suspend(void);
+void omv_protocol_resume(void);
 
 // Helper function to exec scripts in stdio buffer.
 // Returns false, if no script is ready, true on executing the script.

--- a/protocol/omv_protocol_channel.h
+++ b/protocol/omv_protocol_channel.h
@@ -139,6 +139,8 @@ struct omv_protocol_channel {
     // Stdin-specific function to execute scripts internall (not exposed via ioctl).
     bool (*exec) (const omv_protocol_channel_t *channel);
     // Transport-specific functions (for channel ID 0 only)
+    void (*suspend) (const omv_protocol_channel_t *channel);
+    void (*resume) (const omv_protocol_channel_t *channel);
     bool (*is_active) (const omv_protocol_channel_t *channel);
 };
 

--- a/protocol/omv_protocol_channel_tinyusb.c
+++ b/protocol/omv_protocol_channel_tinyusb.c
@@ -24,9 +24,7 @@
  * OpenMV Protocol USB Channel.
  */
 #if OMV_USB_STACK_TINYUSB
-#include "py/stream.h"
 #include "py/mphal.h"
-#include "py/ringbuf.h"
 #include "py/runtime.h"
 
 #include "omv_common.h"
@@ -34,25 +32,30 @@
 #include "omv_protocol.h"
 #include "board_config.h"
 #include "tusb.h"
+#include "device/dcd.h"
+#include "pendsv.h"
 
 #ifndef OMV_PROTOCOL_USB_CHANNEL_TIMEOUT_MS
 #define OMV_PROTOCOL_USB_CHANNEL_TIMEOUT_MS (1500)
 #endif
 
-static bool usb_channel_active;
+static volatile bool usb_channel_active;
+static volatile bool usb_channel_masked;
+static volatile bool usb_channel_pending;
+static mp_sched_node_t usb_protocol_node;
+
+static void usb_channel_suspend(const omv_protocol_channel_t *channel);
+static void usb_channel_resume(const omv_protocol_channel_t *channel);
 
 static size_t usb_channel_size(const omv_protocol_channel_t *channel) {
-    if (tud_task_event_ready()) {
-        tud_task_ext(0, false);
-    }
     return tud_cdc_available();
 }
 
 static int usb_channel_flush(const omv_protocol_channel_t *channel) {
-    if (tud_task_event_ready()) {
-        tud_task_ext(0, false);
-    }
-    return tud_cdc_write_flush();
+    usb_channel_suspend(channel);
+    int ret = tud_cdc_write_flush();
+    usb_channel_resume(channel);
+    return ret;
 }
 
 static bool usb_channel_is_active(const omv_protocol_channel_t *channel) {
@@ -64,12 +67,6 @@ static int usb_channel_read(const omv_protocol_channel_t *channel, uint32_t offs
     uint32_t start_ms = mp_hal_ticks_ms();
     while (bytes < size && !check_timeout_ms(start_ms, OMV_PROTOCOL_USB_CHANNEL_TIMEOUT_MS)) {
         bytes += tud_cdc_read((uint8_t *) data + bytes, size - bytes);
-        if (tud_task_event_ready()) {
-            tud_task_ext(0, false);
-        }
-        if (bytes < size) {
-            mp_event_handle_nowait();
-        }
     }
 
     return bytes;
@@ -80,21 +77,48 @@ static int usb_channel_write(const omv_protocol_channel_t *channel, uint32_t off
     uint32_t start_ms = mp_hal_ticks_ms();
     while (bytes < size && !check_timeout_ms(start_ms, OMV_PROTOCOL_USB_CHANNEL_TIMEOUT_MS)) {
         bytes += tud_cdc_write((uint8_t *) data + bytes, size - bytes);
-        if (tud_task_event_ready()) {
-            tud_task_ext(0, false);
-        }
-        if (bytes < size) {
-            mp_event_handle_nowait();
-        }
     }
 
     return bytes;
 }
 
-static void usb_channel_task(mp_sched_node_t *node) {
-    tud_task_ext(0, false);
-    if (omv_protocol_is_active()) {
+// Runs from main thread via scheduler node - safe for Python channels.
+static void usb_protocol_task(mp_sched_node_t *node) {
+    if (usb_channel_active && !usb_channel_masked) {
         omv_protocol_task();
+    }
+}
+
+// Wrap tud_task_ext to prevent MicroPython or any other code from
+// calling it while the protocol channel is active. Only usb_channel_pump
+// (from PendSV) should call tud_task_ext via __real_tud_task_ext.
+bool __real_tud_task_ext(uint32_t timeout_ms, bool in_isr);
+bool __wrap_tud_task_ext(uint32_t timeout_ms, bool in_isr) {
+    if (usb_channel_active) {
+        return false;
+    }
+    return __real_tud_task_ext(timeout_ms, in_isr);
+}
+
+// Runs from PendSV - drains USB events then schedules protocol for main thread.
+static void usb_channel_pump(void) {
+    if (usb_channel_masked) {
+        usb_channel_pending = true;
+    } else {
+        __real_tud_task_ext(0, true);
+        mp_sched_schedule_node(&usb_protocol_node, usb_protocol_task);
+        usb_channel_pending = false;
+    }
+}
+
+static void usb_channel_suspend(const omv_protocol_channel_t *channel) {
+    usb_channel_masked = true;
+}
+
+static void usb_channel_resume(const omv_protocol_channel_t *channel) {
+    usb_channel_masked = false;
+    if (usb_channel_pending) {
+        pendsv_schedule_dispatch(PENDSV_DISPATCH_OMV_PROTOCOL, usb_channel_pump);
     }
 }
 
@@ -102,13 +126,9 @@ static void usb_channel_task(mp_sched_node_t *node) {
 void tud_cdc_rx_cb(uint8_t itf) {
     extern void __mp_tud_cdc_rx_cb(uint8_t itf);
 
-    if (!omv_protocol_is_active()) {
+    if (!usb_channel_active) {
         __mp_tud_cdc_rx_cb(itf);
     }
-}
-
-void tud_cdc_line_coding_cb(uint8_t itf, cdc_line_coding_t const *coding) {
-    usb_channel_active = (coding->bit_rate == OMV_PROTOCOL_MAGIC_BAUDRATE);
 }
 
 void tud_cdc_line_state_cb(uint8_t instance, bool dtr, bool rts) {
@@ -117,11 +137,7 @@ void tud_cdc_line_state_cb(uint8_t instance, bool dtr, bool rts) {
     cdc_line_coding_t coding;
     tud_cdc_get_line_coding(&coding);
 
-    if (!dtr) {
-        usb_channel_active = false;
-    } else {
-        usb_channel_active = (coding.bit_rate == OMV_PROTOCOL_MAGIC_BAUDRATE);
-    }
+    usb_channel_active = dtr && (coding.bit_rate == OMV_PROTOCOL_MAGIC_BAUDRATE);
 
     if (!usb_channel_active) {
         __mp_tud_cdc_line_state_cb(instance, dtr, rts);
@@ -129,13 +145,16 @@ void tud_cdc_line_state_cb(uint8_t instance, bool dtr, bool rts) {
 }
 
 void tud_event_hook_cb(uint8_t rhport, uint32_t eventid, bool in_isr) {
-    static mp_sched_node_t usb_channel_node;
     extern void __mp_tud_event_hook_cb(uint8_t rhport, uint32_t eventid, bool in_isr);
 
-    if (!omv_protocol_is_active()) {
+    if (eventid == DCD_EVENT_BUS_RESET) {
+        usb_channel_active = false;
+    }
+
+    if (!usb_channel_active) {
         __mp_tud_event_hook_cb(rhport, eventid, in_isr);
-    } else if (tud_task_event_ready()) {
-        mp_sched_schedule_node(&usb_channel_node, usb_channel_task);
+    } else {
+        pendsv_schedule_dispatch(PENDSV_DISPATCH_OMV_PROTOCOL, usb_channel_pump);
     }
 }
 
@@ -149,6 +168,8 @@ const omv_protocol_channel_t omv_usb_channel = {
     .read = usb_channel_read,
     .write = usb_channel_write,
     .flush = usb_channel_flush,
+    .suspend = usb_channel_suspend,
+    .resume = usb_channel_resume,
     .is_active = usb_channel_is_active
 };
 #endif // OMV_USB_STACK_TINYUSB


### PR DESCRIPTION
This PR runs TinyUSB polling from PendSV dispatch scheduled right from USB IRQ (tud_event_cb). PendSV mostly runs right after USB IRQ returns, which makes USB respond almost instantly. The dispatch callback also schedules the protocol to run in VM context where it's safe to raise.

There's still room for improvement here, we could run the protocol polling from the dispatch callback directly, so the flow would be: USB IRQ -> dispatch -> PendSV -> tud_task + protocol_task. However, this is more tricky as we'll need to make sure nothing raises exceptions and we'll need to gate PendSV around critical sections (like gc_ functions).
