### PR TITLE
modules: Add raw_bpp control from py_csi_ng.

### DIFF
--- a/common/omv_csi.c
+++ b/common/omv_csi.c
@@ -1340,10 +1340,12 @@ __weak int omv_csi_set_framebuffers(omv_csi_t *csi, size_t count) {
     // TODO pass this to resize.
     #if OMV_CSI_HW_CROP_ENABLE
     // If hardware cropping is supported, use window size.
-    size_t frame_size = csi->fb->u * csi->fb->v * 2;
+    size_t frame_size = csi->fb->u * csi->fb->v * csi->fb->raw_bpp;
     #else
     // Otherwise, use the real frame size.
-    size_t frame_size = csi->resolution[csi->framesize][0] * csi->resolution[csi->framesize][1] * 2;
+    size_t frame_size = csi->resolution[csi->framesize][0] *
+                        csi->resolution[csi->framesize][1] *
+                        csi->fb->raw_bpp;
     #endif
 
     if (count == -1) {

--- a/lib/imlib/framebuffer.c
+++ b/lib/imlib/framebuffer.c
@@ -44,18 +44,18 @@ void framebuffer_init0() {
     bool enabled = framebuffer_get(FB_STREAM_ID)->enabled;
 
     // Initialize the main framebuffer.
-    framebuffer_init(framebuffer_get(FB_MAINFB_ID), NULL, 0, true, true);
+    framebuffer_init(framebuffer_get(FB_MAINFB_ID), NULL, 0, true, true, FRAMEBUFFER_RAW_BPP_DEF);
 
     // Initialize the streaming buffer.
     framebuffer_init(framebuffer_get(FB_STREAM_ID), &_sb_memory_start,
-                     &_sb_memory_end - &_sb_memory_start, false, enabled);
+                     &_sb_memory_end - &_sb_memory_start, false, enabled, FRAMEBUFFER_RAW_BPP_DEF);
 
     // Reset embedded header
     framebuffer_t *fb = framebuffer_get(FB_STREAM_ID);
     memset(fb->raw_base, 0, sizeof(framebuffer_header_t));
 }
 
-void framebuffer_init(framebuffer_t *fb, void *buff, size_t size, bool dynamic, bool enabled) {
+void framebuffer_init(framebuffer_t *fb, void *buff, size_t size, bool dynamic, bool enabled, int raw_bpp) {
     // Clear framebuffers
     memset(fb, 0, sizeof(framebuffer_t));
 
@@ -63,6 +63,7 @@ void framebuffer_init(framebuffer_t *fb, void *buff, size_t size, bool dynamic, 
     fb->raw_base = buff;
     fb->dynamic = dynamic;
     fb->enabled = enabled;
+    fb->raw_bpp = raw_bpp;
     #if OMV_RAW_PREVIEW_ENABLE
     fb->raw_w = OMV_RAW_PREVIEW_WIDTH;
     fb->raw_h = OMV_RAW_PREVIEW_HEIGHT;

--- a/lib/imlib/framebuffer.h
+++ b/lib/imlib/framebuffer.h
@@ -35,6 +35,10 @@
 #define FRAMEBUFFER_ALIGNMENT    OMV_CACHE_LINE_SIZE
 #endif
 
+#ifndef FRAMEBUFFER_RAW_BPP_DEF
+#define FRAMEBUFFER_RAW_BPP_DEF  2
+#endif
+
 // Framebuffer ID
 typedef enum {
     FB_MAINFB_ID    = 0,
@@ -81,6 +85,7 @@ typedef struct framebuffer {
     uint8_t enabled;        // Enable/disable framebuffer
     uint8_t quality;        // JPEG compression quality (1-100)
     uint8_t raw_enabled;    // Enable raw streaming
+    uint32_t raw_bpp;       // Bytes per pixel for resizing.
     uint32_t source;        // Stream buffer source ID.
     size_t raw_size;        // Raw buffer size.
     char *raw_base;         // Raw buffer address.
@@ -123,7 +128,7 @@ typedef struct __attribute__((packed)) framebuffer_header {
 void framebuffer_init0();
 
 // Initializes a frame buffer instance.
-void framebuffer_init(framebuffer_t *fb, void *buff, size_t size, bool dynamic, bool enabled);
+void framebuffer_init(framebuffer_t *fb, void *buff, size_t size, bool dynamic, bool enabled, int raw_bpp);
 
 // Initializes an image from the frame buffer.
 void framebuffer_to_image(framebuffer_t *fb, image_t *img);

--- a/modules/py_csi_ng.c
+++ b/modules/py_csi_ng.c
@@ -1346,12 +1346,13 @@ static mp_obj_t py_csi_read_reg(mp_obj_t self_in, mp_obj_t addr) {
 static MP_DEFINE_CONST_FUN_OBJ_2(py_csi_read_reg_obj, py_csi_read_reg);
 
 mp_obj_t py_csi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    enum { ARG_id, ARG_delays, ARG_fflush, ARG_stream };
+    enum { ARG_id, ARG_delays, ARG_fflush, ARG_stream, ARG_raw_bpp };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_cid, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = -1 } },
         { MP_QSTR_delays, MP_ARG_BOOL | MP_ARG_KW_ONLY,  {.u_bool = true} },
         { MP_QSTR_fflush, MP_ARG_BOOL | MP_ARG_KW_ONLY,  {.u_bool = true} },
         { MP_QSTR_stream, MP_ARG_OBJ | MP_ARG_KW_ONLY,  {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_raw_bpp, MP_ARG_INT | MP_ARG_KW_ONLY,  {.u_int = -1} },
     };
 
     // Parse args.
@@ -1359,6 +1360,7 @@ mp_obj_t py_csi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, 
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     omv_csi_t *csi = omv_csi_get(args[ARG_id].u_int);
+    int raw_bpp = args[ARG_raw_bpp].u_int;
 
     if (!csi || !csi->detected) {
         omv_csi_raise_error(OMV_CSI_ERROR_ISC_UNDETECTED);
@@ -1373,7 +1375,9 @@ mp_obj_t py_csi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, 
 
     if (csi->fb == NULL) {
         csi->fb = (framebuffer_t *) m_malloc(sizeof(framebuffer_t));
-        framebuffer_init(csi->fb, NULL, 0, true, true);
+        framebuffer_init(csi->fb, NULL, 0, true, true, raw_bpp > 0 ? raw_bpp : FRAMEBUFFER_RAW_BPP_DEF);
+    } else if (raw_bpp > 0) {
+        framebuffer_init(csi->fb, NULL, 0, true, true, raw_bpp);
     }
 
     // Set the streaming source.

--- a/modules/py_helper.c
+++ b/modules/py_helper.c
@@ -595,7 +595,7 @@ void py_helper_set_to_framebuffer(image_t *img) {
     #endif
 
     // Resize the frame buffer to fit the biggest uncompressed image.
-    framebuffer_resize(fb, 1, OMV_MAX(image_size(img), fb->u * fb->v * 2));
+    framebuffer_resize(fb, 1, OMV_MAX(image_size(img), fb->u * fb->v * fb->raw_bpp));
 
     // This should never be NULL after resizing the frame buffer.
     vbuffer_t *buffer = framebuffer_acquire(fb, FB_FLAG_FREE | FB_FLAG_PEEK);


### PR DESCRIPTION
Fixes: https://github.com/openmv/openmv/issues/3103

Restores previous larger resolution grayscale image processing on older boards like the OpenMV M4, M7, H7 and Arduino Nicla without SDRAM. You can now do:

```
import csi
import time

csi0 = csi.CSI(raw_bpp=1)
csi0.reset()
csi0.pixformat(csi.GRAYSCALE) # or BAYER
csi0.framesize(csi.VGA)
csi0.snapshot(time=2000)

clock = time.clock()

while True:
    clock.tick()
    img = csi0.snapshot()
    print(clock.fps())
```

To set the frame buffer to support GRAYSCALE/BAYER images only.