### PR TITLE
lib/cmsis: Program the HSLV_VDDIO4 fuse on the STM32N6.

### DIFF
--- a/boot/include/header.h
+++ b/boot/include/header.h
@@ -48,7 +48,7 @@
 // Bootloader version numbers.
 #define OMV_BOOT_VERSION_MAJOR          (1)
 #define OMV_BOOT_VERSION_MINOR          (0)
-#define OMV_BOOT_VERSION_PATCH          (3)
+#define OMV_BOOT_VERSION_PATCH          (4)
 
 #ifndef LINKER_SCRIPT
 #include <stdint.h>

--- a/lib/cmsis/src/st/system_stm32n6.c
+++ b/lib/cmsis/src/st/system_stm32n6.c
@@ -31,6 +31,7 @@
 #include "partition_stm32n6xx.h"
 
 #define BSEC_HW_CONFIG_ID        124U
+#define BSEC_HWS_HSLV_VDDIO4     (1U<<14)
 #define BSEC_HWS_HSLV_VDDIO3     (1U<<15)
 #define BSEC_HWS_HSLV_VDDIO2     (1U<<16)
 
@@ -497,7 +498,7 @@ void SystemClock_Config(void) {
     // Check if high speed IO optimization fuse is set.
     uint32_t fuse;
     BSEC_HandleTypeDef hbsec = { .Instance = BSEC };
-    uint32_t mask = BSEC_HWS_HSLV_VDDIO2 | BSEC_HWS_HSLV_VDDIO3;
+    uint32_t mask = BSEC_HWS_HSLV_VDDIO2 | BSEC_HWS_HSLV_VDDIO3 | BSEC_HWS_HSLV_VDDIO4;
     if (HAL_BSEC_OTP_Read(&hbsec, BSEC_HW_CONFIG_ID, &fuse) != HAL_OK) {
         __fatal_error("HAL_BSEC_OTP_Read");
     } else if ((fuse & mask) != mask) {


### PR DESCRIPTION
The SD card bus pins on the N6 are in the VDDIO4 power domain, which supports switching to the 1.8V range at runtime for UHS-I mode.  The VDDIO4VRSEL 1.8V pad range selection is ignored by the hardware unless the HSLV_VDDIO4 OTP fuse (RM0486 Table 18, OTP word 124 bit 14) is programmed, so program it alongside the existing VDDIO2/3 fuses.

VDDIO4 still boots in the 3.3V range: the SD driver only switches the range at runtime after a UHS-I card acknowledges the 1.8V voltage switch, and without this fuse it detects that the switch did not take effect and falls back to 3.3V operation.  Verified on both a fused board (SDR104 at 200MHz works) and an unfused board (clean fallback, fuse verified untouched).

Required to get the speed for https://github.com/micropython/micropython/pull/19623.

...

NOTE: Since only the bootloader writes the fuses... the speed upgrade won't take effect until the bootloader is updated. Should fuse programming be moved to the app?
