### PR TITLE
boards: Add SPI sdcard support for the AE3.

### DIFF
--- a/boards/OPENMV_AE3/manifest.py
+++ b/boards/OPENMV_AE3/manifest.py
@@ -3,6 +3,7 @@ add_library("openmv-lib", "$(OMV_LIB_DIR)")
 
 # Drivers
 require("lsm6dsox")
+require("sdcard")
 freeze ("$(OMV_LIB_DIR)/", "ssd1351.py")
 freeze ("$(OMV_LIB_DIR)/", "pca9674a.py")
 freeze ("$(OMV_LIB_DIR)/", "vl53l1x.py")


### PR DESCRIPTION
Add sdcard support for the AE3 battery shield.

Usage for the shield has already been documented: https://docs.openmv.io/v5.0.0/openmvcam/shields/ae3-battery-shield.html