### PR TITLE
modules/py_image: Fix OOB write in get_pixel().

### DIFF
--- a/modules/py_image.c
+++ b/modules/py_image.c
@@ -731,7 +731,11 @@ static mp_obj_t py_image_get_pixel(size_t n_args, const mp_obj_t *pos_args, mp_m
         }
         case PIXFORMAT_BAYER_ANY:
             if (arg_rgbtuple) {
-                uint16_t pixel; imlib_debayer_line(arg_x, arg_x + 1, arg_y, &pixel, PIXFORMAT_RGB565, arg_img);
+                // Line functions store pixels at their source column.
+                uint16_t *row = uma_malloc(arg_img->w * sizeof(uint16_t), UMA_FAST);
+                imlib_debayer_line(arg_x, arg_x + 1, arg_y, row, PIXFORMAT_RGB565, arg_img);
+                uint16_t pixel = row[arg_x];
+                uma_free(row);
                 mp_obj_t pixel_tuple[3];
                 pixel_tuple[0] = mp_obj_new_int(COLOR_RGB565_TO_R8(pixel));
                 pixel_tuple[1] = mp_obj_new_int(COLOR_RGB565_TO_G8(pixel));
@@ -742,7 +746,11 @@ static mp_obj_t py_image_get_pixel(size_t n_args, const mp_obj_t *pos_args, mp_m
             }
         case PIXFORMAT_YUV_ANY:
             if (arg_rgbtuple) {
-                uint16_t pixel; imlib_deyuv_line(arg_x, arg_x + 1, arg_y, &pixel, PIXFORMAT_RGB565, arg_img);
+                // Line functions store pixels at their source column.
+                uint16_t *row = uma_malloc(arg_img->w * sizeof(uint16_t), UMA_FAST);
+                imlib_deyuv_line(arg_x, arg_x + 1, arg_y, row, PIXFORMAT_RGB565, arg_img);
+                uint16_t pixel = row[arg_x];
+                uma_free(row);
                 mp_obj_t pixel_tuple[3];
                 pixel_tuple[0] = mp_obj_new_int(COLOR_RGB565_TO_R8(pixel));
                 pixel_tuple[1] = mp_obj_new_int(COLOR_RGB565_TO_G8(pixel));


### PR DESCRIPTION
imlib_debayer_line() and imlib_deyuv_line() store each converted pixel at its source column, so the destination must be a full row wide. get_pixel() passed the address of a single uint16_t, so for bayer and YUV images the pixel was written past that local, at a caller-controlled offset, and the local itself was left unset.

Convert into a row allocated with uma_malloc() and read back the requested column.