### PR TITLE
modules/py_csi_ng.c: Return custom frame size.

### DIFF
--- a/modules/py_csi_ng.c
+++ b/modules/py_csi_ng.c
@@ -317,6 +317,14 @@ static mp_obj_t py_csi_framesize(size_t n_args, const mp_obj_t *args) {
         if (self->csi->framesize == OMV_CSI_FRAMESIZE_INVALID) {
             omv_csi_raise_error(OMV_CSI_ERROR_INVALID_FRAMESIZE);
         }
+
+        if (self->csi->framesize == OMV_CSI_FRAMESIZE_CUSTOM) {
+            return mp_obj_new_tuple(2, (mp_obj_t []) {
+                mp_obj_new_int(self->csi->resolution[OMV_CSI_FRAMESIZE_CUSTOM][0]),
+                mp_obj_new_int(self->csi->resolution[OMV_CSI_FRAMESIZE_CUSTOM][1]),
+            });
+        }
+
         return mp_obj_new_int(self->csi->framesize);
     }
 

--- a/scripts/unittest/tests/capture.py
+++ b/scripts/unittest/tests/capture.py
@@ -5,7 +5,10 @@ def unittest(data_path, temp_path):
     csi0 = csi.CSI()
     csi0.reset()
     csi0.pixformat(csi.RGB565)
-    csi0.framesize(csi.QQVGA)
+    custom_framesize = (160, 120)
+    csi0.framesize(custom_framesize)
+    if csi0.framesize() != custom_framesize:
+        return False
 
     # Capture a frame
     img = csi0.snapshot()


### PR DESCRIPTION
## Summary

When CSI.framesize() is queried after configuring a tuple such as (320, 320), return the configured width and height instead of the internal CUSTOM enum.
The existing integer-enum return value remains unchanged for predefined frame sizes.

## Test coverage
The capture unit test now configures the virtual camera with a custom 160 by 120 frame size, verifies that the getter returns the same tuple, and then captures the existing reference frame.
Fixes #2950
## Local validation
- git diff --check\n- python3 -m py_compile scripts/unittest/tests/capture.py
- A complete firmware matrix build is left to project CI because the local checkout does not have the OpenMV SDK and target toolchains installed.