### PR TITLE
ci: Bump cryptography to 48.0.1

### DIFF
--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -2,7 +2,7 @@ flake8==6.0.0
 pytest==9.0.3
 ethos-u-vela==4.2.0
 tabulate==0.9.0
-cryptography==46.0.7
+cryptography==48.0.1
 pyelftools==0.27
 colorama==0.4.6
 mpremote


### PR DESCRIPTION
Fixes Dependabot alert #6 (GHSA-537c-gmf6-5ccf, high severity): cryptography wheels prior to 48.0.1 statically link a vulnerable OpenSSL version.