### PR TITLE
protocol: softtimer-based polling.

### DIFF
--- a/modules/py_protocol.c
+++ b/modules/py_protocol.c
@@ -311,32 +311,11 @@ MP_DEFINE_CONST_OBJ_TYPE(
 /***************************************************************************
 * Protocol Module
 ***************************************************************************/
-static void py_protocol_task(mp_sched_node_t *node) {
-    omv_protocol_task();
-}
-
-static void py_protocol_schedule(void) {
-    static mp_sched_node_t protocol_task_node;
-    mp_sched_schedule_node(&protocol_task_node, py_protocol_task);
-}
-
-// Soft timer callback to call py_protocol_poll
-static void py_protocol_soft_timer_callback(soft_timer_entry_t *self) {
-    return py_protocol_schedule();
-}
-
 // Protocol active check
 static mp_obj_t py_protocol_is_active(void) {
     return mp_obj_new_bool(omv_protocol_is_active());
 }
 static MP_DEFINE_CONST_FUN_OBJ_0(py_protocol_is_active_obj, py_protocol_is_active);
-
-// Schedule protocol task function
-static mp_obj_t py_protocol_poll(void) {
-    py_protocol_schedule();
-    return mp_const_none;
-}
-static MP_DEFINE_CONST_FUN_OBJ_0(py_protocol_poll_obj, py_protocol_poll);
 
 // Protocol init function
 static mp_obj_t py_protocol_init(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
@@ -349,7 +328,7 @@ static mp_obj_t py_protocol_init(size_t n_args, const mp_obj_t *pos_args, mp_map
         { MP_QSTR_rtx_retries, MP_ARG_INT, {.u_int = OMV_PROTOCOL_DEF_RTX_RETRIES} },
         { MP_QSTR_rtx_timeout_ms, MP_ARG_INT, {.u_int = OMV_PROTOCOL_DEF_RTX_TIMEOUT_MS} },
         { MP_QSTR_lock_interval_ms, MP_ARG_INT, {.u_int = OMV_PROTOCOL_MIN_LOCK_INTERVAL_MS} },
-        { MP_QSTR_timer_ms, MP_ARG_INT, {.u_int = 0} },
+        { MP_QSTR_poll_ms, MP_ARG_INT, {.u_int = 0} },
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
@@ -365,9 +344,8 @@ static mp_obj_t py_protocol_init(size_t n_args, const mp_obj_t *pos_args, mp_map
         .rtx_retries = args[5].u_int,
         .rtx_timeout_ms = args[6].u_int,
         .lock_intval_ms = args[7].u_int,
+        .poll_ms = args[8].u_int,
     };
-
-    uint32_t timer_ms = args[8].u_int;
 
     if (omv_protocol_init(&config)) {
         mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("Failed to initialize protocol"));
@@ -382,16 +360,6 @@ static mp_obj_t py_protocol_init(size_t n_args, const mp_obj_t *pos_args, mp_map
     #if OMV_PROFILER_ENABLE
     omv_protocol_register_channel(&omv_profile_channel);
     #endif // OMV_PROFILER_ENABLE
-
-    // Start periodic timer if timer_ms > 0
-    if (timer_ms > 0) {
-        soft_timer_entry_t *timer = m_new_obj(soft_timer_entry_t);
-        soft_timer_static_init(timer, SOFT_TIMER_MODE_PERIODIC,
-                               timer_ms, py_protocol_soft_timer_callback);
-        timer->flags = SOFT_TIMER_FLAG_GC_ALLOCATED;
-        soft_timer_insert(timer, timer_ms);
-        MP_STATE_PORT(protocol_soft_timer) = MP_OBJ_FROM_PTR(timer);
-    }
 
     return mp_const_none;
 }
@@ -470,7 +438,6 @@ static const mp_rom_map_elem_t protocol_globals_table[] = {
     // Protocol management functions
     { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&py_protocol_init_obj) },
     { MP_ROM_QSTR(MP_QSTR_is_active), MP_ROM_PTR(&py_protocol_is_active_obj) },
-    { MP_ROM_QSTR(MP_QSTR_poll), MP_ROM_PTR(&py_protocol_poll_obj) },
     { MP_ROM_QSTR(MP_QSTR_register), MP_ROM_PTR(&py_protocol_register_obj) },
 
     // Channel flags constants
@@ -498,8 +465,7 @@ const mp_obj_module_t protocol_module = {
 // Register the module
 MP_REGISTER_EXTENSIBLE_MODULE(MP_QSTR_protocol, protocol_module);
 
-// Register root pointers for dynamic protocol channels and soft timer
-MP_REGISTER_ROOT_POINTER(mp_obj_t protocol_soft_timer);
+// Register root pointers for dynamic protocol channels.
 MP_REGISTER_ROOT_POINTER(mp_obj_t protocol_channels[OMV_PROTOCOL_MAX_CHANNELS]);
 
 #endif // MICROPY_PY_PROTOCOL

--- a/ports/alif/main.c
+++ b/ports/alif/main.c
@@ -167,6 +167,9 @@ soft_reset:
     mod_network_init();
     #endif
 
+    // Execute _boot.py.
+    pyexec_frozen_module("_boot.py", false);
+
     // Initialize TinyUSB after the filesystem is mounted.
     #if MICROPY_HW_ENABLE_USBDEV
     if (!tusb_inited()) {
@@ -178,9 +181,6 @@ soft_reset:
     // Initialize OpenMV protocol
     omv_protocol_init_default();
     #endif
-
-    // Execute _boot.py.
-    pyexec_frozen_module("_boot.py", false);
 
     // Run boot.py every reset and main.py on first soft-reset
     if (pyexec_file_if_exists("boot.py") && first_soft_reset) {
@@ -216,6 +216,7 @@ soft_reset_exit:
 #endif
     mp_hal_set_interrupt_char(-1);
     mp_printf(MP_PYTHON_PRINTER, "MPY: soft reboot\n");
+    omv_protocol_deinit();
     #if MICROPY_PY_CSI
     omv_csi_abort_all();
     #endif
@@ -237,7 +238,6 @@ soft_reset_exit:
     machine_pwm_deinit_all();
     machine_pin_irq_deinit();
     imlib_deinit();
-    omv_protocol_deinit();
     soft_timer_deinit();
     dma_deinit_all();
     gc_sweep_all();

--- a/ports/mimxrt/main.c
+++ b/ports/mimxrt/main.c
@@ -107,7 +107,6 @@ soft_reset:
     machine_i2s_init0();
     #endif
     machine_rtc_start();
-    omv_protocol_init_default();
 
     #if MICROPY_PY_LWIP
     // lwIP can only be initialized once, because the system timeout
@@ -162,6 +161,9 @@ soft_reset:
         tusb_init();
     }
 
+    // Initialize OpenMV protocol
+    omv_protocol_init_default();
+
     // Run boot.py every reset and main.py on first soft-reset
     if (pyexec_file_if_exists("boot.py") && first_soft_reset) {
         pyexec_file_if_exists("main.py");
@@ -190,6 +192,7 @@ soft_reset:
     // soft reset
     mp_hal_set_interrupt_char(-1);
     mp_printf(MP_PYTHON_PRINTER, "MPY: soft reboot\n");
+    omv_protocol_deinit();
     #if MICROPY_PY_CSI
     omv_csi_abort_all();
     #endif
@@ -214,7 +217,6 @@ soft_reset:
     machine_i2s_deinit_all();
     #endif
     machine_pwm_deinit_all();
-    omv_protocol_deinit();
     soft_timer_deinit();
     imlib_deinit();
     gc_sweep_all();

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -137,9 +137,6 @@ void NORETURN __stack_chk_fail(void) {
 #endif
 
 int main(void) {
-    #if MICROPY_HW_SDRAM_SIZE
-    bool sdram_ok = false;
-    #endif
     bool first_soft_reset = true;
 
     // Initialize SysTick.
@@ -164,7 +161,9 @@ int main(void) {
     HAL_Init();
 
     #if MICROPY_HW_SDRAM_SIZE
-    sdram_ok = sdram_init();
+    if (!sdram_init()) {
+        __fatal_error("Failed to init sdram!");
+    }
     #endif
 
     #if MICROPY_HW_SDRAM_STARTUP_TEST
@@ -271,6 +270,10 @@ soft_reset:
     cyw43_wifi_ap_set_password(&cyw43_state, 8, (const uint8_t *) "pybd0123");
     #endif
 
+    #if MICROPY_PY_NETWORK
+    mod_network_init();
+    #endif
+
     #if MICROPY_HW_STM_USB_STACK && MICROPY_HW_ENABLE_USB
     pyb_usb_init0();
     #endif
@@ -290,13 +293,6 @@ soft_reset:
     #if MICROPY_PY_IMU
     py_imu_init();
     #endif // MICROPY_PY_IMU
-
-    #if MICROPY_PY_NETWORK
-    mod_network_init();
-    #endif
-
-    // Initialize OpenMV protocol
-    omv_protocol_init_default();
 
     // Execute _boot.py to set up the filesystem.
     pyexec_frozen_module("_boot.py", false);
@@ -326,12 +322,8 @@ soft_reset:
     mp_usbd_init();
     #endif
 
-    // report if SDRAM failed
-    #if MICROPY_HW_SDRAM_SIZE
-    if (first_soft_reset && !sdram_ok) {
-        __fatal_error("Failed to init sdram!");
-    }
-    #endif
+    // Initialize OpenMV protocol
+    omv_protocol_init_default();
 
     // Run boot.py every reset and main.py on first soft-reset
     if (pyexec_file_if_exists("boot.py") && first_soft_reset) {
@@ -361,6 +353,7 @@ soft_reset:
     // soft reset
     mp_hal_set_interrupt_char(-1);
     mp_printf(MP_PYTHON_PRINTER, "MPY: soft reboot\n");
+    omv_protocol_deinit();
     #if MICROPY_PY_CSI
     omv_csi_abort_all();
     #endif
@@ -407,7 +400,6 @@ soft_reset:
     py_audio_deinit();
     #endif
     imlib_deinit();
-    omv_protocol_deinit();
     soft_timer_deinit();
     #if MICROPY_HW_ENABLE_USB_RUNTIME_DEVICE && MICROPY_HW_TINYUSB_STACK
     mp_usbd_deinit();

--- a/protocol/omv_protocol.c
+++ b/protocol/omv_protocol.c
@@ -31,6 +31,8 @@
 
 #include "py/mphal.h"
 #include "py/gc.h"
+#include "py/runtime.h"
+#include "shared/runtime/softtimer.h"
 #include "umalloc.h"
 #include "omv_csi.h"
 #include "omv_crc.h"
@@ -45,6 +47,9 @@
 // Static global protocol context
 static omv_protocol_context_t ctx;
 static omv_protocol_config_t default_config;
+static soft_timer_entry_t protocol_timer;
+static mp_sched_node_t protocol_sched_node;
+static void omv_protocol_poll_callback(soft_timer_entry_t *self);
 
 int omv_protocol_init(const omv_protocol_config_t *config) {
     if (!config) {
@@ -77,6 +82,13 @@ int omv_protocol_init(const omv_protocol_config_t *config) {
     // Initialize buffer
     omv_buffer_init(&ctx.buffer, ctx.rawbuf, sizeof(ctx.rawbuf));
 
+    // Start periodic poll timer if configured.
+    if (config->poll_ms > 0) {
+        soft_timer_static_init(&protocol_timer, SOFT_TIMER_MODE_PERIODIC,
+                               config->poll_ms, omv_protocol_poll_callback);
+        soft_timer_insert(&protocol_timer, config->poll_ms);
+    }
+
     return 0;
 }
 
@@ -90,6 +102,7 @@ int omv_protocol_init_default() {
         .rtx_retries = OMV_PROTOCOL_DEF_RTX_RETRIES,
         .rtx_timeout_ms = OMV_PROTOCOL_DEF_RTX_TIMEOUT_MS,
         .lock_intval_ms = OMV_PROTOCOL_MIN_LOCK_INTERVAL_MS,
+        .poll_ms = OMV_PROTOCOL_DEF_POLL_MS,
     };
 
     if (omv_protocol_init(&config) != 0) {
@@ -116,6 +129,10 @@ int omv_protocol_init_default() {
 }
 
 void omv_protocol_deinit(void) {
+    if (ctx.config.poll_ms > 0) {
+        soft_timer_remove(&protocol_timer);
+    }
+
     // Deinitialize all channels, unregister dynamic ones.
     for (int i = 0; i < OMV_PROTOCOL_MAX_CHANNELS; i++) {
         if (ctx.channels[i]) {
@@ -153,6 +170,21 @@ void omv_protocol_reset(void) {
 bool omv_protocol_is_active(void) {
     const omv_protocol_channel_t *transport = omv_protocol_find_transport();
     return transport && transport->is_active(transport);
+}
+
+static void omv_protocol_task(mp_sched_node_t *node) {
+    for (int i = 0; i < ctx.channels_count; i++) {
+        const omv_protocol_channel_t *channel = ctx.channels[i];
+        if (channel && channel->tick) {
+            channel->tick(channel);
+        }
+    }
+
+    omv_protocol_poll();
+}
+
+static void omv_protocol_poll_callback(soft_timer_entry_t *self) {
+    mp_sched_schedule_node(&protocol_sched_node, omv_protocol_task);
 }
 
 bool omv_protocol_exec_script(void) {
@@ -307,14 +339,6 @@ int omv_protocol_send_event(uint8_t channel_id, uint16_t event, bool wait_ack) {
         ret = omv_protocol_send_packet(opcode, channel_id, sizeof(event), &event, flags);
     }
 
-    // The state machine returns immediately after finding an event ACK so we need
-    // to run it one more time to handle any buffered commands. This is especially
-    // important for the USB transport, as it schedules the task on receive IRQs,
-    // which may not occur again if the host is waiting on a reply.
-    if (ret != -1 && wait_ack) {
-        omv_protocol_task();
-    }
-
     return ret;
 }
 
@@ -387,7 +411,7 @@ int omv_protocol_send_packet(uint8_t opcode, uint8_t channel_id, size_t size, co
             }
 
             for (uint32_t start = OMV_PROTOCOL_TICKS_MS(); ctx.wait_for_ack; OMV_PROTOCOL_EVENT_POLL()) {
-                if (omv_protocol_task() == -1) {
+                if (omv_protocol_poll() == -1) {
                     return -1;
                 }
 
@@ -431,7 +455,7 @@ int omv_protocol_send_packet(uint8_t opcode, uint8_t channel_id, size_t size, co
     return 0;
 }
 
-int omv_protocol_task(void) {
+int omv_protocol_poll(void) {
     size_t available = 0;
     const omv_protocol_channel_t *transport = omv_protocol_find_transport();
 

--- a/protocol/omv_protocol.h
+++ b/protocol/omv_protocol.h
@@ -53,9 +53,11 @@
 #define OMV_PROTOCOL_HEADER_SIZE            (10)    // SYNC[2] SEQ[1] CHAN[1] FLAGS[1] OPCODE[1] LEN[2] CRC[2]
 
 #define OMV_PROTOCOL_MAX_CHANNELS           (32)
+#define OMV_PROTOCOL_DEF_POLL_MS            (50)
 #define OMV_PROTOCOL_DEF_RTX_RETRIES        (3)
 #define OMV_PROTOCOL_DEF_RTX_TIMEOUT_MS     (500)   // Doubled after each timeout
 #define OMV_PROTOCOL_MIN_LOCK_INTERVAL_MS   (10)
+
 #define OMV_PROTOCOL_MAGIC_BAUDRATE         (921600)
 
 #ifndef OMV_PROTOCOL_DEFAULT_CHANNELS
@@ -332,6 +334,7 @@ typedef struct {
     uint16_t rtx_retries;
     uint16_t rtx_timeout_ms;
     uint16_t lock_intval_ms;
+    uint16_t poll_ms;
 } omv_protocol_config_t;
 
 // Protocol context
@@ -395,7 +398,7 @@ int omv_protocol_send_event(uint8_t channel_id, uint16_t event, bool wait_ack);
 int omv_protocol_send_packet(uint8_t opcode, uint8_t channel_id, size_t size, const void *data, uint8_t flags);
 
 // Call on events or periodically to process events
-int omv_protocol_task(void);
+int omv_protocol_poll(void);
 
 // Process assembled packet
 void omv_protocol_process(const omv_protocol_packet_t *packet);

--- a/protocol/omv_protocol_channel.h
+++ b/protocol/omv_protocol_channel.h
@@ -138,6 +138,8 @@ struct omv_protocol_channel {
     int (*ioctl) (const omv_protocol_channel_t *channel, uint32_t cmd, size_t len, void *arg);
     // Stdin-specific function to execute scripts internall (not exposed via ioctl).
     bool (*exec) (const omv_protocol_channel_t *channel);
+    // Channel tick (called periodically from the protocol task).
+    void (*tick) (const omv_protocol_channel_t *channel);
     // Transport-specific functions (for channel ID 0 only)
     bool (*is_active) (const omv_protocol_channel_t *channel);
 };

--- a/protocol/omv_protocol_channel_stdio.c
+++ b/protocol/omv_protocol_channel_stdio.c
@@ -40,11 +40,15 @@
 #define OMV_PROTOCOL_STDIO_BUFFER_SIZE  (1024)
 #endif
 
+#ifndef OMV_PROTOCOL_STDIO_FLUSH_MS
+#define OMV_PROTOCOL_STDIO_FLUSH_MS     (50)
+#endif
 
 typedef struct {
     vstr_t vstrbuf;
     bool script_running;
     bool notified;
+    uint32_t last_notify_ms;
     ringbuf_t ringbuf;
     uint8_t rawbuf[OMV_PROTOCOL_STDIO_BUFFER_SIZE];
 } stdio_channel_context_t;
@@ -60,6 +64,7 @@ static int stdin_channel_init(const omv_protocol_channel_t *channel) {
 
 static int stdout_channel_init(const omv_protocol_channel_t *channel) {
     stdio_channel_context_t *ctx = channel->priv;
+    ctx->last_notify_ms = 0;
 
     // Initialize ring buffer once to keep output from previous runs.
     if (ctx->ringbuf.buf == NULL) {
@@ -203,10 +208,11 @@ mp_uint_t __wrap_mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
         ctx->notified = false;
     }
 
-    // Notify the host once when the buffer crosses the 25% threshold.
-    // Cleared when the host reads, or when the ringbufer overflows.
-    if (!ctx->notified && ringbuf_avail(rb) > (rb->size / 4)) {
+    // Notify the host once when the buffer crosses the 50% threshold.
+    // Cleared when the host reads, or when the ringbuffer overflows.
+    if (!ctx->notified && ringbuf_avail(rb) > (rb->size / 2)) {
         ctx->notified = true;
+        ctx->last_notify_ms = mp_hal_ticks_ms();
         omv_protocol_send_event(OMV_PROTOCOL_CHANNEL_ID_STDOUT, OMV_PROTOCOL_EVENT_NOTIFY, false);
     }
 
@@ -225,6 +231,15 @@ const omv_protocol_channel_t omv_stdin_channel = {
     .exec = stdin_channel_exec
 };
 
+static void stdout_channel_tick(const omv_protocol_channel_t *channel) {
+    stdio_channel_context_t *ctx = channel->priv;
+    if (ringbuf_avail(&ctx->ringbuf)
+        && (mp_hal_ticks_ms() - ctx->last_notify_ms) >= OMV_PROTOCOL_STDIO_FLUSH_MS) {
+        ctx->last_notify_ms = mp_hal_ticks_ms();
+        omv_protocol_send_event(OMV_PROTOCOL_CHANNEL_ID_STDOUT, OMV_PROTOCOL_EVENT_NOTIFY, false);
+    }
+}
+
 const omv_protocol_channel_t omv_stdout_channel = {
     .priv = &stdio_channel_ctx,
     .id = OMV_PROTOCOL_CHANNEL_ID_STDOUT,
@@ -234,4 +249,5 @@ const omv_protocol_channel_t omv_stdout_channel = {
     .poll = stdout_channel_poll,
     .size = stdio_channel_size,
     .read = stdio_channel_read,
+    .tick = stdout_channel_tick,
 };

--- a/protocol/omv_protocol_channel_stmusb.c
+++ b/protocol/omv_protocol_channel_stmusb.c
@@ -65,7 +65,7 @@ static int usb_channel_write(const omv_protocol_channel_t *channel, uint32_t off
 
 static void usb_channel_task(mp_sched_node_t *node) {
     if (usb_channel_active) {
-        omv_protocol_task();
+        omv_protocol_poll();
     }
 }
 

--- a/protocol/omv_protocol_channel_tinyusb.c
+++ b/protocol/omv_protocol_channel_tinyusb.c
@@ -109,8 +109,8 @@ static int usb_channel_write(const omv_protocol_channel_t *channel, uint32_t off
 
 static void usb_channel_task(mp_sched_node_t *node) {
     tud_task_ext(0, false);
-    if (omv_protocol_is_active()) {
-        omv_protocol_task();
+    if (usb_channel_active) {
+        omv_protocol_poll();
     }
 }
 
@@ -118,7 +118,7 @@ static void usb_channel_task(mp_sched_node_t *node) {
 void tud_cdc_rx_cb(uint8_t itf) {
     extern void __mp_tud_cdc_rx_cb(uint8_t itf);
 
-    if (!omv_protocol_is_active()) {
+    if (!usb_channel_active) {
         __mp_tud_cdc_rx_cb(itf);
     }
 }

--- a/scripts/examples/12-Protocol/network_transport.py
+++ b/scripts/examples/12-Protocol/network_transport.py
@@ -110,7 +110,7 @@ if __name__ == "__main__":
     # MTU(1500) - IP(20) - UDP(8) - Header(10) - CRC(4) = 1458
     MAX_PAYLOAD = 1400
 
-    # Connect to WiFi first (before protocol.init starts the timer)
+    # Connect to WiFi first (before protocol.init starts the poll timer)
     network.hostname(HOSTNAME)
     wlan = network.WLAN(network.STA_IF)
     wlan.active(True)
@@ -133,7 +133,7 @@ if __name__ == "__main__":
         rtx_retries=3,  # Retransmission retry count
         rtx_timeout_ms=100,  # Timeout before retransmission (WiFi RTT ~5ms)
         lock_interval_ms=10,  # Minimum locking interval
-        timer_ms=10,  # Schedules the protocol task every 10ms
+        poll_ms=10,  # Schedules the protocol task every 10ms
     )
 
     # Register the network transport

--- a/scripts/examples/12-Protocol/uart_transport.py
+++ b/scripts/examples/12-Protocol/uart_transport.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
         rtx_retries=3,          # Retransmission retry count
         rtx_timeout_ms=500,     # Timeout before retransmission (doubled after each try)
         lock_interval_ms=10,    # Minimum locking interval
-        timer_ms=10,            # Schedules the protocol task every 10ms
+        poll_ms=10,             # Schedules the protocol task every 10ms
     )
 
     # Register the transport


### PR DESCRIPTION
Move softtimer scheduling into the protocol core so it self-schedules periodic ticks. The soft-timer interval is now controlled via  `poll_ms` in `config_t` which Python transports can override.

Additionally, add new `tick` channel op called from `omv_protocol_poll` to allow channels to perform periodic work. This is implemented by the stdio stdout channel to flush unnotified data using `last_notify_ms` timestamp. This makes the stdout channel adaptive; sends low-rate events periodically, and more events if overflows are detected.