### PR TITLE
ports/stm32: Add ccm support.

### DIFF
--- a/common/omv_csi.h
+++ b/common/omv_csi.h
@@ -270,6 +270,18 @@ typedef enum {
 
 typedef struct _omv_csi omv_csi_t;
 
+typedef struct {
+    float coeffs[3][3];
+    float offsets[3];
+    float avg[3];
+} omv_csi_ccm_entry_t;
+
+// Entries must be sorted warmest to coolest (descending R/B ratio of avg).
+typedef struct {
+    size_t count;
+    const omv_csi_ccm_entry_t *entries;
+} omv_csi_ccm_t;
+
 typedef struct _omv_csi_callback_t {
     void (*fun) (void *);
     void *arg;
@@ -410,6 +422,7 @@ typedef struct _omv_csi {
     int (*snapshot) (omv_csi_t *csi, image_t *image, uint32_t flags);
     int (*post_process) (omv_csi_t *csi, image_t *image, uint32_t flags);
     int (*isp_reset) (omv_csi_t *csi);
+    int (*isp_set_ccm) (omv_csi_t *csi, const omv_csi_ccm_t *ccm);
 } omv_csi_t;
 
 // CSI array

--- a/drivers/sensors/pag7936.c
+++ b/drivers/sensors/pag7936.c
@@ -450,6 +450,32 @@ static const uint16_t hd_regs[][2] = {
     { 0x0000,               0x00 },
 };
 
+static const omv_csi_ccm_entry_t pag7936_ccm_entries[] = {
+    {   // INC (incandescent, ~2902K)
+        .coeffs = { {  1.425f,  0.172f, -0.597f },
+                    { -0.601f,  2.272f, -0.671f },
+                    { -0.452f, -1.811f,  3.263f } },
+        .avg = { 19.916f, 19.251f, 6.855f }, // 2.905 R/B
+    },
+    {   // TL84 (fluorescent, ~3836K)
+        .coeffs = { {  1.594f, -0.332f, -0.261f },
+                    { -0.537f,  2.080f, -0.543f },
+                    { -0.062f, -1.172f,  2.234f } },
+        .avg = { 43.362f, 54.614f, 23.002f }, // 1.885 R/B
+    },
+    {   // D65 (daylight, ~6728K)
+        .coeffs = { {  1.572f, -0.309f, -0.263f },
+                    { -0.349f,  2.173f, -0.824f },
+                    { -0.029f, -0.891f,  1.920f } },
+        .avg = { 20.056f, 34.807f, 20.315f }, // 0.987 R/B
+    },
+};
+
+static const omv_csi_ccm_t pag7936_ccm = {
+    .count = OMV_ARRAY_SIZE(pag7936_ccm_entries),
+    .entries = pag7936_ccm_entries,
+};
+
 // Apply AE/AG hardware mode based on current manual/auto state.
 // gain: register value to write (already clamped), or -1 to freeze from sensor readback.
 // expo: exposure in sensor line units (already clamped), or -1 to freeze from sensor readback.
@@ -804,6 +830,10 @@ int pag7936_init(omv_csi_t *csi) {
     csi->get_rgb_gain_db = get_rgb_gain_db;
     csi->set_hmirror = set_hmirror;
     csi->set_vflip = set_vflip;
+
+    if (csi->isp_set_ccm != NULL) {
+        csi->isp_set_ccm(csi, &pag7936_ccm);
+    }
 
     // Override standard resolutions
     csi->resolution[OMV_CSI_FRAMESIZE_HD][0] = 1280;

--- a/drivers/sensors/ps5520.c
+++ b/drivers/sensors/ps5520.c
@@ -108,6 +108,32 @@ typedef struct ps5520_state {
 
 static ps5520_state_t ps5520_state = {};
 
+static const omv_csi_ccm_entry_t ps5520_ccm_entries[] = {
+    {   // INC (incandescent, ~2902K)
+        .coeffs = { {  1.641f, -0.200f, -0.441f },
+                    { -0.527f,  2.000f, -0.473f },
+                    { -0.498f, -1.332f,  2.830f } },
+        .avg = { 98.102f, 88.470f, 38.084f }, // 2.576 R/B
+    },
+    {   // TL84 (fluorescent, ~3836K)
+        .coeffs = { {  1.546f, -0.405f, -0.141f },
+                    { -0.276f,  1.514f, -0.238f },
+                    { -0.093f, -0.859f,  1.952f } },
+        .avg = { 75.998f, 99.201f, 46.641f }, // 1.629 R/B
+    },
+    {   // D65 (daylight, ~6728K)
+        .coeffs = { {  1.619f, -0.589f, -0.030f },
+                    { -0.192f,  1.617f, -0.425f },
+                    { -0.075f, -0.802f,  1.877f } },
+        .avg = { 62.369f, 104.878f, 67.813f }, // 0.920 R/B
+    },
+};
+
+static const omv_csi_ccm_t ps5520_ccm = {
+    .count = OMV_ARRAY_SIZE(ps5520_ccm_entries),
+    .entries = ps5520_ccm_entries,
+};
+
 static const uint8_t sw_reset_regs[][2] = {
     { 0xEF, 0x05 },
     { 0x0F, 0x00 },
@@ -1645,6 +1671,10 @@ int ps5520_init(omv_csi_t *csi) {
     csi->get_rgb_gain_db = get_rgb_gain_db;
     csi->set_hmirror = set_hmirror;
     csi->set_vflip = set_vflip;
+
+    if (csi->isp_set_ccm != NULL) {
+        csi->isp_set_ccm(csi, &ps5520_ccm);
+    }
 
     return 0;
 }

--- a/ports/stm32/omv_csi.c
+++ b/ports/stm32/omv_csi.c
@@ -135,6 +135,15 @@ int stm_csi_isp_reset(omv_csi_t *csi) {
     return 0;
 }
 
+static int stm_csi_set_ccm(omv_csi_t *csi, const omv_csi_ccm_t *ccm) {
+    #if USE_DCMIPP
+    if (csi->mipi_if) {
+        csi->ccm = ccm;
+    }
+    #endif // USE_DCMIPP
+    return 0;
+}
+
 static int stm_csi_config(omv_csi_t *csi, omv_csi_config_t config) {
     if (config == OMV_CSI_CONFIG_INIT) {
         if (!csi->mipi_if) {
@@ -785,6 +794,7 @@ int omv_csi_ops_init(omv_csi_t *csi) {
     csi->shutdown = stm_csi_shutdown;
     csi->snapshot = stm_csi_snapshot;
     csi->isp_reset = stm_csi_isp_reset;
+    csi->isp_set_ccm = stm_csi_set_ccm;
 
     // Set CSI clock ops.
     csi->clk->freq = OMV_CSI_CLK_FREQUENCY;

--- a/ports/stm32/port_config.h
+++ b/ports/stm32/port_config.h
@@ -153,6 +153,7 @@ typedef I2C_HandleTypeDef *omv_i2c_dev_t;
     struct {                         \
         DCMIPP_HandleTypeDef dcmipp; \
         DMA_QListTypeDef dma_queue;  \
+        const omv_csi_ccm_t *ccm;    \
     };
 #else
 #define OMV_CSI_PORT_BITS_DCMIPP

--- a/ports/stm32/stm_isp.c
+++ b/ports/stm32/stm_isp.c
@@ -38,6 +38,81 @@
 #include "board_config.h"
 
 #ifdef DCMIPP
+// Matrix3x3_Coeff: 11-bit signed, 2 int + 8 dec -> 1.0 = 256.
+// Added3x1_Coeff:  10-bit signed, 9 int + 0 dec -> 1.0 = 1.
+#define DCMIPP_CCM(v)         ((int16_t) fast_roundf((v) * 256.0f))
+#define DCMIPP_CCM_OFFSET(v)  ((int16_t) fast_roundf(v))
+
+// Piecewise-linear interpolation of the calibrated CCMs along the R/B ratio
+// axis. Entries must be sorted warmest -> coolest (descending R/B). The live point
+// is bracketed between the two adjacent entries that span it and blended;
+// avg is the EMA-smoothed R, G, B from the AWB statistics.
+static void stm_isp_apply_ccm(omv_csi_t *csi, uint32_t pipe, const uint32_t avg[3]) {
+    const omv_csi_ccm_t *ccm = csi->ccm;
+
+    if (ccm == NULL || ccm->count == 0) {
+        return;
+    }
+
+    float cur_rb = (float) avg[0] / OMV_MAX(avg[2], 1);
+    size_t i;
+
+    // Walk warmest -> coolest until cur_rb is greater than the entry's R/B ratio.
+    for (i = 0; i < ccm->count; i++) {
+        if (cur_rb >= ccm->entries[i].avg[0] / OMV_MAX(ccm->entries[i].avg[2], 1.0f)) {
+            break;
+        }
+    }
+
+    // Pick the adjacent entries to blend between.
+    size_t warm = (i == 0) ? 0 : i - 1;
+    size_t cool = (i == ccm->count) ? ccm->count - 1 : i;
+
+    const omv_csi_ccm_entry_t *e_warm = &ccm->entries[warm];
+    const omv_csi_ccm_entry_t *e_cool = &ccm->entries[cool];
+    float t = 0.0f;
+
+    if (warm != cool) {
+        // Interpolate between the warm and cool entries.
+        float rb_warm = e_warm->avg[0] / OMV_MAX(e_warm->avg[2], 1.0f);
+        float rb_cool = e_cool->avg[0] / OMV_MAX(e_cool->avg[2], 1.0f);
+        t = (rb_warm - cur_rb) / (rb_warm - rb_cool);
+    }
+
+    float u = 1.0f - t;
+    float coeffs[3][3];
+    float offsets[3];
+
+    // Blend the CCM coefficients and offsets.
+    for (int r = 0; r < 3; r++) {
+        for (int c = 0; c < 3; c++) {
+            coeffs[r][c] = u * e_warm->coeffs[r][c] + t * e_cool->coeffs[r][c];
+        }
+
+        offsets[r] = u * e_warm->offsets[r] + t * e_cool->offsets[r];
+    }
+
+    DCMIPP_ColorConversionConfTypeDef cfg = {
+        .ClampOutputSamples = ENABLE,
+        .OutputSamplesType = DCMIPP_CLAMP_RGB,
+        .RR = DCMIPP_CCM(coeffs[0][0]),
+        .RG = DCMIPP_CCM(coeffs[0][1]),
+        .RB = DCMIPP_CCM(coeffs[0][2]),
+        .RA = DCMIPP_CCM_OFFSET(offsets[0]),
+        .GR = DCMIPP_CCM(coeffs[1][0]),
+        .GG = DCMIPP_CCM(coeffs[1][1]),
+        .GB = DCMIPP_CCM(coeffs[1][2]),
+        .GA = DCMIPP_CCM_OFFSET(offsets[1]),
+        .BR = DCMIPP_CCM(coeffs[2][0]),
+        .BG = DCMIPP_CCM(coeffs[2][1]),
+        .BB = DCMIPP_CCM(coeffs[2][2]),
+        .BA = DCMIPP_CCM_OFFSET(offsets[2]),
+    };
+
+    HAL_DCMIPP_PIPE_SetISPColorConversionConfig(&csi->dcmipp, pipe, &cfg);
+    HAL_DCMIPP_PIPE_EnableISPColorConversion(&csi->dcmipp, pipe);
+}
+
 float stm_isp_update_awb(omv_csi_t *csi, uint32_t pipe, uint32_t n_pixels) {
     uint32_t avg[3];
     uint32_t shift[3];
@@ -87,6 +162,7 @@ float stm_isp_update_awb(omv_csi_t *csi, uint32_t pipe, uint32_t n_pixels) {
     };
 
     HAL_DCMIPP_PIPE_SetISPExposureConfig(&csi->dcmipp, pipe, &expcfg);
+    stm_isp_apply_ccm(csi, pipe, avg);
 
     return luminance;
 }


### PR DESCRIPTION
Adds color matrix calibration support for the PS5520 and PAG7936. The color matrices come from values that Pixart tuned for OpenMV using the N6 with either sensor. CCM values are mixed together using Piecewise linear bracketing, which is an industry-standard way to adjust the applied color matrix based on the 

Here are some examples of what this does:

PS5520 before:
<img width="1920" height="1080" alt="FHD-before" src="https://github.com/user-attachments/assets/8b2dba0a-5e30-4e1f-8985-d0db390c3316" />

PS5520 After:
<img width="1920" height="1080" alt="FHD-after" src="https://github.com/user-attachments/assets/84528dd0-8804-4436-86be-ab5c4bb59fba" />

PAG7936 Before:
<img width="1274" height="795" alt="HD_before" src="https://github.com/user-attachments/assets/da056c57-2132-47cc-89a8-3ce6719ac6f3" />

PAG7936 After:
<img width="1269" height="796" alt="HD_after" src="https://github.com/user-attachments/assets/6dad06bb-33df-4f8d-97c0-638a263d9c65" />

...

The PS5520 appears to work very well with this PR. For the PAG7936, this greatly amplifies the noise from the PAG7936 sensor. The denoise feature of the PAG7936 needs to be activated to reduce this. Additionally, the PAG7936 suffers from limited dynamic range when viewing outdoors and in dark scenes, causing bad image quality.

Improvements to the PAG7936 driver need to be applied before this PR is usable. In particular, the denoise feature of the PAG7936 sensor needs to be enabled to reduce the RGB noise in the image.

