### PR TITLE
ports/stm32: Add image scaler support.

### DIFF
--- a/boards/OPENMV_N6/board_config.h
+++ b/boards/OPENMV_N6/board_config.h
@@ -316,6 +316,7 @@
 #define OMV_CSI_HW_CROP_ENABLE              (1)
 #define OMV_CSI_MAX_DEVICES                 (3)
 #define OMV_CSI_STATS_ENABLE                (1)
+#define OMV_CSI_HW_SCALE_ENABLE             (1)
 
 #define OMV_CSI_D0_PIN                      (&omv_pin_A1_DCMI)
 #define OMV_CSI_D1_PIN                      (&omv_pin_A10_DCMI)

--- a/common/omv_csi.h
+++ b/common/omv_csi.h
@@ -377,6 +377,12 @@ typedef struct _omv_csi {
     // Resolution table
     uint16_t resolution[OMV_CSI_FRAMESIZE_MAX][2];
 
+    #ifdef OMV_CSI_HW_SCALE_ENABLE
+    // Sensor raw resolution output (i.e. before cropping and scaling).
+    uint16_t src_w;
+    uint16_t src_h;
+    #endif // OMV_CSI_HW_SCALE_ENABLE
+
     // Sensor function pointers
     int (*reset) (omv_csi_t *csi);
     int (*sleep) (omv_csi_t *csi, int enable);

--- a/drivers/sensors/pag7936.c
+++ b/drivers/sensors/pag7936.c
@@ -181,6 +181,7 @@
 typedef struct {
     bool gain_auto;
     bool expo_auto;
+    int framerate;
 } pag7936_state_t;
 
 static pag7936_state_t pag7936_state = {};
@@ -498,6 +499,7 @@ static int reset(omv_csi_t *csi) {
     pag7936_state_t *state = csi->priv;
     state->gain_auto = true;
     state->expo_auto = true;
+    state->framerate = PAG7936_HD_FPS_MAX;
     csi->gainceiling = OMV_CSI_GAINCEILING_16X;
     // Write default registers
     for (int i = 0; default_regs[i][0] && ret == 0; i++) {
@@ -544,19 +546,49 @@ static int set_pixformat(omv_csi_t *csi, pixformat_t pixformat) {
     }
 }
 
-static int set_framesize(omv_csi_t *csi, omv_csi_framesize_t framesize) {
+// Pick the largest native sensor mode that meets the requested framerate.
+static omv_csi_framesize_t get_framesize(omv_csi_t *csi, omv_csi_framesize_t target, int framerate) {
+    #ifndef OMV_CSI_HW_SCALE_ENABLE
+    return target;
+    #endif
+
+    uint32_t w = csi->resolution[target][0];
+    uint32_t h = csi->resolution[target][1];
+
+    if (w > csi->resolution[OMV_CSI_FRAMESIZE_VGA][0] ||
+        h > csi->resolution[OMV_CSI_FRAMESIZE_VGA][1] ||
+        framerate <= PAG7936_HD_FPS_MAX) {
+        return OMV_CSI_FRAMESIZE_HD;
+    }
+
+    if (w > csi->resolution[OMV_CSI_FRAMESIZE_QVGA][0] ||
+        h > csi->resolution[OMV_CSI_FRAMESIZE_QVGA][1] ||
+        framerate <= PAG7936_VGA_FPS_MAX) {
+        return OMV_CSI_FRAMESIZE_VGA;
+    }
+
+    return OMV_CSI_FRAMESIZE_QVGA;
+}
+
+static int configure(omv_csi_t *csi, omv_csi_framesize_t target, int framerate) {
+    pag7936_state_t *state = csi->priv;
     int ret = 0;
     const uint16_t(*regs)[2];
+    uint8_t reg;
+    omv_csi_framesize_t framesize = get_framesize(csi, target, framerate);
 
     switch (framesize) {
         case OMV_CSI_FRAMESIZE_HD:
             regs = hd_regs;
+            framerate = IM_MIN(framerate, PAG7936_HD_FPS_MAX);
             break;
         case OMV_CSI_FRAMESIZE_VGA:
             regs = vga_regs;
+            framerate = IM_MIN(framerate, PAG7936_VGA_FPS_MAX);
             break;
         case OMV_CSI_FRAMESIZE_QVGA:
             regs = qvga_regs;
+            framerate = IM_MIN(framerate, PAG7936_QVGA_FPS_MAX);
             break;
         default:
             return -1;
@@ -566,27 +598,10 @@ static int set_framesize(omv_csi_t *csi, omv_csi_framesize_t framesize) {
         ret |= omv_i2c_write_reg(csi->i2c, csi->slv_addr, regs[i][0], 2, regs[i][1], 1);
     }
 
-    return ret;
-}
-
-static int set_framerate(omv_csi_t *csi, int framerate) {
-    pag7936_state_t *state = csi->priv;
-    uint8_t reg;
-    int ret = 0;
-
-    switch (csi->framesize) {
-        case OMV_CSI_FRAMESIZE_HD:
-            framerate = IM_MIN(framerate, PAG7936_HD_FPS_MAX);
-            break;
-        case OMV_CSI_FRAMESIZE_VGA:
-            framerate = IM_MIN(framerate, PAG7936_VGA_FPS_MAX);
-            break;
-        case OMV_CSI_FRAMESIZE_QVGA:
-            framerate = IM_MIN(framerate, PAG7936_QVGA_FPS_MAX);
-            break;
-        default:
-            return -1;
-    }
+    #ifdef OMV_CSI_HW_SCALE_ENABLE
+    csi->src_w = csi->resolution[framesize][0];
+    csi->src_h = csi->resolution[framesize][1];
+    #endif
 
     int32_t frame_time = FT_CLK / framerate;
 
@@ -621,6 +636,41 @@ static int set_framerate(omv_csi_t *csi, int framerate) {
     }
 
     return ret;
+}
+
+static int set_framesize(omv_csi_t *csi, omv_csi_framesize_t framesize) {
+    pag7936_state_t *state = csi->priv;
+    uint32_t w = csi->resolution[framesize][0];
+    uint32_t h = csi->resolution[framesize][1];
+
+    if (w > csi->resolution[OMV_CSI_FRAMESIZE_HD][0] ||
+        h > csi->resolution[OMV_CSI_FRAMESIZE_HD][1]) {
+        return -1;
+    }
+
+    #ifndef OMV_CSI_HW_SCALE_ENABLE
+    if (framesize != OMV_CSI_FRAMESIZE_HD &&
+        framesize != OMV_CSI_FRAMESIZE_VGA &&
+        framesize != OMV_CSI_FRAMESIZE_QVGA) {
+        return -1;
+    }
+    #endif
+
+    return configure(csi, framesize, state->framerate);
+}
+
+static int set_framerate(omv_csi_t *csi, int framerate) {
+    pag7936_state_t *state = csi->priv;
+    state->framerate = framerate;
+
+    if (csi->framesize == OMV_CSI_FRAMESIZE_INVALID) {
+        return 0;
+    }
+
+    // Disable any ongoing frame capture.
+    omv_csi_abort(csi, true, false);
+
+    return configure(csi, csi->framesize, framerate);
 }
 
 static int set_gainceiling(omv_csi_t *csi, omv_csi_gainceiling_t gainceiling) {

--- a/drivers/sensors/ps5520.c
+++ b/drivers/sensors/ps5520.c
@@ -42,6 +42,9 @@
 #include "omv_csi.h"
 #include "py/mphal.h"
 
+#define SENSOR_WIDTH            2592
+#define SENSOR_HEIGHT           1944
+
 #define REG_BANK                (0xEF)
 
 // Bank #0
@@ -155,6 +158,9 @@ static const uint8_t stream_off_regs[][2] = {
     { 0x00, 0x00 }, // End
 };
 
+// These per-resolution register tables are only used without the ISP scaler;
+// with the scaler the sensor runs at full resolution and the ISP scales down.
+#ifndef OMV_CSI_HW_SCALE_ENABLE
 static const uint8_t res_640x480_regs[][2] = {
     // PS5520_640x480x30fps_24MHz_2Lane_RAW10_840Mbps_20190408_C10A.asc
     { 0xEF, 0x05 },
@@ -937,6 +943,7 @@ static const uint8_t res_2560x1440_regs[][2] = {
     { 0xFF, 0x02 }, // Delay 2 ms
     { 0x00, 0x00 }, // End
 };
+#endif // OMV_CSI_HW_SCALE_ENABLE
 
 static const uint8_t res_2592x1944_regs[][2] = {
     // PS5520_2592x1944x30fps_24MHz_2Lane_RAW10_840Mbps_20190408_C10A.asc
@@ -1145,7 +1152,14 @@ static int reset(omv_csi_t *csi) {
     int16_t lpf;
 
     // Set resolution
+    #ifdef OMV_CSI_HW_SCALE_ENABLE
+    // With the hardware scaler the sensor always runs at full resolution and the
+    // ISP scales down; the old per-resolution register tables are used otherwise.
+    ret |= write_registers(csi, sw_reset_regs);
+    ret |= write_registers(csi, res_2592x1944_regs);
+    #else
     ret |= write_registers(csi, res_640x480_regs);
+    #endif // OMV_CSI_HW_SCALE_ENABLE
 
     ps5520->enable_agc = true;
     ps5520->agc_gain = PS5520_DEF_GAIN;
@@ -1241,7 +1255,15 @@ static int set_pixformat(omv_csi_t *csi, pixformat_t pixformat) {
 }
 
 static int set_framesize(omv_csi_t *csi, omv_csi_framesize_t framesize) {
+    uint32_t w = csi->resolution[framesize][0];
+    uint32_t h = csi->resolution[framesize][1];
+
+    if (w > SENSOR_WIDTH || h > SENSOR_HEIGHT) {
+        return -1;
+    }
+
     int ret = 0;
+    #ifndef OMV_CSI_HW_SCALE_ENABLE
     const uint8_t(*regs)[2];
 
     switch (framesize) {
@@ -1272,6 +1294,7 @@ static int set_framesize(omv_csi_t *csi, omv_csi_framesize_t framesize) {
 
     // Set resolution
     ret |= write_registers(csi, regs);
+    #endif // OMV_CSI_HW_SCALE_ENABLE
     return ret;
 }
 
@@ -1645,6 +1668,12 @@ int ps5520_init(omv_csi_t *csi) {
     csi->get_rgb_gain_db = get_rgb_gain_db;
     csi->set_hmirror = set_hmirror;
     csi->set_vflip = set_vflip;
+
+    #ifdef OMV_CSI_HW_SCALE_ENABLE
+    // Source resolution for the ISP scaler (sensor runs at full resolution).
+    csi->src_w = SENSOR_WIDTH;
+    csi->src_h = SENSOR_HEIGHT;
+    #endif // OMV_CSI_HW_SCALE_ENABLE
 
     return 0;
 }

--- a/ports/stm32/omv_csi.c
+++ b/ports/stm32/omv_csi.c
@@ -432,7 +432,7 @@ static void stm_csi_frame_event(omv_csi_t *csi, uint32_t pipe) {
     // The ISP AWB stats lag by one frame. So, drop the first frame when not initialized.
     #if defined(OMV_CSI_STATS_ENABLE)
     if (csi->raw_output && csi->stats_enabled && !csi->stats.initialized) {
-        stm_isp_update_awb(csi, DCMIPP_PIPE, fb->u * fb->v);
+        stm_isp_update_awb(csi, DCMIPP_PIPE);
         csi->drop_frame = true;
     }
     #endif // OMV_CSI_STATS_ENABLE
@@ -590,15 +590,7 @@ static int stm_csi_snapshot(omv_csi_t *csi, image_t *image, uint32_t flags) {
                 return OMV_CSI_ERROR_INVALID_FRAMESIZE;
             }
 
-            // Configure crop
-            DCMIPP_CropConfTypeDef ccfg = {
-                .HStart = fb->x,
-                .VStart = fb->y,
-                .HSize = fb->u,
-                .VSize = fb->v,
-            };
-            if (HAL_DCMIPP_PIPE_SetCropConfig(&csi->dcmipp, DCMIPP_PIPE, &ccfg) != HAL_OK ||
-                HAL_DCMIPP_PIPE_EnableCrop(&csi->dcmipp, DCMIPP_PIPE) != HAL_OK) {
+            if (stm_isp_set_scaler(csi, DCMIPP_PIPE)) {
                 return OMV_CSI_ERROR_CSI_INIT_FAILED;
             }
 
@@ -798,7 +790,7 @@ static int stm_csi_snapshot(omv_csi_t *csi, image_t *image, uint32_t flags) {
 
     #if USE_DCMIPP
     if (csi->raw_output) {
-        float luminance = stm_isp_update_awb(csi, DCMIPP_PIPE, fb->u * fb->v);
+        float luminance = stm_isp_update_awb(csi, DCMIPP_PIPE);
         if (csi->ioctl) {
             omv_csi_ioctl(csi, OMV_CSI_IOCTL_UPDATE_AGC_AEC, fast_floorf(luminance));
         }

--- a/ports/stm32/stm_isp.c
+++ b/ports/stm32/stm_isp.c
@@ -38,11 +38,15 @@
 #include "board_config.h"
 
 #ifdef DCMIPP
-float stm_isp_update_awb(omv_csi_t *csi, uint32_t pipe, uint32_t n_pixels) {
+float stm_isp_update_awb(omv_csi_t *csi, uint32_t pipe) {
     uint32_t avg[3];
     uint32_t shift[3];
     uint32_t multi[3];
     float luminance;
+
+    uint32_t src_w = csi->src_w ? csi->src_w : csi->resolution[csi->framesize][0];
+    uint32_t src_h = csi->src_h ? csi->src_h : csi->resolution[csi->framesize][1];
+    uint32_t n_pixels = src_w * src_h;
 
     for (int i = 0; i < 3; i++) {
         // DCMIPP_STATEXT_MODULE1
@@ -201,6 +205,126 @@ int stm_isp_update_gamma_table(omv_csi_t *csi, uint32_t pipe,
 
     if (HAL_DCMIPP_PIPE_SetISPCtrlContrastConfig(&csi->dcmipp, pipe,
                                                  (DCMIPP_ContrastConfTypeDef *) &g_tab) != HAL_OK) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static int stm_isp_axis_scaler(uint32_t src, int dec, uint32_t dst,
+                               uint32_t *ratio_out, uint32_t *div_out) {
+    // 16-bit fields, used as unsigned 3 integer 13 fixed-point (3.13).
+    // Valid values are 8192 (= 1x) to 65535 (= 7.999x).
+    uint32_t ratio = 8192 * (src >> dec) / dst;
+
+    if (ratio > 65535) {
+        return -1;
+    }
+
+    *ratio_out = ratio;
+    // 10-bit fields, used as unsigned 10 decimal.
+    // Valid values are 128 (= inv8x) to 1023 (= inv1x).
+    *div_out = (1024 * 8192 - 1) / ratio;
+    return 0;
+}
+
+int stm_isp_set_scaler(omv_csi_t *csi, uint32_t pipe) {
+    framebuffer_t *fb = csi->fb;
+    uint32_t dst_w = csi->resolution[csi->framesize][0];
+    uint32_t dst_h = csi->resolution[csi->framesize][1];
+    uint32_t src_w = csi->src_w ? csi->src_w : dst_w;
+    uint32_t src_h = csi->src_h ? csi->src_h : dst_h;
+
+    if (csi->pixformat == PIXFORMAT_BAYER && (src_w != dst_w || src_h != dst_h)) {
+        return -1;
+    }
+
+    // Compute center trimmed aspect ratio (AR) correct crop.
+    uint32_t ar_x;
+    uint32_t ar_y;
+    uint32_t ar_w;
+    uint32_t ar_h;
+
+    if (src_w * dst_h > dst_w * src_h) {
+        // src is wider than dst: crop horizontally, keep full height.
+        ar_h = src_h;
+        ar_w = src_h * dst_w / dst_h;
+        ar_x = (src_w - ar_w) / 2;
+        ar_y = 0;
+    } else {
+        // src is taller than dst: crop vertically, keep full width.
+        ar_w = src_w;
+        ar_h = src_w * dst_h / dst_w;
+        ar_x = 0;
+        ar_y = (src_h - ar_h) / 2;
+    }
+
+    // Combine AR crop with user window (coordinates in output/target space).
+    ar_x += fb->x * ar_w / dst_w;
+    ar_y += fb->y * ar_h / dst_h;
+    ar_w = fb->u * ar_w / dst_w;
+    ar_h = fb->v * ar_h / dst_h;
+
+    // Determine decimation and downsize ratios.
+    int h_dec = -1;
+    int v_dec = -1;
+    uint32_t h_ratio;
+    uint32_t h_div;
+    uint32_t v_ratio;
+    uint32_t v_div;
+
+    for (int i = 0; i < 4; i++) {
+        if (!stm_isp_axis_scaler(ar_w, i, fb->u, &h_ratio, &h_div)) {
+            h_dec = i;
+            break;
+        }
+    }
+
+    for (int i = 0; i < 4; i++) {
+        if (!stm_isp_axis_scaler(ar_h, i, fb->v, &v_ratio, &v_div)) {
+            v_dec = i;
+            break;
+        }
+    }
+
+    // Target image is too small.
+    if (h_dec < 0 || v_dec < 0) {
+        return -1;
+    }
+
+    DCMIPP_CropConfTypeDef ccfg = {
+        .HStart = ar_x,
+        .VStart = ar_y,
+        .HSize = ar_w,
+        .VSize = ar_h,
+    };
+
+    if (HAL_DCMIPP_PIPE_SetCropConfig(&csi->dcmipp, pipe, &ccfg) != HAL_OK ||
+        HAL_DCMIPP_PIPE_EnableCrop(&csi->dcmipp, pipe) != HAL_OK) {
+        return -1;
+    }
+
+    DCMIPP_DecimationConfTypeDef dec = {
+        .HRatio = (h_dec << DCMIPP_P1DECR_HDEC_Pos),
+        .VRatio = (v_dec << DCMIPP_P1DECR_VDEC_Pos),
+    };
+
+    if (HAL_DCMIPP_PIPE_SetDecimationConfig(&csi->dcmipp, pipe, &dec) != HAL_OK ||
+        HAL_DCMIPP_PIPE_EnableDecimation(&csi->dcmipp, pipe) != HAL_OK) {
+        return -1;
+    }
+
+    DCMIPP_DownsizeTypeDef ds = {
+        .HSize = fb->u,
+        .VSize = fb->v,
+        .HRatio = h_ratio,
+        .VRatio = v_ratio,
+        .HDivFactor = h_div,
+        .VDivFactor = v_div,
+    };
+
+    if (HAL_DCMIPP_PIPE_SetDownsizeConfig(&csi->dcmipp, pipe, &ds) != HAL_OK ||
+        HAL_DCMIPP_PIPE_EnableDownsize(&csi->dcmipp, pipe) != HAL_OK) {
         return -1;
     }
 

--- a/ports/stm32/stm_isp.h
+++ b/ports/stm32/stm_isp.h
@@ -41,7 +41,8 @@
 int stm_isp_init(omv_csi_t *csi, uint32_t pipe, pixformat_t pixformat, bool raw_output);
 int stm_isp_update_gamma_table(omv_csi_t *csi, uint32_t pipe,
                                float brightness, float contrast, float gamma);
-float stm_isp_update_awb(omv_csi_t *csi, uint32_t pipe, uint32_t n_pixels);
+float stm_isp_update_awb(omv_csi_t *csi, uint32_t pipe);
+int stm_isp_set_scaler(omv_csi_t *csi, uint32_t pipe);
 #endif
 
 #endif // __STM_ISP_H__


### PR DESCRIPTION
Adds image scaler support. Drastically improves the PSS520/PAG7936 image quality. Also allows for the N6 to handle any resolution with the PS5520/PAG7936. @aqsnyder 

Before:
<img width="640" height="480" alt="vga-before" src="https://github.com/user-attachments/assets/eee20f4e-02f8-45c8-8734-779c0d2d1f45" />

After:
<img width="640" height="480" alt="vga-after" src="https://github.com/user-attachments/assets/ac42fa04-e7ae-4de4-99dc-d7b467904d70" />

The image scaler enables the PS5520 to output any resolution now. So, all the extra resolution tables are eliminated except the 2592x1944 table. The image scaler can output down to 40x30. Cropping is also operational.

...

PAG7936 Before (QVGA):

<img width="1035" height="647" alt="image" src="https://github.com/user-attachments/assets/a5359339-6bd9-4b06-89de-85e0ab872b0d" />

PAG7936 After (QVGA):

<img width="1039" height="648" alt="image" src="https://github.com/user-attachments/assets/e49520f9-c455-4cb7-b464-a9f1b32a8a90" />




