### PR TITLE
common: Fix green AWB blowout on bright scenes.

### DIFF
--- a/common/omv_csi.c
+++ b/common/omv_csi.c
@@ -1157,6 +1157,16 @@ __weak int omv_csi_get_rgb_gain_db(omv_csi_t *csi, float *r_gain_db, float *g_ga
 void omv_csi_stats_update(omv_csi_t *csi, uint32_t *r, uint32_t *g, uint32_t *b, uint32_t ms) {
     omv_csi_stats_t *stats = &csi->stats;
 
+    // Freeze the EMA when raw R/G/B ratios collapse toward 1.0 — that means
+    // saturated pixels are pinning all channels equal, which would bias AWB
+    // toward "no correction" and tint unsaturated regions green. AEC still
+    // sees live luminance and drops exposure to resolve the saturation.
+    uint32_t min = IM_MIN(*r, IM_MIN(*g, *b));
+    uint32_t max = IM_MAX(*r, IM_MAX(*g, *b));
+    if (min * 3 > max * 2) {
+        return;
+    }
+
     if (!stats->initialized) {
         stats->initialized = true;
         stats->last_ms = ms;

--- a/ports/stm32/omv_csi.c
+++ b/ports/stm32/omv_csi.c
@@ -404,6 +404,14 @@ static void stm_csi_frame_event(omv_csi_t *csi, uint32_t pipe) {
     HAL_NVIC_EnableIRQ(csi->dma_irqn);
     #endif
 
+    // The ISP AWB stats lag by one frame. So, drop the first frame when not initialized.
+    #if defined(OMV_CSI_STATS_ENABLE)
+    if (csi->raw_output && csi->stats_enabled && !csi->stats.initialized) {
+        stm_isp_update_awb(csi, DCMIPP_PIPE, fb->u * fb->v);
+        csi->drop_frame = true;
+    }
+    #endif // OMV_CSI_STATS_ENABLE
+
     csi->first_line = false;
     if (csi->drop_frame) {
         csi->drop_frame = false;


### PR DESCRIPTION
Fixes the first frame being green on the STM32 (Alif doesn't have this problem) and AWB turning the image green on bright scenes.