### PR TITLE
drivers/sensors: Lower PAG7936 mipi rate to 800 Mb/s max.

### DIFF
--- a/drivers/sensors/pag7936.c
+++ b/drivers/sensors/pag7936.c
@@ -782,7 +782,7 @@ int pag7936_init(omv_csi_t *csi) {
     csi->cfa_format = SUBFORMAT_ID_BGGR;
     #if OMV_PAG7936_MIPI_CSI2
     csi->mipi_if = 1;
-    csi->mipi_brate = 1200;
+    csi->mipi_brate = 800;
     #endif
 
     // Initialize csi ops.

--- a/drivers/sensors/pag7936.c
+++ b/drivers/sensors/pag7936.c
@@ -456,6 +456,7 @@ static const uint16_t hd_regs[][2] = {
 static int ae_apply(omv_csi_t *csi, int gain, int expo) {
     pag7936_state_t *state = csi->priv;
     uint8_t reg;
+    uint8_t tmp;
     int ret = omv_i2c_read_reg(csi->i2c, csi->slv_addr, AE_EXPO_MANUAL, 2, &reg, 1);
 
     if (state->gain_auto && state->expo_auto) {
@@ -476,12 +477,12 @@ static int ae_apply(omv_csi_t *csi, int gain, int expo) {
             expo = PAG7936_EXPOSURE(exph, expm, expl) / PAG7936_EXP_DIV;
         }
 
-        ret |= omv_i2c_read_reg(csi->i2c, csi->slv_addr, AE_GAIN_MANUAL_10_8, 2, &reg, 1);
-        ret |= omv_i2c_write_reg(csi->i2c, csi->slv_addr, AE_GAIN_MANUAL_10_8, 2, PAG7936_GAIN_H(reg, gain), 1);
+        ret |= omv_i2c_read_reg(csi->i2c, csi->slv_addr, AE_GAIN_MANUAL_10_8, 2, &tmp, 1);
+        ret |= omv_i2c_write_reg(csi->i2c, csi->slv_addr, AE_GAIN_MANUAL_10_8, 2, PAG7936_GAIN_H(tmp, gain), 1);
         ret |= omv_i2c_write_reg(csi->i2c, csi->slv_addr, AE_GAIN_MANUAL_7_0, 2, PAG7936_GAIN_L(gain), 1);
 
-        ret |= omv_i2c_read_reg(csi->i2c, csi->slv_addr, AE_EXPO_MANUAL_17_16, 2, &reg, 1);
-        ret |= omv_i2c_write_reg(csi->i2c, csi->slv_addr, AE_EXPO_MANUAL_17_16, 2, PAG7936_EXPOSURE_H(reg, expo), 1);
+        ret |= omv_i2c_read_reg(csi->i2c, csi->slv_addr, AE_EXPO_MANUAL_17_16, 2, &tmp, 1);
+        ret |= omv_i2c_write_reg(csi->i2c, csi->slv_addr, AE_EXPO_MANUAL_17_16, 2, PAG7936_EXPOSURE_H(tmp, expo), 1);
         ret |= omv_i2c_write_reg(csi->i2c, csi->slv_addr, AE_EXPO_MANUAL_15_8, 2, PAG7936_EXPOSURE_M(expo), 1);
         ret |= omv_i2c_write_reg(csi->i2c, csi->slv_addr, AE_EXPO_MANUAL_7_0, 2, PAG7936_EXPOSURE_L(expo), 1);
 

--- a/drivers/sensors/pag7936.c
+++ b/drivers/sensors/pag7936.c
@@ -168,7 +168,7 @@
 
 #if OMV_PAG7936_MIPI_CSI2
 #define PAG7936_WIDTH_ALIGN         (8)
-#define PAG7936_QVGA_FPS_MAX        (480)
+#define PAG7936_QVGA_FPS_MAX        (470)
 #define PAG7936_VGA_FPS_MAX         (240)
 #define PAG7936_HD_FPS_MAX          (120)
 #else

--- a/ports/stm32/omv_csi.c
+++ b/ports/stm32/omv_csi.c
@@ -126,6 +126,31 @@ static bool stm_csi_is_active(omv_csi_t *csi) {
     return (DCMI->CR & DCMI_CR_ENABLE);
 }
 
+#if USE_DCMIPP
+// Map a numeric MIPI bitrate (Mb/s) to the closest DCMIPP_CSI_PHY_BT_* enum.
+static uint32_t stm_csi_mipi_bitrate(uint32_t mbps) {
+    static const uint16_t bitrates[] = {
+        80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 190, // +10
+        205, 220, 235, 250, // +15
+        275, 300, 325, 350, // +25
+        400, 450, 500, 550, 600, 650, 700, 750, 800, 850, 900, 950, // +50
+        1000, 1050, 1100, 1150, 1200, 1250, 1300, 1350, 1400, 1450, 1500, 1550, // +50
+        1600, 1650, 1700, 1750, 1800, 1850, 1900, 1950, 2000, 2050, 2100, 2150, // +50
+        2200, 2250, 2300, 2350, 2400, 2450, 2500 // +50
+    };
+    size_t best = 0;
+    uint32_t best_diff = abs((int) mbps - (int) bitrates[0]);
+    for (size_t i = 1; i < OMV_ARRAY_SIZE(bitrates); i++) {
+        uint32_t diff = abs((int) mbps - (int) bitrates[i]);
+        if (diff < best_diff) {
+            best = i;
+            best_diff = diff;
+        }
+    }
+    return best;
+}
+#endif // USE_DCMIPP
+
 int stm_csi_isp_reset(omv_csi_t *csi) {
     #if USE_DCMIPP
     if (csi->mipi_if) {
@@ -203,7 +228,7 @@ static int stm_csi_config(omv_csi_t *csi, omv_csi_config_t config) {
             DCMIPP_CSI_ConfTypeDef scfg = {
                 .NumberOfLanes = DCMIPP_CSI_TWO_DATA_LANES,
                 .DataLaneMapping = DCMIPP_CSI_PHYSICAL_DATA_LANES,
-                .PHYBitrate = (csi->mipi_brate == 850) ? DCMIPP_CSI_PHY_BT_850 : DCMIPP_CSI_PHY_BT_1200,
+                .PHYBitrate = stm_csi_mipi_bitrate(csi->mipi_brate),
             };
 
             if (HAL_DCMIPP_CSI_SetConfig(&csi->dcmipp, &scfg) != HAL_OK) {


### PR DESCRIPTION
Not quite sure what was going on here, but the PAG7936 MIPI rate is set for 1200 Mb/s when the datasheet says the max is 800 Mb/s. 

Couldn't find any emails from Pixart that say it does more than 800 Mb/s... The sensor appears to work with the setting changed to 800 Mb/s or 1200 Mb/s.