### PR TITLE
modules/py_csi_ng: Return custom frame size

### DIFF
--- a/modules/py_csi_ng.c
+++ b/modules/py_csi_ng.c
@@ -317,6 +317,14 @@ static mp_obj_t py_csi_framesize(size_t n_args, const mp_obj_t *args) {
         if (self->csi->framesize == OMV_CSI_FRAMESIZE_INVALID) {
             omv_csi_raise_error(OMV_CSI_ERROR_INVALID_FRAMESIZE);
         }
+
+        if (self->csi->framesize == OMV_CSI_FRAMESIZE_CUSTOM) {
+            return mp_obj_new_tuple(2, (mp_obj_t []) {
+                mp_obj_new_int(self->csi->resolution[OMV_CSI_FRAMESIZE_CUSTOM][0]),
+                mp_obj_new_int(self->csi->resolution[OMV_CSI_FRAMESIZE_CUSTOM][1]),
+            });
+        }
+
         return mp_obj_new_int(self->csi->framesize);
     }
 

--- a/scripts/unittest/tests/capture.py
+++ b/scripts/unittest/tests/capture.py
@@ -5,7 +5,10 @@ def unittest(data_path, temp_path):
     csi0 = csi.CSI()
     csi0.reset()
     csi0.pixformat(csi.RGB565)
-    csi0.framesize(csi.QQVGA)
+    custom_framesize = (160, 120)
+    csi0.framesize(custom_framesize)
+    if csi0.framesize() != custom_framesize:
+        return False
 
     # Capture a frame
     img = csi0.snapshot()


### PR DESCRIPTION
## Summary

- return the configured width and height tuple when a CSI instance uses a custom frame size
- preserve the existing integer enum result for predefined frame sizes
- extend the capture regression test to verify the custom-size getter round trip

Previously, csi.framesize((width, height)) stored the custom resolution, but csi.framesize() exposed the internal custom enum instead of that resolution.

Closes #2950

## Validation

- python3 -m py_compile scripts/unittest/tests/capture.py
- git diff --check

The repository firmware matrix and QEMU/FVP tests are left to CI because they require the OpenMV SDK and target environments.