### PR TITLE
imlib: Use uint8_t for magic byte buffers.

### DIFF
--- a/lib/imlib/imlib.c
+++ b/lib/imlib/imlib.c
@@ -653,7 +653,7 @@ static save_image_format_t imblib_parse_extension(image_t *img, const char *path
 }
 
 bool imlib_read_geometry(file_t *fp, image_t *img, const char *path, img_read_settings_t *rs) {
-    char magic[4];
+    uint8_t magic[4];
     file_open(fp, path, FA_READ | FA_OPEN_EXISTING);
     file_read(fp, &magic, 4);
     file_close(fp);
@@ -692,7 +692,7 @@ bool imlib_read_geometry(file_t *fp, image_t *img, const char *path, img_read_se
 #if defined(IMLIB_ENABLE_IMAGE_FILE_IO)
 void imlib_load_image(image_t *img, const char *path) {
     file_t fp;
-    char magic[4];
+    uint8_t magic[4];
     file_open(&fp, path, FA_READ | FA_OPEN_EXISTING);
     file_read(&fp, &magic, 4);
     file_close(&fp);


### PR DESCRIPTION
The file format dispatch in `imlib_read_geometry()` and `imlib_load_image()` reads the first 4 bytes of a file into a `char magic[4]` buffer and then compares against `0xFF` and `0x89` to detect JPEG and PNG. char's sign is implementation-defined; ARM GCC defaults to unsigned but x86 GCC defaults to signed, so on a non-ARM host `(signed char)0xFF == 0xFF` becomes `-1 == 255` and JPEG / PNG detection silently fails.

Use `uint8_t` instead so the magic byte comparison is unambiguous on any compiler, regardless of host or toolchain default.

Discovered while bringing up the unix port (#2868); split out as a small fix here so it can land independently.

