### PR TITLE
tools/modelc: drop redundant npu_driver.py pass.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ export OMV_LIB_DIR:=$(TOP_DIR)/scripts/libraries
 export FROZEN_MANIFEST:=$(OMV_BOARD_CONFIG_DIR)/manifest.py
 
 # Prepend SDK bin directories to PATH.
-export STEDGEAI_CORE := $(SDK_DIR)/stedgeai
+STEDGEAI_CORE := $(SDK_DIR)/stedgeai
 STEDGEAI_UTIL := Utilities/$(if $(filter Darwin,$(shell uname -s)),macarm,linux)
 export PATH := $(SDK_DIR)/gcc/bin:$(SDK_DIR)/llvm/bin:$(SDK_DIR)/cmake/bin:$(SDK_DIR)/python/bin:$(SDK_DIR)/stcubeprog/bin:$(STEDGEAI_CORE)/$(STEDGEAI_UTIL):$(SDK_DIR)/bin:$(SDK_DIR)/fvp/bin:$(PATH)
 

--- a/tools/modelc.py
+++ b/tools/modelc.py
@@ -66,7 +66,6 @@ def vela_compile(model_path, build_dir, vela_args):
     os.rename(f"{build_dir}/{model}_vela.tflite", f"{build_dir}/{model}.tflite")
 
 def stedge_compile(model_path, build_dir, profile, stedge_args=None):
-    core_dir = os.environ["STEDGEAI_CORE"]
     config = os.path.realpath("lib/stai/scripts/neuralart.json")
     model_name = os.path.basename(os.path.splitext(model_path)[0])
     model_ext = os.path.splitext(model_path)[1]
@@ -77,7 +76,8 @@ def stedge_compile(model_path, build_dir, profile, stedge_args=None):
     for var in ["RM", "CFLAGS", "CPPFLAGS", "CXXFLAGS", "LDFLAGS", 'MAKEFLAGS']:
         env.pop(var, None)
 
-    # Step 1: stedgeai generate
+    # --relocatable: stedgeai builds the position-independent .bin we
+    # load on-device, in one go (no separate npu_driver.py pass needed).
     generate_command = [
         "stedgeai",
         "generate",
@@ -105,29 +105,7 @@ def stedge_compile(model_path, build_dir, profile, stedge_args=None):
             print(e.stderr, file=sys.stderr)
         raise(e)
 
-    # Step 2: Python relocation script
-    reloc_command = [
-        sys.executable,  # Uses current Python interpreter
-        os.path.join(core_dir, "scripts/N6_reloc/npu_driver.py"),
-        "--input", os.path.join(output_dir, "gen", "network.c"),
-        "--output", output_dir,
-        "--verbosity", "1",
-    ]
-
-    try:
-        result = subprocess.run(reloc_command, check=True, text=True, env=env,
-                                stdin=subprocess.DEVNULL,
-                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    except subprocess.CalledProcessError as e:
-        print(f"{C_RED}Relocation script failed for {model_path} "
-              f"(exit code {e.returncode}){C_RESET}", file=sys.stderr)
-        print(" ".join(reloc_command), file=sys.stderr)
-        if e.stdout:
-            print(e.stdout, file=sys.stderr)
-        if e.stderr:
-            print(e.stderr, file=sys.stderr)
-        raise(e)
-
+    # The summary table we want to surface to the user is in generate's stdout.
     match = re.search(
         r"([ \t]+XIP size.*?Table: mempool.*?\n)", result.stdout, re.DOTALL | re.MULTILINE
     )
@@ -136,7 +114,10 @@ def stedge_compile(model_path, build_dir, profile, stedge_args=None):
         print(f"{C_GREEN}Model: {model_name}{C_RESET}")
         print(C_BLUE + output + C_RESET + "\n")
 
-    os.rename(f"{output_dir}/network_rel.bin", f"{build_dir}/{model_name}{model_ext}")
+    os.rename(
+        f"{output_dir}/workspace/network_npu_reloc_build/network_rel.bin",
+        f"{build_dir}/{model_name}{model_ext}",
+    )
 
 if __name__ == '__main__':
     # python tools/tflite2c.py --input lib/models/fomo_face_detection.tflite --build-dir /tmp/build_st --stedge-args "--target stm32n6"


### PR DESCRIPTION
The two-step generate + npu_driver pattern came from pre-release ST scripts that staged the relocatable build manually. The stable stedgeai CLI does everything in one pass when invoked with --relocatable, so the second pass is dead weight (and requires an external make on PATH).