### PR TITLE
ports/stm32: Fix Nema memory leaks.

### DIFF
--- a/ports/stm32/stm_nema.c
+++ b/ports/stm32/stm_nema.c
@@ -24,6 +24,7 @@
  * STM32 Nema HAL layer.
  */
 #include <stdlib.h>
+#include <stdio.h>
 #include STM32_HAL_H
 
 #include "board_config.h"
@@ -52,6 +53,18 @@ static nema_ringbuffer_t ring_buf = {{0}};
 uint8_t OMV_ATTR_SECTION(OMV_ATTR_ALIGNED(RING_BUFFER[OMV_GPU_NEMA_RING_SIZE], 32), ".dma_buffer");
 #endif
 
+#ifdef NDEBUG
+#define nema_assert(expr) ((void) 0)
+#else
+static void nema_assert_fail(const char *expr, const char *file, int line) {
+    printf("nema ASSERT: %s at %s:%d\n", expr, file, line);
+    //__asm volatile ("bkpt #0");
+    for (;;) {
+    }
+}
+#define nema_assert(expr) do { if (!(expr)) nema_assert_fail(#expr, __FILE__, __LINE__); } while (0)
+#endif
+
 int32_t nema_sys_init(void) {
     // Initialize GPU2D
     gpu2d.Instance = GPU2D;
@@ -71,6 +84,10 @@ int32_t nema_sys_init(void) {
     ring_buf.bo.base_virt = RING_BUFFER;
     ring_buf.bo.base_phys = (uint32_t) RING_BUFFER;
     #else
+    // Free previous ring buffer on re-init (soft-reset).
+    if (ring_buf.bo.base_virt) {
+        nema_buffer_destroy(&ring_buf.bo);
+    }
     ring_buf.bo = nema_buffer_create(OMV_GPU_NEMA_RING_SIZE);
     #endif
 
@@ -96,7 +113,7 @@ int nema_wait_irq_cl(int cl_id) {
         if (elapsed >= OMV_GPU_NEMA_TIMEOUT_MS) {
             return -1;
         }
-        mp_event_wait_ms(OMV_GPU_NEMA_TIMEOUT_MS - elapsed);
+        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_ONLY);
     }
     return 0;
 }
@@ -151,13 +168,13 @@ void nema_buffer_flush(nema_buffer_t *bo) {
 }
 
 void nema_host_free(void *ptr) {
-    if (ptr) {
-        free(ptr);
-    }
+    free(ptr);
 }
 
 void *nema_host_malloc(unsigned size) {
-    return aligned_alloc(OMV_CACHE_LINE_SIZE, OMV_ALIGN_TO(size, OMV_CACHE_LINE_SIZE));
+    void *ptr = aligned_alloc(OMV_CACHE_LINE_SIZE, OMV_ALIGN_TO(size, OMV_CACHE_LINE_SIZE));
+    nema_assert(ptr);
+    return ptr;
 }
 
 int nema_mutex_lock(int mutex_id) {


### PR DESCRIPTION
Free previous ring buffer on re-init to prevent heap leak on soft-reset, and use mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_ONLY) in the GPU wait loop to avoid raising exceptions that would leak the command list.