### PR TITLE
protocol: Support re-initialization of the protocol.

### DIFF
--- a/protocol/omv_protocol.c
+++ b/protocol/omv_protocol.c
@@ -84,6 +84,7 @@ int omv_protocol_init(const omv_protocol_config_t *config) {
 
     // Start periodic poll timer if configured.
     if (config->poll_ms > 0) {
+        soft_timer_remove(&protocol_timer);     // no-op if unlinked, unlinks if linked
         soft_timer_static_init(&protocol_timer, SOFT_TIMER_MODE_PERIODIC,
                                config->poll_ms, omv_protocol_poll_callback);
         soft_timer_insert(&protocol_timer, config->poll_ms);


### PR DESCRIPTION
omv_protocol_init() must remove the soft timer first on reinit.

Scripts here suffer from this issue on being run: https://github.com/openmv/openmv/tree/master/scripts/examples/12-Protocol