### PR TITLE
csi: Add OMV_CSI_FLAG_NO_UPDATE flag.

### DIFF
--- a/common/omv_csi.c
+++ b/common/omv_csi.c
@@ -1649,7 +1649,7 @@ __weak int omv_csi_snapshot(omv_csi_t *csi, image_t *image, uint32_t flags) {
     // as it might have been captured in non-blocking mode but not used yet.
     if (buffer && (buffer->flags & VB_FLAG_USED)) {
         framebuffer_t *stream_fb = framebuffer_get(FB_STREAM_ID);
-        if (omv_csi_match(csi, stream_fb->source)) {
+        if (!(flags & OMV_CSI_FLAG_NO_UPDATE) && omv_csi_match(csi, stream_fb->source)) {
             image_t tmp;
             framebuffer_to_image(csi->fb, &tmp);
             framebuffer_update_preview(&tmp);

--- a/common/omv_csi.h
+++ b/common/omv_csi.h
@@ -193,8 +193,9 @@ typedef enum {
 } omv_csi_framesize_t;
 
 typedef enum {
-    OMV_CSI_FLAG_NON_BLOCK      = (1 << 0),
-    OMV_CSI_FLAG_NO_POST        = (1 << 1),
+    OMV_CSI_FLAG_NO_UPDATE      = (1 << 0),
+    OMV_CSI_FLAG_NON_BLOCK      = (1 << 1),
+    OMV_CSI_FLAG_NO_POST        = (1 << 2),
     OMV_CSI_FLAG_IOCTL_ABORT    = (1 << 8),
 } omv_csi_flags_t;
 

--- a/drivers/sensors/genx320.c
+++ b/drivers/sensors/genx320.c
@@ -533,7 +533,7 @@ static int ioctl(omv_csi_t *csi, int request, va_list ap) {
             genx->events = (ec_event_t *) va_arg(ap, ec_event_t *);
 
             image_t image;
-            ret = omv_csi_snapshot(csi, &image, 0);
+            ret = omv_csi_snapshot(csi, &image, OMV_CSI_FLAG_NO_UPDATE);
             break;
         }
         case OMV_CSI_IOCTL_GENX320_READ_EVENTS_RAW: {
@@ -546,7 +546,7 @@ static int ioctl(omv_csi_t *csi, int request, va_list ap) {
             }
 
             image_t *img = (image_t *) va_arg(ap, image_t *);
-            ret = omv_csi_snapshot(csi, img, OMV_CSI_FLAG_NO_POST);
+            ret = omv_csi_snapshot(csi, img, OMV_CSI_FLAG_NO_POST | OMV_CSI_FLAG_NO_UPDATE);
             break;
         }
         case OMV_CSI_IOCTL_GENX320_CALIBRATE: {
@@ -569,7 +569,7 @@ static int ioctl(omv_csi_t *csi, int request, va_list ap) {
                 mp_printf(MP_PYTHON_PRINTER, "CSI: Calibrating - %d%%\n", ((i * 50) / event_count));
 
                 image_t image;
-                ret = omv_csi_snapshot(csi, &image, OMV_CSI_FLAG_NO_POST);
+                ret = omv_csi_snapshot(csi, &image, OMV_CSI_FLAG_NO_POST | OMV_CSI_FLAG_NO_UPDATE);
                 if (ret < 0) {
                     uma_free(histogram);
                     return ret;


### PR DESCRIPTION
Replace the implicit "always update preview on snapshot when source
matches" behavior with a self-documenting opt-out: by default the
matched CSI's framebuffer is pushed to the IDE stream, and callers that
must bypass it (e.g. raw event reads where the framebuffer is not a
viewable image) pass OMV_CSI_FLAG_NO_UPDATE.

Apply NO_UPDATE in the genx320 READ_EVENTS, READ_EVENTS_RAW, and
CALIBRATE paths so the raw 1024xN event buffer is never pushed to the
preview, which previously raced against the user's img.flush() and
produced scrambled frames in event mode.

The issue with raw event data being shown in the IDE preview is fixed.

Fixes: https://github.com/openmv/openmv/issues/3157