### PR TITLE
drivers/sensors: Add PAG7936 strobe mode support.

### DIFF
--- a/common/omv_csi.h
+++ b/common/omv_csi.h
@@ -242,6 +242,8 @@ typedef enum {
     OMV_CSI_IOCTL_GENX320_CALIBRATE       = 0x25,
     OMV_CSI_IOCTL_GENX320_SET_STC         = 0x26,
     OMV_CSI_IOCTL_GENX320_READ_EVENTS_RAW = 0x27,
+    OMV_CSI_IOCTL_SET_STROBE_MODE         = 0x28,
+    OMV_CSI_IOCTL_GET_STROBE_MODE         = 0x29,
     OMV_CSI_IOCTL_UPDATE_AGC_AEC          = 0x7F
 } omv_csi_ioctl_t;
 

--- a/drivers/sensors/pag7936.c
+++ b/drivers/sensors/pag7936.c
@@ -39,6 +39,7 @@
 #include <stdio.h>
 
 #include "omv_i2c.h"
+#include "omv_gpio.h"
 #include "omv_csi.h"
 #include "py/mphal.h"
 
@@ -99,6 +100,11 @@
 #define SENSOR_TRIGGER_MODE_0       (0x02)
 #define SENSOR_TRIGGER_MODE_1       (0x03)
 #define SENSOR_SOFTWARE_TRIGGER     (0x00EA)
+#define SENSOR_GPIO0                (0x0077)
+#define SENSOR_GPIO0_OUTPUT         (0xC2)
+#define SENSOR_GPIO0_INPUT          (0x02)
+#define SENSOR_GPIO0_SEL            (0x0082)
+#define SENSOR_GPIO0_SEL_LED        (0x01)
 #define ISP_EN_H                    (0x0800)
 #define ISP_EN_H_EN                 (0x01)
 #define ISP_TEST_MODE               (0x0801)
@@ -882,6 +888,35 @@ static int ioctl(omv_csi_t *csi, int request, va_list ap) {
             ret |= omv_i2c_read_reg(csi->i2c, csi->slv_addr, SENSOR_TG_EN, 2, &reg, 1);
             if (ret >= 0) {
                 *enable = (reg & SENSOR_TG_EN_FLAG) ? 0 : 1;
+            }
+            break;
+        }
+        case OMV_CSI_IOCTL_SET_STROBE_MODE: {
+            int enable = va_arg(ap, int);
+
+            if (enable) {
+                // Stop driving the trigger pin, the sensor outputs its strobe on it.
+                if (csi->fsync_pin) {
+                    omv_gpio_config(csi->fsync_pin, OMV_GPIO_MODE_INPUT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_LOW, -1);
+                }
+                ret |= omv_i2c_write_reg(csi->i2c, csi->slv_addr, SENSOR_GPIO0, 2, SENSOR_GPIO0_OUTPUT, 1);
+                ret |= omv_i2c_write_reg(csi->i2c, csi->slv_addr, SENSOR_GPIO0_SEL, 2, SENSOR_GPIO0_SEL_LED, 1);
+            } else {
+                ret |= omv_i2c_write_reg(csi->i2c, csi->slv_addr, SENSOR_GPIO0_SEL, 2, 0, 1);
+                ret |= omv_i2c_write_reg(csi->i2c, csi->slv_addr, SENSOR_GPIO0, 2, SENSOR_GPIO0_INPUT, 1);
+                if (csi->fsync_pin) {
+                    omv_gpio_config(csi->fsync_pin, OMV_GPIO_MODE_OUTPUT, OMV_GPIO_PULL_NONE, OMV_GPIO_SPEED_LOW, -1);
+                    omv_gpio_write(csi->fsync_pin, 0);
+                }
+            }
+            break;
+        }
+        case OMV_CSI_IOCTL_GET_STROBE_MODE: {
+            int *enable = va_arg(ap, int *);
+            uint8_t reg;
+            ret |= omv_i2c_read_reg(csi->i2c, csi->slv_addr, SENSOR_GPIO0_SEL, 2, &reg, 1);
+            if (ret >= 0) {
+                *enable = (reg & SENSOR_GPIO0_SEL_LED) ? 1 : 0;
             }
             break;
         }

--- a/modules/py_csi_ng.c
+++ b/modules/py_csi_ng.c
@@ -945,6 +945,7 @@ static mp_obj_t py_csi_ioctl(size_t n_args, const mp_obj_t *args) {
         }
 
         case OMV_CSI_IOCTL_SET_TRIGGERED_MODE:
+        case OMV_CSI_IOCTL_SET_STROBE_MODE:
         case OMV_CSI_IOCTL_SET_FOV_WIDE:
         case OMV_CSI_IOCTL_SET_NIGHT_MODE: {
             if (n_args == 1) {
@@ -954,6 +955,7 @@ static mp_obj_t py_csi_ioctl(size_t n_args, const mp_obj_t *args) {
         }
 
         case OMV_CSI_IOCTL_GET_TRIGGERED_MODE:
+        case OMV_CSI_IOCTL_GET_STROBE_MODE:
         case OMV_CSI_IOCTL_GET_FOV_WIDE:
         case OMV_CSI_IOCTL_GET_NIGHT_MODE: {
             int enabled;
@@ -1557,6 +1559,8 @@ static const mp_rom_map_elem_t globals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_IOCTL_GET_READOUT_WINDOW),    MP_ROM_INT(OMV_CSI_IOCTL_GET_READOUT_WINDOW) },
     { MP_ROM_QSTR(MP_QSTR_IOCTL_SET_TRIGGERED_MODE),    MP_ROM_INT(OMV_CSI_IOCTL_SET_TRIGGERED_MODE) },
     { MP_ROM_QSTR(MP_QSTR_IOCTL_GET_TRIGGERED_MODE),    MP_ROM_INT(OMV_CSI_IOCTL_GET_TRIGGERED_MODE) },
+    { MP_ROM_QSTR(MP_QSTR_IOCTL_SET_STROBE_MODE),       MP_ROM_INT(OMV_CSI_IOCTL_SET_STROBE_MODE) },
+    { MP_ROM_QSTR(MP_QSTR_IOCTL_GET_STROBE_MODE),       MP_ROM_INT(OMV_CSI_IOCTL_GET_STROBE_MODE) },
     { MP_ROM_QSTR(MP_QSTR_IOCTL_SET_FOV_WIDE),          MP_ROM_INT(OMV_CSI_IOCTL_SET_FOV_WIDE) },
     { MP_ROM_QSTR(MP_QSTR_IOCTL_GET_FOV_WIDE),          MP_ROM_INT(OMV_CSI_IOCTL_GET_FOV_WIDE) },
     #if (OMV_OV5640_AF_ENABLE == 1)


### PR DESCRIPTION
Adds an IOCTL that makes the sensor output its exposure strobe on the trigger pin, in the opposite direction of triggered mode. The MCU stops driving the trigger pin while this mode is on so the sensor can drive it, and resumes driving it when the mode is turned off.

NOTE: There's a 1K resistor between the camera and the MCU pin to handle if both are driving at the same time. So, there's no danger of short circuits.

Fixes: https://github.com/openmv/openmv/issues/3193