### PR TITLE
lib/imlib: Fix JPEG software and hardward paths issues.

### DIFF
--- a/lib/imlib/framebuffer.c
+++ b/lib/imlib/framebuffer.c
@@ -343,7 +343,7 @@ void framebuffer_update_preview(image_t *src) {
 
     // Compress the frame if the raw image didn't fit or the format is non-mutable.
     if (!raw_stream) {
-        overflow = jpeg_compress(src, &dst, fb->quality, false, JPEG_SUBSAMPLING_AUTO);
+        overflow = jpeg_compress(src, &dst, fb->quality, JPEG_SUBSAMPLING_AUTO);
     }
 
     if (overflow) {

--- a/lib/imlib/imlib.c
+++ b/lib/imlib/imlib.c
@@ -594,68 +594,88 @@ uint16_t imlib_yuv_to_rgb(uint8_t y, int8_t u, int8_t v) {
 ////////////////////////////////////////////////////////////////////////////////
 
 #if defined(IMLIB_ENABLE_IMAGE_FILE_IO)
-static save_image_format_t imblib_parse_extension(image_t *img, const char *path) {
-    size_t l = strlen(path);
-    const char *p = path + l;
-    if (l >= 5) {
-        if (((p[-1] == 'g') || (p[-1] == 'G'))
-            && ((p[-2] == 'e') || (p[-2] == 'E'))
-            && ((p[-3] == 'p') || (p[-3] == 'P'))
-            && ((p[-4] == 'j') || (p[-4] == 'J'))
-            && ((p[-5] == '.') || (p[-5] == '.'))) {
-            // Will convert to JPG if not.
-            return FORMAT_JPG;
-        }
-    }
-    if (l >= 4) {
-        if (((p[-1] == 'g') || (p[-1] == 'G'))
-            && ((p[-2] == 'p') || (p[-2] == 'P'))
-            && ((p[-3] == 'j') || (p[-3] == 'J'))
-            && ((p[-4] == '.') || (p[-4] == '.'))) {
-            // Will convert to JPG if not.
-            return FORMAT_JPG;
-        } else if (((p[-1] == 'g') || (p[-1] == 'G'))
-                   && ((p[-2] == 'n') || (p[-2] == 'N'))
-                   && ((p[-3] == 'p') || (p[-3] == 'P'))
-                   && ((p[-4] == '.') || (p[-4] == '.'))) {
-            // Will convert to PNG if not.
-            return FORMAT_PNG;
-        } else if (((p[-1] == 'p') || (p[-1] == 'P'))
-                   && ((p[-2] == 'm') || (p[-2] == 'M'))
-                   && ((p[-3] == 'b') || (p[-3] == 'B'))
-                   && ((p[-4] == '.') || (p[-4] == '.'))) {
-            if (IM_IS_JPEG(img) || IM_IS_BAYER(img)) {
-                mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("Image is not BMP!"));
-            }
-            return FORMAT_BMP;
-        } else if (((p[-1] == 'm') || (p[-1] == 'M'))
-                   && ((p[-2] == 'p') || (p[-2] == 'P'))
-                   && ((p[-3] == 'p') || (p[-3] == 'P'))
-                   && ((p[-4] == '.') || (p[-4] == '.'))) {
-            if (!IM_IS_RGB565(img)) {
-                mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("Image is not PPM!"));
-            }
-            return FORMAT_PNM;
-        } else if (((p[-1] == 'm') || (p[-1] == 'M'))
-                   && ((p[-2] == 'g') || (p[-2] == 'G'))
-                   && ((p[-3] == 'p') || (p[-3] == 'P'))
-                   && ((p[-4] == '.') || (p[-4] == '.'))) {
-            if (!IM_IS_GS(img)) {
-                mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("Image is not PGM!"));
-            }
-            return FORMAT_PNM;
-        } else if (((p[-1] == 'w') || (p[-1] == 'W'))
-                   && ((p[-2] == 'a') || (p[-2] == 'A'))
-                   && ((p[-3] == 'r') || (p[-3] == 'R'))
-                   && ((p[-4] == '.') || (p[-4] == '.'))) {
-            if (!IM_IS_BAYER(img)) {
-                mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("Image is not BAYER!"));
-            }
-            return FORMAT_RAW;
-        }
+typedef struct imlib_extension {
+    const char *ext;
+    save_image_format_t format;
+} imlib_extension_t;
 
+static const imlib_extension_t imlib_extensions[] = {
+    { ".jpeg", FORMAT_JPG },
+    { ".jpg",  FORMAT_JPG },
+    { ".png",  FORMAT_PNG },
+    { ".bmp",  FORMAT_BMP },
+    { ".ppm",  FORMAT_PNM },
+    { ".pgm",  FORMAT_PNM },
+    { ".raw",  FORMAT_RAW },
+};
+
+// Case-insensitive suffix match. The suffix must be lower case.
+static bool imlib_ends_with(const char *str, size_t len, const char *suffix) {
+    size_t n = strlen(suffix);
+
+    if (len < n) {
+        return false;
     }
-    return FORMAT_DONT_CARE;
+
+    for (str += len - n; n; n--, str++, suffix++) {
+        char c = *str;
+        if ((c >= 'A') && (c <= 'Z')) {
+            c += 'a' - 'A';
+        }
+        if (c != *suffix) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static save_image_format_t imlib_parse_extension(image_t *img, const char *path) {
+    size_t len = strlen(path);
+    const imlib_extension_t *e = NULL;
+
+    for (size_t i = 0; i < OMV_ARRAY_SIZE(imlib_extensions); i++) {
+        if (imlib_ends_with(path, len, imlib_extensions[i].ext)) {
+            e = &imlib_extensions[i];
+            break;
+        }
+    }
+
+    if (e == NULL) {
+        return FORMAT_DONT_CARE;
+    }
+
+    bool supported = true;
+
+    switch (e->format) {
+        // Compressed images are copied as-is, and can't be converted.
+        case FORMAT_JPG:
+            supported = !img->is_compressed || IM_IS_JPEG(img);
+            break;
+        case FORMAT_PNG:
+            supported = !img->is_compressed || (img->pixfmt == PIXFORMAT_PNG);
+            break;
+        case FORMAT_BMP:
+            supported = !IM_IS_JPEG(img) && !IM_IS_BAYER(img);
+            break;
+        case FORMAT_PNM:
+            // .pgm writes P5 from grayscale, .ppm writes P6 from RGB565.
+            supported = (e->ext[2] == 'g') ? IM_IS_GS(img) : IM_IS_RGB565(img);
+            break;
+        case FORMAT_RAW:
+            supported = IM_IS_BAYER(img);
+            break;
+        case FORMAT_DONT_CARE:
+            // A new format won't compile until it's added here.
+            break;
+    }
+
+    if (!supported) {
+        mp_raise_msg_varg(&mp_type_OSError,
+                          MP_ERROR_TEXT("Image can't be saved as %s"), e->ext);
+    }
+
+    return e->format;
 }
 
 bool imlib_read_geometry(file_t *fp, image_t *img, const char *path, img_read_settings_t *rs) {
@@ -690,7 +710,7 @@ bool imlib_read_geometry(file_t *fp, image_t *img, const char *path, img_read_se
     } else {
         file_raise_format(NULL);
     }
-    imblib_parse_extension(img, path); // Enforce extension!
+    imlib_parse_extension(img, path); // Enforce extension!
     return vflipped;
 }
 #endif  //IMLIB_ENABLE_IMAGE_FILE_IO
@@ -720,11 +740,11 @@ void imlib_load_image(image_t *img, const char *path) {
     } else {
         file_raise_format(NULL);
     }
-    imblib_parse_extension(img, path); // Enforce extension!
+    imlib_parse_extension(img, path); // Enforce extension!
 }
 
 void imlib_save_image(image_t *img, const char *path, rectangle_t *roi, int quality) {
-    switch (imblib_parse_extension(img, path)) {
+    switch (imlib_parse_extension(img, path)) {
         case FORMAT_BMP:
             bmp_write_subimg(img, path, roi);
             break;

--- a/lib/imlib/imlib.h
+++ b/lib/imlib/imlib.h
@@ -1271,7 +1271,7 @@ void imlib_hardware_venc_deinit();
 void jpeg_get_mcu(image_t *src, int x_offset, int y_offset, int dx, int dy,
                   int8_t *Y0, int8_t *CB, int8_t *CR);
 void jpeg_decompress(image_t *dst, image_t *src);
-int jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_subsampling_t subsampling);
+int jpeg_compress(image_t *src, image_t *dst, int quality, jpeg_subsampling_t subsampling);
 bool jpeg_is_valid(image_t *img);
 int jpeg_clean_trailing_bytes(int bpp, uint8_t *data);
 void jpeg_read_geometry(file_t *fp, image_t *img, const char *path, jpg_read_settings_t *rs);

--- a/lib/imlib/imlib.h
+++ b/lib/imlib/imlib.h
@@ -1271,7 +1271,7 @@ void imlib_hardware_venc_deinit();
 void jpeg_get_mcu(image_t *src, int x_offset, int y_offset, int dx, int dy,
                   int8_t *Y0, int8_t *CB, int8_t *CR);
 void jpeg_decompress(image_t *dst, image_t *src);
-bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_subsampling_t subsampling);
+int jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_subsampling_t subsampling);
 bool jpeg_is_valid(image_t *img);
 int jpeg_clean_trailing_bytes(int bpp, uint8_t *data);
 void jpeg_read_geometry(file_t *fp, image_t *img, const char *path, jpg_read_settings_t *rs);
@@ -1279,7 +1279,7 @@ void jpeg_read_pixels(file_t *fp, image_t *img);
 void jpeg_read(image_t *img, const char *path);
 void jpeg_write(image_t *img, const char *path, int quality);
 void png_decompress(image_t *dst, image_t *src);
-bool png_compress(image_t *src, image_t *dst);
+int png_compress(image_t *src, image_t *dst);
 void png_read_geometry(file_t *fp, image_t *img, const char *path, png_read_settings_t *rs);
 void png_read_pixels(file_t *fp, image_t *img);
 void png_read(image_t *img, const char *path);

--- a/lib/imlib/jpege.c
+++ b/lib/imlib/jpege.c
@@ -937,7 +937,7 @@ static void jpeg_write_headers(jpeg_buf_t *jpeg_buf, int w, int h, int bpp, jpeg
     jpeg_put_bytes(jpeg_buf, (uint8_t [3]) {0x00, 0x3F, 0x0}, 3);
 }
 
-int jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_subsampling_t subsampling) {
+int jpeg_compress(image_t *src, image_t *dst, int quality, jpeg_subsampling_t subsampling) {
     bool owned = false;
 
     if (src->is_compressed) {
@@ -949,7 +949,6 @@ int jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_su
         dst->data = uma_malloc(size, UMA_CACHE);
         dst->size = IMLIB_IMAGE_MAX_SIZE(size);
         owned = true;
-        realloc = true;
     }
 
     // JPEG buffer
@@ -959,7 +958,7 @@ int jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_su
         .length = dst->size,
         .bitc = 0,
         .bitb = 0,
-        .realloc = realloc,
+        .realloc = owned,
         .overflow = false,
     };
 
@@ -1272,7 +1271,7 @@ int jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_su
     dst->data = jpeg_buf.buf;
 
     // Trim the unused tail of the buffer.
-    if (realloc && ((jpeg_buf.length - jpeg_buf.idx) >= 1024)) {
+    if (owned && ((jpeg_buf.length - jpeg_buf.idx) >= 1024)) {
         // Shrinking a block resizes it in place, so this can't fail.
         dst->data = uma_realloc(dst->data, dst->size, UMA_CACHE);
     }
@@ -1414,7 +1413,7 @@ void jpeg_write(image_t *img, const char *path, int quality) {
 
         // Compress before creating the file, so that a failure doesn't leave
         // an empty one behind.
-        if (jpeg_compress(img, &out, quality, false, JPEG_SUBSAMPLING_AUTO)) {
+        if (jpeg_compress(img, &out, quality, JPEG_SUBSAMPLING_AUTO)) {
             mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("Compression Failed!"));
         }
 

--- a/lib/imlib/jpege.c
+++ b/lib/imlib/jpege.c
@@ -582,44 +582,51 @@ static const uint16_t UVAC_HT[256][2] = {
     {0x0000, 0x0000}, {0x0000, 0x0000}, {0x0000, 0x0000}, {0x0000, 0x0000},
 };
 
-// Check if the output buffer is nearly full and allocate more space
-// if needed. If realloc is disabled, return true to halt the encoding.
+// Grow the output buffer, flagging an overflow and returning false if it
+// can't grow. The 1KB minimum covers the largest write the callers make.
+static bool jpeg_buf_realloc(jpeg_buf_t *jpeg_buf) {
+    if (jpeg_buf->realloc == false) {
+        // Can't realloc buffer
+        jpeg_buf->overflow = true;
+        return false;
+    }
+
+    // Grow by half the buffer's size to avoid one realloc, and one buffer
+    // copy, per fixed number of bytes encoded.
+    int length = jpeg_buf->length + IM_MAX(jpeg_buf->length / 2, 1024);
+
+    // UMA_MAYBE to fall back to the overflow path instead of raising.
+    uint8_t *buf = uma_realloc(jpeg_buf->buf, length, UMA_CACHE | UMA_MAYBE);
+    if (buf == NULL) {
+        jpeg_buf->overflow = true;
+        return false;
+    }
+
+    jpeg_buf->buf = buf;
+    jpeg_buf->length = length;
+    return true;
+}
+
+// Check if the output buffer is nearly full and allocate more space if needed,
+// so that encoding stops on a block boundary. Returns true to halt encoding.
 static int jpeg_check_highwater(jpeg_buf_t *jpeg_buf) {
     if ((jpeg_buf->idx + 1) >= jpeg_buf->length - 256) {
-        if (jpeg_buf->realloc == false) {
-            // Can't realloc buffer
-            jpeg_buf->overflow = true;
-            return 1;
-        }
-        jpeg_buf->length += 1024;
-        jpeg_buf->buf = uma_realloc(jpeg_buf->buf, jpeg_buf->length, 0);
+        return jpeg_buf_realloc(jpeg_buf) ? 0 : 1;
     }
     return 0;
 }
 
 static void jpeg_put_char(jpeg_buf_t *jpeg_buf, char c) {
-    if ((jpeg_buf->idx + 1) >= jpeg_buf->length) {
-        if (jpeg_buf->realloc == false) {
-            // Can't realloc buffer
-            jpeg_buf->overflow = true;
-            return;
-        }
-        jpeg_buf->length += 1024;
-        jpeg_buf->buf = uma_realloc(jpeg_buf->buf, jpeg_buf->length, 0);
+    if (((jpeg_buf->idx + 1) >= jpeg_buf->length) && !jpeg_buf_realloc(jpeg_buf)) {
+        return;
     }
 
     jpeg_buf->buf[jpeg_buf->idx++] = c;
 }
 
 static void jpeg_put_bytes(jpeg_buf_t *jpeg_buf, const void *data, int size) {
-    if ((jpeg_buf->idx + size) >= jpeg_buf->length) {
-        if (jpeg_buf->realloc == false) {
-            // Can't realloc buffer
-            jpeg_buf->overflow = true;
-            return;
-        }
-        jpeg_buf->length += 1024;
-        jpeg_buf->buf = uma_realloc(jpeg_buf->buf, jpeg_buf->length, 0);
+    if (((jpeg_buf->idx + size) >= jpeg_buf->length) && !jpeg_buf_realloc(jpeg_buf)) {
+        return;
     }
 
     memcpy(jpeg_buf->buf + jpeg_buf->idx, data, size);
@@ -931,14 +938,18 @@ static void jpeg_write_headers(jpeg_buf_t *jpeg_buf, int w, int h, int bpp, jpeg
 }
 
 bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_subsampling_t subsampling) {
+    bool owned = false;
+
+    if (src->is_compressed) {
+        return true;
+    }
+
     if (!dst->data) {
         uint32_t size = IM_MIN(uma_avail(0), JPEG_MAX_ALLOC_SIZE);
         dst->data = uma_malloc(size, UMA_CACHE);
         dst->size = IMLIB_IMAGE_MAX_SIZE(size);
-    }
-
-    if (src->is_compressed) {
-        return true;
+        owned = true;
+        realloc = true;
     }
 
     // JPEG buffer
@@ -999,7 +1010,7 @@ bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_s
                 }
 
                 if (jpeg_buf.overflow) {
-                    return true;
+                    goto overflow;
                 }
             }
             break;
@@ -1103,7 +1114,7 @@ bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_s
                 }
 
                 if (jpeg_buf.overflow) {
-                    return true;
+                    goto overflow;
                 }
             }
             break;
@@ -1240,7 +1251,7 @@ bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_s
                 }
 
                 if (jpeg_buf.overflow) {
-                    return true;
+                    goto overflow;
                 }
 
                 // Advance to the next rows.
@@ -1259,7 +1270,24 @@ bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_s
 
     dst->size = jpeg_buf.idx;
     dst->data = jpeg_buf.buf;
+
+    // Trim the unused tail of the buffer.
+    if (realloc && ((jpeg_buf.length - jpeg_buf.idx) >= 1024)) {
+        // Shrinking a block resizes it in place, so this can't fail.
+        dst->data = uma_realloc(dst->data, dst->size, UMA_CACHE);
+    }
     return false;
+
+overflow:
+    if (owned) {
+        dst->size = 0;
+        dst->data = NULL;
+        uma_free(jpeg_buf.buf);
+    } else {
+        dst->size = jpeg_buf.idx;
+        dst->data = jpeg_buf.buf;
+    }
+    return true;
 }
 
 #endif // (OMV_JPEG_CODEC_ENABLE == 0)
@@ -1375,19 +1403,25 @@ void jpeg_read(image_t *img, const char *path) {
 
 void jpeg_write(image_t *img, const char *path, int quality) {
     file_t fp;
-    file_open(&fp, path, FA_WRITE | FA_CREATE_ALWAYS);
+
     if (IM_IS_JPEG(img)) {
+        file_open(&fp, path, FA_WRITE | FA_CREATE_ALWAYS);
         file_write(&fp, img->data, img->size);
+        file_close(&fp);
     } else {
         // alloc in jpeg compress
         image_t out = { .w = img->w, .h = img->h, .pixfmt = PIXFORMAT_JPEG, .size = 0, .data = NULL };
-        // When jpeg_compress needs more memory than in currently allocated it
-        // will try to realloc. MP will detect that the pointer is outside of
-        // the heap and return NULL which will cause an out of memory error.
-        jpeg_compress(img, &out, quality, false, JPEG_SUBSAMPLING_AUTO);
+
+        // Compress before creating the file, so that a failure doesn't leave
+        // an empty one behind.
+        if (jpeg_compress(img, &out, quality, false, JPEG_SUBSAMPLING_AUTO)) {
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("Compression Failed!"));
+        }
+
+        file_open(&fp, path, FA_WRITE | FA_CREATE_ALWAYS);
         file_write(&fp, out.data, out.size);
+        file_close(&fp);
         uma_free(out.data);
     }
-    file_close(&fp);
 }
 #endif //IMLIB_ENABLE_IMAGE_FILE_IO)

--- a/lib/imlib/jpege.c
+++ b/lib/imlib/jpege.c
@@ -937,11 +937,11 @@ static void jpeg_write_headers(jpeg_buf_t *jpeg_buf, int w, int h, int bpp, jpeg
     jpeg_put_bytes(jpeg_buf, (uint8_t [3]) {0x00, 0x3F, 0x0}, 3);
 }
 
-bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_subsampling_t subsampling) {
+int jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_subsampling_t subsampling) {
     bool owned = false;
 
     if (src->is_compressed) {
-        return true;
+        return -1;
     }
 
     if (!dst->data) {
@@ -1276,7 +1276,7 @@ bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_s
         // Shrinking a block resizes it in place, so this can't fail.
         dst->data = uma_realloc(dst->data, dst->size, UMA_CACHE);
     }
-    return false;
+    return 0;
 
 overflow:
     if (owned) {
@@ -1287,7 +1287,7 @@ overflow:
         dst->size = jpeg_buf.idx;
         dst->data = jpeg_buf.buf;
     }
-    return true;
+    return -1;
 }
 
 #endif // (OMV_JPEG_CODEC_ENABLE == 0)

--- a/lib/imlib/mjpeg.c
+++ b/lib/imlib/mjpeg.c
@@ -186,7 +186,7 @@ void mjpeg_write(file_t *fp, int width, int height, uint32_t *frames, uint32_t *
             }
         }
         dst_img.data = NULL;
-        if (jpeg_compress(&temp, &dst_img, quality, false, JPEG_SUBSAMPLING_AUTO)) {
+        if (jpeg_compress(&temp, &dst_img, quality, JPEG_SUBSAMPLING_AUTO)) {
             if (temp.data != img->data) {
                 uma_free(temp.data);
             }

--- a/lib/imlib/mjpeg.c
+++ b/lib/imlib/mjpeg.c
@@ -186,7 +186,12 @@ void mjpeg_write(file_t *fp, int width, int height, uint32_t *frames, uint32_t *
             }
         }
         dst_img.data = NULL;
-        jpeg_compress(&temp, &dst_img, quality, false, JPEG_SUBSAMPLING_AUTO);
+        if (jpeg_compress(&temp, &dst_img, quality, false, JPEG_SUBSAMPLING_AUTO)) {
+            if (temp.data != img->data) {
+                uma_free(temp.data);
+            }
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("Compression Failed!"));
+        }
     }
 
     uint32_t size_padded = (((dst_img.size + 3) / 4) * 4);

--- a/lib/imlib/png.c
+++ b/lib/imlib/png.c
@@ -197,9 +197,9 @@ unsigned lodepng_convert_cb(unsigned char *out, const unsigned char *in,
 }
 
 #if defined(IMLIB_ENABLE_PNG_ENCODER)
-bool png_compress(image_t *src, image_t *dst) {
+int png_compress(image_t *src, image_t *dst) {
     if (src->is_compressed) {
-        return true;
+        return -1;
     }
 
     LodePNGState state;
@@ -265,7 +265,7 @@ bool png_compress(image_t *src, image_t *dst) {
         }
         uma_free(png_data);
     }
-    return false;
+    return 0;
 }
 #endif // IMLIB_ENABLE_PNG_ENCODER
 
@@ -317,7 +317,7 @@ void png_decompress(image_t *dst, image_t *src) {
 
 
 #if !defined(IMLIB_ENABLE_PNG_ENCODER)
-bool png_compress(image_t *src, image_t *dst) {
+int png_compress(image_t *src, image_t *dst) {
     mp_raise_msg_varg(&mp_type_RuntimeError, MP_ERROR_TEXT("PNG encoder is not enabled"));
 }
 #endif

--- a/lib/imlib/png.c
+++ b/lib/imlib/png.c
@@ -379,9 +379,11 @@ void png_read(image_t *img, const char *path) {
 
 void png_write(image_t *img, const char *path) {
     file_t fp;
-    file_open(&fp, path, FA_WRITE | FA_CREATE_ALWAYS);
+
     if (img->pixfmt == PIXFORMAT_PNG) {
+        file_open(&fp, path, FA_WRITE | FA_CREATE_ALWAYS);
         file_write(&fp, img->data, img->size);
+        file_close(&fp);
     } else {
         image_t out = {
             .w = img->w,
@@ -390,10 +392,17 @@ void png_write(image_t *img, const char *path) {
             .size = 0,
             .data = NULL // alloc in png compress
         };
-        png_compress(img, &out);
+
+        // Compress before creating the file, so that a failure doesn't leave
+        // an empty one behind.
+        if (png_compress(img, &out)) {
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("Compression Failed!"));
+        }
+
+        file_open(&fp, path, FA_WRITE | FA_CREATE_ALWAYS);
         file_write(&fp, out.data, out.size);
+        file_close(&fp);
         uma_free(out.data);
     }
-    file_close(&fp);
 }
 #endif //IMLIB_ENABLE_IMAGE_FILE_IO)

--- a/modules/py_image.c
+++ b/modules/py_image.c
@@ -938,7 +938,7 @@ static mp_obj_t py_image_to(pixformat_t pixfmt, mp_rom_obj_t default_color_palet
             }
 
             if (((dst_img.pixfmt == PIXFORMAT_JPEG) &&
-                 jpeg_compress(&temp, &dst_img_tmp, args[ARG_quality].u_int, false, args[ARG_subsampling].u_int))
+                 jpeg_compress(&temp, &dst_img_tmp, args[ARG_quality].u_int, args[ARG_subsampling].u_int))
                 || ((dst_img.pixfmt == PIXFORMAT_PNG) && png_compress(&temp, &dst_img_tmp))) {
                 mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("Compression Failed!"));
             }

--- a/ports/stm32/stm_jpeg.c
+++ b/ports/stm32/stm_jpeg.c
@@ -82,10 +82,14 @@ static const uint8_t JPEG_APP0[] = {
 // width  must be multiple of 4, in range [96, 8176]
 // height must be multiple of 2, in range [32, 8176]
 //
-// Returns -1 if format/dimensions are not supported.
-// Returns  0 on success.
-// Returns  1 on HW error or output overflow.
-static int jpeg_compress_vc8000(image_t *src, image_t *dst, int quality, jpeg_subsampling_t subsampling) {
+#define JPEG_ERR_UNSUPPORTED    (-1)    // Format/dimensions not supported, try another encoder.
+#define JPEG_ERR_FAILED         (-2)    // Encoder or hardware error.
+#define JPEG_ERR_OVERFLOW       (-3)    // Output buffer too small for the encoded image.
+
+// Returns 0 on success, or one of the negative error codes above. The output
+// buffer is freed on failure, if it was allocated here.
+static int jpeg_compress_vc8000(image_t *src, image_t *dst, int quality, bool realloc,
+                                jpeg_subsampling_t subsampling) {
     JpegEncFrameType frameType;
 
     switch (src->pixfmt) {
@@ -96,7 +100,7 @@ static int jpeg_compress_vc8000(image_t *src, image_t *dst, int quality, jpeg_su
             frameType = JPEGENC_YUV422_INTERLEAVED_YUYV;
             break;
         default:
-            return -1;
+            return JPEG_ERR_UNSUPPORTED;
     }
 
     JpegEncCodingMode codingMode = JPEGENC_422_MODE;
@@ -106,7 +110,7 @@ static int jpeg_compress_vc8000(image_t *src, image_t *dst, int quality, jpeg_su
             codingMode = JPEGENC_420_MODE;
         }
     } else if (subsampling == JPEG_SUBSAMPLING_444) {
-        return -1;
+        return JPEG_ERR_UNSUPPORTED;
     } else if (subsampling == JPEG_SUBSAMPLING_422) {
         codingMode = JPEGENC_422_MODE;
     } else if (subsampling == JPEG_SUBSAMPLING_420) {
@@ -115,16 +119,19 @@ static int jpeg_compress_vc8000(image_t *src, image_t *dst, int quality, jpeg_su
 
     if ((src->w & 3) || (src->w < 96) || (8176 < src->w) ||
         (src->h & 1) || (src->h < 32) || (8176 < src->h)) {
-        return -1;
+        return JPEG_ERR_UNSUPPORTED;
     }
+
+    // realloc allows resizing the buffer, owned means it's also ours to free.
+    uint32_t alloc_size = dst->size;
+    bool owned = false;
 
     if (!dst->data) {
         dst->size = IMLIB_IMAGE_MAX_SIZE(IM_MIN(uma_avail(0), JPEG_MAX_ALLOC_SIZE));
         dst->data = uma_malloc(dst->size, UMA_CACHE);
-    }
-
-    if (src->is_compressed) {
-        return 1;
+        alloc_size = dst->size;
+        owned = true;
+        realloc = true;
     }
 
     JpegEncCfg cfg = {
@@ -150,12 +157,12 @@ static int jpeg_compress_vc8000(image_t *src, image_t *dst, int quality, jpeg_su
     JpegEncInst inst = {};
 
     if (JpegEncInit(&cfg, &inst) != JPEGENC_OK) {
-        jpeg_error = 1;
+        jpeg_error = JPEG_ERR_FAILED;
         goto exit_cleanup;
     }
 
     if (JpegEncSetPictureSize(inst, &cfg) != JPEGENC_OK) {
-        jpeg_error = 1;
+        jpeg_error = JPEG_ERR_FAILED;
         goto exit_cleanup;
     }
 
@@ -182,7 +189,7 @@ static int jpeg_compress_vc8000(image_t *src, image_t *dst, int quality, jpeg_su
         mp_uint_t elapsed = mp_hal_ticks_ms() - tickstart;
 
         if (elapsed > JPEG_CODEC_TIMEOUT) {
-            jpeg_error = 1;
+            jpeg_error = JPEG_ERR_FAILED;
             goto exit_cleanup;
         }
 
@@ -193,20 +200,25 @@ static int jpeg_compress_vc8000(image_t *src, image_t *dst, int quality, jpeg_su
             JpegEncRelease(inst);
 
             if (JpegEncInit(&cfg, &inst) != JPEGENC_OK) {
-                jpeg_error = 1;
+                jpeg_error = JPEG_ERR_FAILED;
                 goto exit_cleanup;
             }
 
             if (JpegEncSetPictureSize(inst, &cfg) != JPEGENC_OK) {
-                jpeg_error = 1;
+                jpeg_error = JPEG_ERR_FAILED;
                 goto exit_cleanup;
             }
 
             continue;
         }
 
+        if (ret == JPEGENC_OUTPUT_BUFFER_OVERFLOW) {
+            jpeg_error = JPEG_ERR_OVERFLOW;
+            goto exit_cleanup;
+        }
+
         if (ret != JPEGENC_FRAME_READY && ret != JPEGENC_RESTART_INTERVAL) {
-            jpeg_error = 1;
+            jpeg_error = JPEG_ERR_FAILED;
             goto exit_cleanup;
         }
     }
@@ -219,11 +231,22 @@ static int jpeg_compress_vc8000(image_t *src, image_t *dst, int quality, jpeg_su
     // Clean trailing data after 0xFFD9 at the end of the jpeg byte stream.
     dst->size = jpeg_clean_trailing_bytes(dst->size, dst->data);
 
+    // Trim the unused tail of the buffer.
+    if (realloc && ((alloc_size - dst->size) >= 1024)) {
+        // Shrinking a block resizes it in place, so this can't fail.
+        dst->data = uma_realloc(dst->data, dst->size, UMA_CACHE);
+    }
+
 exit_cleanup:
 
     JpegEncRelease(inst);
 
-    // caller frees dst->data on error
+    if (jpeg_error && owned) {
+        uma_free(dst->data);
+        dst->size = 0;
+        dst->data = NULL;
+    }
+
     return jpeg_error;
 }
 #endif // OMV_VENC_CODEC_ENABLE
@@ -285,11 +308,15 @@ static void jpeg_compress_data_ready(JPEG_HandleTypeDef *hjpeg, uint8_t *pDataOu
 }
 
 bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_subsampling_t subsampling) {
+    if (src->is_compressed) {
+        return true;
+    }
+
     #if (OMV_VENC_CODEC_ENABLE == 1)
-    // Try VC8000 first. Returns -1 if not handled (fall through), 0=success, 1=error.
-    int vc = jpeg_compress_vc8000(src, dst, quality, subsampling);
-    if (vc >= 0) {
-        return (bool) vc;
+    // Try VC8000 first, and fall through to the HW codec if it can't encode this image.
+    int vc = jpeg_compress_vc8000(src, dst, quality, realloc, subsampling);
+    if (vc != JPEG_ERR_UNSUPPORTED) {
+        return vc != 0;
     }
     #endif // OMV_VENC_CODEC_ENABLE
 
@@ -341,8 +368,10 @@ bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_s
     int src_w_mcus_bytes = src_w_mcus * mcu_size;
     int src_w_mcus_bytes_2 = src_w_mcus_bytes * 2;
 
-    // If dst->data == NULL then we need to allocate space for the payload which will be freed
-    // by the caller. We have to alloc this memory for all cases if we return from the method.
+    // realloc allows resizing the buffer, owned means it's also ours to free.
+    uint32_t alloc_size = dst->size;
+    bool owned = false;
+
     if (!dst->data) {
         uint32_t avail = uma_avail(0);
         uint32_t space = src_w_mcus_bytes_2 + JPEG_ALLOC_PADDING;
@@ -353,11 +382,12 @@ bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_s
 
         dst->size = IMLIB_IMAGE_MAX_SIZE(IM_MIN(avail - space, JPEG_MAX_ALLOC_SIZE));
         dst->data = uma_malloc(dst->size, UMA_CACHE);
+        alloc_size = dst->size;
+        owned = true;
+        realloc = true;
     }
 
-    if (src->is_compressed) {
-        return true;
-    }
+    bool jpeg_overflow = false;
 
     // Compute size of the APP0 header with cache alignment padding.
     int app0_size = sizeof(JPEG_APP0);
@@ -366,7 +396,8 @@ bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_s
     int app0_total_size = app0_size + app0_padding_size;
 
     if (dst->size < app0_total_size) {
-        return true; // overflow
+        jpeg_overflow = true;
+        goto exit_free;
     }
 
     // Adjust JPEG size and address by app0 header size.
@@ -375,10 +406,9 @@ bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_s
 
     // Destination is too small.
     if (dst->size < (JPEG_OUTPUT_CHUNK_SIZE * 2)) {
-        return true; // overflow
+        jpeg_overflow = true;
+        goto exit_free;
     }
-
-    bool jpeg_overflow = false;
 
     JPEG_state.out_data_len_max = dst->size;
     JPEG_state.out_data_len = 0;
@@ -552,6 +582,12 @@ bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_s
     // Clean trailing data after 0xFFD9 at the end of the jpeg byte stream.
     dst->size = jpeg_clean_trailing_bytes(dst->size, dst->data);
 
+    // Trim the unused tail of the buffer.
+    if (realloc && ((alloc_size - dst->size) >= 1024)) {
+        // Shrinking a block resizes it in place, so this can't fail.
+        dst->data = uma_realloc(dst->data, dst->size, UMA_CACHE);
+    }
+
 exit_cleanup:
     // Cleanup jpeg state.
     HAL_JPEG_Abort(&JPEG_state.jpeg_descr);
@@ -559,6 +595,15 @@ exit_cleanup:
     HAL_JPEG_UnRegisterGetDataCallback(&JPEG_state.jpeg_descr);
 
     uma_free(mcu_row_buffer); // after DMA is aborted
+
+exit_free:
+    // A truncated JPEG is of no use to the caller, so don't return one.
+    if (jpeg_overflow && owned) {
+        uma_free(dst->data);
+        dst->size = 0;
+        dst->data = NULL;
+    }
+
     return jpeg_overflow;
 }
 

--- a/ports/stm32/stm_jpeg.c
+++ b/ports/stm32/stm_jpeg.c
@@ -103,18 +103,11 @@ static int jpeg_compress_vc8000(image_t *src, image_t *dst, int quality, bool re
             return JPEG_ERR_UNSUPPORTED;
     }
 
-    JpegEncCodingMode codingMode = JPEGENC_422_MODE;
-
-    if (subsampling == JPEG_SUBSAMPLING_AUTO) {
-        if (quality <= 35) {
-            codingMode = JPEGENC_420_MODE;
-        }
-    } else if (subsampling == JPEG_SUBSAMPLING_444) {
+    // This encoder is built without JPEGENC_422_MODE_SUPPORTED, so it always encodes
+    // in 4:2:0 mode and ignores cfg.codingMode. Let the HW codec, which supports the
+    // other modes, handle anything else that's explicitly requested.
+    if ((subsampling != JPEG_SUBSAMPLING_AUTO) && (subsampling != JPEG_SUBSAMPLING_420)) {
         return JPEG_ERR_UNSUPPORTED;
-    } else if (subsampling == JPEG_SUBSAMPLING_422) {
-        codingMode = JPEGENC_422_MODE;
-    } else if (subsampling == JPEG_SUBSAMPLING_420) {
-        codingMode = JPEGENC_420_MODE;
     }
 
     if ((src->w & 3) || (src->w < 96) || (8176 < src->w) ||
@@ -145,7 +138,7 @@ static int jpeg_compress_vc8000(image_t *src, image_t *dst, int quality, bool re
         .qLevel = quality / 10,
         .restartInterval = 0,
         .codingType = JPEGENC_WHOLE_FRAME,
-        .codingMode = codingMode,
+        .codingMode = JPEGENC_420_MODE,
         .rotation = JPEGENC_ROTATE_0,
         .unitsType = JPEGENC_DOTS_PER_INCH,
         .markerType = JPEGENC_SINGLE_MARKER,

--- a/ports/stm32/stm_jpeg.c
+++ b/ports/stm32/stm_jpeg.c
@@ -300,16 +300,16 @@ static void jpeg_compress_data_ready(JPEG_HandleTypeDef *hjpeg, uint8_t *pDataOu
     }
 }
 
-bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_subsampling_t subsampling) {
+int jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_subsampling_t subsampling) {
     if (src->is_compressed) {
-        return true;
+        return -1;
     }
 
     #if (OMV_VENC_CODEC_ENABLE == 1)
     // Try VC8000 first, and fall through to the HW codec if it can't encode this image.
     int vc = jpeg_compress_vc8000(src, dst, quality, realloc, subsampling);
     if (vc != JPEG_ERR_UNSUPPORTED) {
-        return vc != 0;
+        return (vc == 0) ? 0 : -1;
     }
     #endif // OMV_VENC_CODEC_ENABLE
 
@@ -345,7 +345,7 @@ bool jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_s
                 JPEG_Info.ChromaSubsampling = JPEG_422_SUBSAMPLING;
             } else if (subsampling == JPEG_SUBSAMPLING_420) {
                 // not supported
-                return true;
+                return -1;
             }
             break;
         default:
@@ -597,7 +597,7 @@ exit_free:
         dst->data = NULL;
     }
 
-    return jpeg_overflow;
+    return jpeg_overflow ? -1 : 0;
 }
 
 static void jpeg_decompress_data_ready_abort(JPEG_HandleTypeDef *hjpeg, uint8_t *pDataOut, uint32_t OutDataLength) {

--- a/ports/stm32/stm_jpeg.c
+++ b/ports/stm32/stm_jpeg.c
@@ -88,8 +88,7 @@ static const uint8_t JPEG_APP0[] = {
 
 // Returns 0 on success, or one of the negative error codes above. The output
 // buffer is freed on failure, if it was allocated here.
-static int jpeg_compress_vc8000(image_t *src, image_t *dst, int quality, bool realloc,
-                                jpeg_subsampling_t subsampling) {
+static int jpeg_compress_vc8000(image_t *src, image_t *dst, int quality, jpeg_subsampling_t subsampling) {
     JpegEncFrameType frameType;
 
     switch (src->pixfmt) {
@@ -115,7 +114,6 @@ static int jpeg_compress_vc8000(image_t *src, image_t *dst, int quality, bool re
         return JPEG_ERR_UNSUPPORTED;
     }
 
-    // realloc allows resizing the buffer, owned means it's also ours to free.
     uint32_t alloc_size = dst->size;
     bool owned = false;
 
@@ -124,7 +122,6 @@ static int jpeg_compress_vc8000(image_t *src, image_t *dst, int quality, bool re
         dst->data = uma_malloc(dst->size, UMA_CACHE);
         alloc_size = dst->size;
         owned = true;
-        realloc = true;
     }
 
     JpegEncCfg cfg = {
@@ -225,7 +222,7 @@ static int jpeg_compress_vc8000(image_t *src, image_t *dst, int quality, bool re
     dst->size = jpeg_clean_trailing_bytes(dst->size, dst->data);
 
     // Trim the unused tail of the buffer.
-    if (realloc && ((alloc_size - dst->size) >= 1024)) {
+    if (owned && ((alloc_size - dst->size) >= 1024)) {
         // Shrinking a block resizes it in place, so this can't fail.
         dst->data = uma_realloc(dst->data, dst->size, UMA_CACHE);
     }
@@ -300,14 +297,14 @@ static void jpeg_compress_data_ready(JPEG_HandleTypeDef *hjpeg, uint8_t *pDataOu
     }
 }
 
-int jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_subsampling_t subsampling) {
+int jpeg_compress(image_t *src, image_t *dst, int quality, jpeg_subsampling_t subsampling) {
     if (src->is_compressed) {
         return -1;
     }
 
     #if (OMV_VENC_CODEC_ENABLE == 1)
     // Try VC8000 first, and fall through to the HW codec if it can't encode this image.
-    int vc = jpeg_compress_vc8000(src, dst, quality, realloc, subsampling);
+    int vc = jpeg_compress_vc8000(src, dst, quality, subsampling);
     if (vc != JPEG_ERR_UNSUPPORTED) {
         return (vc == 0) ? 0 : -1;
     }
@@ -361,7 +358,6 @@ int jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_su
     int src_w_mcus_bytes = src_w_mcus * mcu_size;
     int src_w_mcus_bytes_2 = src_w_mcus_bytes * 2;
 
-    // realloc allows resizing the buffer, owned means it's also ours to free.
     uint32_t alloc_size = dst->size;
     bool owned = false;
 
@@ -377,7 +373,6 @@ int jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_su
         dst->data = uma_malloc(dst->size, UMA_CACHE);
         alloc_size = dst->size;
         owned = true;
-        realloc = true;
     }
 
     bool jpeg_overflow = false;
@@ -576,7 +571,7 @@ int jpeg_compress(image_t *src, image_t *dst, int quality, bool realloc, jpeg_su
     dst->size = jpeg_clean_trailing_bytes(dst->size, dst->data);
 
     // Trim the unused tail of the buffer.
-    if (realloc && ((alloc_size - dst->size) >= 1024)) {
+    if (owned && ((alloc_size - dst->size) >= 1024)) {
         // Shrinking a block resizes it in place, so this can't fail.
         dst->data = uma_realloc(dst->data, dst->size, UMA_CACHE);
     }


### PR DESCRIPTION
The bug that started this: a 5 MP capture at quality 100 saved a 2.2 MB file with no EOI marker and a blank lower half. On overflow the encoders returned "failed" but left `dst->size` at the allocation size, and `jpeg_write` ignored the return and wrote the whole buffer. All `jpeg_compress` implementations now share one contract, matching `png_compress`:

```
true  == failed  == nothing to clean up, our buffer is freed
false == success == the caller owns a valid buffer
```

### JPEG encoders fixes

- Enable the software encoder's realloc path for buffers it owns. It existed, but every caller disabled it, so overflow was always fatal.
- Grow by half the buffer size instead of a fixed 1 KB, which cost one realloc and one full copy per 1 KB encoded, and keep the `UMA_CACHE` flag across the realloc.
- Free the output buffer on failure and trim it to the encoded size on success, in all three encoders.
- Raise in `jpeg_write` and `mjpeg_write` instead of writing the buffer regardless.
- Replace VC8000's `-1/0/1` return convention, with named error codes, to distinguish buffer overflows from hardware faults.
- Move the `is_compressed` check above the allocation, so that path no longer allocates a buffer only to fail.

### Save-path validation

`.jpg` and `.png` were the only extensions with no format check.

- Saving a **PNG as `.jpg`** reached `jpeg_compress` with a compressed source and wrote up to **1 MB of uninitialised heap to disk**. Now raises.
- Saving a **JPEG as `.png`** wrote an empty file. Now raises.
- An image already in the target format is still copied as-is.
- Replace the per-character extension matching with a table and a suffix match.
- Make the format switch exhaustive, so build fails if a new format is added without validation.
- Check `png_compress`'s return value in `png_write`, and compress before creating the file so a failure doesn't leave an empty one behind.

### VC8000 subsampling

- The driver is built without `JPEGENC_422_MODE_SUPPORTED`, so it forces 4:2:0 and ignores `cfg.codingMode` entirely; an explicit 4:2:2 request was silently honoured as 4:2:0.
- Report anything but 4:2:0 as unsupported and fall back to the HAL codec, as 4:4:4 already did.

### Follow-ups, not in this PR
  - The buffer sizing question from #3231.
  - Uncovered an unrelated USB/protocol/TinyUSB issue.