### PR TITLE
scripts/examples: Fix scripts that reference names they never import.

### DIFF
--- a/scripts/examples/02-Image-Processing/02-Color-Tracking/multi_color_blob_tracking.py
+++ b/scripts/examples/02-Image-Processing/02-Color-Tracking/multi_color_blob_tracking.py
@@ -7,6 +7,7 @@
 # This example shows off multi color blob tracking using the OpenMV Cam.
 
 import csi
+import image
 import time
 import math
 

--- a/scripts/examples/02-Image-Processing/02-Color-Tracking/single_color_code_tracking.py
+++ b/scripts/examples/02-Image-Processing/02-Color-Tracking/single_color_code_tracking.py
@@ -10,6 +10,7 @@
 # only track colored objects which have both the colors below in them.
 
 import csi
+import image
 import time
 import math
 

--- a/scripts/examples/02-Image-Processing/02-Color-Tracking/single_color_grayscale_blob_tracking.py
+++ b/scripts/examples/02-Image-Processing/02-Color-Tracking/single_color_grayscale_blob_tracking.py
@@ -7,6 +7,7 @@
 # This example shows off single color grayscale tracking using the OpenMV Cam.
 
 import csi
+import image
 import time
 import math
 

--- a/scripts/examples/02-Image-Processing/02-Color-Tracking/single_color_rgb565_blob_tracking.py
+++ b/scripts/examples/02-Image-Processing/02-Color-Tracking/single_color_rgb565_blob_tracking.py
@@ -7,6 +7,7 @@
 # This example shows off single color RGB565 tracking using the OpenMV Cam.
 
 import csi
+import image
 import time
 import math
 

--- a/scripts/examples/50-Arduino-Boards/Giga-H7/50-Board-Control/i2c_scanner.py
+++ b/scripts/examples/50-Arduino-Boards/Giga-H7/50-Board-Control/i2c_scanner.py
@@ -8,4 +8,4 @@ from machine import I2C
 
 i2c = I2C(1, freq=400_000)
 for addr in i2c.scan():
-    print("Found device at address %d:0x%x" % (bus, addr))
+    print("Found device at address 0x%x" % (addr,))

--- a/scripts/examples/50-Arduino-Boards/Portenta-H7/52-LoRa/lora-example.py
+++ b/scripts/examples/50-Arduino-Boards/Portenta-H7/52-LoRa/lora-example.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2013-2023 OpenMV LLC. All rights reserved.
 # https://github.com/openmv/openmv/blob/master/LICENSE
 #
+from time import sleep_ms
 from lora import *
 
 lora = Lora(band=BAND_EU868, poll_ms=60000, debug=False)

--- a/scripts/examples/50-OpenMV-Boards/60-Shields/65-IMU-Shield/imu_read.py
+++ b/scripts/examples/50-OpenMV-Boards/60-Shields/65-IMU-Shield/imu_read.py
@@ -3,6 +3,7 @@
 # https://github.com/openmv/openmv/blob/master/LICENSE
 #
 from machine import I2C
+from bno055 import BNO055
 import time
 
 i2c = I2C(2)


### PR DESCRIPTION
Reported by a user: the color-tracking examples call image.get_major_axis_line()/get_minor_axis_line() but lost their 'import image' in the sensor-to-csi refactor, so they raise NameError the moment a blob with elongation > 0.5 is found.  An AST scan of every example for names that are read but never bound found four more of the same class:

- 02-Color-Tracking (4 files): add the missing 'import image'.
- Giga-H7 i2c_scanner.py: the print still referenced 'bus' from the multi-bus template it was adapted from; print the address only.
- Portenta-H7 lora-example.py: sleep_ms() only resolved because 'from lora import *' happens to leak time.sleep_ms from the library's own imports; import it explicitly.
- 65-IMU-Shield imu_read.py: BNO055 was never imported.

Verified image.get_major_axis_line()/get_minor_axis_line() exist and resolve on an OpenMV AE3, and the scan now reports no unresolved names across all examples.