### PR TITLE
modules/py_csi_ng: Export custom resolution symbol.

### DIFF
--- a/common/omv_csi.c
+++ b/common/omv_csi.c
@@ -835,7 +835,7 @@ __weak int omv_csi_set_pixformat(omv_csi_t *csi, pixformat_t pixformat) {
 }
 
 __weak int omv_csi_set_framesize(omv_csi_t *csi, omv_csi_framesize_t framesize) {
-    if (csi->framesize == framesize) {
+    if (csi->framesize == framesize && framesize != OMV_CSI_FRAMESIZE_CUSTOM) {
         // No change
         return 0;
     }

--- a/modules/py_csi_ng.c
+++ b/modules/py_csi_ng.c
@@ -1524,6 +1524,9 @@ static const mp_rom_map_elem_t globals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_NORMAL),          MP_ROM_INT(OMV_CSI_SDE_NORMAL) },    /* Normal/No SDE */
     { MP_ROM_QSTR(MP_QSTR_NEGATIVE),        MP_ROM_INT(OMV_CSI_SDE_NEGATIVE) },  /* Negative image */
 
+    // Custom Resolution
+    { MP_ROM_QSTR(MP_QSTR_CUSTOM),          MP_ROM_INT(OMV_CSI_FRAMESIZE_CUSTOM) },   /* WxH       */
+
     // C/SIF Resolutions
     { MP_ROM_QSTR(MP_QSTR_QCIF),            MP_ROM_INT(OMV_CSI_FRAMESIZE_QCIF) },     /* 176x144   */
     { MP_ROM_QSTR(MP_QSTR_CIF),             MP_ROM_INT(OMV_CSI_FRAMESIZE_CIF) },      /* 352x288   */


### PR DESCRIPTION
Getting the custom resolution back already works with `csi.width()` and `csi.height()`, there was just no export to compare against. Additionally, fix setting custom framesize twice.

Fixes: https://github.com/openmv/openmv/issues/2950