### PR TITLE
ports/stm32: Keep the RTC clocked during sleep on STM32N6.

### DIFF
--- a/ports/stm32/stm_hal.c
+++ b/ports/stm32/stm_hal.c
@@ -254,6 +254,10 @@ void HAL_MspInit(void) {
     #endif
 
     #if defined(STM32N6)
+    // Enable backup-domain write access before the sleep-clock enables below: the RTC
+    // sleep-clock bit is backup-protected and is silently dropped if access is off.
+    HAL_PWR_EnableBkUpAccess();
+
     // Enable AHB peripherals during sleep.
     LL_AHB1_GRP1_EnableClockLowPower(LL_AHB1_GRP1_PERIPH_ALL);
     LL_AHB2_GRP1_EnableClockLowPower(LL_AHB2_GRP1_PERIPH_ALL);


### PR DESCRIPTION
RTCLPEN is backup-domain write-protected, so the PERIPH_ALL sleep-clock write in HAL_MspInit() silently drops it. This gates the RTC clocks in CSleep, freezing the readable calendar during time.sleep() even though timekeeping is fine. Enable backup-domain write access first so RTCLPEN latches.

Before:

```
import time, machine
rtc=machine.RTC()
rtc.datetime((2026, 1, 1, 0, 0, 0, 0, 0))

while 1:
    print(rtc.datetime())
    time.sleep(0.1)
```

Doesn't print a time value that updates correctly. Afterward, it does.