### PR TITLE
ports: Sync main.c with MicroPython v1.29.0 port changes.

### DIFF
--- a/ports/alif/main.c
+++ b/ports/alif/main.c
@@ -90,6 +90,7 @@
 NORETURN void __fatal_error(const char *msg);
 extern void machine_pwm_deinit_all(void);
 extern void machine_pin_irq_deinit(void);
+extern void machine_can_deinit_all(void);
 
 int main(void) {
     bool first_soft_reset = true; (void) first_soft_reset;
@@ -99,6 +100,7 @@ int main(void) {
 
     pendsv_init();
     lptimer_init();
+    machine_init();
     machine_rtc_init();
 
     #if MICROPY_HW_ENABLE_UART_REPL
@@ -241,8 +243,12 @@ soft_reset_exit:
     #if MICROPY_PY_MACHINE_I2C_TARGET
     mp_machine_i2c_target_deinit_all();
     #endif
+    #if MICROPY_PY_MACHINE_CAN
+    machine_can_deinit_all();
+    #endif
     machine_pwm_deinit_all();
     machine_pin_irq_deinit();
+    machine_set_soft_reset();
     imlib_deinit();
     soft_timer_deinit();
     dma_deinit_all();


### PR DESCRIPTION
### Summary

Mirrors the init/deinit changes made in MicroPython's port `main.c` files
between the previous submodule pin (`dd98455`) and v1.29.0 (`57a7b25`), in the
same relative places:

* **stm32**: `mod_network_init()` moved earlier in the soft-reset sequence
  (right after `timer_init0()`, before CAN init), matching upstream's
  net-before-boot.py change.
* **mimxrt**: added the `abort()` stub upstream added.
* **alif**: call `machine_init()` at startup (reset-cause tracking), and on
  soft reset call `machine_can_deinit_all()` (under `MICROPY_PY_MACHINE_CAN`)
  and `machine_set_soft_reset()`, matching upstream's teardown order.

Note on `machine.mem_backup`: upstream's stm32 `main.c` hook for it
(`machine_mem_backup_init()`) was already cherry-picked into the previous
submodule pin, and our `main.c` already calls it in upstream's position
(right after `rtc_init_start()`), so no change was needed — see test results
below. The alif/mimxrt mem_backup implementations hook in via
`MICROPY_PY_MACHINE_MEM_BACKUP_INCLUDEFILE` with no `main.c` involvement.

### Build testing

All targets clean-built with this branch:

| Target | Result |
|---|---|
| OPENMV_N6 | OK |
| OPENMV_AE3 | OK |
| OPENMV_RT1060 | OK |
| OPENMV4P | OK |
| OPENMV4 | OK — **99.92% of FLASH_TEXT (~1.4 KB headroom)** |
| OPENMV3 | OK |
| OPENMV2 | OK |
| ARDUINO_NICLA_VISION | OK |
| ARDUINO_PORTENTA_H7 | OK |

Two build caveats worth knowing:

1. **Clean-build after this bump.** Stale build directories from the old pin
   produce qstr/frozen-content redeclaration errors, and in one case a phantom
   `FLASH_TEXT` overflow on OPENMV4. `rm -rf build/<TARGET>` first.
2. **OPENMV4 is nearly full** (99.92% of FLASH_TEXT after a clean build).
   It fits, but there's ~1.4 KB of headroom left on this PR.

### Hardware testing — full 9-board pass

Every board was flashed with this branch's firmware and ran a smoke test
covering RTC, LED, camera capture (3 snapshots), WiFi scan, ethernet DHCP
(where a cable is attached), and BLE enable/disable:

| Board | Firmware | Camera | WiFi scan | Ethernet | BLE | RTC | LED |
|---|---|---|---|---|---|---|---|
| OpenMV N6 | 1.29.0 | PASS 320x200 (PAG7936) | PASS 21 APs (CYW43439) | PASS DHCP .188 | PASS | PASS | PASS |
| OpenMV AE3 | 1.29.0 | PASS 320x200 (PAG7936) | PASS 21 APs (CYW43439/SPI) | n/a | PASS | PASS | PASS |
| OpenMV RT1062 | 1.29.0 | PASS 320x240 (OV5640) | PASS 17 APs (CYW4343W) | PASS DHCP .2 | PASS | PASS | PASS |
| OpenMV H7 Plus | 1.29.0 | PASS 320x240 (OV5640) | PASS 12 APs (WINC1500) | n/a | n/a | PASS | PASS |
| OpenMV H7 | 1.29.0 | PASS 320x240 (OV7725) | PASS 21 APs (WINC1500) | n/a | n/a | PASS | PASS |
| OpenMV M7 | 1.29.0 | PASS 320x240 (OV7725) | PASS 13 APs (WINC1500) | n/a | n/a | PASS | PASS |
| OpenMV M4 | 1.29.0 | PASS 320x240 (OV7725) | PASS 12 APs (WINC1500) | n/a | n/a | PASS | PASS |
| Nicla Vision | 1.29.0 | PASS 320x240 (GC2145) | PASS 25 APs (CYW4343W) | n/a | PASS | PASS | PASS |
| Portenta H7 | 1.29.0 | PASS 320x240 (HM0360) | PASS 20 APs (CYW4343W) | PASS DHCP .38 | PASS | PASS | PASS |

Ports covered: stm32 (N6 + H7 Plus + H7/M7/M4 classics + both Arduino H747
boards), mimxrt (RT1062), alif (AE3). Radios covered: CYW43439 (SDIO and
SPI attach), CYW4343W, WINC1500. `os.uname()` confirmed 1.29.0 on every
board.

### machine.mem_backup verification

* **N6 (stm32)**: `machine.mem_backup(-1)` reports 2 regions — 8192 bytes
  (backup SRAM) + 32 bytes (BKP registers). Read/write works, and values
  written to backup SRAM **survive `machine.reset()`** (verified with a
  3-byte sentinel).
* **RT1062 (mimxrt)**: 1 region, 8 bytes (SNVS), read/write OK.
* **AE3 (alif)**: 1 region, 1020 bytes, read/write OK.

### Other observations

* The long-standing Portenta CDC instability we saw on older fork builds did
  not reproduce on this firmware — mpremote/raw-REPL worked normally over CDC
  once no script was running.
* Nicla RTC came up with the correct (previously set) date after reflashing,
  i.e. the LSI prescaler timekeeping work behaves under 1.29 as well.

### Extended testing

Beyond the base smoke test, the following was exercised on the same builds:

**WiFi associate + TCP traffic** (directly exercises the relocated
`mod_network_init()` on stm32):

| Board | Radio | Result |
|---|---|---|
| OpenMV N6 | CYW43439 | Associate + DHCP (192.168.0.185) + TCP connect to the gateway: PASS. DNS query answered. (Outbound internet is blocked on the bench LAN, so only LAN TCP was exercised.) |
| OpenMV H7 | WINC1500 | Associate + DHCP (192.168.0.136) + TCP connect to the gateway: PASS. |
| OpenMV RT1062 | Ethernet | DHCP + TCP connect to the gateway: PASS. |

**Soft-reset cycling (alif)** — exercises the new `machine_set_soft_reset()`
and the soft-reset deinit path added in this PR:

* AE3: 6 consecutive soft-reset cycles; `machine.reset_cause()` returned
  `SOFT_RESET` on every cycle, and the CYW43 came back up and scanned
  successfully after each one (deinit/reinit path healthy).

**Camera throughput** (QVGA, 30 timed frames after warm-up):

* N6 / PAG7936: 117.6 FPS
* RT1062 / OV5640: 46.7 FPS

**Deep sleep**:

* N6: `machine.deepsleep(5000)` sleeps and wakes cleanly, REPL returns.
  Note: after wake `machine.reset_cause()` reads 0 rather than
  `DEEPSLEEP_RESET` — the bootloader clears the standby flag before the
  application sees it. Same pattern already exists on the Arduino MCUboot
  boards, so this looks pre-existing rather than a 1.29 regression, but
  flagging it.

**machine.mem_backup** (new in this MicroPython release for mimxrt/alif):

* N6: 2 regions (8192 B backup SRAM + 32 B BKP registers), read/write OK,
  values survive `machine.reset()`.
* RT1062: 1 region (8 B, SNVS), read/write OK.
* AE3: 1 region (1020 B), read/write OK.
* The stm32 `main.c` init hook for this predates this bump (the previous
  submodule pin already cherry-picked upstream's commit), which is why no
  `main.c` change appears for it here; verified our call site matches
  upstream's position.

**Misc**: I2C bus scans ACK real devices on the RT1062 (0x15/0x3c/0x48);
`gc`, heap allocation, and `/flash` access exercised implicitly throughout.

**Not covered** (no bench fixtures): CAN/FDCAN traffic (the new alif
machine_can driver and N6 FDCAN are build-verified only — no transceiver on
the bench), IDE frame streaming (headless bench), and audio/mic paths.



