### PR TITLE
scripts/libraries: Add waveform channel widget.

### DIFF
--- a/scripts/libraries/protocol/protocol/__init__.py
+++ b/scripts/libraries/protocol/protocol/__init__.py
@@ -6,6 +6,9 @@
 # in the board's manifest and CBORChannel will be importable from
 # protocol directly.
 
+import struct
+import time
+
 import cbor2
 from uprotocol import *  # noqa: F401
 
@@ -14,6 +17,9 @@ from uprotocol import *  # noqa: F401
 _N = 0        # name
 _U = 1        # unit
 _V = 2        # numeric value
+_VS = 3       # string value
+_T = 6        # time
+_UT = 7       # update time
 _VD = 8       # data value
 
 # 2D data extension keys.
@@ -33,9 +39,11 @@ _W_OPTS = -34  # select options
 class CBORChannel:
     """A protocol channel backend that serializes named fields to CBOR.
 
-    Supports display widgets (label, depth) and interactive controls
-    (toggle, slider, select) with on_read/on_write callbacks.
-    Slider values can be set as (min, max, value) tuples.
+    Supports display widgets (label, text, depth, waveform) and
+    interactive controls (toggle, pushbutton, slider, spinbox, select,
+    radio, lineedit) with on_read/on_write callbacks. Slider and spinbox
+    values can be set as (min, max, value) tuples; waveform values are
+    set to interleaved sample bytes.
 
     Usage::
 
@@ -62,40 +70,52 @@ class CBORChannel:
         self._on_read = on_read
         self._on_write = on_write
         self._dirty = False
+        self._t_us = 0
+        self._t_prev = time.ticks_us()
 
     def add(self, name, type, value=None, unit=None,
             min=None, max=None, step=None, options=None,
-            width=None, height=None):
+            width=None, height=None, sample_rate=None,
+            series=1, typecode=None):
         """Add a named field to the channel.
 
         Args:
             name: Display name (must be unique within this channel).
-            type: Widget type - "label", "toggle", "slider", "select",
-                  or "depth".
+            type: Widget type - "label", "text", "toggle", "pushbutton",
+                  "slider", "spinbox", "select", "radio", "lineedit",
+                  "depth", or "waveform".
             value: Initial value. Defaults depend on type.
-            unit: Unit string for label/slider (e.g. "Cel", "%RH").
-            min: Minimum value (slider range or depth range).
-            max: Maximum value (slider range or depth range).
-            step: Step size (slider).
-            options: List of option strings (select).
+            unit: Unit string for label/slider/spinbox/waveform (e.g.
+                "Cel", "%RH").
+            min: Minimum value (slider/spinbox range or depth range).
+            max: Maximum value (slider/spinbox range or depth range).
+            step: Step size (slider/spinbox).
+            options: List of option strings (select/radio), or of series
+                names (waveform).
             width: Pixel width (depth).
             height: Pixel height (depth).
+            sample_rate: Samples per second (waveform).
+            series: Interleaved series count (waveform, e.g. 3 for XYZ).
+            typecode: array typecode of the waveform samples (e.g. "H",
+                  "f", "h"); "H" (uint16) when omitted.
         """
         field = {_N: name, _W_TYPE: type}
         if type == "label":
             field[_V] = value if value is not None else 0
             if unit:
                 field[_U] = unit
-        elif type == "toggle":
+        elif type in ("text", "lineedit"):
+            field[_V] = value if value is not None else ""
+        elif type in ("toggle", "pushbutton"):
             field[_V] = value if value is not None else False
-        elif type == "slider":
+        elif type in ("slider", "spinbox"):
             field[_V] = value if value is not None else (min if min is not None else 0)
             field[_W_MIN] = min if min is not None else 0
             field[_W_MAX] = max if max is not None else 100
             field[_W_STEP] = step if step is not None else 1
             if unit:
                 field[_U] = unit
-        elif type == "select":
+        elif type in ("select", "radio"):
             field[_V] = value if value is not None else ""
             field[_W_OPTS] = options if options is not None else []
         elif type == "depth":
@@ -104,6 +124,20 @@ class CBORChannel:
             field[_H] = height
             field[_MIN] = min if min is not None else 0
             field[_MAX] = max if max is not None else 1000
+        elif type == "waveform":
+            field[_VD] = b""
+            field[_W] = 0
+            field[_H] = series if series else 1
+            field[_MIN] = min if min is not None else 0
+            field[_MAX] = max if max is not None else 65535
+            if unit:
+                field[_U] = unit
+            if sample_rate:
+                field[_UT] = 1.0 / sample_rate
+            if typecode is not None:
+                field[_VS] = typecode
+            if options is not None:
+                field[_W_OPTS] = options
         self._index[name] = len(self._fields)
         self._fields.append(field)
         self._serialize()
@@ -114,10 +148,18 @@ class CBORChannel:
 
     def __setitem__(self, name, value):
         f = self._fields[self._index[name]]
-        if _VD in f:
+        if f.get(_W_TYPE) == "waveform":
+            f[_VD] = value
+            itemsize = struct.calcsize(f.get(_VS, "H"))
+            f[_W] = len(value) // (itemsize * f[_H])
+            now = time.ticks_us()
+            self._t_us += time.ticks_diff(now, self._t_prev)
+            self._t_prev = now
+            f[_T] = self._t_us
+        elif _VD in f:
             f[_VD] = value
         elif isinstance(value, tuple):
-            if f[_W_TYPE] == "slider":
+            if f[_W_TYPE] in ("slider", "spinbox"):
                 f[_W_MIN] = value[0]
                 f[_W_MAX] = value[1]
                 f[_V] = value[2]


### PR DESCRIPTION
OpenMV IDE now has support for the CBOR channel widgets. I added a few widgets to make a complete package.

## New widget examples

Each is added to a `CBORChannel` with `ch.add(...)`. Display widgets are
updated with `ch[name] = ...`; control widgets deliver user input to the
channel's `on_write(ch, name, value)` callback.

### Displays

```python
# text - static or rich text (HTML), updatable live
ch.add("Status", type="text", value="<b>Ready.</b>")
ch["Status"] = "Running..."
```

```python
# waveform - a 1D time series plotted live. The value you assign is the raw
# bytes of an array of samples. add() declares the sample rate, the element
# type (typecode, "H"/uint16 by default), and the display range.
from array import array

ch.add("Mic", type="waveform", sample_rate=16000, min=0, max=65535)

mic = array("H", (0 for _ in range(512)))          # 512 uint16 samples
while True:
    for i in range(len(mic)):
        mic[i] = read_mic_sample()                 # fill the chunk
    ch["Mic"] = bytes(mic)                          # assign it as bytes
```

```python
# Multi-series: set series=N and interleave the samples sample-by-sample,
# i.e. [x0, y0, z0, x1, y1, z1, ...]. Here three float32 axes.
from array import array

ch.add("IMU", type="waveform", sample_rate=100, series=3,
       typecode="f", min=-2.0, max=2.0)

imu = array("f", (0.0 for _ in range(128 * 3)))    # 128 samples x 3 axes
while True:
    for i in range(128):
        x, y, z = read_imu()
        imu[(i * 3) + 0] = x
        imu[(i * 3) + 1] = y
        imu[(i * 3) + 2] = z
    ch["IMU"] = bytes(imu)
```

### Controls (values arrive in `on_write`)

```python
# pushbutton - momentary action, writes True on click
ch.add("Calibrate", type="pushbutton")

# spinbox - precise stepped number, also takes a (min, max, value) tuple
ch.add("Gap", type="spinbox", min=0.0, max=15.0, step=0.1, value=1.5, unit="mm")
ch["Gap"] = (0.0, 20.0, 2.5)                             # optionally rescale live

# radio - options rendered as radio buttons
ch.add("Mode", type="radio", options=["Idle", "Track", "Record"], value="Idle")

# lineedit - writable string
ch.add("Device Name", type="lineedit", value="openmv-cam")
```