### PR TITLE
drivers/sensors: Fix BAYER capture on the N6. 

### DIFF
--- a/drivers/sensors/pag7936.c
+++ b/drivers/sensors/pag7936.c
@@ -588,15 +588,29 @@ static int read_reg_seq(omv_csi_t *csi, uint16_t addr, size_t size, uint8_t *buf
     return ret;
 }
 
+static int configure(omv_csi_t *csi, omv_csi_framesize_t target, int framerate);
+
 static int set_pixformat(omv_csi_t *csi, pixformat_t pixformat) {
     switch (pixformat) {
         case PIXFORMAT_RGB565:
         case PIXFORMAT_BAYER:
         case PIXFORMAT_GRAYSCALE:
-            return 0;
+            break;
         default:
             return -1;
     }
+
+    #ifdef OMV_CSI_HW_SCALE_ENABLE
+    // BAYER can't be ISP-scaled, so re-select the sensor mode when toggling it.
+    if ((pixformat == PIXFORMAT_BAYER || csi->pixformat == PIXFORMAT_BAYER) &&
+        csi->framesize != OMV_CSI_FRAMESIZE_INVALID) {
+        pag7936_state_t *state = csi->priv;
+        csi->pixformat = pixformat;  // configure() reads it; the caller sets it after
+        return configure(csi, csi->framesize, state->framerate);
+    }
+    #endif
+
+    return 0;
 }
 
 // Pick the largest native sensor mode that meets the requested framerate.
@@ -604,6 +618,12 @@ static omv_csi_framesize_t get_framesize(omv_csi_t *csi, omv_csi_framesize_t tar
     #ifndef OMV_CSI_HW_SCALE_ENABLE
     return target;
     #endif
+
+    // The ISP scaler cannot rescale raw BAYER, so the sensor must produce the
+    // requested size directly. QVGA/VGA/HD are all native sensor modes.
+    if (csi->pixformat == PIXFORMAT_BAYER) {
+        return target;
+    }
 
     pag7936_state_t *state = csi->priv;
     uint32_t w = csi->resolution[target][0];

--- a/drivers/sensors/ps5520.c
+++ b/drivers/sensors/ps5520.c
@@ -172,7 +172,6 @@ static const uint8_t stream_off_regs[][2] = {
 
 // These per-resolution register tables are only used without the ISP scaler;
 // with the scaler the sensor runs at full resolution and the ISP scales down.
-#ifndef OMV_CSI_HW_SCALE_ENABLE
 static const uint8_t res_640x480_regs[][2] = {
     // PS5520_640x480x30fps_24MHz_2Lane_RAW10_840Mbps_20190408_C10A.asc
     { 0xEF, 0x05 },
@@ -955,7 +954,6 @@ static const uint8_t res_2560x1440_regs[][2] = {
     { 0xFF, 0x02 }, // Delay 2 ms
     { 0x00, 0x00 }, // End
 };
-#endif // OMV_CSI_HW_SCALE_ENABLE
 
 static const uint8_t res_2592x1944_regs[][2] = {
     // PS5520_2592x1944x30fps_24MHz_2Lane_RAW10_840Mbps_20190408_C10A.asc
@@ -1260,15 +1258,28 @@ static int write_registers(omv_csi_t *csi, const uint8_t(*regs)[2]) {
     return ret;
 }
 
+static int set_framesize(omv_csi_t *csi, omv_csi_framesize_t framesize);
+
 static int set_pixformat(omv_csi_t *csi, pixformat_t pixformat) {
     switch (pixformat) {
         case PIXFORMAT_RGB565:
         case PIXFORMAT_BAYER:
         case PIXFORMAT_GRAYSCALE:
-            return 0;
+            break;
         default:
             return -1;
     }
+
+    #ifdef OMV_CSI_HW_SCALE_ENABLE
+    // BAYER can't be ISP-scaled, so re-select the sensor mode when toggling it.
+    if ((pixformat == PIXFORMAT_BAYER || csi->pixformat == PIXFORMAT_BAYER) &&
+        csi->framesize != OMV_CSI_FRAMESIZE_INVALID) {
+        csi->pixformat = pixformat;  // set_framesize() reads it; the caller sets it after
+        return set_framesize(csi, csi->framesize);
+    }
+    #endif
+
+    return 0;
 }
 
 static int set_framesize(omv_csi_t *csi, omv_csi_framesize_t framesize) {
@@ -1280,7 +1291,21 @@ static int set_framesize(omv_csi_t *csi, omv_csi_framesize_t framesize) {
     }
 
     int ret = 0;
-    #ifndef OMV_CSI_HW_SCALE_ENABLE
+
+    #ifdef OMV_CSI_HW_SCALE_ENABLE
+    // BAYER can't be ISP-scaled, so it runs at a native mode; other formats run
+    // at full resolution and the ISP scales down.
+    if (csi->pixformat != PIXFORMAT_BAYER) {
+        csi->src_w = SENSOR_WIDTH;
+        csi->src_h = SENSOR_HEIGHT;
+        ret |= write_registers(csi, sw_reset_regs);
+        ret |= write_registers(csi, res_2592x1944_regs);
+        return ret;
+    }
+    csi->src_w = w;
+    csi->src_h = h;
+    #endif // OMV_CSI_HW_SCALE_ENABLE
+
     const uint8_t(*regs)[2];
 
     switch (framesize) {
@@ -1311,7 +1336,6 @@ static int set_framesize(omv_csi_t *csi, omv_csi_framesize_t framesize) {
 
     // Set resolution
     ret |= write_registers(csi, regs);
-    #endif // OMV_CSI_HW_SCALE_ENABLE
     return ret;
 }
 


### PR DESCRIPTION
## N6: allow BAYER capture at the sensor's native resolutions (PAG7936, PS5520)

> ### Note — behavior change + a flash trade-off to flag
>
> **This is not a bug fix.** BAYER only succeeding at the sensor's **maximum**
> resolution and failing at smaller sizes was **intentional**: BAYER can't be
> rescaled by the ISP (decimation destroys the pattern), so with hardware
> scaling it was deliberately limited to the full native readout while everything
> else went through the scaler as a debayered format.
>
> This PR **extends** BAYER to run the sensor at whichever native mode matches
> the requested size, so BAYER works at all native resolutions (and cleanly
> reports "unsupported" where a sensor has no native mode for the size, e.g.
> PS5520 QVGA).
>
> **The trade-off I want to flag:** on **PS5520** this brings back the
> per-resolution register tables (`res_640x480` … `res_2560x1440`) that were
> previously compiled out on the scaler path — **1,526 bytes** of flash (about
> 1.7 KB including the driver code changes). BAYER needs them to run the sensor
> at a native size; there's no way to produce a smaller BAYER frame without them.
> **PAG7936 costs nothing** — its native-mode tables are always compiled (that
> sensor is designed around native modes and scales between them).
>
> So this is a design decision, not a correctness one: **keep native-resolution
> BAYER on PS5520 and pay 1,526 bytes of flash, or keep BAYER max-res-only and
> leave those tables dropped.** #3253 reads as a bug report, but the non-max-res 
> failure was by design — let's settle the direction before merging.

### Background

On the N6 (`OMV_CSI_HW_SCALE_ENABLE`) the sensor runs larger than the requested
framesize and the DCMIPP ISP scales down. The ISP can't rescale raw BAYER, so
`stm_isp_set_scaler()` rejects the pipe whenever `src != dst` — BAYER succeeded
only where the sensor already ran at the requested size:

- **PAG7936** picks the largest native mode for the framerate, so e.g. a QVGA
  request ran the sensor at HD → `src != dst` → BAYER refused.
- **PS5520** always ran at full resolution (2592×1944), so BAYER succeeded only
  at full res and refused every smaller size.

Symptom in both cases: `RuntimeError: Failed to initialize the CSI interface.`

### Change

For BAYER, run the sensor at a native mode matching the requested framesize so
`src == dst`; debayered formats keep using the scaler.

- **PAG7936**: `get_framesize()` returns the requested size directly for BAYER
  (QVGA/VGA/HD are native modes) instead of upscaling for framerate. No new
  tables — its mode tables are always compiled.
- **PS5520**: `set_framesize()` programs the per-resolution register table for
  BAYER, and keeps full-resolution-plus-scale for the other formats. This
  compiles the `res_640x480` … `res_2560x1440` tables back in on the scaler path
  (1,526 bytes) — see the note above.

Both drivers re-apply configuration when the pixel format is toggled to or from
BAYER, so the source size stays correct regardless of `pixformat` / `framesize`
call order.

### Testing

Verified on N6 hardware (GCC 14.3 SDK toolchain, flashed via J-Link):

**PAG7936**

| Format | Result |
|---|---|
| BAYER QVGA / VGA / HD | now captures — 320×200 / 640×400 / 1280×800 |
| RGB565 QVGA/VGA, GRAYSCALE QVGA | unchanged |
| framesize→pixformat order, RGB↔BAYER runtime toggle | works |

**PS5520**

| Format | Result |
|---|---|
| BAYER VGA / HD / SXGA-M / FHD / QHD / WQXGA2 | now captures (was full-res only) |
| BAYER QVGA | reported unsupported (no native QVGA mode) |
| RGB565 QVGA (scaled), GRAYSCALE HD | unchanged |
| framesize→pixformat order, RGB↔BAYER runtime toggle | works |
