### PR TITLE
lib/imlib: Update jpeg max size limit to be dynamic.

### DIFF
--- a/lib/imlib/imlib.h
+++ b/lib/imlib/imlib.h
@@ -835,7 +835,7 @@ bool image_get_mask_pixel(image_t *ptr, int x, int y);
 #define JPEG_444_YCBCR_MCU_SIZE    ((JPEG_444_GS_MCU_SIZE) * 3)
 #define JPEG_422_YCBCR_MCU_SIZE    ((JPEG_444_GS_MCU_SIZE) * 4)
 #define JPEG_420_YCBCR_MCU_SIZE    ((JPEG_444_GS_MCU_SIZE) * 6)
-#define JPEG_MAX_ALLOC_SIZE        (1024UL * 1024UL) // 1 MB
+#define JPEG_MIN_JPEG_SIZE         (4UL * 1024UL) // 4 KB
 
 typedef enum jpeg_subsampling {
     JPEG_SUBSAMPLING_AUTO = 0,

--- a/lib/imlib/jpege.c
+++ b/lib/imlib/jpege.c
@@ -932,7 +932,7 @@ static void jpeg_write_headers(jpeg_buf_t *jpeg_buf, int w, int h, int bpp, jpeg
 
 bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_subsampling_t subsampling) {
     if (!dst->data) {
-        uint32_t size = IM_MIN(uma_avail(0), JPEG_MAX_ALLOC_SIZE);
+        uint32_t size = IM_MIN(uma_avail(0), src->w * src->h * quality / 100 + JPEG_MIN_JPEG_SIZE);
         dst->data = uma_malloc(size, UMA_CACHE);
         dst->size = IMLIB_IMAGE_MAX_SIZE(size);
     }

--- a/ports/stm32/stm_jpeg.c
+++ b/ports/stm32/stm_jpeg.c
@@ -119,7 +119,7 @@ static int jpeg_compress_vc8000(image_t *src, image_t *dst, int quality, jpeg_su
     }
 
     if (!dst->data) {
-        dst->size = IMLIB_IMAGE_MAX_SIZE(IM_MIN(uma_avail(0), JPEG_MAX_ALLOC_SIZE));
+        dst->size = IMLIB_IMAGE_MAX_SIZE(IM_MIN(uma_avail(0), src->w * src->h * quality / 100 + JPEG_MIN_JPEG_SIZE));
         dst->data = uma_malloc(dst->size, UMA_CACHE);
     }
 
@@ -351,7 +351,7 @@ bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_s
             uma_fail();
         }
 
-        dst->size = IMLIB_IMAGE_MAX_SIZE(IM_MIN(avail - space, JPEG_MAX_ALLOC_SIZE));
+        dst->size = IMLIB_IMAGE_MAX_SIZE(IM_MIN(avail - space, src->w * src->h * quality / 100 + JPEG_MIN_JPEG_SIZE));
         dst->data = uma_malloc(dst->size, UMA_CACHE);
     }
 


### PR DESCRIPTION
Fixes: https://github.com/openmv/openmv/issues/3227

1MB is not large enough for a very complex scene for the maximum JPEG size with a 5MP image.

This change only modifies behavior when there's no destination buffer set. This does not affect the stream buffer, which passes in its destination size.