### PR TITLE
ports: Allow placing lwIP memory in a dedicated section.

### DIFF
--- a/ports/alif/mp_config.h
+++ b/ports/alif/mp_config.h
@@ -61,4 +61,11 @@ void __fatal_error(const char *);
 #define MICROPY_WRAP_TUD_CDC_LINE_STATE_CB(name) __mp_ ## name
 #define MICROPY_WRAP_TUD_EVENT_HOOK_CB(name) __mp_ ## name
 
+// Place lwIP memory in a dedicated section to allow relocating it.
+// Note: alignment is enforced without adding trailing padding bytes.
+#if MICROPY_PY_LWIP_RELOCATE_MEM
+#define LWIP_DECLARE_MEMORY_ALIGNED(variable_name, size) \
+    __attribute__((section(".lwip"), aligned(MEM_ALIGNMENT))) u8_t variable_name[size]
+#endif
+
 #include <mpconfigport.h>

--- a/ports/mimxrt/mp_config.h
+++ b/ports/mimxrt/mp_config.h
@@ -53,4 +53,11 @@
 #define MICROPY_WRAP_TUD_CDC_LINE_STATE_CB(name) __mp_ ## name
 #define MICROPY_WRAP_TUD_EVENT_HOOK_CB(name) __mp_ ## name
 
+// Place lwIP memory in a dedicated section to allow relocating it.
+// Note: alignment is enforced without adding trailing padding bytes.
+#if MICROPY_PY_LWIP_RELOCATE_MEM
+#define LWIP_DECLARE_MEMORY_ALIGNED(variable_name, size) \
+    __attribute__((section(".lwip"), aligned(MEM_ALIGNMENT))) u8_t variable_name[size]
+#endif
+
 #include <mpconfigport.h>

--- a/ports/stm32/mp_config.h
+++ b/ports/stm32/mp_config.h
@@ -60,4 +60,11 @@ void __fatal_error(const char *);
 #define MICROPY_WRAP_TUD_CDC_LINE_STATE_CB(name) __mp_ ## name
 #define MICROPY_WRAP_TUD_EVENT_HOOK_CB(name) __mp_ ## name
 
+// Place lwIP memory in a dedicated section to allow relocating it.
+// Note: alignment is enforced without adding trailing padding bytes.
+#if MICROPY_PY_LWIP_RELOCATE_MEM
+#define LWIP_DECLARE_MEMORY_ALIGNED(variable_name, size) \
+    __attribute__((section(".lwip"), aligned(MEM_ALIGNMENT))) u8_t variable_name[size]
+#endif
+
 #include <mpconfigport.h>


### PR DESCRIPTION
Place lwIP memory in its own section to allow to relocating it via the linker script. If this section is not defined this falls through to .bss. This macro also aligns the memory without adding trailing padding bytes. See comments in src/include/lwip/arch.h