### PR TITLE
drivers/sensors: Ad FLIR Lepton 3.1 and UW support.

### DIFF
--- a/common/omv_csi.c
+++ b/common/omv_csi.c
@@ -1723,6 +1723,8 @@ const char *omv_csi_name(omv_csi_t *csi) {
         case LEPTON_2_0:         return "Lepton 2.0";
         case LEPTON_2_5:         return "Lepton 2.5";
         case LEPTON_3_0:         return "Lepton 3.0";
+        case LEPTON_3_1R:        return "Lepton 3.1R";
+        case LEPTON_UW:          return "Lepton UW";
         case LEPTON_3_5:         return "Lepton 3.5";
         case HM01B0_ID:          return "HM01B0";
         case HM0360_ID:          return "HM0360";

--- a/common/omv_csi.h
+++ b/common/omv_csi.h
@@ -85,6 +85,8 @@
 #define LEPTON_2_0              (0x5420)
 #define LEPTON_2_5              (0x5425)
 #define LEPTON_3_0              (0x5430)
+#define LEPTON_3_1R             (0x5431)
+#define LEPTON_UW               (0x5432)
 #define LEPTON_3_5              (0x5435)
 #define HM01B0_ID               (0xB0)
 #define HM0360_ID               (0x60)

--- a/drivers/sensors/lepton.c
+++ b/drivers/sensors/lepton.c
@@ -307,6 +307,8 @@ static int lepton_config(omv_csi_t *csi, bool measurement_mode, bool high_temp_m
     LEP_SYS_GAIN_MODE_E gain_mode = high_temp_mode ? LEP_SYS_GAIN_MODE_LOW : LEP_SYS_GAIN_MODE_HIGH;
 
     bool hasSetSysGainMode = csi->chip_id == LEPTON_3_5 ||
+                             csi->chip_id == LEPTON_UW ||
+                             csi->chip_id == LEPTON_3_1R ||
                              csi->chip_id == LEPTON_3_0 ||
                              csi->chip_id == LEPTON_2_5;
 
@@ -377,6 +379,10 @@ static int config(omv_csi_t *csi, omv_csi_config_t config) {
         // 01/00 == Shutter/NoShutter
         if (!strncmp(part.value, "500-0771", 8)) {
             csi->chip_id = LEPTON_3_5;
+        } else if (!strncmp(part.value, "500-1387", 8)) {
+            csi->chip_id = LEPTON_UW;
+        } else if (!strncmp(part.value, "500-0758", 8)) {
+            csi->chip_id = LEPTON_3_1R;
         } else if (!strncmp(part.value, "500-0726", 8)) {
             csi->chip_id = LEPTON_3_0;
         } else if (!strncmp(part.value, "500-0763", 8)) {


### PR DESCRIPTION
Adds support for recent FLIR Lepton modules. See: https://groupgets.com/collections/lepton