### PR TITLE
boards/OPENMV_N6: Add dedicated standby RAM region.

### DIFF
--- a/boards/OPENMV_N6/board_config.h
+++ b/boards/OPENMV_N6/board_config.h
@@ -144,6 +144,7 @@
 // Linker script constants (see common.ld.S).
 #define OMV_MAIN_MEMORY                     SRAM1  // Data/BSS memory
 #define OMV_STACK_MEMORY                    SRAM1  // stack memory
+#define OMV_STANDBY_MEMORY                  SSRAM
 #define OMV_RAMFUNC_MEMORY                  ITCM
 #define OMV_STACK_SIZE                      (64K)
 #define OMV_HEAP_MEMORY                     SRAM1  // libc/sbrk heap memory
@@ -176,8 +177,10 @@
 #define OMV_DTCM_LENGTH                     128K
 #define OMV_ITCM_ORIGIN                     0x10000000
 #define OMV_ITCM_LENGTH                     64K
-#define OMV_SRAM1_ORIGIN                    0x34000000  // AXISRAM1
-#define OMV_SRAM1_LENGTH                    1M          // 1MB
+#define OMV_SSRAM_ORIGIN                    0x34000000  // AXISRAM1 (Retained during standby)
+#define OMV_SSRAM_LENGTH                    8K          // 8KB
+#define OMV_SRAM1_ORIGIN                    0x34002000  // AXISRAM1
+#define OMV_SRAM1_LENGTH                    1016K       // 1016K
 #define OMV_SRAM2_ORIGIN                    0x34100000  // AXISRAM2
 #define OMV_SRAM2_LENGTH                    1M          // 1MB
 #define OMV_SRAM3_ORIGIN                    0x34200000  // AXISRAM3-6 (NPU AXI SRAMs)

--- a/ports/stm32/stm.ld.S
+++ b/ports/stm32/stm.ld.S
@@ -66,6 +66,9 @@ MEMORY
   #if defined(OMV_DRAM_ORIGIN)
   DRAM (xrw)        : ORIGIN = OMV_DRAM_ORIGIN,      LENGTH = OMV_DRAM_LENGTH
   #endif
+  #if defined(OMV_SSRAM_ORIGIN)
+  SSRAM (xrw)       : ORIGIN = OMV_SSRAM_ORIGIN,     LENGTH = OMV_SSRAM_LENGTH
+  #endif
   #if defined(OMV_FLASH_FFS_ORIGIN)
   FLASH_FFS (rx)    : ORIGIN = OMV_FLASH_FFS_ORIGIN, LENGTH = OMV_FLASH_FFS_LENGTH
   #endif
@@ -158,6 +161,13 @@ SECTIONS
     . = ALIGN(32);
     _cm4_ram_end = .;
   } >OMV_CM4_BOOT_MEMORY
+  #endif
+
+  #ifdef OMV_STANDBY_MEMORY
+  .standby_mem (NOLOAD) : ALIGN(4)
+  {
+    *(.standby_mem)
+  } >OMV_STANDBY_MEMORY
   #endif
 
   #ifdef OMV_RAMFUNC_MEMORY


### PR DESCRIPTION
Requires: https://github.com/openmv/micropython/pull/141

1. Creates a new standby region that `_boot_mem` can be assigned to.
2. Carves 8KB of RAM out of the first 80KB  (which are retained during standby) of AXISRAM1 for the standby ram region.
3. Moves the reset RAM function out of the ITCM, freeing up space for the stack to move there, and allowing the UMA fast SRAM pool to be increased by 66KB.

Change 3 is not required for the deep sleep fix. But it seems like an obvious thing to do now.

Deep sleep with gpio wakeup and RTC work as expected.