### PR TITLE
drivers/sensors: Add PAG7936 halt for safe shutdown. 

### DIFF
--- a/common/omv_csi.c
+++ b/common/omv_csi.c
@@ -336,6 +336,12 @@ __weak int omv_csi_reset(omv_csi_t *csi, bool hard) {
     }
 
     if (hard) {
+        // Stop the sensor's activity cleanly.
+        if (csi->power_on && csi->halt_req) {
+            omv_csi_sleep(csi, true);
+            mp_hal_delay_ms(10);
+        }
+
         // Disable the bus before reset.
         omv_i2c_enable(csi->i2c, false);
 
@@ -708,6 +714,12 @@ __weak int omv_csi_shutdown(omv_csi_t *csi, int enable) {
 
     // Disable any ongoing frame capture.
     omv_csi_abort(csi, true, false);
+
+    // Stop the sensor's activity cleanly.
+    if (enable && csi->power_on && csi->halt_req) {
+        omv_csi_sleep(csi, true);
+        mp_hal_delay_ms(10);
+    }
 
     #if defined(OMV_CSI_POWER_PIN)
     if (enable) {

--- a/common/omv_csi.h
+++ b/common/omv_csi.h
@@ -325,6 +325,7 @@ typedef struct _omv_csi {
         uint32_t mipi_if    : 1;  // CSI-2 interface.
         uint32_t mipi_brate : 12; // CSI-2 interface bitrate.
         uint32_t auxiliary  : 1;  // Indicates that the sensor can be used in dual-CSI config.
+        uint32_t halt_req   : 1;  // Indicates that the sensor requires sleeping before reset/shutdown.
     };
 
     const uint16_t *color_palette;    // Color palette used for color lookup.

--- a/drivers/sensors/pag7936.c
+++ b/drivers/sensors/pag7936.c
@@ -907,6 +907,7 @@ int pag7936_init(omv_csi_t *csi) {
     csi->mipi_if = 1;
     csi->mipi_brate = 800;
     #endif
+    csi->halt_req = 1;
 
     // Initialize csi ops.
     csi->reset = reset;


### PR DESCRIPTION
When used with an extension cable of 80mm or 120mm length, the PAG7936 locks up when reset without idling the sensor first. Sleeping the sensor first before reset/pwdn mitigates the issue. See: https://forums.openmv.io/t/n6-ribbon-cable/11808/3?u=kwagyeman

Tested against the N6 with a PAG7936 with no cable, a PAG7936 with a 120mm cable, and the dual PAG7936 + Lepton and GENX320 modules with no cables and cables. Also tested against the AE3.



