### PR TITLE
common: Fix green AWB blowout on bright scenes.

### DIFF
--- a/common/omv_csi.c
+++ b/common/omv_csi.c
@@ -1164,6 +1164,17 @@ void omv_csi_stats_update(omv_csi_t *csi, uint32_t *r, uint32_t *g, uint32_t *b,
         stats->g_avg = *g;
         stats->b_avg = *b;
     } else {
+        // Freeze the EMA when raw R/G/B ratios collapse above 2/3rds — that means
+        // saturated pixels are pinning all channels equal, which would bias AWB
+        // toward "no correction" and tint unsaturated regions green. AEC still
+        // sees live luminance and drops exposure to resolve the saturation.
+        uint32_t min = IM_MIN(*r, IM_MIN(*g, *b));
+        uint32_t max = IM_MAX(*r, IM_MAX(*g, *b));
+
+        if (min * 3 > max * 2) {
+            return;
+        }
+
         uint32_t dt_ms = ms - stats->last_ms;
         // Continuous-time EMA gain for elapsed dt: alpha = 1 - exp(-dt/τ)
         float alpha = IM_CLAMP(1.0f - expf(-((float) dt_ms) / OMV_CSI_STATS_TAU_MS), 0.0f, 1.0f);

--- a/ports/stm32/omv_csi.c
+++ b/ports/stm32/omv_csi.c
@@ -404,6 +404,14 @@ static void stm_csi_frame_event(omv_csi_t *csi, uint32_t pipe) {
     HAL_NVIC_EnableIRQ(csi->dma_irqn);
     #endif
 
+    // The ISP AWB stats lag by one frame. So, drop the first frame when not initialized.
+    #if defined(OMV_CSI_STATS_ENABLE)
+    if (csi->raw_output && csi->stats_enabled && !csi->stats.initialized) {
+        stm_isp_update_awb(csi, DCMIPP_PIPE, fb->u * fb->v);
+        csi->drop_frame = true;
+    }
+    #endif // OMV_CSI_STATS_ENABLE
+
     csi->first_line = false;
     if (csi->drop_frame) {
         csi->drop_frame = false;


### PR DESCRIPTION
Previously [common: Fix green AWB blowout on bright scenes.](https://github.com/openmv/openmv/commit/3f22a40099d2ca2f1e27c045b2a16dc40906121c) was not covered by `stats->initialized` being true, leading to a deadlock situation if the R/G/B ratios on the first frame are drastically imbalanced.

This is fixed now by only disabling the EMA update after it's been initialized. The STM32 also drops the first frame and initializes the EMA filter to fix the first frame from the STM32 ISP pipe being green because ISP stats info is from the previous frame.

Tested this on the N6 starting in:
- PS5520 at VGA in total darkness
- PS5520 at VGA in normal lighting
- PS5520 at VGA outside in direct sunlight

Tested this on the N6 starting in:
- PAG7936 at VGA in total darkness
- PAG7936 at VGA in normal lighting
- PAG7936 at VGA outside in direct sunlight

Tested this on the AE3 starting in
- PAG7936 at VGA in total darkness
- PAG7936 at VGA in normal lighting
- PAG7936 at VGA outside in direct sunlight

Issues with the image being green are fixed except in one case. If the camera is pointing into a very bright scene initially when the system starts, where the average AWB values are unbalanced because of the image blowing out due to bright light, then I have no valid AWB values to work with, so the initial AWB settings will be held, which results in the image being green. However, there's not much you can do to fix this until the camera is moved away from the bright light so that a valid AWB estimate can be collected, which will then be locked in.

...

The STM32N6 has a mode where it can remove blown-out pixels from the RGB stats. However, the number of pixels removed from the estimate isn't tracked by hardware... so, you don't have a divisor then to compute the average anymore. They also have a way to count the number of pixels removed, but, not the sums at the same time. So, if you wanted to do the correct count without blown-out pixels, you'd need to alternate the stats counters per frame. Not really workable. Then, for the AE3, since there's no ISP, you'd need to compute the RGB averages while clipping the extremes. So, also not workable compared to getting the average counts from the camera itself.

So, disabling the EMA update when the averages are corrupted due to blown-out pixels is the most reasonable solution until better ISP hardware is available.