### PR TITLE
common/omv_csi: Add manual control of the stats-based AWB gains.

### DIFF
--- a/common/omv_csi.c
+++ b/common/omv_csi.c
@@ -1202,9 +1202,46 @@ void omv_csi_stats_update(omv_csi_t *csi, uint32_t *r, uint32_t *g, uint32_t *b,
 void omv_csi_get_stats(omv_csi_t *csi, uint32_t *r, uint32_t *g, uint32_t *b) {
     omv_csi_stats_t *stats = &csi->stats;
 
+    if (!stats->initialized) {
+        // Return neutral values until the first update.
+        *r = 128;
+        *g = 128;
+        *b = 128;
+        return;
+    }
+
     *r = fast_roundf(stats->r_avg);
     *g = fast_roundf(stats->g_avg);
     *b = fast_roundf(stats->b_avg);
+}
+
+int omv_csi_stats_set_auto_whitebal(omv_csi_t *csi, int enable,
+                                    float r_gain_db, float g_gain_db, float b_gain_db) {
+    csi->stats_enabled = enable;
+
+    if ((enable == 0) && (!isnanf(r_gain_db)) && (!isnanf(g_gain_db)) && (!isnanf(b_gain_db))
+        && (!isinff(r_gain_db)) && (!isinff(g_gain_db)) && (!isinff(b_gain_db))) {
+        omv_csi_stats_t *stats = &csi->stats;
+
+        // The ISP derives the gains from the RGB averages, so store their inverse.
+        stats->initialized = true;
+        stats->r_avg = IM_MAX(128.0f * expf((-r_gain_db / 20.0f) * M_LN10), 1.0f);
+        stats->g_avg = IM_MAX(128.0f * expf((-g_gain_db / 20.0f) * M_LN10), 1.0f);
+        stats->b_avg = IM_MAX(128.0f * expf((-b_gain_db / 20.0f) * M_LN10), 1.0f);
+    }
+
+    return 0;
+}
+
+int omv_csi_stats_get_rgb_gain_db(omv_csi_t *csi, float *r_gain_db, float *g_gain_db, float *b_gain_db) {
+    uint32_t r, g, b;
+    omv_csi_get_stats(csi, &r, &g, &b);
+
+    // The gains are the inverse of the RGB averages, referenced to 128.
+    *r_gain_db = 20.0f * log10f(IM_DIV(128.0f, r));
+    *g_gain_db = 20.0f * log10f(IM_DIV(128.0f, g));
+    *b_gain_db = 20.0f * log10f(IM_DIV(128.0f, b));
+    return 0;
 }
 #endif // defined(OMV_CSI_STATS_ENABLE)
 

--- a/common/omv_csi.h
+++ b/common/omv_csi.h
@@ -544,6 +544,13 @@ void omv_csi_stats_update(omv_csi_t *csi, uint32_t *r, uint32_t *g, uint32_t *b,
 
 // Get RGB moving average values.
 void omv_csi_get_stats(omv_csi_t *csi, uint32_t *r, uint32_t *g, uint32_t *b);
+
+// Set the stats-based white balance gains used by the ISP.
+int omv_csi_stats_set_auto_whitebal(omv_csi_t *csi, int enable,
+                                    float r_gain_db, float g_gain_db, float b_gain_db);
+
+// Get the stats-based white balance gains used by the ISP.
+int omv_csi_stats_get_rgb_gain_db(omv_csi_t *csi, float *r_gain_db, float *g_gain_db, float *b_gain_db);
 #endif // defined(OMV_CSI_STATS_ENABLE)
 
 // Enable auto blc (black level calibration) or set from previous calibration.

--- a/drivers/sensors/pag7936.c
+++ b/drivers/sensors/pag7936.c
@@ -803,21 +803,6 @@ static int get_exposure_us(omv_csi_t *csi, int *exposure_us) {
     return ret;
 }
 
-static int set_auto_whitebal(omv_csi_t *csi, int enable, float r_gain_db, float g_gain_db, float b_gain_db) {
-    csi->stats_enabled = enable;
-    return 0;
-}
-
-static int get_rgb_gain_db(omv_csi_t *csi, float *r_gain_db, float *g_gain_db, float *b_gain_db) {
-    uint32_t r, g, b;
-    omv_csi_get_stats(csi, &r, &g, &b);
-
-    *r_gain_db = 20.0f * log10f(IM_DIV((float) g, r));
-    *g_gain_db = 0.0f;
-    *b_gain_db = 20.0f * log10f(IM_DIV((float) g, b));
-    return 0;
-}
-
 static int set_hmirror(omv_csi_t *csi, int enable) {
     uint8_t reg;
     int ret = omv_i2c_read_reg(csi->i2c, csi->slv_addr, TG_FLIP, 2, &reg, 1);
@@ -924,8 +909,8 @@ int pag7936_init(omv_csi_t *csi) {
     csi->get_gain_db = get_gain_db;
     csi->set_auto_exposure = set_auto_exposure;
     csi->get_exposure_us = get_exposure_us;
-    csi->set_auto_whitebal = set_auto_whitebal;
-    csi->get_rgb_gain_db = get_rgb_gain_db;
+    csi->set_auto_whitebal = omv_csi_stats_set_auto_whitebal;
+    csi->get_rgb_gain_db = omv_csi_stats_get_rgb_gain_db;
     csi->set_hmirror = set_hmirror;
     csi->set_vflip = set_vflip;
 

--- a/drivers/sensors/ps5520.c
+++ b/drivers/sensors/ps5520.c
@@ -1501,21 +1501,6 @@ static int get_exposure_us(omv_csi_t *csi, int *exposure_us) {
     return ret;
 }
 
-static int set_auto_whitebal(omv_csi_t *csi, int enable, float r_gain_db, float g_gain_db, float b_gain_db) {
-    csi->stats_enabled = enable;
-    return 0;
-}
-
-static int get_rgb_gain_db(omv_csi_t *csi, float *r_gain_db, float *g_gain_db, float *b_gain_db) {
-    uint32_t r, g, b;
-    omv_csi_get_stats(csi, &r, &g, &b);
-
-    *r_gain_db = 20.0f * log10f(IM_DIV((float) g, r));
-    *g_gain_db = 0.0f;
-    *b_gain_db = 20.0f * log10f(IM_DIV((float) g, b));
-    return 0;
-}
-
 static int set_hmirror(omv_csi_t *csi, int enable) {
     uint8_t reg1, reg2;
     uint16_t hsize;
@@ -1786,8 +1771,8 @@ int ps5520_init(omv_csi_t *csi) {
     csi->get_gain_db = get_gain_db;
     csi->set_auto_exposure = set_auto_exposure;
     csi->get_exposure_us = get_exposure_us;
-    csi->set_auto_whitebal = set_auto_whitebal;
-    csi->get_rgb_gain_db = get_rgb_gain_db;
+    csi->set_auto_whitebal = omv_csi_stats_set_auto_whitebal;
+    csi->get_rgb_gain_db = omv_csi_stats_get_rgb_gain_db;
     csi->set_hmirror = set_hmirror;
     csi->set_vflip = set_vflip;
 


### PR DESCRIPTION
The PAG7936 and PS5520 color gains are computed by the ISP from the RGB statistics. Setting the gains manually now writes the statistics they are derived from, reading them back converts the same values to dB, and the statistics start out neutral instead of black until the first update.

Fixes: https://github.com/openmv/openmv/issues/3050