### PR TITLE
ci: Fix empty release changelog.

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -206,10 +206,9 @@ jobs:
       id: changelog
       uses: mikepenz/release-changelog-builder-action@v6
       with:
-        toTag: ${{ github.sha }}
+        toTag: ${{ github.ref_name }}
         configuration: '.github/workflows/changelog.json'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: '🔥 Create stable release'
       uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64
@@ -260,8 +259,7 @@ jobs:
       with:
         toTag: ${{ github.sha }}
         configuration: '.github/workflows/changelog.json'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: '🔥 Create development release'
       uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64


### PR DESCRIPTION
The changelog action resolves fromTag by matching toTag against the tag list. Passing github.sha never matches, so it fell back to the newest tag, which for a tag push is the release being built, producing an empty range. Use github.ref_name for the stable release instead.

Also pass the token via the action input, the env var is deprecated.