### PR TITLE
drivers/sensors: Fix PAG7936 triggered mode enable on a running sensor.

### DIFF
--- a/drivers/sensors/pag7936.c
+++ b/drivers/sensors/pag7936.c
@@ -889,7 +889,14 @@ static int ioctl(omv_csi_t *csi, int request, va_list ap) {
         }
         case OMV_CSI_IOCTL_SET_TRIGGERED_MODE: {
             int enable = va_arg(ap, int);
+            pag7936_state_t *state = csi->priv;
             ret |= omv_i2c_write_reg(csi->i2c, csi->slv_addr, SENSOR_OPMODE, 2, SENSOR_OPMODE_SUSPEND, 1);
+
+            // The suspend command takes effect at the next frame boundary, and the
+            // trigger configuration below is ignored unless the sensor has actually
+            // suspended -- wait out the in-flight frame (per the datasheet's state
+            // transition flow, which requires a one-frame delay after suspend).
+            mp_hal_delay_ms((state->framerate > 0) ? ((2000 / state->framerate) + 1) : 100);
 
             if (enable) {
                 ret |= omv_i2c_write_reg(csi->i2c, csi->slv_addr, SENSOR_TG_EN, 2, 0, 1);


### PR DESCRIPTION
Enabling triggered mode while the sensor was streaming silently failed at the larger frame sizes: the suspend command only takes effect at the next frame boundary, and the trigger configuration written immediately after it is ignored unless the sensor has actually suspended.  At QVGA the ~8ms frames happened to end inside the I2C write sequence, so it worked; at VGA and HD the whole sequence landed within one frame and the sensor kept free-running with the trigger registers reading back as enabled.  This made the triggered_mode.py example (which enables the mode after configuring and warming up the sensor) a no-op, only working if the ioctl was moved to before pixformat/framesize.

Wait out the in-flight frame after commanding suspend, per the datasheet's state-transition flow which requires a one-frame delay there, before writing the trigger configuration.

Verified on an OpenMV AE3 with the FSYNC pulses suppressed as a diagnostic: before the fix, snapshots kept flowing at VGA/HD after enabling triggered mode (and starved at QVGA); after the fix, snapshots starve at every frame size until triggered, and with FSYNC restored the stock example order works at QVGA, VGA and HD, with disable returning the sensor to free-running.