### PR TITLE
lib/micropython: Update submodule.

### DIFF
--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -244,6 +244,9 @@ soft_reset:
     sdcard_init();
     #endif
     rtc_init_start(false);
+    #if MICROPY_PY_MACHINE_MEM_BACKUP
+    machine_mem_backup_init();
+    #endif
     #if MICROPY_PY_LWIP
     // lwIP can only be initialized once, because the system timeout
     // list (next_timeout), is only ever reset by BSS clearing.


### PR DESCRIPTION
- stm32/mpu: Reuse MPU_ATTRIBUTES_NUMBER0 for all non-cacheable uses.
- stm32: Enable machine.mem_backup via backup SRAM or BKP registers.