### PR TITLE
Add pixel-exact blob contour drawing

### DIFF
--- a/lib/imlib/blob.c
+++ b/lib/imlib/blob.c
@@ -136,6 +136,103 @@ static float calc_roundness(float blob_a, float blob_b, float blob_c) {
     return IM_DIV(roundness_min, roundness_max);
 }
 
+void imlib_draw_contours(image_t *ptr, rectangle_t *roi, list_t *thresholds, bool invert, int color) {
+    if (!list_size(thresholds)) {
+        return;
+    }
+
+    image_t bmp;
+    bmp.w = ptr->w;
+    bmp.h = ptr->h;
+    bmp.pixfmt = PIXFORMAT_BINARY;
+    bmp.data = uma_calloc(image_size(&bmp), 0);
+
+    list_for_each(it, thresholds) {
+        color_thresholds_list_lnk_data_t *lnk_data = list_get_data(it);
+
+        switch (ptr->pixfmt) {
+            case PIXFORMAT_BINARY: {
+                for (int y = roi->y, yy = roi->y + roi->h; y < yy; y++) {
+                    imlib_poll_events();
+                    uint32_t *row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(ptr, y);
+                    uint32_t *bmp_row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(&bmp, y);
+                    for (int x = roi->x, xx = roi->x + roi->w; x < xx; x++) {
+                        if (COLOR_THRESHOLD_BINARY(IMAGE_GET_BINARY_PIXEL_FAST(row_ptr, x), lnk_data, invert)) {
+                            IMAGE_SET_BINARY_PIXEL_FAST(bmp_row_ptr, x);
+                        }
+                    }
+                }
+                break;
+            }
+            case PIXFORMAT_GRAYSCALE: {
+                for (int y = roi->y, yy = roi->y + roi->h; y < yy; y++) {
+                    imlib_poll_events();
+                    uint8_t *row_ptr = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(ptr, y);
+                    uint32_t *bmp_row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(&bmp, y);
+                    for (int x = roi->x, xx = roi->x + roi->w; x < xx; x++) {
+                        if (COLOR_THRESHOLD_GRAYSCALE(IMAGE_GET_GRAYSCALE_PIXEL_FAST(row_ptr, x), lnk_data, invert)) {
+                            IMAGE_SET_BINARY_PIXEL_FAST(bmp_row_ptr, x);
+                        }
+                    }
+                }
+                break;
+            }
+            case PIXFORMAT_RGB565: {
+                for (int y = roi->y, yy = roi->y + roi->h; y < yy; y++) {
+                    imlib_poll_events();
+                    uint16_t *row_ptr = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(ptr, y);
+                    uint32_t *bmp_row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(&bmp, y);
+                    for (int x = roi->x, xx = roi->x + roi->w; x < xx; x++) {
+                        if (COLOR_THRESHOLD_RGB565(IMAGE_GET_RGB565_PIXEL_FAST(row_ptr, x), lnk_data, invert)) {
+                            IMAGE_SET_BINARY_PIXEL_FAST(bmp_row_ptr, x);
+                        }
+                    }
+                }
+                break;
+            }
+            default: {
+                break;
+            }
+        }
+    }
+
+    int x_min = roi->x;
+    int y_min = roi->y;
+    int x_max = roi->x + roi->w - 1;
+    int y_max = roi->y + roi->h - 1;
+
+    for (int y = y_min; y <= y_max; y++) {
+        imlib_poll_events();
+        uint32_t *row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(&bmp, y);
+        for (int x = x_min; x <= x_max; x++) {
+            if (!IMAGE_GET_BINARY_PIXEL_FAST(row_ptr, x)) {
+                continue;
+            }
+
+            bool edge = (x == x_min) || (x == x_max) || (y == y_min) || (y == y_max);
+
+            if (!edge) {
+                uint32_t *prev_row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(&bmp, y - 1);
+                uint32_t *next_row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(&bmp, y + 1);
+                edge = (!IMAGE_GET_BINARY_PIXEL_FAST(prev_row_ptr, x - 1)) ||
+                       (!IMAGE_GET_BINARY_PIXEL_FAST(prev_row_ptr, x)) ||
+                       (!IMAGE_GET_BINARY_PIXEL_FAST(prev_row_ptr, x + 1)) ||
+                       (!IMAGE_GET_BINARY_PIXEL_FAST(row_ptr, x - 1)) ||
+                       (!IMAGE_GET_BINARY_PIXEL_FAST(row_ptr, x + 1)) ||
+                       (!IMAGE_GET_BINARY_PIXEL_FAST(next_row_ptr, x - 1)) ||
+                       (!IMAGE_GET_BINARY_PIXEL_FAST(next_row_ptr, x)) ||
+                       (!IMAGE_GET_BINARY_PIXEL_FAST(next_row_ptr, x + 1));
+            }
+
+            if (edge) {
+                imlib_set_pixel(ptr, x, y, color);
+            }
+        }
+    }
+
+    uma_free(bmp.data);
+}
+
 void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int x_stride, unsigned int y_stride,
                       list_t *thresholds, bool invert, unsigned int area_threshold, unsigned int pixels_threshold,
                       bool merge, int margin, bool (*threshold_cb) (void *, find_blobs_list_lnk_data_t *),

--- a/lib/imlib/blob.c
+++ b/lib/imlib/blob.c
@@ -136,25 +136,149 @@ static float calc_roundness(float blob_a, float blob_b, float blob_c) {
     return IM_DIV(roundness_min, roundness_max);
 }
 
-void imlib_draw_contours(image_t *ptr, rectangle_t *roi, list_t *thresholds, bool invert, int color) {
+static void imlib_select_blob_component(image_t *out, image_t *in, rectangle_t *roi, point_t *seed) {
+    if ((seed->x < roi->x) || (seed->x >= (roi->x + roi->w)) ||
+        (seed->y < roi->y) || (seed->y >= (roi->y + roi->h))) {
+        return;
+    }
+
+    uint32_t *seed_row = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(in, seed->y);
+    if (!IMAGE_GET_BINARY_PIXEL_FAST(seed_row, seed->x)) {
+        return;
+    }
+
+    lifo_t lifo;
+    size_t lifo_len;
+    lifo_alloc_all(&lifo, &lifo_len, sizeof(xylr_t));
+
+    int x = seed->x;
+    int y = seed->y;
+
+    for (;;) {
+        int left = x, right = x;
+        uint32_t *row = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(in, y);
+        uint32_t *out_row = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(out, y);
+
+        while ((left > roi->x) &&
+               (!IMAGE_GET_BINARY_PIXEL_FAST(out_row, left - 1)) &&
+               IMAGE_GET_BINARY_PIXEL_FAST(row, left - 1)) {
+            left--;
+        }
+
+        while ((right < (roi->x + roi->w - 1)) &&
+               (!IMAGE_GET_BINARY_PIXEL_FAST(out_row, right + 1)) &&
+               IMAGE_GET_BINARY_PIXEL_FAST(row, right + 1)) {
+            right++;
+        }
+
+        for (int i = left; i <= right; i++) {
+            IMAGE_SET_BINARY_PIXEL_FAST(out_row, i);
+        }
+
+        int top_left = left;
+        int bot_left = left;
+        bool break_out = false;
+
+        for (;;) {
+            if (lifo_size(&lifo) < lifo_len) {
+                if (y > roi->y) {
+                    row = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(in, y - 1);
+                    out_row = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(out, y - 1);
+
+                    bool recurse = false;
+                    for (int i = top_left; i <= right; i++) {
+                        if ((!IMAGE_GET_BINARY_PIXEL_FAST(out_row, i)) &&
+                            IMAGE_GET_BINARY_PIXEL_FAST(row, i)) {
+                            xylr_t context;
+                            context.x = x;
+                            context.y = y;
+                            context.l = left;
+                            context.r = right;
+                            context.t_l = i + 1;
+                            context.b_l = bot_left;
+                            lifo_enqueue(&lifo, &context);
+                            x = i;
+                            y = y - 1;
+                            recurse = true;
+                            break;
+                        }
+                    }
+                    if (recurse) {
+                        break;
+                    }
+                }
+
+                if (y < (roi->y + roi->h - 1)) {
+                    row = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(in, y + 1);
+                    out_row = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(out, y + 1);
+
+                    bool recurse = false;
+                    for (int i = bot_left; i <= right; i++) {
+                        if ((!IMAGE_GET_BINARY_PIXEL_FAST(out_row, i)) &&
+                            IMAGE_GET_BINARY_PIXEL_FAST(row, i)) {
+                            xylr_t context;
+                            context.x = x;
+                            context.y = y;
+                            context.l = left;
+                            context.r = right;
+                            context.t_l = top_left;
+                            context.b_l = i + 1;
+                            lifo_enqueue(&lifo, &context);
+                            x = i;
+                            y = y + 1;
+                            recurse = true;
+                            break;
+                        }
+                    }
+                    if (recurse) {
+                        break;
+                    }
+                }
+            }
+
+            if (!lifo_size(&lifo)) {
+                break_out = true;
+                break;
+            }
+
+            xylr_t context;
+            lifo_dequeue(&lifo, &context);
+            x = context.x;
+            y = context.y;
+            left = context.l;
+            right = context.r;
+            top_left = context.t_l;
+            bot_left = context.b_l;
+        }
+
+        if (break_out) {
+            break;
+        }
+    }
+
+    lifo_free(&lifo);
+}
+
+void imlib_draw_contours(image_t *dst, image_t *src, rectangle_t *roi, list_t *thresholds,
+                         bool invert, int color, image_t *mask, point_t *seed) {
     if (!list_size(thresholds)) {
         return;
     }
 
     image_t bmp;
-    bmp.w = ptr->w;
-    bmp.h = ptr->h;
+    bmp.w = src->w;
+    bmp.h = src->h;
     bmp.pixfmt = PIXFORMAT_BINARY;
     bmp.data = uma_calloc(image_size(&bmp), 0);
 
     list_for_each(it, thresholds) {
         color_thresholds_list_lnk_data_t *lnk_data = list_get_data(it);
 
-        switch (ptr->pixfmt) {
+        switch (src->pixfmt) {
             case PIXFORMAT_BINARY: {
                 for (int y = roi->y, yy = roi->y + roi->h; y < yy; y++) {
                     imlib_poll_events();
-                    uint32_t *row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(ptr, y);
+                    uint32_t *row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(src, y);
                     uint32_t *bmp_row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(&bmp, y);
                     for (int x = roi->x, xx = roi->x + roi->w; x < xx; x++) {
                         if (COLOR_THRESHOLD_BINARY(IMAGE_GET_BINARY_PIXEL_FAST(row_ptr, x), lnk_data, invert)) {
@@ -167,7 +291,7 @@ void imlib_draw_contours(image_t *ptr, rectangle_t *roi, list_t *thresholds, boo
             case PIXFORMAT_GRAYSCALE: {
                 for (int y = roi->y, yy = roi->y + roi->h; y < yy; y++) {
                     imlib_poll_events();
-                    uint8_t *row_ptr = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(ptr, y);
+                    uint8_t *row_ptr = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(src, y);
                     uint32_t *bmp_row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(&bmp, y);
                     for (int x = roi->x, xx = roi->x + roi->w; x < xx; x++) {
                         if (COLOR_THRESHOLD_GRAYSCALE(IMAGE_GET_GRAYSCALE_PIXEL_FAST(row_ptr, x), lnk_data, invert)) {
@@ -180,7 +304,7 @@ void imlib_draw_contours(image_t *ptr, rectangle_t *roi, list_t *thresholds, boo
             case PIXFORMAT_RGB565: {
                 for (int y = roi->y, yy = roi->y + roi->h; y < yy; y++) {
                     imlib_poll_events();
-                    uint16_t *row_ptr = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(ptr, y);
+                    uint16_t *row_ptr = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(src, y);
                     uint32_t *bmp_row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(&bmp, y);
                     for (int x = roi->x, xx = roi->x + roi->w; x < xx; x++) {
                         if (COLOR_THRESHOLD_RGB565(IMAGE_GET_RGB565_PIXEL_FAST(row_ptr, x), lnk_data, invert)) {
@@ -196,6 +320,17 @@ void imlib_draw_contours(image_t *ptr, rectangle_t *roi, list_t *thresholds, boo
         }
     }
 
+    image_t component;
+    image_t *contours = &bmp;
+    if (seed) {
+        component.w = src->w;
+        component.h = src->h;
+        component.pixfmt = PIXFORMAT_BINARY;
+        component.data = uma_calloc(image_size(&component), 0);
+        imlib_select_blob_component(&component, &bmp, roi, seed);
+        contours = &component;
+    }
+
     int x_min = roi->x;
     int y_min = roi->y;
     int x_max = roi->x + roi->w - 1;
@@ -203,7 +338,7 @@ void imlib_draw_contours(image_t *ptr, rectangle_t *roi, list_t *thresholds, boo
 
     for (int y = y_min; y <= y_max; y++) {
         imlib_poll_events();
-        uint32_t *row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(&bmp, y);
+        uint32_t *row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(contours, y);
         for (int x = x_min; x <= x_max; x++) {
             if (!IMAGE_GET_BINARY_PIXEL_FAST(row_ptr, x)) {
                 continue;
@@ -212,8 +347,8 @@ void imlib_draw_contours(image_t *ptr, rectangle_t *roi, list_t *thresholds, boo
             bool edge = (x == x_min) || (x == x_max) || (y == y_min) || (y == y_max);
 
             if (!edge) {
-                uint32_t *prev_row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(&bmp, y - 1);
-                uint32_t *next_row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(&bmp, y + 1);
+                uint32_t *prev_row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(contours, y - 1);
+                uint32_t *next_row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(contours, y + 1);
                 edge = (!IMAGE_GET_BINARY_PIXEL_FAST(prev_row_ptr, x - 1)) ||
                        (!IMAGE_GET_BINARY_PIXEL_FAST(prev_row_ptr, x)) ||
                        (!IMAGE_GET_BINARY_PIXEL_FAST(prev_row_ptr, x + 1)) ||
@@ -225,11 +360,17 @@ void imlib_draw_contours(image_t *ptr, rectangle_t *roi, list_t *thresholds, boo
             }
 
             if (edge) {
-                imlib_set_pixel(ptr, x, y, color);
+                imlib_set_pixel(dst, x, y, color);
+                if (mask) {
+                    imlib_set_pixel(mask, x, y, -1);
+                }
             }
         }
     }
 
+    if (seed) {
+        uma_free(component.data);
+    }
     uma_free(bmp.data);
 }
 

--- a/lib/imlib/blob.c
+++ b/lib/imlib/blob.c
@@ -136,242 +136,184 @@ static float calc_roundness(float blob_a, float blob_b, float blob_c) {
     return IM_DIV(roundness_min, roundness_max);
 }
 
-static void imlib_select_blob_component(image_t *out, image_t *in, rectangle_t *roi, point_t *seed) {
-    if ((seed->x < roi->x) || (seed->x >= (roi->x + roi->w)) ||
-        (seed->y < roi->y) || (seed->y >= (roi->y + roi->h))) {
-        return;
-    }
+typedef struct contour_writer {
+    point_t start, last;
+    uint8_t *data;
+    uint32_t len, alloc;
+    bool has_point;
+} contour_writer_t;
 
-    uint32_t *seed_row = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(in, seed->y);
-    if (!IMAGE_GET_BINARY_PIXEL_FAST(seed_row, seed->x)) {
-        return;
-    }
-
-    lifo_t lifo;
-    size_t lifo_len;
-    lifo_alloc_all(&lifo, &lifo_len, sizeof(xylr_t));
-
-    int x = seed->x;
-    int y = seed->y;
-
-    for (;;) {
-        int left = x, right = x;
-        uint32_t *row = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(in, y);
-        uint32_t *out_row = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(out, y);
-
-        while ((left > roi->x) &&
-               (!IMAGE_GET_BINARY_PIXEL_FAST(out_row, left - 1)) &&
-               IMAGE_GET_BINARY_PIXEL_FAST(row, left - 1)) {
-            left--;
-        }
-
-        while ((right < (roi->x + roi->w - 1)) &&
-               (!IMAGE_GET_BINARY_PIXEL_FAST(out_row, right + 1)) &&
-               IMAGE_GET_BINARY_PIXEL_FAST(row, right + 1)) {
-            right++;
-        }
-
-        for (int i = left; i <= right; i++) {
-            IMAGE_SET_BINARY_PIXEL_FAST(out_row, i);
-        }
-
-        int top_left = left;
-        int bot_left = left;
-        bool break_out = false;
-
-        for (;;) {
-            if (lifo_size(&lifo) < lifo_len) {
-                if (y > roi->y) {
-                    row = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(in, y - 1);
-                    out_row = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(out, y - 1);
-
-                    bool recurse = false;
-                    for (int i = top_left; i <= right; i++) {
-                        if ((!IMAGE_GET_BINARY_PIXEL_FAST(out_row, i)) &&
-                            IMAGE_GET_BINARY_PIXEL_FAST(row, i)) {
-                            xylr_t context;
-                            context.x = x;
-                            context.y = y;
-                            context.l = left;
-                            context.r = right;
-                            context.t_l = i + 1;
-                            context.b_l = bot_left;
-                            lifo_enqueue(&lifo, &context);
-                            x = i;
-                            y = y - 1;
-                            recurse = true;
-                            break;
-                        }
-                    }
-                    if (recurse) {
-                        break;
-                    }
-                }
-
-                if (y < (roi->y + roi->h - 1)) {
-                    row = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(in, y + 1);
-                    out_row = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(out, y + 1);
-
-                    bool recurse = false;
-                    for (int i = bot_left; i <= right; i++) {
-                        if ((!IMAGE_GET_BINARY_PIXEL_FAST(out_row, i)) &&
-                            IMAGE_GET_BINARY_PIXEL_FAST(row, i)) {
-                            xylr_t context;
-                            context.x = x;
-                            context.y = y;
-                            context.l = left;
-                            context.r = right;
-                            context.t_l = top_left;
-                            context.b_l = i + 1;
-                            lifo_enqueue(&lifo, &context);
-                            x = i;
-                            y = y + 1;
-                            recurse = true;
-                            break;
-                        }
-                    }
-                    if (recurse) {
-                        break;
-                    }
-                }
-            }
-
-            if (!lifo_size(&lifo)) {
-                break_out = true;
-                break;
-            }
-
-            xylr_t context;
-            lifo_dequeue(&lifo, &context);
-            x = context.x;
-            y = context.y;
-            left = context.l;
-            right = context.r;
-            top_left = context.t_l;
-            bot_left = context.b_l;
-        }
-
-        if (break_out) {
-            break;
-        }
-    }
-
-    lifo_free(&lifo);
+static void contour_writer_init(contour_writer_t *writer) {
+    writer->start.x = 0;
+    writer->start.y = 0;
+    writer->last.x = 0;
+    writer->last.y = 0;
+    writer->data = NULL;
+    writer->len = 0;
+    writer->alloc = 0;
+    writer->has_point = false;
 }
 
-void imlib_draw_contours(image_t *dst, image_t *src, rectangle_t *roi, list_t *thresholds,
-                         bool invert, int color, image_t *mask, point_t *seed) {
-    if (!list_size(thresholds)) {
+static void contour_writer_reserve(contour_writer_t *writer, uint32_t bytes) {
+    uint32_t needed = writer->len + bytes;
+    if (needed <= writer->alloc) {
         return;
     }
 
-    image_t bmp;
-    bmp.w = src->w;
-    bmp.h = src->h;
-    bmp.pixfmt = PIXFORMAT_BINARY;
-    bmp.data = uma_calloc(image_size(&bmp), 0);
+    uint32_t alloc = writer->alloc ? writer->alloc : 32;
+    while (alloc < needed) {
+        uint32_t next = alloc * 2;
+        if (next <= alloc) {
+            alloc = needed;
+            break;
+        }
+        alloc = next;
+    }
+    writer->data = writer->data ? m_realloc(writer->data, alloc) : m_malloc(alloc);
+    writer->alloc = alloc;
+}
 
-    list_for_each(it, thresholds) {
-        color_thresholds_list_lnk_data_t *lnk_data = list_get_data(it);
+static void contour_writer_append_anchor(contour_writer_t *writer, int x, int y) {
+    contour_writer_reserve(writer, 5);
+    writer->data[writer->len++] = FIND_BLOBS_CONTOUR_ANCHOR;
+    writer->data[writer->len++] = x & 0xff;
+    writer->data[writer->len++] = (x >> 8) & 0xff;
+    writer->data[writer->len++] = y & 0xff;
+    writer->data[writer->len++] = (y >> 8) & 0xff;
+}
 
-        switch (src->pixfmt) {
-            case PIXFORMAT_BINARY: {
-                for (int y = roi->y, yy = roi->y + roi->h; y < yy; y++) {
-                    imlib_poll_events();
-                    uint32_t *row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(src, y);
-                    uint32_t *bmp_row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(&bmp, y);
-                    for (int x = roi->x, xx = roi->x + roi->w; x < xx; x++) {
-                        if (COLOR_THRESHOLD_BINARY(IMAGE_GET_BINARY_PIXEL_FAST(row_ptr, x), lnk_data, invert)) {
-                            IMAGE_SET_BINARY_PIXEL_FAST(bmp_row_ptr, x);
-                        }
-                    }
-                }
-                break;
-            }
-            case PIXFORMAT_GRAYSCALE: {
-                for (int y = roi->y, yy = roi->y + roi->h; y < yy; y++) {
-                    imlib_poll_events();
-                    uint8_t *row_ptr = IMAGE_COMPUTE_GRAYSCALE_PIXEL_ROW_PTR(src, y);
-                    uint32_t *bmp_row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(&bmp, y);
-                    for (int x = roi->x, xx = roi->x + roi->w; x < xx; x++) {
-                        if (COLOR_THRESHOLD_GRAYSCALE(IMAGE_GET_GRAYSCALE_PIXEL_FAST(row_ptr, x), lnk_data, invert)) {
-                            IMAGE_SET_BINARY_PIXEL_FAST(bmp_row_ptr, x);
-                        }
-                    }
-                }
-                break;
-            }
-            case PIXFORMAT_RGB565: {
-                for (int y = roi->y, yy = roi->y + roi->h; y < yy; y++) {
-                    imlib_poll_events();
-                    uint16_t *row_ptr = IMAGE_COMPUTE_RGB565_PIXEL_ROW_PTR(src, y);
-                    uint32_t *bmp_row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(&bmp, y);
-                    for (int x = roi->x, xx = roi->x + roi->w; x < xx; x++) {
-                        if (COLOR_THRESHOLD_RGB565(IMAGE_GET_RGB565_PIXEL_FAST(row_ptr, x), lnk_data, invert)) {
-                            IMAGE_SET_BINARY_PIXEL_FAST(bmp_row_ptr, x);
-                        }
-                    }
-                }
-                break;
-            }
-            default: {
-                break;
-            }
+static void contour_writer_append_point(contour_writer_t *writer, int x, int y) {
+    if (!writer->has_point) {
+        writer->start.x = x;
+        writer->start.y = y;
+        writer->last.x = x;
+        writer->last.y = y;
+        writer->has_point = true;
+        return;
+    }
+
+    int dx = x - writer->last.x;
+    int dy = y - writer->last.y;
+    if ((-FIND_BLOBS_CONTOUR_DELTA_OFFSET <= dx) && (dx <= FIND_BLOBS_CONTOUR_DELTA_OFFSET) &&
+        (-FIND_BLOBS_CONTOUR_DELTA_OFFSET <= dy) && (dy <= FIND_BLOBS_CONTOUR_DELTA_OFFSET)) {
+        contour_writer_reserve(writer, 1);
+        writer->data[writer->len++] =
+            ((dx + FIND_BLOBS_CONTOUR_DELTA_OFFSET) & FIND_BLOBS_CONTOUR_DELTA_MASK) |
+            (((dy + FIND_BLOBS_CONTOUR_DELTA_OFFSET) & FIND_BLOBS_CONTOUR_DELTA_MASK) << 3);
+    } else {
+        contour_writer_append_anchor(writer, x, y);
+    }
+
+    writer->last.x = x;
+    writer->last.y = y;
+}
+
+static void contour_writer_append_run(contour_writer_t *writer, int left, int right, int y) {
+    for (int x = left; x <= right; x++) {
+        contour_writer_append_point(writer, x, y);
+    }
+}
+
+static void contour_writer_free(contour_writer_t *writer) {
+    if (writer->data) {
+        m_free(writer->data);
+        writer->data = NULL;
+    }
+    writer->len = 0;
+    writer->alloc = 0;
+    writer->has_point = false;
+}
+
+static void contour_writer_finish(contour_writer_t *writer, find_blobs_list_lnk_data_t *blob) {
+    blob->contour_start = writer->start;
+    blob->contour_len = writer->len;
+    blob->contour = writer->data;
+    blob->contour_valid = writer->has_point;
+
+    writer->data = NULL;
+    writer->len = 0;
+    writer->alloc = 0;
+    writer->has_point = false;
+}
+
+static void imlib_free_blob_contour(find_blobs_list_lnk_data_t *blob) {
+    if (blob->contour) {
+        m_free(blob->contour);
+    }
+    blob->contour_start.x = 0;
+    blob->contour_start.y = 0;
+    blob->contour_len = 0;
+    blob->contour = NULL;
+    blob->contour_valid = false;
+}
+
+static void imlib_merge_blob_contours(find_blobs_list_lnk_data_t *dst, find_blobs_list_lnk_data_t *src) {
+    if (!src->contour_valid) {
+        return;
+    }
+
+    if (!dst->contour_valid) {
+        dst->contour_start = src->contour_start;
+        dst->contour_len = src->contour_len;
+        dst->contour = src->contour;
+        dst->contour_valid = true;
+        src->contour_len = 0;
+        src->contour = NULL;
+        src->contour_valid = false;
+        return;
+    }
+
+    uint32_t old_len = dst->contour_len;
+    uint32_t new_len = old_len + 5 + src->contour_len;
+    dst->contour = dst->contour ? m_realloc(dst->contour, new_len) : m_malloc(new_len);
+    uint8_t *out = dst->contour + old_len;
+    out[0] = FIND_BLOBS_CONTOUR_ANCHOR;
+    out[1] = src->contour_start.x & 0xff;
+    out[2] = (src->contour_start.x >> 8) & 0xff;
+    out[3] = src->contour_start.y & 0xff;
+    out[4] = (src->contour_start.y >> 8) & 0xff;
+    if (src->contour_len) {
+        memcpy(out + 5, src->contour, src->contour_len);
+    }
+    dst->contour_len = new_len;
+
+    imlib_free_blob_contour(src);
+}
+
+static void imlib_draw_contour_pixel(image_t *dst, int x, int y, int color, image_t *mask) {
+    if ((0 <= x) && (x < dst->w) && (0 <= y) && (y < dst->h)) {
+        imlib_set_pixel(dst, x, y, color);
+        if (mask) {
+            imlib_set_pixel(mask, x, y, -1);
         }
     }
+}
 
-    image_t component;
-    image_t *contours = &bmp;
-    if (seed) {
-        component.w = src->w;
-        component.h = src->h;
-        component.pixfmt = PIXFORMAT_BINARY;
-        component.data = uma_calloc(image_size(&component), 0);
-        imlib_select_blob_component(&component, &bmp, roi, seed);
-        contours = &component;
+void imlib_draw_contours(image_t *dst, point_t *start, const uint8_t *contour, uint32_t contour_len,
+                         int color, image_t *mask) {
+    if ((!contour) && contour_len) {
+        return;
     }
 
-    int x_min = roi->x;
-    int y_min = roi->y;
-    int x_max = roi->x + roi->w - 1;
-    int y_max = roi->y + roi->h - 1;
+    int x = start->x;
+    int y = start->y;
+    imlib_draw_contour_pixel(dst, x, y, color, mask);
 
-    for (int y = y_min; y <= y_max; y++) {
-        imlib_poll_events();
-        uint32_t *row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(contours, y);
-        for (int x = x_min; x <= x_max; x++) {
-            if (!IMAGE_GET_BINARY_PIXEL_FAST(row_ptr, x)) {
-                continue;
+    for (uint32_t i = 0; i < contour_len; i++) {
+        uint8_t value = contour[i];
+        if (value == FIND_BLOBS_CONTOUR_ANCHOR) {
+            if ((i + 4) >= contour_len) {
+                break;
             }
-
-            bool edge = (x == x_min) || (x == x_max) || (y == y_min) || (y == y_max);
-
-            if (!edge) {
-                uint32_t *prev_row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(contours, y - 1);
-                uint32_t *next_row_ptr = IMAGE_COMPUTE_BINARY_PIXEL_ROW_PTR(contours, y + 1);
-                edge = (!IMAGE_GET_BINARY_PIXEL_FAST(prev_row_ptr, x - 1)) ||
-                       (!IMAGE_GET_BINARY_PIXEL_FAST(prev_row_ptr, x)) ||
-                       (!IMAGE_GET_BINARY_PIXEL_FAST(prev_row_ptr, x + 1)) ||
-                       (!IMAGE_GET_BINARY_PIXEL_FAST(row_ptr, x - 1)) ||
-                       (!IMAGE_GET_BINARY_PIXEL_FAST(row_ptr, x + 1)) ||
-                       (!IMAGE_GET_BINARY_PIXEL_FAST(next_row_ptr, x - 1)) ||
-                       (!IMAGE_GET_BINARY_PIXEL_FAST(next_row_ptr, x)) ||
-                       (!IMAGE_GET_BINARY_PIXEL_FAST(next_row_ptr, x + 1));
-            }
-
-            if (edge) {
-                imlib_set_pixel(dst, x, y, color);
-                if (mask) {
-                    imlib_set_pixel(mask, x, y, -1);
-                }
-            }
+            x = (int16_t) (contour[i + 1] | (contour[i + 2] << 8));
+            y = (int16_t) (contour[i + 3] | (contour[i + 4] << 8));
+            i += 4;
+        } else {
+            x += (value & FIND_BLOBS_CONTOUR_DELTA_MASK) - FIND_BLOBS_CONTOUR_DELTA_OFFSET;
+            y += ((value >> 3) & FIND_BLOBS_CONTOUR_DELTA_MASK) - FIND_BLOBS_CONTOUR_DELTA_OFFSET;
         }
+        imlib_draw_contour_pixel(dst, x, y, color, mask);
     }
-
-    if (seed) {
-        uma_free(component.data);
-    }
-    uma_free(bmp.data);
 }
 
 void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int x_stride, unsigned int y_stride,
@@ -379,7 +321,7 @@ void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int 
                       bool merge, int margin, bool (*threshold_cb) (void *, find_blobs_list_lnk_data_t *),
                       void *threshold_cb_arg,
                       bool (*merge_cb) (void *, find_blobs_list_lnk_data_t *, find_blobs_list_lnk_data_t *),
-                      void *merge_cb_arg, unsigned int x_hist_bins_max, unsigned int y_hist_bins_max) {
+                      void *merge_cb_arg, unsigned int x_hist_bins_max, unsigned int y_hist_bins_max, bool contours) {
     // Same size as the image so we don't have to translate.
     image_t bmp;
     bmp.w = ptr->w;
@@ -448,6 +390,9 @@ void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int 
                                 memset(y_hist_bins, 0, ptr->h * sizeof(uint16_t));
                             }
 
+                            contour_writer_t contour_writer;
+                            contour_writer_init(&contour_writer);
+
                             // Scanline Flood Fill Algorithm //
 
                             for (;;) {
@@ -471,6 +416,12 @@ void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int 
 
                                 for (int i = left; i <= right; i++) {
                                     IMAGE_SET_BINARY_PIXEL_FAST(bmp_row, i);
+                                }
+                                if (contours) {
+                                    contour_writer_append_point(&contour_writer, left, y);
+                                    if (right != left) {
+                                        contour_writer_append_point(&contour_writer, right, y);
+                                    }
                                 }
 
                                 int sum = sum_m_to_n(left, right);
@@ -546,12 +497,19 @@ void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int 
                                                     break;
                                                 }
 
-                                                blob_perimeter += (!ok) && (i != left) && (i != right);
+                                                bool edge = (!ok) && (i != left) && (i != right);
+                                                if (contours && edge) {
+                                                    contour_writer_append_point(&contour_writer, i, y);
+                                                }
+                                                blob_perimeter += edge;
                                             }
                                             if (recurse) {
                                                 break;
                                             }
                                         } else {
+                                            if (contours) {
+                                                contour_writer_append_run(&contour_writer, left + 1, right - 1, y);
+                                            }
                                             blob_perimeter += right - left + 1;
                                         }
 
@@ -582,15 +540,25 @@ void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int 
                                                     break;
                                                 }
 
-                                                blob_perimeter += (!ok) && (i != left) && (i != right);
+                                                bool edge = (!ok) && (i != left) && (i != right);
+                                                if (contours && edge) {
+                                                    contour_writer_append_point(&contour_writer, i, y);
+                                                }
+                                                blob_perimeter += edge;
                                             }
                                             if (recurse) {
                                                 break;
                                             }
                                         } else {
+                                            if (contours) {
+                                                contour_writer_append_run(&contour_writer, left + 1, right - 1, y);
+                                            }
                                             blob_perimeter += right - left + 1;
                                         }
                                     } else {
+                                        if (contours) {
+                                            contour_writer_append_run(&contour_writer, left + 1, right - 1, y);
+                                        }
                                         blob_perimeter += (right - left + 1) * 2;
                                     }
 
@@ -663,6 +631,11 @@ void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int 
                                 lnk_blob.x_hist_bins = NULL;
                                 lnk_blob.y_hist_bins_count = 0;
                                 lnk_blob.y_hist_bins = NULL;
+                                lnk_blob.contour_start.x = 0;
+                                lnk_blob.contour_start.y = 0;
+                                lnk_blob.contour_len = 0;
+                                lnk_blob.contour = NULL;
+                                lnk_blob.contour_valid = false;
                                 // These store the current average accumulation.
                                 lnk_blob.centroid_x_acc = lnk_blob.centroid_x * lnk_blob.pixels;
                                 lnk_blob.centroid_y_acc = lnk_blob.centroid_y * lnk_blob.pixels;
@@ -686,6 +659,10 @@ void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int 
                                            &lnk_blob.y_hist_bins_count);
                                 }
 
+                                if (contours) {
+                                    contour_writer_finish(&contour_writer, &lnk_blob);
+                                }
+
                                 bool add_to_list = threshold_cb_arg == NULL;
                                 if (!add_to_list) {
                                     add_to_list = threshold_cb(threshold_cb_arg, &lnk_blob);
@@ -700,9 +677,11 @@ void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int 
                                     if (lnk_blob.y_hist_bins) {
                                         m_free(lnk_blob.y_hist_bins);
                                     }
+                                    imlib_free_blob_contour(&lnk_blob);
                                 }
                             }
 
+                            contour_writer_free(&contour_writer);
                             x = old_x;
                             y = old_y;
                         }
@@ -750,6 +729,9 @@ void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int 
                                 memset(y_hist_bins, 0, ptr->h * sizeof(uint16_t));
                             }
 
+                            contour_writer_t contour_writer;
+                            contour_writer_init(&contour_writer);
+
                             // Scanline Flood Fill Algorithm //
 
                             for (;;) {
@@ -773,6 +755,12 @@ void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int 
 
                                 for (int i = left; i <= right; i++) {
                                     IMAGE_SET_BINARY_PIXEL_FAST(bmp_row, i);
+                                }
+                                if (contours) {
+                                    contour_writer_append_point(&contour_writer, left, y);
+                                    if (right != left) {
+                                        contour_writer_append_point(&contour_writer, right, y);
+                                    }
                                 }
 
                                 int sum = sum_m_to_n(left, right);
@@ -848,12 +836,19 @@ void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int 
                                                     break;
                                                 }
 
-                                                blob_perimeter += (!ok) && (i != left) && (i != right);
+                                                bool edge = (!ok) && (i != left) && (i != right);
+                                                if (contours && edge) {
+                                                    contour_writer_append_point(&contour_writer, i, y);
+                                                }
+                                                blob_perimeter += edge;
                                             }
                                             if (recurse) {
                                                 break;
                                             }
                                         } else {
+                                            if (contours) {
+                                                contour_writer_append_run(&contour_writer, left + 1, right - 1, y);
+                                            }
                                             blob_perimeter += right - left + 1;
                                         }
 
@@ -884,15 +879,25 @@ void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int 
                                                     break;
                                                 }
 
-                                                blob_perimeter += (!ok) && (i != left) && (i != right);
+                                                bool edge = (!ok) && (i != left) && (i != right);
+                                                if (contours && edge) {
+                                                    contour_writer_append_point(&contour_writer, i, y);
+                                                }
+                                                blob_perimeter += edge;
                                             }
                                             if (recurse) {
                                                 break;
                                             }
                                         } else {
+                                            if (contours) {
+                                                contour_writer_append_run(&contour_writer, left + 1, right - 1, y);
+                                            }
                                             blob_perimeter += right - left + 1;
                                         }
                                     } else {
+                                        if (contours) {
+                                            contour_writer_append_run(&contour_writer, left + 1, right - 1, y);
+                                        }
                                         blob_perimeter += (right - left + 1) * 2;
                                     }
 
@@ -965,6 +970,11 @@ void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int 
                                 lnk_blob.x_hist_bins = NULL;
                                 lnk_blob.y_hist_bins_count = 0;
                                 lnk_blob.y_hist_bins = NULL;
+                                lnk_blob.contour_start.x = 0;
+                                lnk_blob.contour_start.y = 0;
+                                lnk_blob.contour_len = 0;
+                                lnk_blob.contour = NULL;
+                                lnk_blob.contour_valid = false;
                                 // These store the current average accumulation.
                                 lnk_blob.centroid_x_acc = lnk_blob.centroid_x * lnk_blob.pixels;
                                 lnk_blob.centroid_y_acc = lnk_blob.centroid_y * lnk_blob.pixels;
@@ -988,6 +998,10 @@ void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int 
                                            &lnk_blob.y_hist_bins_count);
                                 }
 
+                                if (contours) {
+                                    contour_writer_finish(&contour_writer, &lnk_blob);
+                                }
+
                                 bool add_to_list = threshold_cb_arg == NULL;
                                 if (!add_to_list) {
                                     add_to_list = threshold_cb(threshold_cb_arg, &lnk_blob);
@@ -1002,9 +1016,11 @@ void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int 
                                     if (lnk_blob.y_hist_bins) {
                                         m_free(lnk_blob.y_hist_bins);
                                     }
+                                    imlib_free_blob_contour(&lnk_blob);
                                 }
                             }
 
+                            contour_writer_free(&contour_writer);
                             x = old_x;
                             y = old_y;
                         }
@@ -1052,6 +1068,9 @@ void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int 
                                 memset(y_hist_bins, 0, ptr->h * sizeof(uint16_t));
                             }
 
+                            contour_writer_t contour_writer;
+                            contour_writer_init(&contour_writer);
+
                             // Scanline Flood Fill Algorithm //
 
                             for (;;) {
@@ -1075,6 +1094,12 @@ void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int 
 
                                 for (int i = left; i <= right; i++) {
                                     IMAGE_SET_BINARY_PIXEL_FAST(bmp_row, i);
+                                }
+                                if (contours) {
+                                    contour_writer_append_point(&contour_writer, left, y);
+                                    if (right != left) {
+                                        contour_writer_append_point(&contour_writer, right, y);
+                                    }
                                 }
 
                                 int sum = sum_m_to_n(left, right);
@@ -1150,12 +1175,19 @@ void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int 
                                                     break;
                                                 }
 
-                                                blob_perimeter += (!ok) && (i != left) && (i != right);
+                                                bool edge = (!ok) && (i != left) && (i != right);
+                                                if (contours && edge) {
+                                                    contour_writer_append_point(&contour_writer, i, y);
+                                                }
+                                                blob_perimeter += edge;
                                             }
                                             if (recurse) {
                                                 break;
                                             }
                                         } else {
+                                            if (contours) {
+                                                contour_writer_append_run(&contour_writer, left + 1, right - 1, y);
+                                            }
                                             blob_perimeter += right - left + 1;
                                         }
 
@@ -1186,15 +1218,25 @@ void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int 
                                                     break;
                                                 }
 
-                                                blob_perimeter += (!ok) && (i != left) && (i != right);
+                                                bool edge = (!ok) && (i != left) && (i != right);
+                                                if (contours && edge) {
+                                                    contour_writer_append_point(&contour_writer, i, y);
+                                                }
+                                                blob_perimeter += edge;
                                             }
                                             if (recurse) {
                                                 break;
                                             }
                                         } else {
+                                            if (contours) {
+                                                contour_writer_append_run(&contour_writer, left + 1, right - 1, y);
+                                            }
                                             blob_perimeter += right - left + 1;
                                         }
                                     } else {
+                                        if (contours) {
+                                            contour_writer_append_run(&contour_writer, left + 1, right - 1, y);
+                                        }
                                         blob_perimeter += (right - left + 1) * 2;
                                     }
 
@@ -1267,6 +1309,11 @@ void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int 
                                 lnk_blob.x_hist_bins = NULL;
                                 lnk_blob.y_hist_bins_count = 0;
                                 lnk_blob.y_hist_bins = NULL;
+                                lnk_blob.contour_start.x = 0;
+                                lnk_blob.contour_start.y = 0;
+                                lnk_blob.contour_len = 0;
+                                lnk_blob.contour = NULL;
+                                lnk_blob.contour_valid = false;
                                 // These store the current average accumulation.
                                 lnk_blob.centroid_x_acc = lnk_blob.centroid_x * lnk_blob.pixels;
                                 lnk_blob.centroid_y_acc = lnk_blob.centroid_y * lnk_blob.pixels;
@@ -1290,6 +1337,10 @@ void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int 
                                            &lnk_blob.y_hist_bins_count);
                                 }
 
+                                if (contours) {
+                                    contour_writer_finish(&contour_writer, &lnk_blob);
+                                }
+
                                 bool add_to_list = threshold_cb_arg == NULL;
                                 if (!add_to_list) {
                                     add_to_list = threshold_cb(threshold_cb_arg, &lnk_blob);
@@ -1304,9 +1355,11 @@ void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int 
                                     if (lnk_blob.y_hist_bins) {
                                         m_free(lnk_blob.y_hist_bins);
                                     }
+                                    imlib_free_blob_contour(&lnk_blob);
                                 }
                             }
 
+                            contour_writer_free(&contour_writer);
                             x = old_x;
                             y = old_y;
                         }
@@ -1373,6 +1426,7 @@ void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int 
                                        &tmp_blob.y_hist_bins_count,
                                        y_hist_bins_max);
                         }
+                        imlib_merge_blob_contours(&lnk_blob, &tmp_blob);
                         // Merge corners...
                         for (int i = 0; i < FIND_BLOBS_CORNERS_RESOLUTION; i++) {
                             float z_dst = (lnk_blob.corners[i].x * cos_table[FIND_BLOBS_ANGLE_RESOLUTION * i]) +

--- a/lib/imlib/imlib.h
+++ b/lib/imlib/imlib.h
@@ -1545,6 +1545,7 @@ void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int 
                       bool (*threshold_cb) (void *, find_blobs_list_lnk_data_t *), void *threshold_cb_arg,
                       bool (*merge_cb) (void *, find_blobs_list_lnk_data_t *, find_blobs_list_lnk_data_t *), void *merge_cb_arg,
                       unsigned int x_hist_bins_max, unsigned int y_hist_bins_max);
+void imlib_draw_contours(image_t *ptr, rectangle_t *roi, list_t *thresholds, bool invert, int color);
 // Shape Detection
 size_t trace_line(image_t *ptr, line_t *l, int *theta_buffer, uint32_t *mag_buffer, point_t *point_buffer); // helper/internal
 void merge_alot(list_t *out, int threshold, int theta_threshold); // helper/internal

--- a/lib/imlib/imlib.h
+++ b/lib/imlib/imlib.h
@@ -1545,7 +1545,8 @@ void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int 
                       bool (*threshold_cb) (void *, find_blobs_list_lnk_data_t *), void *threshold_cb_arg,
                       bool (*merge_cb) (void *, find_blobs_list_lnk_data_t *, find_blobs_list_lnk_data_t *), void *merge_cb_arg,
                       unsigned int x_hist_bins_max, unsigned int y_hist_bins_max);
-void imlib_draw_contours(image_t *ptr, rectangle_t *roi, list_t *thresholds, bool invert, int color);
+void imlib_draw_contours(image_t *dst, image_t *src, rectangle_t *roi, list_t *thresholds,
+                         bool invert, int color, image_t *mask, point_t *seed);
 // Shape Detection
 size_t trace_line(image_t *ptr, line_t *l, int *theta_buffer, uint32_t *mag_buffer, point_t *point_buffer); // helper/internal
 void merge_alot(list_t *out, int threshold, int theta_threshold); // helper/internal

--- a/lib/imlib/imlib.h
+++ b/lib/imlib/imlib.h
@@ -1088,6 +1088,9 @@ typedef struct statistics {
 
 #define FIND_BLOBS_CORNERS_RESOLUTION    20 // multiple of 4
 #define FIND_BLOBS_ANGLE_RESOLUTION      (360 / FIND_BLOBS_CORNERS_RESOLUTION)
+#define FIND_BLOBS_CONTOUR_ANCHOR        0x80
+#define FIND_BLOBS_CONTOUR_DELTA_OFFSET  3
+#define FIND_BLOBS_CONTOUR_DELTA_MASK    0x7
 
 typedef struct find_blobs_list_lnk_data {
     point_t corners[FIND_BLOBS_CORNERS_RESOLUTION];
@@ -1096,6 +1099,10 @@ typedef struct find_blobs_list_lnk_data {
     float centroid_x, centroid_y, rotation, roundness;
     uint16_t x_hist_bins_count, y_hist_bins_count, *x_hist_bins, *y_hist_bins;
     float centroid_x_acc, centroid_y_acc, rotation_acc_x, rotation_acc_y, roundness_acc;
+    point_t contour_start;
+    uint32_t contour_len;
+    uint8_t *contour;
+    bool contour_valid;
 } find_blobs_list_lnk_data_t;
 
 typedef struct find_lines_list_lnk_data {
@@ -1544,9 +1551,9 @@ void imlib_find_blobs(list_t *out, image_t *ptr, rectangle_t *roi, unsigned int 
                       bool merge, int margin,
                       bool (*threshold_cb) (void *, find_blobs_list_lnk_data_t *), void *threshold_cb_arg,
                       bool (*merge_cb) (void *, find_blobs_list_lnk_data_t *, find_blobs_list_lnk_data_t *), void *merge_cb_arg,
-                      unsigned int x_hist_bins_max, unsigned int y_hist_bins_max);
-void imlib_draw_contours(image_t *dst, image_t *src, rectangle_t *roi, list_t *thresholds,
-                         bool invert, int color, image_t *mask, point_t *seed);
+                      unsigned int x_hist_bins_max, unsigned int y_hist_bins_max, bool contours);
+void imlib_draw_contours(image_t *dst, point_t *start, const uint8_t *contour, uint32_t contour_len,
+                         int color, image_t *mask);
 // Shape Detection
 size_t trace_line(image_t *ptr, line_t *l, int *theta_buffer, uint32_t *mag_buffer, point_t *point_buffer); // helper/internal
 void merge_alot(list_t *out, int threshold, int theta_threshold); // helper/internal

--- a/modules/py_image.c
+++ b/modules/py_image.c
@@ -1571,12 +1571,15 @@ static mp_obj_t py_image_draw_edges(size_t n_args, const mp_obj_t *pos_args, mp_
 static MP_DEFINE_CONST_FUN_OBJ_KW(py_image_draw_edges_obj, 2, py_image_draw_edges);
 
 static mp_obj_t py_image_draw_contours(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum { ARG_thresholds, ARG_color, ARG_invert, ARG_roi };
+    enum { ARG_thresholds, ARG_color, ARG_invert, ARG_roi, ARG_image, ARG_mask, ARG_seed };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_thresholds, MP_ARG_OBJ | MP_ARG_REQUIRED },
         { MP_QSTR_color,     MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
         { MP_QSTR_invert,    MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = false} },
         { MP_QSTR_roi,       MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_image,     MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_mask,      MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_seed,      MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_rom_obj = MP_ROM_NONE} },
     };
 
     image_t *image = py_helper_arg_to_image(pos_args[0], ARG_IMAGE_MUTABLE);
@@ -1588,9 +1591,32 @@ static mp_obj_t py_image_draw_contours(size_t n_args, const mp_obj_t *pos_args, 
     py_helper_arg_to_thresholds(args[ARG_thresholds].u_obj, &thresholds);
 
     if (list_size(&thresholds)) {
-        rectangle_t roi = py_helper_arg_to_roi(args[ARG_roi].u_obj, image);
+        image_t *src = image;
+        if (args[ARG_image].u_obj != mp_const_none) {
+            src = py_helper_arg_to_image(args[ARG_image].u_obj, ARG_IMAGE_UNCOMPRESSED | ARG_IMAGE_ALLOC);
+            PY_ASSERT_TRUE_MSG((src->w == image->w) && (src->h == image->h),
+                               "Source image must match destination image size.");
+        }
+
+        image_t *mask = NULL;
+        if (args[ARG_mask].u_obj != mp_const_none) {
+            mask = py_helper_arg_to_image(args[ARG_mask].u_obj, ARG_IMAGE_MUTABLE | ARG_IMAGE_ALLOC);
+            PY_ASSERT_TRUE_MSG((mask->w == image->w) && (mask->h == image->h),
+                               "Mask image must match destination image size.");
+        }
+
+        rectangle_t roi = py_helper_arg_to_roi(args[ARG_roi].u_obj, src);
+        point_t seed, *seed_ptr = NULL;
+        if (args[ARG_seed].u_obj != mp_const_none) {
+            mp_obj_t *vec;
+            mp_obj_get_array_fixed_n(args[ARG_seed].u_obj, 2, &vec);
+            seed.x = mp_obj_get_int(vec[0]);
+            seed.y = mp_obj_get_int(vec[1]);
+            seed_ptr = &seed;
+        }
+
         int color = py_helper_arg_to_color(image, args[ARG_color].u_obj, -1); // White.
-        imlib_draw_contours(image, &roi, &thresholds, args[ARG_invert].u_bool, color);
+        imlib_draw_contours(image, src, &roi, &thresholds, args[ARG_invert].u_bool, color, mask, seed_ptr);
     }
 
     list_free(&thresholds);

--- a/modules/py_image.c
+++ b/modules/py_image.c
@@ -1570,6 +1570,34 @@ static mp_obj_t py_image_draw_edges(size_t n_args, const mp_obj_t *pos_args, mp_
 }
 static MP_DEFINE_CONST_FUN_OBJ_KW(py_image_draw_edges_obj, 2, py_image_draw_edges);
 
+static mp_obj_t py_image_draw_contours(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_thresholds, ARG_color, ARG_invert, ARG_roi };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_thresholds, MP_ARG_OBJ | MP_ARG_REQUIRED },
+        { MP_QSTR_color,     MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_invert,    MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = false} },
+        { MP_QSTR_roi,       MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_rom_obj = MP_ROM_NONE} },
+    };
+
+    image_t *image = py_helper_arg_to_image(pos_args[0], ARG_IMAGE_MUTABLE);
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    list_t thresholds;
+    list_init(&thresholds, sizeof(color_thresholds_list_lnk_data_t));
+    py_helper_arg_to_thresholds(args[ARG_thresholds].u_obj, &thresholds);
+
+    if (list_size(&thresholds)) {
+        rectangle_t roi = py_helper_arg_to_roi(args[ARG_roi].u_obj, image);
+        int color = py_helper_arg_to_color(image, args[ARG_color].u_obj, -1); // White.
+        imlib_draw_contours(image, &roi, &thresholds, args[ARG_invert].u_bool, color);
+    }
+
+    list_free(&thresholds);
+    return pos_args[0];
+}
+static MP_DEFINE_CONST_FUN_OBJ_KW(py_image_draw_contours_obj, 2, py_image_draw_contours);
+
 static mp_obj_t py_image_draw_keypoints(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_color, ARG_size, ARG_thickness, ARG_fill };
     static const mp_arg_t allowed_args[] = {
@@ -4619,6 +4647,7 @@ static const mp_rom_map_elem_t locals_dict_table[] = {
     {MP_ROM_QSTR(MP_QSTR_draw_detection),      MP_ROM_PTR(&py_image_draw_detection_obj)},
     {MP_ROM_QSTR(MP_QSTR_draw_arrow),          MP_ROM_PTR(&py_image_draw_arrow_obj)},
     {MP_ROM_QSTR(MP_QSTR_draw_edges),          MP_ROM_PTR(&py_image_draw_edges_obj)},
+    {MP_ROM_QSTR(MP_QSTR_draw_contours),       MP_ROM_PTR(&py_image_draw_contours_obj)},
     #if (OMV_GENX320_ENABLE == 1)
     {MP_ROM_QSTR(MP_QSTR_draw_event_histogram), MP_ROM_PTR(&py_image_draw_event_histogram_obj)},
     #endif // OMV_GENX320_ENABLE == 1

--- a/modules/py_image.c
+++ b/modules/py_image.c
@@ -1570,56 +1570,52 @@ static mp_obj_t py_image_draw_edges(size_t n_args, const mp_obj_t *pos_args, mp_
 }
 static MP_DEFINE_CONST_FUN_OBJ_KW(py_image_draw_edges_obj, 2, py_image_draw_edges);
 
+// Blob field indices shared by drawing and module-level geometry helpers.
+#define BLOB_INDEX_PIXELS       6
+#define BLOB_INDEX_PERIMETER    10
+#define BLOB_INDEX_MIN_CORNERS  15
+#define BLOB_INDEX_CONTOUR      23
+
 static mp_obj_t py_image_draw_contours(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum { ARG_thresholds, ARG_color, ARG_invert, ARG_roi, ARG_image, ARG_mask, ARG_seed };
+    enum { ARG_blob, ARG_color, ARG_mask };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_thresholds, MP_ARG_OBJ | MP_ARG_REQUIRED },
-        { MP_QSTR_color,     MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
-        { MP_QSTR_invert,    MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = false} },
-        { MP_QSTR_roi,       MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_rom_obj = MP_ROM_NONE} },
-        { MP_QSTR_image,     MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_rom_obj = MP_ROM_NONE} },
-        { MP_QSTR_mask,      MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_rom_obj = MP_ROM_NONE} },
-        { MP_QSTR_seed,      MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_blob,  MP_ARG_OBJ | MP_ARG_REQUIRED },
+        { MP_QSTR_color, MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_mask,  MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_rom_obj = MP_ROM_NONE} },
     };
 
     image_t *image = py_helper_arg_to_image(pos_args[0], ARG_IMAGE_MUTABLE);
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    list_t thresholds;
-    list_init(&thresholds, sizeof(color_thresholds_list_lnk_data_t));
-    py_helper_arg_to_thresholds(args[ARG_thresholds].u_obj, &thresholds);
-
-    if (list_size(&thresholds)) {
-        image_t *src = image;
-        if (args[ARG_image].u_obj != mp_const_none) {
-            src = py_helper_arg_to_image(args[ARG_image].u_obj, ARG_IMAGE_UNCOMPRESSED | ARG_IMAGE_ALLOC);
-            PY_ASSERT_TRUE_MSG((src->w == image->w) && (src->h == image->h),
-                               "Source image must match destination image size.");
-        }
-
-        image_t *mask = NULL;
-        if (args[ARG_mask].u_obj != mp_const_none) {
-            mask = py_helper_arg_to_image(args[ARG_mask].u_obj, ARG_IMAGE_MUTABLE | ARG_IMAGE_ALLOC);
-            PY_ASSERT_TRUE_MSG((mask->w == image->w) && (mask->h == image->h),
-                               "Mask image must match destination image size.");
-        }
-
-        rectangle_t roi = py_helper_arg_to_roi(args[ARG_roi].u_obj, src);
-        point_t seed, *seed_ptr = NULL;
-        if (args[ARG_seed].u_obj != mp_const_none) {
-            mp_obj_t *vec;
-            mp_obj_get_array_fixed_n(args[ARG_seed].u_obj, 2, &vec);
-            seed.x = mp_obj_get_int(vec[0]);
-            seed.y = mp_obj_get_int(vec[1]);
-            seed_ptr = &seed;
-        }
-
-        int color = py_helper_arg_to_color(image, args[ARG_color].u_obj, -1); // White.
-        imlib_draw_contours(image, src, &roi, &thresholds, args[ARG_invert].u_bool, color, mask, seed_ptr);
+    image_t *mask = NULL;
+    if (args[ARG_mask].u_obj != mp_const_none) {
+        mask = py_helper_arg_to_image(args[ARG_mask].u_obj, ARG_IMAGE_MUTABLE | ARG_IMAGE_ALLOC);
+        PY_ASSERT_TRUE_MSG((mask->w == image->w) && (mask->h == image->h),
+                           "Mask image must match destination image size.");
     }
 
-    list_free(&thresholds);
+    size_t blob_len;
+    mp_obj_t *blob_items;
+    mp_obj_tuple_get(args[ARG_blob].u_obj, &blob_len, &blob_items);
+    PY_ASSERT_TRUE_MSG(blob_len > BLOB_INDEX_CONTOUR, "Expected a blob object.");
+
+    mp_obj_t contour_obj = blob_items[BLOB_INDEX_CONTOUR];
+    if (contour_obj != mp_const_none) {
+        mp_obj_t *contour_items;
+        mp_obj_get_array_fixed_n(contour_obj, 3, &contour_items);
+
+        point_t start;
+        start.x = mp_obj_get_int(contour_items[0]);
+        start.y = mp_obj_get_int(contour_items[1]);
+
+        mp_buffer_info_t bufinfo;
+        mp_get_buffer_raise(contour_items[2], &bufinfo, MP_BUFFER_READ);
+
+        int color = py_helper_arg_to_color(image, args[ARG_color].u_obj, -1); // White.
+        imlib_draw_contours(image, &start, bufinfo.buf, bufinfo.len, color, mask);
+    }
+
     return pos_args[0];
 }
 static MP_DEFINE_CONST_FUN_OBJ_KW(py_image_draw_contours_obj, 2, py_image_draw_contours);
@@ -3437,13 +3433,8 @@ static const qstr blob_fields[] = {
     MP_QSTR_cxf, MP_QSTR_cyf,
     MP_QSTR_elongation, MP_QSTR_area,
     MP_QSTR_density, MP_QSTR_compactness,
-    MP_QSTR_rect,
+    MP_QSTR_rect, MP_QSTR_contour,
 };
-
-// Blob field indices for module-level functions.
-#define BLOB_INDEX_PIXELS       6
-#define BLOB_INDEX_PERIMETER    10
-#define BLOB_INDEX_MIN_CORNERS  15
 
 static void py_get_min_corners(mp_obj_t min_corners, int *x0, int *y0, int *x1, int *y1,
                                int *x2, int *y2, int *x3, int *y3) {
@@ -3492,6 +3483,16 @@ static mp_obj_t py_blob_new(find_blobs_list_lnk_data_t *blob) {
     mp_obj_t w = mp_obj_new_int(blob->rect.w);
     mp_obj_t h = mp_obj_new_int(blob->rect.h);
 
+    mp_obj_t contour = mp_const_none;
+    if (blob->contour_valid) {
+        const uint8_t empty_contour[] = {0};
+        contour = mp_obj_new_tuple(3, (mp_obj_t []) {
+            mp_obj_new_int(blob->contour_start.x),
+            mp_obj_new_int(blob->contour_start.y),
+            mp_obj_new_bytes(blob->contour ? blob->contour : empty_contour, blob->contour_len),
+        });
+    }
+
     mp_obj_t items[] = {
         x, y, w, h,
         mp_obj_new_int(fast_roundf(cxf)),
@@ -3523,6 +3524,7 @@ static mp_obj_t py_blob_new(find_blobs_list_lnk_data_t *blob) {
         density_obj,
         mp_obj_new_float(IM_DIV((pixels * 4.0f * IMLIB_PI), ((float) perimeter * perimeter))),
         mp_obj_new_tuple(4, (mp_obj_t []) {x, y, w, h}),
+        contour,
     };
     return mp_obj_new_attrtuple(blob_fields, MP_ARRAY_SIZE(blob_fields), items);
 }
@@ -3538,7 +3540,8 @@ static mp_obj_t py_image_find_blobs(size_t n_args, const mp_obj_t *pos_args, mp_
     enum {
         ARG_thresholds, ARG_invert, ARG_roi, ARG_x_stride, ARG_y_stride,
         ARG_area_threshold, ARG_pixels_threshold, ARG_merge, ARG_margin,
-        ARG_threshold_cb, ARG_merge_cb, ARG_x_hist_bins_max, ARG_y_hist_bins_max
+        ARG_threshold_cb, ARG_merge_cb, ARG_x_hist_bins_max, ARG_y_hist_bins_max,
+        ARG_contours
     };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_thresholds,       MP_ARG_OBJ | MP_ARG_REQUIRED },
@@ -3554,6 +3557,7 @@ static mp_obj_t py_image_find_blobs(size_t n_args, const mp_obj_t *pos_args, mp_
         { MP_QSTR_merge_cb,         MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_rom_obj = MP_ROM_NONE} },
         { MP_QSTR_x_hist_bins_max, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 0} },
         { MP_QSTR_y_hist_bins_max, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 0} },
+        { MP_QSTR_contours,        MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = false} },
     };
     image_t *image = py_helper_arg_to_image(pos_args[0], ARG_IMAGE_MUTABLE);
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
@@ -3591,7 +3595,7 @@ static mp_obj_t py_image_find_blobs(size_t n_args, const mp_obj_t *pos_args, mp_
                      invert, area_threshold, pixels_threshold, merge, margin,
                      py_image_find_blobs_threshold_cb, threshold_cb,
                      py_image_find_blobs_merge_cb, merge_cb,
-                     x_hist_bins_max, y_hist_bins_max);
+                     x_hist_bins_max, y_hist_bins_max, args[ARG_contours].u_bool);
     list_free(&thresholds);
 
     mp_obj_list_t *objects_list = mp_obj_new_list(list_size(&out), NULL);
@@ -3604,6 +3608,9 @@ static mp_obj_t py_image_find_blobs(size_t n_args, const mp_obj_t *pos_args, mp_
         }
         if (lnk_data.y_hist_bins) {
             m_free(lnk_data.y_hist_bins);
+        }
+        if (lnk_data.contour) {
+            m_free(lnk_data.contour);
         }
     }
 

--- a/scripts/unittest/tests/draw_contours.py
+++ b/scripts/unittest/tests/draw_contours.py
@@ -1,14 +1,27 @@
 def unittest(data_path, temp_path):
     import image
 
-    img = image.Image(9, 9, image.GRAYSCALE)
+    def make_ring():
+        img = image.Image(9, 9, image.GRAYSCALE)
+        for y in range(1, 8):
+            for x in range(1, 8):
+                img.set_pixel((x, y), 255)
+        img.set_pixel((4, 4), 0)
+        return img
 
-    for y in range(1, 8):
-        for x in range(1, 8):
-            img.set_pixel((x, y), 255)
-    img.set_pixel((4, 4), 0)
+    img = make_ring()
+    blobs = img.find_blobs(
+        [(200, 255)],
+        x_stride=1,
+        y_stride=1,
+        pixels_threshold=1,
+        area_threshold=1,
+        contours=True,
+    )
+    if len(blobs) != 1 or blobs[0].contour is None:
+        return False
 
-    img.draw_contours([(200, 255)], color=128, roi=(1, 1, 7, 7))
+    img.draw_contours(blobs[0], color=128)
 
     outline = 0
     inside = 0
@@ -27,24 +40,28 @@ def unittest(data_path, temp_path):
                 return False
 
     direct_ok = (
-        outline == 32
-        and inside == 16
+        outline == 28
+        and inside == 20
         and background == 33
         and img.get_pixel((2, 2)) == 255
-        and img.get_pixel((3, 3)) == 128
+        and img.get_pixel((4, 3)) == 128
+        and img.get_pixel((3, 3)) == 255
         and img.get_pixel((4, 4)) == 0
     )
 
-    src = image.Image(9, 9, image.GRAYSCALE)
-    for y in range(1, 8):
-        for x in range(1, 8):
-            src.set_pixel((x, y), 255)
-    src.set_pixel((4, 4), 0)
-    src.set_pixel((0, 0), 255)
+    src = make_ring()
+    overlay_blob = src.find_blobs(
+        [(200, 255)],
+        x_stride=1,
+        y_stride=1,
+        pixels_threshold=1,
+        area_threshold=1,
+        contours=True,
+    )[0]
 
     overlay = image.Image(9, 9, image.RGB565)
     mask = image.Image(9, 9, image.BINARY)
-    overlay.draw_contours([(200, 255)], color=(255, 0, 0), image=src, mask=mask, seed=(2, 2))
+    overlay.draw_contours(overlay_blob, color=(255, 0, 0), mask=mask)
 
     display = image.Image(9, 9, image.RGB565)
     display.draw_image(src, 0, 0)
@@ -60,14 +77,48 @@ def unittest(data_path, temp_path):
                 mask_count += 1
 
     overlay_ok = (
-        overlay_count == 32
-        and mask_count == 32
+        overlay_count == 28
+        and mask_count == 28
         and src.get_pixel((3, 3)) == 255
-        and mask.get_pixel((0, 0)) == 0
-        and overlay.get_pixel((0, 0)) == (0, 0, 0)
         and overlay.get_pixel((2, 2)) == (0, 0, 0)
         and display.get_pixel((2, 2)) == (255, 255, 255)
-        and display.get_pixel((3, 3)) == (255, 0, 0)
+        and display.get_pixel((4, 3)) == (255, 0, 0)
     )
 
-    return direct_ok and overlay_ok
+    no_contour = make_ring()
+    no_contour_blob = no_contour.find_blobs(
+        [(200, 255)],
+        x_stride=1,
+        y_stride=1,
+        pixels_threshold=1,
+        area_threshold=1,
+    )[0]
+    no_contour.draw_contours(no_contour_blob, color=128)
+    no_contour_ok = no_contour_blob.contour is None and no_contour.get_pixel((1, 1)) == 255
+
+    merged_src = image.Image(7, 4, image.GRAYSCALE)
+    for y in range(1, 3):
+        for x in (1, 2, 4, 5):
+            merged_src.set_pixel((x, y), 255)
+    merged = merged_src.find_blobs(
+        [(200, 255)],
+        x_stride=1,
+        y_stride=1,
+        pixels_threshold=1,
+        area_threshold=1,
+        merge=True,
+        margin=2,
+        contours=True,
+    )
+    if len(merged) != 1 or merged[0].contour is None:
+        return False
+
+    merged_draw = image.Image(7, 4, image.GRAYSCALE)
+    merged_draw.draw_contours(merged[0], color=128)
+    merged_count = 0
+    for y in range(4):
+        for x in range(7):
+            if merged_draw.get_pixel((x, y)) == 128:
+                merged_count += 1
+
+    return direct_ok and overlay_ok and no_contour_ok and merged_count == 8

--- a/scripts/unittest/tests/draw_contours.py
+++ b/scripts/unittest/tests/draw_contours.py
@@ -1,0 +1,36 @@
+def unittest(data_path, temp_path):
+    import image
+
+    img = image.Image(9, 9, image.GRAYSCALE)
+
+    for y in range(1, 8):
+        for x in range(1, 8):
+            img.set_pixel((x, y), 255)
+    img.set_pixel((4, 4), 0)
+
+    img.draw_contours([(200, 255)], color=128, roi=(1, 1, 7, 7))
+
+    outline = 0
+    inside = 0
+    background = 0
+
+    for y in range(9):
+        for x in range(9):
+            pixel = img.get_pixel((x, y))
+            if pixel == 128:
+                outline += 1
+            elif pixel == 255:
+                inside += 1
+            elif pixel == 0:
+                background += 1
+            else:
+                return False
+
+    return (
+        outline == 32
+        and inside == 16
+        and background == 33
+        and img.get_pixel((2, 2)) == 255
+        and img.get_pixel((3, 3)) == 128
+        and img.get_pixel((4, 4)) == 0
+    )

--- a/scripts/unittest/tests/draw_contours.py
+++ b/scripts/unittest/tests/draw_contours.py
@@ -26,7 +26,7 @@ def unittest(data_path, temp_path):
             else:
                 return False
 
-    return (
+    direct_ok = (
         outline == 32
         and inside == 16
         and background == 33
@@ -34,3 +34,40 @@ def unittest(data_path, temp_path):
         and img.get_pixel((3, 3)) == 128
         and img.get_pixel((4, 4)) == 0
     )
+
+    src = image.Image(9, 9, image.GRAYSCALE)
+    for y in range(1, 8):
+        for x in range(1, 8):
+            src.set_pixel((x, y), 255)
+    src.set_pixel((4, 4), 0)
+    src.set_pixel((0, 0), 255)
+
+    overlay = image.Image(9, 9, image.RGB565)
+    mask = image.Image(9, 9, image.BINARY)
+    overlay.draw_contours([(200, 255)], color=(255, 0, 0), image=src, mask=mask, seed=(2, 2))
+
+    display = image.Image(9, 9, image.RGB565)
+    display.draw_image(src, 0, 0)
+    display.draw_image(overlay, 0, 0, mask=mask)
+
+    overlay_count = 0
+    mask_count = 0
+    for y in range(9):
+        for x in range(9):
+            if overlay.get_pixel((x, y)) == (255, 0, 0):
+                overlay_count += 1
+            if mask.get_pixel((x, y)):
+                mask_count += 1
+
+    overlay_ok = (
+        overlay_count == 32
+        and mask_count == 32
+        and src.get_pixel((3, 3)) == 255
+        and mask.get_pixel((0, 0)) == 0
+        and overlay.get_pixel((0, 0)) == (0, 0, 0)
+        and overlay.get_pixel((2, 2)) == (0, 0, 0)
+        and display.get_pixel((2, 2)) == (255, 255, 255)
+        and display.get_pixel((3, 3)) == (255, 0, 0)
+    )
+
+    return direct_ok and overlay_ok


### PR DESCRIPTION
## Summary
- add `Image.draw_contours()` for pixel-exact threshold contour drawing
- support drawing from a separate source image onto an overlay plus optional mask output
- add `seed=(x, y)` to restrict drawing to one connected threshold component
- add unit coverage for direct drawing, overlay compositing, masks, and seeded component selection

## Testing
- `git diff --check upstream/master...HEAD`
- `python -m py_compile scripts/unittest/tests/draw_contours.py`

[contours.bmp](https://github.com/user-attachments/files/28195333/contours.bmp)

