### PR TITLE
modules: Add IMU burst read

### DIFF
--- a/modules/py_imu.c
+++ b/modules/py_imu.c
@@ -382,14 +382,24 @@ static mp_obj_t py_imu_write_reg(mp_obj_t addr, mp_obj_t val) {
 }
 static MP_DEFINE_CONST_FUN_OBJ_2(py_imu_write_reg_obj, py_imu_write_reg);
 
-static mp_obj_t py_imu_read_reg(mp_obj_t addr) {
+static mp_obj_t py_imu_read_reg(size_t n_args, const mp_obj_t *args) {
     error_on_not_ready();
 
+    // Burst read into a caller-provided bytearray when buf is given.
+    if (n_args > 1 && args[1] != mp_const_none) {
+        mp_buffer_info_t bufinfo;
+        mp_get_buffer_raise(args[1], &bufinfo, MP_BUFFER_WRITE);
+        if (bufinfo.len > 0) {
+            LSM_FUNC(read_reg) (&dev_ctx, mp_obj_get_int(args[0]), bufinfo.buf, bufinfo.len);
+        }
+        return mp_const_none;
+    }
+
     uint8_t v;
-    LSM_FUNC(read_reg) (&dev_ctx, mp_obj_get_int(addr), &v, sizeof(v));
+    LSM_FUNC(read_reg) (&dev_ctx, mp_obj_get_int(args[0]), &v, sizeof(v));
     return mp_obj_new_int(v);
 }
-static MP_DEFINE_CONST_FUN_OBJ_1(py_imu_read_reg_obj, py_imu_read_reg);
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(py_imu_read_reg_obj, 1, 2, py_imu_read_reg);
 
 static const mp_rom_map_elem_t globals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),            MP_OBJ_NEW_QSTR(MP_QSTR_imu) },


### PR DESCRIPTION
This PR add `__read_reg_burst(addr: int, buf: bytearray)` to `imu` module. To read LSM6DSM fifo, it is faster and more reliable to use burst read multiple samples at once than multiple `__read_reg`. Tested on AE3.