### PR TITLE
ports/stm32: Move the MPU memory attributes to MAIR1.

### DIFF
--- a/ports/stm32/stm_hal.c
+++ b/ports/stm32/stm_hal.c
@@ -34,8 +34,9 @@
 #include "omv_gpio.h"
 #include "stm_dma.h"
 
-#define MEMATTR_NORMAL_NCACHE      0
-#define MEMATTR_NORMAL_WB_RA_WA    1
+// Note: MicroPython's mpu.h owns MAIR0, so these attributes must stay in MAIR1.
+#define MEMATTR_NORMAL_NCACHE      4
+#define MEMATTR_NORMAL_WB_RA_WA    5
 
 #define RIF_MASTER_INDEX_NONE ((uint32_t) -1)
 


### PR DESCRIPTION
MicroPython's mpu.h overwrites MAIR0 attributes 0 and 1 with 0x44 (non-cacheable), in mpu_init() and in mpu_config_region(), and never restores them. mpu_config_region() is reached from dma_protect_rx_region(), which runs on every SDMMC and SPI DMA read.

MPU region 0 maps the external RAM at 0x90000000 with attribute index 1, so on the N6 the first SD card read, which happens at boot when the card is mounted, left all of external RAM non-cacheable for the rest of the session. The frame buffer is allocated there, so with a card inserted find_blobs on a 640x400 grayscale image took 61.5ms instead of 5.6ms, and the frame rate dropped from 114 to 14 FPS.

Use attribute indices 4 and 5, which are held in MAIR1. MicroPython only ever writes MAIR0, so this splits ownership by register and stays correct if it starts overwriting more MAIR0 attributes.

...

**Pretty much, once the SD card is inserted, the N6 performance is obliterated currently.**

Fixes: https://github.com/openmv/openmv/issues/3222