### PR TITLE
protocol: Clear dynamically allocated channels on soft-reboot.

### DIFF
--- a/ports/alif/main.c
+++ b/ports/alif/main.c
@@ -237,6 +237,7 @@ soft_reset_exit:
     machine_pwm_deinit_all();
     machine_pin_irq_deinit();
     imlib_deinit();
+    omv_protocol_deinit();
     soft_timer_deinit();
     dma_deinit_all();
     gc_sweep_all();

--- a/ports/mimxrt/main.c
+++ b/ports/mimxrt/main.c
@@ -214,6 +214,7 @@ soft_reset:
     machine_i2s_deinit_all();
     #endif
     machine_pwm_deinit_all();
+    omv_protocol_deinit();
     soft_timer_deinit();
     imlib_deinit();
     gc_sweep_all();

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -407,6 +407,7 @@ soft_reset:
     py_audio_deinit();
     #endif
     imlib_deinit();
+    omv_protocol_deinit();
     soft_timer_deinit();
     #if MICROPY_HW_ENABLE_USB_RUNTIME_DEVICE && MICROPY_HW_TINYUSB_STACK
     mp_usbd_deinit();

--- a/protocol/omv_protocol.c
+++ b/protocol/omv_protocol.c
@@ -117,11 +117,16 @@ int omv_protocol_init_default() {
 }
 
 void omv_protocol_deinit(void) {
-    // Deinitialize all channels (including transport at index 0)
+    // Deinitialize all channels, unregister dynamic ones.
     for (int i = 0; i < OMV_PROTOCOL_MAX_CHANNELS; i++) {
-        if (ctx.channels[i] && ctx.channels[i]->deinit) {
-            ctx.channels[i]->deinit(ctx.channels[i]);
-            ctx.channels[i] = NULL;
+        if (ctx.channels[i]) {
+            if (ctx.channels[i]->deinit) {
+                ctx.channels[i]->deinit(ctx.channels[i]);
+            }
+            if (ctx.channels[i]->flags & OMV_PROTOCOL_CHANNEL_FLAG_DYNAMIC) {
+                ctx.channels[i] = NULL;
+                ctx.channels_count--;
+            }
         }
     }
 }


### PR DESCRIPTION
The VM could run the protocol callback right after a soft-reboot, and before the protocol gets a chance to reinitialize its state. This can happen if `tud_event_hook_cb` schedules task and nowait gets called before the protocol init (e.g., from py_tof -> i2c). If custom Python channels are used, this would crash immediately because they're collected on soft-reboot.