### PR TITLE
protocol: Fix OOB write in protocol_register.

### DIFF
--- a/modules/py_protocol.c
+++ b/modules/py_protocol.c
@@ -472,6 +472,6 @@ const mp_obj_module_t protocol_module = {
 MP_REGISTER_EXTENSIBLE_MODULE(MP_QSTR_protocol, protocol_module);
 
 // Register root pointers for dynamic protocol channels.
-MP_REGISTER_ROOT_POINTER(mp_obj_t protocol_channels[OMV_PROTOCOL_MAX_CHANNELS]);
+MP_REGISTER_ROOT_POINTER(mp_obj_t protocol_channels[OMV_PROTOCOL_CHANNEL_MAX]);
 
 #endif // MICROPY_PY_PROTOCOL

--- a/protocol/omv_protocol.c
+++ b/protocol/omv_protocol.c
@@ -135,7 +135,7 @@ void omv_protocol_deinit(void) {
     }
 
     // Deinitialize all channels, unregister dynamic ones.
-    for (int i = 0; i < OMV_PROTOCOL_MAX_CHANNELS; i++) {
+    for (int i = 0; i < OMV_PROTOCOL_CHANNEL_MAX; i++) {
         if (ctx.channels[i]) {
             if (ctx.channels[i]->deinit) {
                 ctx.channels[i]->deinit(ctx.channels[i]);
@@ -212,12 +212,17 @@ int omv_protocol_register_channel(const omv_protocol_channel_t *channel) {
         channel_id = channel->id;
     } else {
         // Find the first free channel
-        for (size_t i = 1; i < OMV_PROTOCOL_MAX_CHANNELS; i++) {
+        for (size_t i = 1; i < OMV_PROTOCOL_CHANNEL_MAX; i++) {
             if (ctx.channels[i] == NULL) {
                 channel_id = i;
                 break;
             }
         }
+    }
+
+    // No free channel slots
+    if (channel_id == -1) {
+        return -1;
     }
 
     // Initialize the channel
@@ -812,7 +817,7 @@ void omv_protocol_process(const omv_protocol_packet_t *packet) {
         case OMV_PROTOCOL_OPCODE_CHANNEL_LIST: {
             // Build list of registered channels
             int ch_count = 0;
-            omv_protocol_channel_entry_t ch_list[OMV_PROTOCOL_MAX_CHANNELS];
+            omv_protocol_channel_entry_t ch_list[OMV_PROTOCOL_CHANNEL_MAX];
 
             for (int i = 0; i < ctx.channels_count; i++) {
                 if (ctx.channels[i] != NULL) {

--- a/protocol/omv_protocol.h
+++ b/protocol/omv_protocol.h
@@ -52,7 +52,6 @@
 #define OMV_PROTOCOL_SYNC_WORD              (0xD5AA)
 #define OMV_PROTOCOL_HEADER_SIZE            (10)    // SYNC[2] SEQ[1] CHAN[1] FLAGS[1] OPCODE[1] LEN[2] CRC[2]
 
-#define OMV_PROTOCOL_MAX_CHANNELS           (32)
 #define OMV_PROTOCOL_DEF_POLL_MS            (50)
 #define OMV_PROTOCOL_DEF_RTX_RETRIES        (3)
 #define OMV_PROTOCOL_DEF_RTX_TIMEOUT_MS     (500)   // Doubled after each timeout
@@ -360,7 +359,7 @@ typedef struct {
 
     // Protocol physical/logical channels
     uint8_t channels_count;
-    const omv_protocol_channel_t *channels[OMV_PROTOCOL_MAX_CHANNELS];
+    const omv_protocol_channel_t *channels[OMV_PROTOCOL_CHANNEL_MAX];
 
     // Protocol Statistics
     omv_protocol_stats_t stats;

--- a/protocol/omv_protocol_channel.h
+++ b/protocol/omv_protocol_channel.h
@@ -38,6 +38,7 @@
 ***************************************************************************/
 
 #define OMV_PROTOCOL_CHANNEL_NAME_SIZE  (14)
+#define OMV_PROTOCOL_CHANNEL_MAX        (32)
 
 /***************************************************************************
 * Channel IOCTL Commands
@@ -93,7 +94,11 @@ typedef enum {
     OMV_PROTOCOL_CHANNEL_ID_STDOUT      = 2,          // Text output (read-only)
     OMV_PROTOCOL_CHANNEL_ID_STREAM      = 3,          // Stream data (read-only)
     OMV_PROTOCOL_CHANNEL_ID_PROFILE     = 4,          // Profiling data (when enabled, read-only)
+    OMV_PROTOCOL_CHANNEL_ID_LAST,                     // Number of reserved channel IDs
 } omv_protocol_channel_id_t;
+
+_Static_assert(OMV_PROTOCOL_CHANNEL_ID_LAST <= OMV_PROTOCOL_CHANNEL_MAX,
+               "Reserved channel IDs must fit in the channels array");
 
 // Channel flags
 typedef enum {


### PR DESCRIPTION
Registering a dynamic protocol channel when all available channel slots are already occupied causes an out-of-bounds write in omv_protocol_register_channel().

Fix OOB write by checking channel_id before registering.

Fixes #3249