### PR TITLE
drivers/genx320: Suppress IDE preview push in event mode.

### DIFF
--- a/drivers/sensors/genx320.c
+++ b/drivers/sensors/genx320.c
@@ -689,6 +689,8 @@ static int post_process_event(omv_csi_t *csi, image_t *image, uint32_t flags) {
         }
     }
 
+    // Invalidate frame.
+    csi->fb->pixfmt = PIXFORMAT_INVALID;
     return valid_count;
 }
 


### PR DESCRIPTION
In event mode the genx320 framebuffer holds raw EVT2.0 dwords laid out as 1024xN, not a viewable image. 

After commit: 9a8077827 ("csi: Remove OMV_CSI_FLAG_UPDATE_FB flag") omv_csi_snapshot() unconditionally pushes the previous framebuffer to FB_STREAM_ID, so each IOCTL_GENX320_READ_EVENTS call enqueues those raw bytes as the IDE preview. The user's subsequent img.flush() of a 320x320 histogram races against the IDE reader through framebuffer_update_preview()'s mutex_try_lock_fair(); when the lock is contended the flush is dropped and the IDE pulls the raw 1024xN event buffer instead, showing as a scrambled strip every few frames.

Invalidate csi->fb->pixfmt at the end of post_process_event() so framebuffer_update_preview() early-returns on the next snapshot, leaving img.flush() as the only writer to the stream buffer.

...

Tested with the GENX320 in event mode on the N6 and RT1062. The issue is fixed.